### PR TITLE
test: Migration script to convert Jest to Vitest

### DIFF
--- a/components/__tests__/blog.test.ts
+++ b/components/__tests__/blog.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 const fs = require('fs');
 
 const path = require('path');

--- a/components/__tests__/index.test.ts
+++ b/components/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, afterAll, it, expect } from 'vitest';
 const OLD_NODE_ENV = process.env.NODE_ENV;
 process.env.NODE_ENV = 'development';
 const antd = require('..');

--- a/components/__tests__/node.test.tsx
+++ b/components/__tests__/node.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, test, expect, vi } from 'vitest';
 import { globSync } from 'glob';
 import * as React from 'react';
 import { renderToString } from 'react-dom/server';
@@ -5,7 +6,7 @@ import type { Options } from '../../tests/shared/demoTest';
 
 (global as any).testConfig = {};
 
-jest.mock('../../tests/shared/demoTest', () => {
+vi.mock('../../tests/shared/demoTest', () => {
   function fakeDemoTest(name: string, option: Options = {}) {
     (global as any).testConfig[name] = option;
   }
@@ -17,7 +18,7 @@ jest.mock('../../tests/shared/demoTest', () => {
 
 describe('node', () => {
   beforeAll(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2016-11-22'));
+    vi.useFakeTimers().setSystemTime(new Date('2016-11-22'));
   });
 
   // Find the component exist demo test file

--- a/components/__tests__/setup.test.tsx
+++ b/components/__tests__/setup.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import { render } from '../../tests/utils';
 

--- a/components/_util/__tests__/capitalize.test.ts
+++ b/components/_util/__tests__/capitalize.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import capitalize from '../capitalize';
 
 describe('capitalize', () => {

--- a/components/_util/__tests__/easings.test.ts
+++ b/components/_util/__tests__/easings.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { easeInOutCubic } from '../easings';
 
 describe('Test easings', () => {

--- a/components/_util/__tests__/getScroll.test.ts
+++ b/components/_util/__tests__/getScroll.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import getScroll from '../getScroll';
 
 describe('getScroll', () => {
@@ -7,7 +8,7 @@ describe('getScroll', () => {
   });
 
   it('getScroll window', async () => {
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
       window.pageXOffset = x;
       window.pageYOffset = y;
     });
@@ -18,7 +19,7 @@ describe('getScroll', () => {
   });
 
   it('getScroll document', async () => {
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
       document.documentElement.scrollLeft = x;
       document.documentElement.scrollTop = y;
     });
@@ -30,7 +31,7 @@ describe('getScroll', () => {
 
   it('getScroll div', async () => {
     const div = document.createElement('div');
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
       div.scrollLeft = x;
       div.scrollTop = y;
     });
@@ -42,7 +43,7 @@ describe('getScroll', () => {
 
   it('getScroll documentElement', async () => {
     const div: any = {};
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((x, y) => {
       div.scrollLeft = null;
       div.scrollTop = null;
       div.documentElement = {};

--- a/components/_util/__tests__/getScrollNode.test.ts
+++ b/components/_util/__tests__/getScrollNode.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /** @jest-environment node */
 import getScroll from '../getScroll';
 

--- a/components/_util/__tests__/reactNode.test.tsx
+++ b/components/_util/__tests__/reactNode.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { isValidElement, cloneElement, isFragment, replaceElement } from '../reactNode';
 

--- a/components/_util/__tests__/responsiveObserve.test.tsx
+++ b/components/_util/__tests__/responsiveObserve.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render } from '../../../tests/utils';
 import useResponsiveObserver from '../responsiveObserver';
@@ -11,7 +12,7 @@ describe('Test ResponsiveObserve', () => {
       return null;
     };
     render(<Demo />);
-    const subscribeFunc = jest.fn();
+    const subscribeFunc = vi.fn();
     const token = responsiveObserveRef.subscribe(subscribeFunc);
     expect(
       responsiveObserveRef.matchHandlers[responsiveObserveRef.responsiveMap.xs].mql.matches,

--- a/components/_util/__tests__/scrollTo.test.ts
+++ b/components/_util/__tests__/scrollTo.test.ts
@@ -1,11 +1,12 @@
+import { describe, beforeAll, beforeEach, afterAll, afterEach, it, expect, vi } from 'vitest';
 import { waitFakeTimer } from '../../../tests/utils';
 import scrollTo from '../scrollTo';
 
 describe('Test ScrollTo function', () => {
-  const dateNowMock = jest.spyOn(Date, 'now');
+  const dateNowMock = vi.spyOn(Date, 'now');
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   beforeEach(() => {
@@ -13,16 +14,16 @@ describe('Test ScrollTo function', () => {
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
+    vi.clearAllTimers();
     dateNowMock.mockClear();
   });
 
   it('test scrollTo', async () => {
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
       window.scrollY = y;
       window.pageYOffset = y;
     });
@@ -36,7 +37,7 @@ describe('Test ScrollTo function', () => {
   });
 
   it('test callback - option', async () => {
-    const cbMock = jest.fn();
+    const cbMock = vi.fn();
     scrollTo(1000, {
       callback: cbMock,
     });

--- a/components/_util/__tests__/transButton.test.tsx
+++ b/components/_util/__tests__/transButton.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import TransButton from '../transButton';
 import { render } from '../../../tests/utils';

--- a/components/_util/__tests__/useSyncState.test.tsx
+++ b/components/_util/__tests__/useSyncState.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import useSyncState from '../hooks/useSyncState';
 import { render, fireEvent } from '../../../tests/utils';

--- a/components/_util/__tests__/util.test.tsx
+++ b/components/_util/__tests__/util.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, afterEach, it, expect, vi } from 'vitest';
 /* eslint-disable class-methods-use-this */
 import KeyCode from 'rc-util/lib/KeyCode';
 import React from 'react';
@@ -10,19 +11,19 @@ import TransButton from '../transButton';
 describe('Test utils function', () => {
   describe('throttle', () => {
     beforeAll(() => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
     });
 
     afterAll(() => {
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
 
     afterEach(() => {
-      jest.clearAllTimers();
+      vi.clearAllTimers();
     });
 
     it('throttle function should work', async () => {
-      const callback = jest.fn();
+      const callback = vi.fn();
       const throttled = throttleByAnimationFrame(callback);
       expect(callback).not.toHaveBeenCalled();
 
@@ -35,7 +36,7 @@ describe('Test utils function', () => {
     });
 
     it('throttle function should be canceled', async () => {
-      const callback = jest.fn();
+      const callback = vi.fn();
       const throttled = throttleByAnimationFrame(callback);
 
       throttled();
@@ -106,7 +107,7 @@ describe('Test utils function', () => {
     });
 
     it('should trigger onClick when press enter', () => {
-      const onClick = jest.fn();
+      const onClick = vi.fn();
 
       const { container } = render(<TransButton onClick={onClick}>TransButton</TransButton>);
 
@@ -127,7 +128,7 @@ describe('Test utils function', () => {
     });
 
     it('isStyleSupport return false in service side', () => {
-      const spy = jest
+      const spy = vi
         .spyOn(window.document, 'documentElement', 'get')
         .mockImplementation(() => undefined as unknown as HTMLElement);
       expect(isStyleSupport('color')).toBe(false);

--- a/components/_util/__tests__/warning.test.ts
+++ b/components/_util/__tests__/warning.test.ts
@@ -1,8 +1,9 @@
+import { describe, beforeAll, afterAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 describe('Test warning', () => {
   let spy: jest.SpyInstance;
 
   beforeAll(() => {
-    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    spy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterAll(() => {
@@ -10,7 +11,7 @@ describe('Test warning', () => {
   });
 
   beforeEach(() => {
-    jest.resetModules();
+    vi.resetModules();
   });
 
   afterEach(() => {

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, expect, beforeEach, afterEach, it, vi } from 'vitest';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import { render, fireEvent, getByText, waitFakeTimer, act } from '../../../tests/utils';
@@ -5,7 +6,7 @@ import Wave from '../wave';
 
 (global as any).isVisible = true;
 
-jest.mock('rc-util/lib/Dom/isVisible', () => {
+vi.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => (global as any).isVisible;
   return mockFn;
 });
@@ -29,11 +30,11 @@ describe('Wave component', () => {
     }
 
     (window as any).ResizeObserver = FakeResizeObserver;
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     expect(obCnt).not.toBe(0);
     expect(disCnt).not.toBe(0);
   });
@@ -44,7 +45,7 @@ describe('Wave component', () => {
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
+    vi.clearAllTimers();
     const styles = document.getElementsByTagName('style');
     for (let i = 0; i < styles.length; i += 1) {
       styles[i].remove();
@@ -66,7 +67,7 @@ describe('Wave component', () => {
 
   function waitRaf() {
     act(() => {
-      jest.advanceTimersByTime(100);
+      vi.advanceTimersByTime(100);
     });
   }
 

--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, beforeAll, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React, { useEffect, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import type { InternalAffixClass } from '..';
@@ -23,7 +24,7 @@ const AffixMounter: React.FC<AffixProps> = ({ getInstance, ...restProps }) => {
   const container = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (container.current) {
-      container.current.addEventListener = jest
+      container.current.addEventListener = vi
         .fn()
         .mockImplementation((event: keyof HTMLElementEventMap, cb: (ev: Event) => void) => {
           events[event] = cb;
@@ -43,12 +44,12 @@ describe('Affix Render', () => {
   rtlTest(Affix);
   accessibilityTest(Affix);
 
-  const domMock = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+  const domMock = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
 
   const classRect: Record<string, DOMRect> = { container: { top: 0, bottom: 100 } as DOMRect };
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const entities = getObserverEntities();
     entities.splice(0, entities.length);
   });
@@ -60,8 +61,8 @@ describe('Affix Render', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
-    jest.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllTimers();
   });
 
   afterAll(() => {
@@ -112,7 +113,7 @@ describe('Affix Render', () => {
   });
 
   it('updatePosition when offsetTop changed', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(<AffixMounter offsetTop={0} onChange={onChange} />);
     await waitFakeTimer();
@@ -248,7 +249,7 @@ describe('Affix Render', () => {
       '.fixed', // outer
     ].forEach((selector) => {
       it(`trigger listener when size change: ${selector}`, async () => {
-        const updateCalled = jest.fn();
+        const updateCalled = vi.fn();
         const { container } = render(
           <AffixMounter offsetBottom={0} onTestUpdatePosition={updateCalled} />,
           {

--- a/components/affix/__tests__/image.test.ts
+++ b/components/affix/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Affix image', () => {

--- a/components/alert/__tests__/image.test.ts
+++ b/components/alert/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Alert image', () => {

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Alert from '..';
@@ -15,15 +16,15 @@ describe('Alert', () => {
   accessibilityTest(Alert);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should show close button and could be closed', async () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     render(
       <Alert
         message="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
@@ -36,7 +37,7 @@ describe('Alert', () => {
     await userEvent.click(screen.getByRole('button', { name: /close/i }));
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -76,7 +77,7 @@ describe('Alert', () => {
   });
 
   it('should show error as ErrorBoundary when children have error', () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(warnSpy).toHaveBeenCalledTimes(0);
     // @ts-expect-error
     // eslint-disable-next-line react/jsx-no-undef
@@ -106,7 +107,7 @@ describe('Alert', () => {
     await userEvent.hover(screen.getByRole('alert'));
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
@@ -124,7 +125,7 @@ describe('Alert', () => {
     await userEvent.click(screen.getByRole('alert'));
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, afterAll, it, expect, vi } from 'vitest';
 import { resetWarned } from 'rc-util/lib/warning';
 import React, { useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -18,18 +19,15 @@ function createDiv() {
 let idCounter = 0;
 const getHashUrl = () => `Anchor-API-${idCounter++}`;
 
-jest.mock('scroll-into-view-if-needed', () => jest.fn());
+vi.mock('scroll-into-view-if-needed', () => vi.fn());
 
 describe('Anchor Render', () => {
-  const getBoundingClientRectMock = jest.spyOn(
-    HTMLHeadingElement.prototype,
-    'getBoundingClientRect',
-  );
-  const getClientRectsMock = jest.spyOn(HTMLHeadingElement.prototype, 'getClientRects');
-  const scrollIntoViewMock = jest.createMockFromModule<any>('scroll-into-view-if-needed');
+  const getBoundingClientRectMock = vi.spyOn(HTMLHeadingElement.prototype, 'getBoundingClientRect');
+  const getClientRectsMock = vi.spyOn(HTMLHeadingElement.prototype, 'getClientRects');
+  const scrollIntoViewMock = vi.createMockFromModule<any>('scroll-into-view-if-needed');
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     getBoundingClientRectMock.mockReturnValue({
       width: 100,
       height: 100,
@@ -39,18 +37,18 @@ describe('Anchor Render', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     scrollIntoViewMock.mockReset();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   afterAll(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     getBoundingClientRectMock.mockRestore();
     getClientRectsMock.mockRestore();
   });
@@ -191,7 +189,7 @@ describe('Anchor Render', () => {
 
   it('scrolls the page when clicking a link', async () => {
     const root = createDiv();
-    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
     render(<div id="/faq?locale=en#Q1">Q1</div>, { container: root });
     const { container } = render(
       <Anchor items={[{ key: 'Q1', title: 'Q1', href: '/#/faq?locale=en#Q1' }]} />,
@@ -206,7 +204,7 @@ describe('Anchor Render', () => {
     const hash1 = getHashUrl();
     const hash2 = getHashUrl();
     const root = createDiv();
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     render(
       <div>
         <div id={hash1}>Hello</div>
@@ -265,7 +263,7 @@ describe('Anchor Render', () => {
   it('targetOffset prop', async () => {
     const hash = getHashUrl();
 
-    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
     const root = createDiv();
     render(<h1 id={hash}>Hello</h1>, { container: root });
     const { container, rerender } = render(
@@ -296,7 +294,7 @@ describe('Anchor Render', () => {
   it('targetOffset prop when contain spaces', async () => {
     const hash = `${getHashUrl()} s p a c e s`;
 
-    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
     const root = createDiv();
     render(<h1 id={hash}>Hello</h1>, { container: root });
     const { container, rerender } = render(
@@ -347,7 +345,7 @@ describe('Anchor Render', () => {
   it('onChange event', () => {
     const hash1 = getHashUrl();
     const hash2 = getHashUrl();
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Anchor
         onChange={onChange}
@@ -435,7 +433,7 @@ describe('Anchor Render', () => {
     getBoundingClientRectMock.mockReturnValue({ width: 0, height: 0, top: 1000 } as DOMRect);
     const hash = getHashUrl();
 
-    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
     const root = createDiv();
     render(<h1 id={hash}>Hello</h1>, { container: root });
     const { container, rerender } = render(
@@ -475,7 +473,7 @@ describe('Anchor Render', () => {
   it('test edge case when container is not windows', async () => {
     const hash = getHashUrl();
 
-    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
     const root = createDiv();
     render(<h1 id={hash}>Hello</h1>, { container: root });
 
@@ -529,7 +527,7 @@ describe('Anchor Render', () => {
     it('should trigger onChange when have getCurrentAnchor', () => {
       const hash1 = getHashUrl();
       const hash2 = getHashUrl();
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container } = render(
         <Anchor
           onChange={onChange}
@@ -553,7 +551,7 @@ describe('Anchor Render', () => {
     it('getCurrentAnchor have default link as argument', () => {
       const hash1 = getHashUrl();
       const hash2 = getHashUrl();
-      const getCurrentAnchor = jest.fn();
+      const getCurrentAnchor = vi.fn();
       const { container } = render(
         <Anchor
           getCurrentAnchor={getCurrentAnchor}
@@ -603,7 +601,7 @@ describe('Anchor Render', () => {
     describe('scroll x', () => {
       it('targetOffset horizontal', async () => {
         const hash = getHashUrl();
-        const scrollToSpy = jest.spyOn(window, 'scrollTo');
+        const scrollToSpy = vi.spyOn(window, 'scrollTo');
         const root = createDiv();
         render(<h1 id={hash}>Hello</h1>, { container: root });
         const { container, rerender } = render(
@@ -761,7 +759,7 @@ describe('Anchor Render', () => {
 
     it('scrolls the page when clicking a link', async () => {
       const root = createDiv();
-      const scrollToSpy = jest.spyOn(window, 'scrollTo');
+      const scrollToSpy = vi.spyOn(window, 'scrollTo');
       render(<div id="/faq?locale=en#Q1">Q1</div>, { container: root });
       const { container } = render(
         <Anchor>
@@ -778,7 +776,7 @@ describe('Anchor Render', () => {
       const hash1 = getHashUrl();
       const hash2 = getHashUrl();
       const root = createDiv();
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       render(
         <div>
           <div id={hash1}>Hello</div>
@@ -854,7 +852,7 @@ describe('Anchor Render', () => {
     let errSpy: jest.SpyInstance;
     beforeEach(() => {
       resetWarned();
-      errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
     afterEach(() => {
@@ -971,14 +969,14 @@ describe('Anchor Render', () => {
       const toggleButton = wrapper.container.querySelector('button')!;
 
       fireEvent.click(toggleButton);
-      act(() => jest.runAllTimers());
+      act(() => vi.runAllTimers());
       expect(!!ink.style.left).toBe(true);
       expect(!!ink.style.width).toBe(true);
       expect(ink.style.top).toBe('');
       expect(ink.style.height).toBe('');
 
       fireEvent.click(toggleButton);
-      act(() => jest.runAllTimers());
+      act(() => vi.runAllTimers());
       expect(!!ink.style.top).toBe(true);
       expect(!!ink.style.height).toBe(true);
       expect(ink.style.left).toBe('');

--- a/components/anchor/__tests__/cached-context.test.tsx
+++ b/components/anchor/__tests__/cached-context.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest';
 import React, { memo, useContext } from 'react';
 import { fireEvent, pureRender } from '../../../tests/utils';
 import Anchor from '../Anchor';

--- a/components/anchor/__tests__/image.test.ts
+++ b/components/anchor/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Anchor image', () => {

--- a/components/app/__tests__/image.test.ts
+++ b/components/app/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('app', () => {

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React, { useEffect } from 'react';
 import App from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -11,12 +12,12 @@ describe('App', () => {
   rtlTest(App);
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('single', () => {

--- a/components/auto-complete/__tests__/focus.test.tsx
+++ b/components/auto-complete/__tests__/focus.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterAll, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import AutoComplete from '..';
@@ -5,7 +6,7 @@ import { render } from '../../../tests/utils';
 
 describe('AutoComplete children could be focus', () => {
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   let container: HTMLDivElement;
@@ -15,7 +16,7 @@ describe('AutoComplete children could be focus', () => {
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   afterEach(() => {
@@ -23,31 +24,31 @@ describe('AutoComplete children could be focus', () => {
   });
 
   it('focus() and onFocus', () => {
-    const handleFocus = jest.fn();
+    const handleFocus = vi.fn();
     const { container: wrapper } = render(<AutoComplete onFocus={handleFocus} />, { container });
     wrapper.querySelector('input')?.focus();
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(handleFocus).toHaveBeenCalled();
   });
 
   it('blur() and onBlur', () => {
-    const handleBlur = jest.fn();
+    const handleBlur = vi.fn();
     const { container: wrapper } = render(<AutoComplete onBlur={handleBlur} />, { container });
     wrapper.querySelector('input')?.focus();
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     wrapper.querySelector('input')?.blur();
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(handleBlur).toHaveBeenCalled();
   });
 
   it('child.ref should work', () => {
-    const mockRef = jest.fn();
+    const mockRef = vi.fn();
     render(
       <AutoComplete dataSource={[]}>
         <input ref={mockRef} />

--- a/components/auto-complete/__tests__/image.test.ts
+++ b/components/auto-complete/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('AutoComplete image', () => {

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import AutoComplete from '..';
@@ -49,7 +50,7 @@ describe('AutoComplete', () => {
   });
 
   it('AutoComplete throws error when contains invalid dataSource', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(
       // @ts-ignore
@@ -82,7 +83,7 @@ describe('AutoComplete', () => {
   });
 
   it('should not warning when getInputElement is null', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(<AutoComplete placeholder="input here" allowClear />);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
@@ -100,7 +101,7 @@ describe('AutoComplete', () => {
   it('deprecated dropdownClassName', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
       <AutoComplete
         dropdownClassName="legacy"

--- a/components/avatar/__tests__/Avatar.test.tsx
+++ b/components/avatar/__tests__/Avatar.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
@@ -7,7 +8,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
 import useBreakpoint from '../../grid/hooks/useBreakpoint';
 
-jest.mock('../../grid/hooks/useBreakpoint');
+vi.mock('../../grid/hooks/useBreakpoint');
 
 describe('Avatar Render', () => {
   mountTest(Avatar);
@@ -122,7 +123,7 @@ describe('Avatar Render', () => {
   });
 
   it('should warning when pass a string as icon props', () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Avatar size={64} icon="aa" />);
     expect(warnSpy).not.toHaveBeenCalled();
 
@@ -152,7 +153,7 @@ describe('Avatar Render', () => {
   });
 
   it('support onMouseEnter', () => {
-    const onMouseEnter = jest.fn();
+    const onMouseEnter = vi.fn();
     const { container } = render(<Avatar {...{ onMouseEnter }}>TestString</Avatar>);
     fireEvent.mouseEnter(container.firstChild!);
     expect(onMouseEnter).toHaveBeenCalled();
@@ -191,7 +192,7 @@ describe('Avatar Render', () => {
   });
 
   it('clickable', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<Avatar onClick={onClick}>TestString</Avatar>);
     fireEvent.click(container.querySelector('.ant-avatar-string')!);
     expect(onClick).toHaveBeenCalled();

--- a/components/avatar/__tests__/image.test.ts
+++ b/components/avatar/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Avatar image', () => {

--- a/components/back-top/__tests__/image.test.ts
+++ b/components/back-top/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('BackTop image', () => {

--- a/components/back-top/__tests__/index.test.tsx
+++ b/components/back-top/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import BackTop from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -6,17 +7,17 @@ import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 
 describe('BackTop', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
   mountTest(BackTop);
   rtlTest(BackTop);
 
   it('should scroll to top after click it', async () => {
     const { container } = render(<BackTop />);
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
       window.scrollY = y;
       window.pageYOffset = y;
       document.documentElement.scrollTop = y;
@@ -31,20 +32,20 @@ describe('BackTop', () => {
   });
 
   it('support onClick', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<BackTop onClick={onClick} visibilityHeight={0} />);
     fireEvent.click(container.querySelector<HTMLDivElement>('.ant-back-top')!);
     expect(onClick).toHaveBeenCalled();
   });
 
   it('invalid target', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<BackTop onClick={onClick} target={undefined} />);
     fireEvent.click(container.querySelector<HTMLDivElement>('.ant-back-top')!);
     expect(onClick).toHaveBeenCalled();
   });
   it('should console Error', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<BackTop />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: BackTop] `BackTop` is deprecated, please use `FloatButton.BackTop` instead.',

--- a/components/badge/__tests__/image.test.ts
+++ b/components/badge/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Badge image', () => {

--- a/components/badge/__tests__/index.test.tsx
+++ b/components/badge/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -18,15 +19,15 @@ describe('Badge', () => {
   ));
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('no strict warning', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { rerender } = render(
       <Badge dot>
         <span />
@@ -83,7 +84,7 @@ describe('Badge', () => {
 
     act(() => {
       fireEvent.mouseEnter(container.querySelector('.ant-badge')!);
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
   });
@@ -95,7 +96,7 @@ describe('Badge', () => {
       rerender(<Badge count={count} />);
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
         expect(asFragment().firstChild).toMatchSnapshot();
       });
     }

--- a/components/badge/__tests__/ribbon.test.tsx
+++ b/components/badge/__tests__/ribbon.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import accessibilityTest from '../../../tests/shared/accessibilityTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -12,7 +13,7 @@ describe('Breadcrumb', () => {
   rtlTest(Breadcrumb);
   accessibilityTest(Breadcrumb);
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -326,7 +327,7 @@ describe('Breadcrumb', () => {
 
   it('should console Error when `overlay` in props', () => {
     resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(
       <Breadcrumb>
         <Breadcrumb.Item overlay={<div>test</div>} />
@@ -339,14 +340,14 @@ describe('Breadcrumb', () => {
   });
 
   it('should not console Error when `overlay` not in props', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Breadcrumb items={[{ path: '/', title: 'Test' }]} />);
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
 
   it('should use `onClick`', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const wrapper = render(<Breadcrumb items={[{ title: 'test', onClick }]} />);
     const item = await wrapper.findByText('test');
     item.click();

--- a/components/breadcrumb/__tests__/image.test.ts
+++ b/components/breadcrumb/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Breadcrumb image', () => {

--- a/components/breadcrumb/__tests__/router.test.tsx
+++ b/components/breadcrumb/__tests__/router.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React, { useMemo } from 'react';
 import type { RouterProps } from 'react-router-dom';
 import { Link, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
@@ -25,11 +26,11 @@ const breadcrumbNameMap = {
 
 describe('react router', () => {
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('react router 6', () => {

--- a/components/button/__tests__/delay-timer.test.tsx
+++ b/components/button/__tests__/delay-timer.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { fireEvent, render } from '../../../tests/utils';
@@ -30,16 +31,16 @@ const Content = () => {
 
 it('Delay loading timer in Button component', () => {
   const otherTimer = 9528;
-  jest.spyOn<Window, 'setTimeout'>(window, 'setTimeout').mockReturnValue(otherTimer);
-  jest.restoreAllMocks();
+  vi.spyOn<Window, 'setTimeout'>(window, 'setTimeout').mockReturnValue(otherTimer);
+  vi.restoreAllMocks();
 
   const wrapper = render(<Content />);
 
   const btnTimer = 9527;
-  const setTimeoutMock = jest
+  const setTimeoutMock = vi
     .spyOn<Window, 'setTimeout'>(window, 'setTimeout')
     .mockReturnValue(btnTimer);
-  const clearTimeoutMock = jest.spyOn<Window, 'clearTimeout'>(window, 'clearTimeout');
+  const clearTimeoutMock = vi.spyOn<Window, 'clearTimeout'>(window, 'clearTimeout');
 
   // other component may call setTimeout or clearTimeout
   const setTimeoutCount = () => {
@@ -89,7 +90,7 @@ it('Delay loading timer in Button component', () => {
   expect(setTimeoutCount()).toBe(3);
   expect(clearTimeoutCount()).toBe(2);
 
-  jest.restoreAllMocks();
+  vi.restoreAllMocks();
 });
 it('Delay loading while use loading delay at first time', () => {
   const Demo = () => <Button loading={{ delay: specialDelay }} />;

--- a/components/button/__tests__/image.test.ts
+++ b/components/button/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Button image', () => {

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { SearchOutlined } from '@ant-design/icons';
 import { resetWarned } from 'rc-util/lib/warning';
 import React, { useState } from 'react';
@@ -37,7 +38,7 @@ describe('Button', () => {
 
   it('warns if size is wrong', () => {
     resetWarned();
-    const mockWarn = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const mockWarn = vi.spyOn(console, 'error').mockImplementation(() => {});
     const size = 'who am I';
     // @ts-expect-error: Type '"who am I"' is not assignable to type 'SizeType'.ts(2322)
     render(<Button.Group size={size} />);
@@ -162,22 +163,22 @@ describe('Button', () => {
   });
 
   it('reset when loading back of delay', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { rerender, container } = render(<Button loading={{ delay: 1000 }} />);
     rerender(<Button loading={{ delay: 2000 }} />);
     rerender(<Button loading={false} />);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(0);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should not clickable when button is loading', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <Button loading onClick={onClick}>
         button
@@ -223,7 +224,7 @@ describe('Button', () => {
   });
 
   it('should support to change loading', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender, unmount } = render(<Button>Button</Button>);
     rerender(<Button loading />);
     expect(container.querySelectorAll('.ant-btn-loading').length).toBe(1);
@@ -237,12 +238,12 @@ describe('Button', () => {
     await waitFakeTimer();
     expect(container.querySelectorAll('.ant-btn-loading').length).toBe(0);
     expect(unmount).not.toThrow();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should warning when pass a string as icon props', () => {
     resetWarned();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<Button type="primary" icon="ab" />);
     expect(warnSpy).not.toHaveBeenCalled();
@@ -257,7 +258,7 @@ describe('Button', () => {
 
   it('should warning when pass type=link and ghost=true', () => {
     resetWarned();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Button type="link" ghost />);
     expect(warnSpy).toHaveBeenCalledWith(
       "Warning: [antd: Button] `link` or `text` button can't be a `ghost` button.",
@@ -267,7 +268,7 @@ describe('Button', () => {
 
   it('should warning when pass type=text and ghost=true', () => {
     resetWarned();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Button type="text" ghost />);
     expect(warnSpy).toHaveBeenCalledWith(
       "Warning: [antd: Button] `link` or `text` button can't be a `ghost` button.",
@@ -290,7 +291,7 @@ describe('Button', () => {
   });
 
   it('should not redirect when button is disabled', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <Button href="https://ant.design" onClick={onClick} disabled>
         click me

--- a/components/button/__tests__/wave.test.tsx
+++ b/components/button/__tests__/wave.test.tsx
@@ -1,30 +1,31 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import Button from '..';
 import { act, fireEvent, render } from '../../../tests/utils';
 
-jest.mock('rc-util/lib/Dom/isVisible', () => {
+vi.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => true;
   return mockFn;
 });
 
 describe('click wave effect', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     document.body.innerHTML = '';
   });
 
   async function clickButton(container: HTMLElement) {
     const element = container.firstChild;
     // https://github.com/testing-library/user-event/issues/833
-    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).click(element as Element);
+    await userEvent.setup({ advanceTimers: vi.advanceTimersByTime }).click(element as Element);
     act(() => {
-      jest.advanceTimersByTime(100);
+      vi.advanceTimersByTime(100);
     });
 
     fireEvent(element!, new Event('transitionstart'));

--- a/components/calendar/__tests__/image.test.ts
+++ b/components/calendar/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Calendar image', () => {

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import Dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import MockDate from 'mockdate';
@@ -20,8 +21,8 @@ const ref: {
   calendarHeaderProps?: CalendarHeaderProps<unknown>;
 } = {};
 
-jest.mock('../Header', () => {
-  const HeaderModule = jest.requireActual('../Header');
+vi.mock('../Header', () => {
+  const HeaderModule = vi.requireActual('../Header');
   const HeaderComponent = HeaderModule.default;
   return (props: CalendarHeaderProps<any>) => {
     ref.calendarHeaderProps = props;
@@ -29,8 +30,8 @@ jest.mock('../Header', () => {
   };
 });
 
-jest.mock('rc-picker', () => {
-  const RcPicker = jest.requireActual('rc-picker');
+vi.mock('rc-picker', () => {
+  const RcPicker = vi.requireActual('rc-picker');
   const PickerPanelComponent = RcPicker.PickerPanel;
   return {
     ...RcPicker,
@@ -71,8 +72,8 @@ describe('Calendar', () => {
   it('Calendar should be selectable', () => {
     MockDate.set(Dayjs('2000-01-01').valueOf());
 
-    const onSelect = jest.fn();
-    const onChange = jest.fn();
+    const onSelect = vi.fn();
+    const onChange = vi.fn();
     const { container } = render(<Calendar onSelect={onSelect} onChange={onChange} />);
 
     fireEvent.click(container.querySelector('.ant-picker-cell')!);
@@ -87,7 +88,7 @@ describe('Calendar', () => {
   });
 
   it('only Valid range should be selectable', () => {
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
     const validRange: [Dayjs.Dayjs, Dayjs.Dayjs] = [Dayjs('2018-02-02'), Dayjs('2018-02-18')];
     const wrapper = render(
       <Calendar onSelect={onSelect} validRange={validRange} defaultValue={Dayjs('2018-02-02')} />,
@@ -98,7 +99,7 @@ describe('Calendar', () => {
   });
 
   it('dates other than in valid range should be disabled', () => {
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
     const validRange: [Dayjs.Dayjs, Dayjs.Dayjs] = [Dayjs('2018-02-02'), Dayjs('2018-02-18')];
     const { container } = render(
       <Calendar onSelect={onSelect} validRange={validRange} defaultValue={Dayjs('2018-02-02')} />,
@@ -112,7 +113,7 @@ describe('Calendar', () => {
   });
 
   it('months other than in valid range should be disabled', () => {
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
     const validRange: [Dayjs.Dayjs, Dayjs.Dayjs] = [Dayjs('2018-02-02'), Dayjs('2018-05-18')];
     const { container } = render(
       <Calendar
@@ -187,7 +188,7 @@ describe('Calendar', () => {
   it('Calendar should switch mode', () => {
     const monthMode = 'month';
     const yearMode = 'year';
-    const onPanelChangeStub = jest.fn();
+    const onPanelChangeStub = vi.fn();
     const wrapper = render(<Calendar mode={yearMode} onPanelChange={onPanelChangeStub} />);
     expect(ref.calendarHeaderProps?.mode).toEqual(yearMode);
     wrapper.rerender(<Calendar mode={monthMode} onPanelChange={onPanelChangeStub} />);
@@ -206,7 +207,7 @@ describe('Calendar', () => {
 
   describe('onPanelChange', () => {
     it('trigger when click last month of date', () => {
-      const onPanelChange = jest.fn();
+      const onPanelChange = vi.fn();
       const date = Dayjs('1990-09-03');
       const wrapper = render(<Calendar onPanelChange={onPanelChange} value={date} />);
 
@@ -217,7 +218,7 @@ describe('Calendar', () => {
     });
 
     it('not trigger when in same month', () => {
-      const onPanelChange = jest.fn();
+      const onPanelChange = vi.fn();
       const date = Dayjs('1990-09-03');
       const wrapper = render(<Calendar onPanelChange={onPanelChange} value={date} />);
 
@@ -228,7 +229,7 @@ describe('Calendar', () => {
   });
 
   it('switch should work correctly without prop mode', async () => {
-    const onPanelChange = jest.fn();
+    const onPanelChange = vi.fn();
     const date = Dayjs(new Date(Date.UTC(2017, 7, 9, 8)));
     const wrapper = render(<Calendar onPanelChange={onPanelChange} value={date} />);
 
@@ -268,7 +269,7 @@ describe('Calendar', () => {
     const value = Dayjs('1990-01-03');
     const start = Dayjs('2019-04-01');
     const end = Dayjs('2019-11-01');
-    const onValueChange = jest.fn();
+    const onValueChange = vi.fn();
     createWrapper(start, end, value, onValueChange);
     expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(3));
   });
@@ -277,7 +278,7 @@ describe('Calendar', () => {
     const value = Dayjs('1990-01-03');
     const start = Dayjs('2019-11-01');
     const end = Dayjs('2019-03-01');
-    const onValueChange = jest.fn();
+    const onValueChange = vi.fn();
     createWrapper(start, end, value, onValueChange);
     expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(10));
   });
@@ -286,7 +287,7 @@ describe('Calendar', () => {
     const value = Dayjs('2018-11-03');
     const start = Dayjs('2000-01-01');
     const end = Dayjs('2019-03-01');
-    const onValueChange = jest.fn();
+    const onValueChange = vi.fn();
     const wrapper = render(
       <Header
         prefixCls="ant-picker-calendar"
@@ -309,7 +310,7 @@ describe('Calendar', () => {
     const start = Dayjs('2018-11-01');
     const end = Dayjs('2019-03-01');
     const value = Dayjs('2018-12-03');
-    const onValueChange = jest.fn();
+    const onValueChange = vi.fn();
     const wrapper = render(
       <Header
         prefixCls="ant-picker-calendar"
@@ -328,7 +329,7 @@ describe('Calendar', () => {
   });
 
   it('onTypeChange should work correctly', () => {
-    const onTypeChange = jest.fn();
+    const onTypeChange = vi.fn();
     const value = Dayjs('2018-12-03');
     const wrapper = render(
       <Header
@@ -348,12 +349,12 @@ describe('Calendar', () => {
   });
 
   it('headerRender should work correctly', () => {
-    const onMonthChange = jest.fn();
-    const onYearChange = jest.fn();
-    const onTypeChange = jest.fn();
+    const onMonthChange = vi.fn();
+    const onYearChange = vi.fn();
+    const onTypeChange = vi.fn();
 
     // Year
-    const headerRender = jest.fn(({ value }) => {
+    const headerRender = vi.fn(({ value }) => {
       const year = value.year();
       const options = [];
       for (let i = year - 100; i < year + 100; i += 1) {
@@ -387,7 +388,7 @@ describe('Calendar', () => {
     expect(onYearChange).toHaveBeenCalled();
 
     // Month
-    const headerRenderWithMonth = jest.fn(({ value }) => {
+    const headerRenderWithMonth = vi.fn(({ value }) => {
       const start = 0;
       const end = 12;
       const monthOptions = [];
@@ -430,7 +431,7 @@ describe('Calendar', () => {
     expect(onMonthChange).toHaveBeenCalled();
 
     // Type
-    const headerRenderWithTypeChange = jest.fn(({ type }) => (
+    const headerRenderWithTypeChange = vi.fn(({ type }) => (
       <Group size="small" onChange={onTypeChange} value={type}>
         <Button value="month">Month</Button>
         <Button value="year">Year</Button>
@@ -478,7 +479,7 @@ describe('Calendar', () => {
   });
 
   it('when fullscreen is false, the element returned by dateFullCellRender should be interactive', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <Calendar
         fullscreen={false}
@@ -496,7 +497,7 @@ describe('Calendar', () => {
   it('deprecated dateCellRender and monthCellRender', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
       <Calendar
         dateCellRender={() => <div className="bamboo">Light</div>}
@@ -520,7 +521,7 @@ describe('Calendar', () => {
   it('deprecated dateFullCellRender and monthFullCellRender', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
       <Calendar
         dateFullCellRender={() => <div className="bamboo">Light</div>}

--- a/components/card/__tests__/image.test.ts
+++ b/components/card/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Card image', () => {

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import mountTest from '../../../tests/shared/mountTest';
@@ -12,11 +13,11 @@ describe('Card', () => {
   rtlTest(Card);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should still have padding when card which set padding to 0 is loading', () => {
@@ -48,7 +49,7 @@ describe('Card', () => {
         tab: 'tab2',
       },
     ];
-    const onTabChange = jest.fn();
+    const onTabChange = vi.fn();
     render(
       <Card onTabChange={onTabChange} tabList={tabList}>
         xxx

--- a/components/card/__tests__/type.test.tsx
+++ b/components/card/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Card from '../index';
 

--- a/components/carousel/__tests__/image.test.ts
+++ b/components/carousel/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Carousel image', () => {

--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { CarouselRef } from '..';
 import Carousel from '..';
@@ -10,11 +11,11 @@ describe('Carousel', () => {
   rtlTest(Carousel);
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should has innerSlider', () => {
@@ -65,7 +66,7 @@ describe('Carousel', () => {
         <div>3</div>
       </Carousel>,
     );
-    const spy = jest.spyOn(ref.current?.innerSlider, 'autoPlay');
+    const spy = vi.spyOn(ref.current?.innerSlider, 'autoPlay');
     window.resizeTo(1000, window.outerHeight);
     expect(spy).not.toHaveBeenCalled();
     await waitFakeTimer();
@@ -80,7 +81,7 @@ describe('Carousel', () => {
         <div>3</div>
       </Carousel>,
     );
-    const spy = jest.spyOn(window, 'removeEventListener');
+    const spy = vi.spyOn(window, 'removeEventListener');
     unmount();
     expect(spy).toHaveBeenCalled();
   });

--- a/components/cascader/__tests__/image.test.ts
+++ b/components/cascader/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Cascader image', () => {

--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, afterAll, vi } from 'vitest';
 import React from 'react';
 import type { SingleValueType } from 'rc-cascader/lib/Cascader';
 import type { BaseOptionType, DefaultOptionType } from '..';
@@ -90,7 +91,7 @@ describe('Cascader', () => {
   });
 
   it('popup correctly when panel is open', () => {
-    const onPopupVisibleChange = jest.fn();
+    const onPopupVisibleChange = vi.fn();
     const { container } = render(
       <Cascader options={options} onPopupVisibleChange={onPopupVisibleChange} />,
     );
@@ -123,7 +124,7 @@ describe('Cascader', () => {
   });
 
   it('can be selected', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(<Cascader open options={options} onChange={onChange} />);
 
     clickOption(container, 0, 0);
@@ -284,7 +285,7 @@ describe('Cascader', () => {
       },
     ];
 
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       <Cascader
@@ -320,7 +321,7 @@ describe('Cascader', () => {
   });
 
   describe('limit filtered item count', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     afterAll(() => {
       errorSpy.mockRestore();
@@ -355,7 +356,7 @@ describe('Cascader', () => {
   // FIXME: Move to `rc-tree-select` instead
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should warning if not find `value` in `options`', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Cascader options={[{ label: 'a', value: 'a', children: [{ label: 'b' }] }]} />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Cascader] Not found `value` in `options`.',
@@ -458,7 +459,7 @@ describe('Cascader', () => {
         ],
       },
     ];
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <ConfigProvider direction="rtl">
         <Cascader
@@ -494,7 +495,7 @@ describe('Cascader', () => {
   });
 
   it('can be selected when showSearch', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(<Cascader options={options} onChange={onChange} showSearch />);
     fireEvent.change(container.querySelector('input')!, { target: { value: 'Zh' } });
 
@@ -514,7 +515,7 @@ describe('Cascader', () => {
   });
 
   it('onChange works correctly when the label of fieldNames is the same as value', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const sameNames = { label: 'label', value: 'label' };
     const { container } = render(
       <Cascader options={options} onChange={onChange} showSearch fieldNames={sameNames} />,
@@ -542,7 +543,7 @@ describe('Cascader', () => {
     it('legacy dropdownClassName', () => {
       resetWarned();
 
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const { container } = render(<Cascader dropdownClassName="legacy" open />);
       expect(errSpy).toHaveBeenCalledWith(
         'Warning: [antd: Cascader] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',

--- a/components/cascader/__tests__/type.test.tsx
+++ b/components/cascader/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import type { BaseOptionType } from '..';
 import Cascader from '..';

--- a/components/checkbox/__tests__/checkbox.test.tsx
+++ b/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Checkbox from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -12,8 +13,8 @@ describe('Checkbox', () => {
   rtlTest(Checkbox);
 
   it('responses hover events', () => {
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
 
     const { container } = render(
       <Checkbox onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />,
@@ -29,7 +30,7 @@ describe('Checkbox', () => {
   it('warning if set `value`', () => {
     resetWarned();
 
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Checkbox value />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Checkbox] `value` is not a valid prop, do you mean `checked`?',

--- a/components/checkbox/__tests__/group.test.tsx
+++ b/components/checkbox/__tests__/group.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -14,7 +15,7 @@ describe('CheckboxGroup', () => {
   rtlTest(Checkbox.Group);
 
   it('should work basically', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Checkbox.Group options={['Apple', 'Pear', 'Orange']} onChange={onChange} />,
     );
@@ -29,7 +30,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('does not trigger onChange callback of both Checkbox and CheckboxGroup when CheckboxGroup is disabled', () => {
-    const onChangeGroup = jest.fn();
+    const onChangeGroup = vi.fn();
 
     const options = [
       { label: 'Apple', value: 'Apple' },
@@ -46,7 +47,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('does not prevent onChange callback from Checkbox when CheckboxGroup is not disabled', () => {
-    const onChangeGroup = jest.fn();
+    const onChangeGroup = vi.fn();
 
     const options = [
       { label: 'Apple', value: 'Apple' },
@@ -94,7 +95,7 @@ describe('CheckboxGroup', () => {
 
   // https://github.com/ant-design/ant-design/issues/12642
   it('should trigger onChange in sub Checkbox', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Checkbox.Group>
         <Checkbox value="my" onChange={onChange} />
@@ -107,7 +108,7 @@ describe('CheckboxGroup', () => {
 
   // https://github.com/ant-design/ant-design/issues/16376
   it('onChange should filter removed value', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container, rerender } = render(
       <Checkbox.Group defaultValue={[1]} onChange={onChange}>
         <Checkbox key={1} value={1} />
@@ -126,7 +127,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('checkbox should register value again after value changed', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container, rerender } = render(
       <Checkbox.Group defaultValue={[1]} onChange={onChange}>
         <Checkbox key={1} value={1} />
@@ -144,7 +145,7 @@ describe('CheckboxGroup', () => {
 
   // https://github.com/ant-design/ant-design/issues/17297
   it('onChange should keep the order of the original values', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Checkbox.Group onChange={onChange}>
         <Checkbox key={1} value={1} />
@@ -187,7 +188,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('skipGroup', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Checkbox.Group onChange={onChange}>
         <Checkbox value={1} />
@@ -199,7 +200,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('Table rowSelection', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Checkbox.Group onChange={onChange}>
         <Table
@@ -220,7 +221,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('should support number option', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       <Checkbox.Group options={[1, 'Pear', 'Orange']} onChange={onChange} />,
@@ -231,7 +232,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('should store latest checkbox value if changed', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const Demo: React.FC = () => {
       const [v, setV] = useState('');

--- a/components/checkbox/__tests__/image.test.ts
+++ b/components/checkbox/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Checkbox image', () => {

--- a/components/checkbox/__tests__/type.test.tsx
+++ b/components/checkbox/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Checkbox from '..';
 import Input from '../../input';

--- a/components/collapse/__tests__/image.test.ts
+++ b/components/collapse/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Collapse image', () => {

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { waitFakeTimer, render, fireEvent } from '../../../tests/utils';
@@ -7,13 +8,13 @@ describe('Collapse', () => {
   // eslint-disable-next-line global-require
   const Collapse = require('..').default;
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   // fix React concurrent
   function triggerAllTimer() {
     for (let i = 0; i < 10; i += 1) {
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
     }
   }
@@ -74,7 +75,7 @@ describe('Collapse', () => {
   });
 
   it('could be expand and collapse', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(
       <Collapse>
         <Collapse.Panel header="This is panel header 1" key="1">
@@ -90,7 +91,7 @@ describe('Collapse', () => {
     expect(
       container.querySelector('.ant-collapse-item')?.classList.contains('ant-collapse-item-active'),
     ).toBe(true);
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('could override default openMotion', () => {
@@ -125,8 +126,8 @@ describe('Collapse', () => {
   });
 
   it('should end motion when set activeKey while hiding', async () => {
-    jest.useFakeTimers();
-    const spiedRAF = jest
+    vi.useFakeTimers();
+    const spiedRAF = vi
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation((cb) => setTimeout(cb, 16.66));
 
@@ -157,7 +158,7 @@ describe('Collapse', () => {
     expect(container.querySelectorAll('.ant-motion-collapse').length).toBe(0);
 
     spiedRAF.mockRestore();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('ref should work', () => {

--- a/components/config-provider/__tests__/components.test.tsx
+++ b/components/config-provider/__tests__/components.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import React from 'react';
@@ -58,7 +59,7 @@ import TreeSelect from '../../tree-select';
 import Upload from '../../upload';
 
 dayjs.extend(customParseFormat);
-jest.mock('rc-util/lib/Portal');
+vi.mock('rc-util/lib/Portal');
 
 describe('ConfigProvider', () => {
   describe('components', () => {

--- a/components/config-provider/__tests__/container.test.tsx
+++ b/components/config-provider/__tests__/container.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import ConfigProvider from '..';
 import Cascader from '../../cascader';
@@ -8,7 +9,7 @@ import { render, fireEvent } from '../../../tests/utils';
 
 describe('ConfigProvider.GetPopupContainer', () => {
   it('Datepicker', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
     render(
       <ConfigProvider getPopupContainer={getPopupContainer}>
         <DatePicker open />
@@ -18,7 +19,7 @@ describe('ConfigProvider.GetPopupContainer', () => {
   });
 
   it('Slider', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
     const wrapper = render(
       <ConfigProvider getPopupContainer={getPopupContainer}>
         <Slider />
@@ -29,7 +30,7 @@ describe('ConfigProvider.GetPopupContainer', () => {
   });
 
   it('Drawer', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
     const Demo: React.FC<{ open?: boolean }> = ({ open }) => (
       <ConfigProvider getPopupContainer={getPopupContainer}>
         <Drawer open={open} />
@@ -40,7 +41,7 @@ describe('ConfigProvider.GetPopupContainer', () => {
   });
 
   it('Cascader', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
     render(<Cascader getPopupContainer={getPopupContainer} open />);
     expect(getPopupContainer).toHaveBeenCalled();
   });

--- a/components/config-provider/__tests__/cssinjs.test.tsx
+++ b/components/config-provider/__tests__/cssinjs.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, it, expect } from 'vitest';
 import * as React from 'react';
 import { SmileOutlined } from '@ant-design/icons';
 import ConfigProvider from '..';

--- a/components/config-provider/__tests__/form.test.tsx
+++ b/components/config-provider/__tests__/form.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -11,7 +12,7 @@ import Input from '../../input';
 import zhCN from '../../locale/zh_CN';
 import InputNumber from '../../input-number';
 
-jest.mock('scroll-into-view-if-needed');
+vi.mock('scroll-into-view-if-needed');
 
 describe('ConfigProvider.Form', () => {
   (scrollIntoView as any).mockImplementation(() => {});
@@ -21,11 +22,11 @@ describe('ConfigProvider.Form', () => {
   });
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     (scrollIntoView as any).mockRestore();
   });
 
@@ -59,12 +60,12 @@ describe('ConfigProvider.Form', () => {
       });
 
       await act(async () => {
-        jest.runAllTimers();
+        vi.runAllTimers();
         await Promise.resolve();
       });
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       expect(container.querySelector('.ant-form-item-explain')).toHaveTextContent('请输入姓名');
@@ -82,12 +83,12 @@ describe('ConfigProvider.Form', () => {
       });
 
       await act(async () => {
-        jest.runAllTimers();
+        vi.runAllTimers();
         await Promise.resolve();
       });
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       const explains = Array.from(container.querySelectorAll('.ant-form-item-explain'));
@@ -132,12 +133,12 @@ describe('ConfigProvider.Form', () => {
       });
 
       await act(async () => {
-        jest.runAllTimers();
+        vi.runAllTimers();
         await Promise.resolve();
       });
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       expect(container.querySelectorAll('.ant-form-item-explain')).toHaveLength(2);
@@ -216,7 +217,7 @@ describe('ConfigProvider.Form', () => {
   describe('form scrollToFirstError', () => {
     it('set object, form not set', async () => {
       (scrollIntoView as any).mockImplementation(() => {});
-      const onFinishFailed = jest.fn();
+      const onFinishFailed = vi.fn();
 
       const { container } = render(
         <ConfigProvider form={{ scrollToFirstError: { block: 'center' } }}>
@@ -245,7 +246,7 @@ describe('ConfigProvider.Form', () => {
 
     it('not set, form set object', async () => {
       (scrollIntoView as any).mockImplementation(() => {});
-      const onFinishFailed = jest.fn();
+      const onFinishFailed = vi.fn();
 
       const { container } = render(
         <ConfigProvider>
@@ -274,7 +275,7 @@ describe('ConfigProvider.Form', () => {
 
     it('set object, form set false', async () => {
       (scrollIntoView as any).mockImplementation(() => {});
-      const onFinishFailed = jest.fn();
+      const onFinishFailed = vi.fn();
 
       const { container } = render(
         <ConfigProvider form={{ scrollToFirstError: { block: 'center' } }}>

--- a/components/config-provider/__tests__/image.test.ts
+++ b/components/config-provider/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('ConfigProvider image', () => {

--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { SmileOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 import type { ConfigConsumerProps } from '..';

--- a/components/config-provider/__tests__/locale.test.tsx
+++ b/components/config-provider/__tests__/locale.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useEffect, useState } from 'react';
 import { closePicker, openPicker, selectCell } from '../../date-picker/__tests__/utils';
 import ConfigProvider from '..';
@@ -33,12 +34,12 @@ describe('ConfigProvider.Locale', () => {
         setShowButton(true);
       }, []);
       const openConfirm = () => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
         Modal.confirm({ title: 'title', content: 'Some descriptions' });
         act(() => {
-          jest.runAllTimers();
+          vi.runAllTimers();
         });
-        jest.useRealTimers();
+        vi.useRealTimers();
       };
       return (
         <ConfigProvider locale={zhCN}>

--- a/components/config-provider/__tests__/memo.test.tsx
+++ b/components/config-provider/__tests__/memo.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import ConfigProvider from '..';
 import Tooltip from '../../tooltip';
@@ -22,7 +23,7 @@ describe('ConfigProvider', () => {
 
   it('should not generate new context config when render', () => {
     const MemoedSibling = React.memo(Sibling);
-    const spy = jest.fn();
+    const spy = vi.fn();
     const App: React.FC = () => {
       const [pageHeader, setPageHeader] = useState({ ghost: true });
       const [, forceRender] = React.useReducer((v) => v + 1, 1);
@@ -56,7 +57,7 @@ describe('ConfigProvider', () => {
 
   it('should not generate new context config in nested ConfigProvider when render', () => {
     const MemoedSibling = React.memo(Sibling);
-    const spy = jest.fn();
+    const spy = vi.fn();
     const App: React.FC = () => {
       const [pageHeader, setPageHeader] = useState({ ghost: true });
       const [, forceRender] = React.useReducer((v) => v + 1, 1);

--- a/components/config-provider/__tests__/nonce.test.tsx
+++ b/components/config-provider/__tests__/nonce.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, afterEach, it } from 'vitest';
 import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import { SmileOutlined } from '@ant-design/icons';
 import IconContext from '@ant-design/icons/lib/components/Context';

--- a/components/config-provider/__tests__/pagination.test.tsx
+++ b/components/config-provider/__tests__/pagination.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import ConfigProvider from '..';
 import { render } from '../../../tests/utils';

--- a/components/config-provider/__tests__/static.test.ts
+++ b/components/config-provider/__tests__/static.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import ConfigProvider, { globalConfig } from '..';
 
 describe('ConfigProvider.config', () => {

--- a/components/config-provider/__tests__/target.test.tsx
+++ b/components/config-provider/__tests__/target.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import ConfigProvider from '..';
 import Affix from '../../affix';
@@ -6,8 +7,8 @@ import { act, render } from '../../../tests/utils';
 
 describe('ConfigProvider.getTargetContainer', () => {
   it('Affix', () => {
-    jest.useFakeTimers();
-    const getTargetContainer = jest.fn(() => window);
+    vi.useFakeTimers();
+    const getTargetContainer = vi.fn(() => window);
     render(
       <ConfigProvider getTargetContainer={getTargetContainer}>
         <Affix>
@@ -17,16 +18,16 @@ describe('ConfigProvider.getTargetContainer', () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(getTargetContainer).toHaveBeenCalled();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('Anchor', () => {
-    jest.useFakeTimers();
-    const getTargetContainer = jest.fn(() => window);
+    vi.useFakeTimers();
+    const getTargetContainer = vi.fn(() => window);
     render(
       <ConfigProvider getTargetContainer={getTargetContainer}>
         <Anchor>
@@ -36,10 +37,10 @@ describe('ConfigProvider.getTargetContainer', () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(getTargetContainer).toHaveBeenCalled();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 });

--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
 import { kebabCase } from 'lodash';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
 import React from 'react';
@@ -13,7 +14,7 @@ const { defaultAlgorithm, darkAlgorithm, compactAlgorithm } = theme;
 // eslint-disable-next-line no-var
 var mockCanUseDom = true;
 
-jest.mock('rc-util/lib/Dom/canUseDom', () => () => mockCanUseDom);
+vi.mock('rc-util/lib/Dom/canUseDom', () => () => mockCanUseDom);
 
 describe('ConfigProvider.Theme', () => {
   beforeEach(() => {
@@ -44,7 +45,7 @@ describe('ConfigProvider.Theme', () => {
   it('warning for SSR', () => {
     resetWarned();
 
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockCanUseDom = false;
     expect(canUseDom()).toBeFalsy();
 

--- a/components/config-provider/__tests__/useConfig.test.tsx
+++ b/components/config-provider/__tests__/useConfig.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import ConfigProvider from '..';
 import Form from '../../form';
@@ -51,7 +52,7 @@ describe('ConfigProvider.useConfig', () => {
       return <div>{ctx}</div>;
     };
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<App />);
 

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, afterAll, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import 'dayjs/locale/mk'; // to test local in 'prop locale should works' test case
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -14,10 +15,10 @@ dayjs.extend(customParseFormat);
 
 let triggerProps: TriggerProps;
 
-jest.mock('@rc-component/trigger', () => {
-  let Trigger = jest.requireActual('@rc-component/trigger/lib/mock');
+vi.mock('@rc-component/trigger', () => {
+  let Trigger = vi.requireActual('@rc-component/trigger/lib/mock');
   Trigger = Trigger.default || Trigger;
-  const h: typeof React = jest.requireActual('react');
+  const h: typeof React = vi.requireActual('react');
 
   return {
     default: h.forwardRef<unknown, TriggerProps>((props, ref) => {
@@ -29,7 +30,7 @@ jest.mock('@rc-component/trigger', () => {
 });
 
 describe('DatePicker', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   focusTest(DatePicker, { refFocus: true });
 
@@ -279,7 +280,7 @@ describe('DatePicker', () => {
   it('legacy dropdownClassName', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(<DatePicker dropdownClassName="legacy" open />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: DatePicker] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',

--- a/components/date-picker/__tests__/QuarterPicker.test.tsx
+++ b/components/date-picker/__tests__/QuarterPicker.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import DatePicker from '..';
 import { render } from '../../../tests/utils';
@@ -8,7 +9,7 @@ const { QuarterPicker } = DatePicker;
 describe('QuarterPicker', () => {
   it('should support style prop', () => {
     resetWarned();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(<QuarterPicker style={{ width: 400 }} />);
     expect(container.firstChild).toMatchSnapshot();

--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import React, { useState } from 'react';
@@ -118,7 +119,7 @@ describe('RangePicker', () => {
   it('legacy dropdownClassName', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(<DatePicker.RangePicker dropdownClassName="legacy" open />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: DatePicker.RangePicker] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',

--- a/components/date-picker/__tests__/WeekPicker.test.tsx
+++ b/components/date-picker/__tests__/WeekPicker.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 import React from 'react';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';

--- a/components/date-picker/__tests__/image.test.ts
+++ b/components/date-picker/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('DatePicker image', () => {

--- a/components/date-picker/__tests__/mount.test.ts
+++ b/components/date-picker/__tests__/mount.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import DatePicker from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';

--- a/components/date-picker/__tests__/other.test.tsx
+++ b/components/date-picker/__tests__/other.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import customParseFormat from 'dayjs/plugin/customParseFormat';

--- a/components/date-picker/__tests__/type.test.tsx
+++ b/components/date-picker/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import type { Dayjs } from 'dayjs';
 import * as React from 'react';
 import DatePicker from '..';

--- a/components/descriptions/__tests__/image.test.ts
+++ b/components/descriptions/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Descriptions image', () => {

--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import MockDate from 'mockdate';
 import React from 'react';
 import Descriptions from '..';
@@ -8,7 +9,7 @@ import { render } from '../../../tests/utils';
 describe('Descriptions', () => {
   mountTest(Descriptions);
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     MockDate.reset();
@@ -162,7 +163,7 @@ describe('Descriptions', () => {
         <Descriptions.Item key="bamboo">1</Descriptions.Item>
       </Descriptions>,
     );
-    expect(jest.spyOn(document, 'createElement')).not.toHaveBeenCalled();
+    expect(vi.spyOn(document, 'createElement')).not.toHaveBeenCalled();
   });
 
   // https://github.com/ant-design/ant-design/issues/19887

--- a/components/divider/__tests__/image.test.ts
+++ b/components/divider/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Divider image', () => {

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import { render } from '../../../tests/utils';
 import Divider from '..';
@@ -7,7 +8,7 @@ describe('Divider', () => {
   mountTest(Divider);
 
   it('not show children when vertical', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(<Divider type="vertical">Bamboo</Divider>);
     expect(container.querySelector('.ant-divider-inner-text')).toBeFalsy();

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import type { DrawerProps } from '..';
@@ -21,16 +22,16 @@ describe('Drawer', () => {
   rtlTest(Drawer);
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   function triggerMotion() {
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     const mask = document.querySelector('.ant-drawer-mask');
@@ -44,7 +45,7 @@ describe('Drawer', () => {
     }
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
   }
 
@@ -190,7 +191,7 @@ describe('Drawer', () => {
   });
 
   it('ConfigProvider should not warning', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(
       <ConfigProvider virtual>
@@ -212,7 +213,7 @@ describe('Drawer', () => {
 
   describe('style migrate', () => {
     it('not warning with getContainer', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       resetWarned();
 
       render(<Drawer getContainer={() => document.body} />);
@@ -222,7 +223,7 @@ describe('Drawer', () => {
     });
 
     it('not warning with getContainer false', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       resetWarned();
 
       render(<Drawer getContainer={false} />);
@@ -232,7 +233,7 @@ describe('Drawer', () => {
     });
 
     it('warning with getContainer & style', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       resetWarned();
 
       render(<Drawer getContainer={false} style={{ position: 'absolute' }} />);

--- a/components/drawer/__tests__/DrawerEvent.test.tsx
+++ b/components/drawer/__tests__/DrawerEvent.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { DrawerProps } from '..';
 import Drawer from '..';
@@ -11,11 +12,11 @@ const DrawerTest: React.FC<DrawerProps> = (props) => (
 
 describe('Drawer', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('render correctly', () => {
@@ -32,7 +33,7 @@ describe('Drawer', () => {
   });
 
   it('mask trigger onClose', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const { container } = render(<DrawerTest onClose={onClose} />);
 
     fireEvent.click(container.querySelector('.ant-drawer-mask')!);
@@ -40,7 +41,7 @@ describe('Drawer', () => {
   });
 
   it('close button trigger onClose', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const { container } = render(<DrawerTest onClose={onClose} />);
 
     fireEvent.click(container.querySelector('.ant-drawer-close')!);
@@ -48,7 +49,7 @@ describe('Drawer', () => {
   });
 
   it('maskClosable no trigger onClose', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const { container } = render(<DrawerTest onClose={onClose} maskClosable={false} />);
 
     fireEvent.click(container.querySelector('.ant-drawer-mask')!);
@@ -61,7 +62,7 @@ describe('Drawer', () => {
 
     rerender(<DrawerTest destroyOnClose open={false} />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('.ant-drawer')).toBeFalsy();
@@ -73,7 +74,7 @@ describe('Drawer', () => {
 
     rerender(<DrawerTest open={false} />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.animationEnd(container.querySelector('.ant-drawer-content')!);
 
@@ -87,7 +88,7 @@ describe('Drawer', () => {
     // Hide
     rerender(<DrawerTest open={false} getContainer={false} />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.animationEnd(container.querySelector('.ant-drawer-content-wrapper')!);
     expect(container.querySelector('.ant-drawer-content-wrapper-hidden')).toBeTruthy();
@@ -100,19 +101,19 @@ describe('Drawer', () => {
     // Hide
     rerender(<DrawerTest open={false} getContainer={false} />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.animationEnd(container.querySelector('.ant-drawer-content-wrapper')!);
     expect(container.querySelector('.ant-drawer-content-wrapper-hidden')).toBeTruthy();
   });
 
   it('test afterOpenChange', async () => {
-    const afterOpenChange = jest.fn();
+    const afterOpenChange = vi.fn();
     const { container, rerender } = render(<DrawerTest open afterOpenChange={afterOpenChange} />);
     rerender(<DrawerTest open={false} afterOpenChange={afterOpenChange} />);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.animationEnd(container.querySelector('.ant-drawer-content-wrapper')!);
 
@@ -120,16 +121,16 @@ describe('Drawer', () => {
   });
 
   it('test legacy afterVisibleChange', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const afterVisibleChange = jest.fn();
+    const afterVisibleChange = vi.fn();
     const { container, rerender } = render(
       <DrawerTest open afterVisibleChange={afterVisibleChange} />,
     );
     rerender(<DrawerTest visible={false} afterVisibleChange={afterVisibleChange} />);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.animationEnd(container.querySelector('.ant-drawer-content-wrapper')!);
 
@@ -145,7 +146,7 @@ describe('Drawer', () => {
   });
 
   it('should support children ref', () => {
-    const fn = jest.fn();
+    const fn = vi.fn();
 
     const refCallback = (ref: HTMLDivElement | null) => {
       expect(typeof ref).toBe('object');

--- a/components/drawer/__tests__/MultiDrawer.test.tsx
+++ b/components/drawer/__tests__/MultiDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import type { DrawerPopupProps } from 'rc-drawer/lib/DrawerPopup';
 import React, { useState } from 'react';
 import Drawer from '..';

--- a/components/drawer/__tests__/demo-extend.test.tsx
+++ b/components/drawer/__tests__/demo-extend.test.tsx
@@ -1,8 +1,9 @@
+import { vi } from 'vitest';
 import * as React from 'react';
 import { extendTest } from '../../../tests/shared/demoTest';
 
-jest.mock('rc-drawer', () => {
-  const Drawer = jest.requireActual('rc-drawer');
+vi.mock('rc-drawer', () => {
+  const Drawer = vi.requireActual('rc-drawer');
   const MockDrawer = Drawer.default;
   return (props: any) => {
     const newProps = {

--- a/components/drawer/__tests__/image.test.ts
+++ b/components/drawer/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Drawer image', () => {

--- a/components/drawer/__tests__/type.test.tsx
+++ b/components/drawer/__tests__/type.test.tsx
@@ -1,9 +1,10 @@
+import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import Drawer from '..';
 
 describe('Drawer.typescript', () => {
   it('Drawer', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const wrapper = (
       <Drawer
         title="Basic Drawer"

--- a/components/dropdown/__tests__/dropdown-button.test.tsx
+++ b/components/dropdown/__tests__/dropdown-button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -7,10 +8,10 @@ import DropdownButton from '../dropdown-button';
 
 let dropdownProps: DropdownProps;
 
-jest.mock('../dropdown', () => {
-  const ActualDropdown = jest.requireActual('../dropdown');
+vi.mock('../dropdown', () => {
+  const ActualDropdown = vi.requireActual('../dropdown');
   const ActualDropdownComponent = ActualDropdown.default;
-  const h: typeof React = jest.requireActual('react');
+  const h: typeof React = vi.requireActual('react');
 
   const MockedDropdown: React.FC<DropdownProps> & {
     Button: typeof ActualDropdownComponent.Button;
@@ -137,7 +138,7 @@ describe('DropdownButton', () => {
     );
   });
   it('should console Error when `overlay` in props', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<DropdownButton overlay={<div>test</div>} />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: Dropdown] `overlay` is deprecated. Please use `menu` instead.',
@@ -145,14 +146,14 @@ describe('DropdownButton', () => {
     errSpy.mockRestore();
   });
   it('should not console Error when `overlay` not in props', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<DropdownButton />);
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
 
   it('should support dropdownRender', () => {
-    const dropdownRender = jest.fn((menu) => <div>Custom Menu {menu}</div>);
+    const dropdownRender = vi.fn((menu) => <div>Custom Menu {menu}</div>);
     render(<DropdownButton open dropdownRender={dropdownRender} />);
     expect(dropdownRender).toHaveBeenCalled();
   });

--- a/components/dropdown/__tests__/image.test.ts
+++ b/components/dropdown/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Dropdown image', () => {

--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { TriggerProps } from 'rc-trigger';
 import Dropdown from '..';
@@ -9,10 +10,10 @@ import { resetWarned } from '../../_util/warning';
 
 let triggerProps: TriggerProps;
 
-jest.mock('rc-trigger', () => {
-  let Trigger = jest.requireActual('rc-trigger/lib/mock');
+vi.mock('rc-trigger', () => {
+  let Trigger = vi.requireActual('rc-trigger/lib/mock');
   Trigger = Trigger.default || Trigger;
-  const h: typeof React = jest.requireActual('react');
+  const h: typeof React = vi.requireActual('react');
 
   return {
     default: h.forwardRef<unknown, TriggerProps>((props, ref) => {
@@ -80,7 +81,7 @@ describe('Dropdown', () => {
   });
 
   it('support Menu expandIcon', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const props: DropDownProps = {
       menu: {
         items: [
@@ -112,11 +113,11 @@ describe('Dropdown', () => {
     );
     await waitFakeTimer();
     expect(container.querySelectorAll('#customExpandIcon').length).toBe(1);
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should warn if use topCenter or bottomCenter', () => {
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(
       <div>
         <Dropdown menu={{ items }} placement="bottomCenter">
@@ -157,7 +158,7 @@ describe('Dropdown', () => {
   });
 
   it('menu item with group', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(
       <Dropdown
         trigger={['click']}
@@ -183,7 +184,7 @@ describe('Dropdown', () => {
     // Open
     fireEvent.click(container.querySelector('a')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     // Close
@@ -192,7 +193,7 @@ describe('Dropdown', () => {
     // Force Motion move on
     for (let i = 0; i < 10; i += 1) {
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
     }
 
@@ -201,14 +202,14 @@ describe('Dropdown', () => {
 
     expect(container.querySelector('.ant-dropdown-hidden')).toBeTruthy();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('legacy visible', () => {
     resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const onOpenChange = jest.fn();
-    const onVisibleChange = jest.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onOpenChange = vi.fn();
+    const onVisibleChange = vi.fn();
 
     const { container, rerender } = render(
       <Dropdown

--- a/components/empty/__tests__/image.test.ts
+++ b/components/empty/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Empty image', () => {

--- a/components/empty/__tests__/index.test.tsx
+++ b/components/empty/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Empty from '..';
 import mountTest from '../../../tests/shared/mountTest';

--- a/components/float-button/__tests__/back-top.test.tsx
+++ b/components/float-button/__tests__/back-top.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import FloatButton from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -7,17 +8,17 @@ import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 const { BackTop } = FloatButton;
 describe('BackTop', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
   mountTest(BackTop);
   rtlTest(BackTop);
 
   it('should scroll to top after click it', async () => {
     const { container } = render(<BackTop />);
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation((_, y) => {
       window.scrollY = y;
       window.pageYOffset = y;
       document.documentElement.scrollTop = y;
@@ -32,14 +33,14 @@ describe('BackTop', () => {
   });
 
   it('support onClick', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<BackTop onClick={onClick} visibilityHeight={0} />);
     fireEvent.click(container.querySelector<HTMLButtonElement>('.ant-float-btn')!);
     expect(onClick).toHaveBeenCalled();
   });
 
   it('support invalid target', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <BackTop onClick={onClick} visibilityHeight={0} target={undefined} />,
     );

--- a/components/float-button/__tests__/group.test.tsx
+++ b/components/float-button/__tests__/group.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import FloatButton from '..';
 import { fireEvent, render } from '../../../tests/utils';
@@ -34,7 +35,7 @@ describe('FloatButtonGroup', () => {
     expect(container.querySelectorAll(`.ant-float-btn-${squareShape}`)).toHaveLength(3);
   });
   it('support onOpenChange for click', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <FloatButton.Group trigger="click" onOpenChange={onOpenChange}>
         <FloatButton />
@@ -46,7 +47,7 @@ describe('FloatButtonGroup', () => {
     expect(onOpenChange).toHaveBeenCalled();
   });
   it('support onOpenChange for hover', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <FloatButton.Group trigger="hover" onOpenChange={onOpenChange}>
         <FloatButton />
@@ -59,7 +60,7 @@ describe('FloatButtonGroup', () => {
     expect(onOpenChange).toHaveBeenCalled();
   });
   it('support click floatButtonGroup not close', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <FloatButton.Group trigger="click" onOpenChange={onOpenChange}>
         <FloatButton />
@@ -72,7 +73,7 @@ describe('FloatButtonGroup', () => {
     expect(onOpenChange).toHaveBeenCalledTimes(1);
   });
   it('support click out auto close', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <FloatButton.Group trigger="click" onOpenChange={onOpenChange}>
         <FloatButton />

--- a/components/float-button/__tests__/image.test.ts
+++ b/components/float-button/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('float-button image', () => {

--- a/components/float-button/__tests__/index.test.tsx
+++ b/components/float-button/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import FloatButton from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -39,13 +40,13 @@ describe('FloatButton', () => {
     expect(container.querySelector(`.ant-float-btn-${squareShape}`)).toBeTruthy();
   });
   it('support onClick', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<FloatButton onClick={onClick} />);
     fireEvent.click(container.querySelector('.ant-float-btn')!);
     expect(onClick).toHaveBeenCalled();
   });
   it('should console Error', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<FloatButton description="test" shape="circle" />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: FloatButton] supported only when `shape` is `square`. Due to narrow space for text, short sentence is recommended.',
@@ -54,14 +55,14 @@ describe('FloatButton', () => {
   });
 
   it('tooltip should support number `0`', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<FloatButton tooltip={0} />);
     fireEvent.mouseEnter(container.querySelector<HTMLDivElement>('.ant-float-btn-body')!);
     await waitFakeTimer();
     const element = container.querySelector('.ant-tooltip')?.querySelector('.ant-tooltip-inner');
     expect(element?.textContent).toBe('0');
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('getOffset should return 0 when radius is 0', () => {

--- a/components/form/__tests__/image.test.ts
+++ b/components/form/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Form image', () => {

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, beforeEach, afterEach, afterAll, it, test, vi } from 'vitest';
 import type { ColProps } from 'antd/es/grid';
 import classNames from 'classnames';
 import type { ChangeEventHandler } from 'react';
@@ -30,7 +31,7 @@ import * as Util from '../util';
 const { RangePicker } = DatePicker;
 const { TextArea } = Input;
 
-jest.mock('scroll-into-view-if-needed');
+vi.mock('scroll-into-view-if-needed');
 
 describe('Form', () => {
   mountTest(Form);
@@ -40,8 +41,8 @@ describe('Form', () => {
   rtlTest(Form.Item);
 
   (scrollIntoView as any).mockImplementation(() => {});
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
   const changeValue = async (
     input: HTMLElement | null | number,
@@ -69,7 +70,7 @@ describe('Form', () => {
 
   beforeEach(() => {
     document.body.innerHTML = '';
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     (scrollIntoView as any).mockReset();
   });
 
@@ -78,8 +79,8 @@ describe('Form', () => {
   });
 
   afterAll(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     errorSpy.mockRestore();
     warnSpy.mockRestore();
     (scrollIntoView as any).mockRestore();
@@ -87,7 +88,7 @@ describe('Form', () => {
 
   describe('noStyle Form.Item', () => {
     it('should show alert when form field is required but empty', async () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
 
       const { container } = render(
         <Form>
@@ -445,7 +446,7 @@ describe('Form', () => {
   });
 
   it('scrollToFirstError', async () => {
-    const onFinishFailed = jest.fn();
+    const onFinishFailed = vi.fn();
 
     const { container } = render(
       <Form scrollToFirstError={{ block: 'center' }} onFinishFailed={onFinishFailed}>
@@ -644,7 +645,7 @@ describe('Form', () => {
 
   // https://github.com/ant-design/ant-design/issues/20948
   it('not repeat render when Form.Item is not a real Field', async () => {
-    const shouldNotRender = jest.fn();
+    const shouldNotRender = vi.fn();
     const StaticInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({
       id,
       value = '',
@@ -653,7 +654,7 @@ describe('Form', () => {
       return <input id={id} value={value} />;
     };
 
-    const shouldRender = jest.fn();
+    const shouldRender = vi.fn();
     const DynamicInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({
       value = '',
       id,
@@ -1193,7 +1194,7 @@ describe('Form', () => {
   });
 
   it('Form Item element id will auto add form_item prefix if form name is empty and item name is in the black list', async () => {
-    const mockFn = jest.spyOn(Util, 'getFieldId');
+    const mockFn = vi.spyOn(Util, 'getFieldId');
     const itemName = 'parentNode';
     // mock getFieldId old logic,if form name is empty ,and item name is parentNode,will get parentNode
     mockFn.mockImplementation(() => itemName);
@@ -1302,7 +1303,7 @@ describe('Form', () => {
   });
 
   it('not warning when remove on validate', async () => {
-    let rejectFn: (reason?: any) => void = jest.fn();
+    let rejectFn: (reason?: any) => void = vi.fn();
 
     const { unmount } = render(
       <Form>
@@ -1577,7 +1578,7 @@ describe('Form', () => {
   });
 
   it('item customize margin', async () => {
-    const computeSpy = jest
+    const computeSpy = vi
       .spyOn(window, 'getComputedStyle')
       .mockImplementation(() => ({ marginBottom: 24 }) as unknown as CSSStyleDeclaration);
 
@@ -1789,7 +1790,7 @@ describe('Form', () => {
   });
 
   it('validate status should be change in order', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const CustomInput = (props: any) => {
       const { status } = Form.Item.useStatus();

--- a/components/form/__tests__/list-noStyle.test.tsx
+++ b/components/form/__tests__/list-noStyle.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import Form from '..';
@@ -7,7 +8,7 @@ import type { FormListOperation } from '../FormList';
 
 describe('Form.List.NoStyle', () => {
   it('nest error should clean up', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
     let operation: FormListOperation;
 
@@ -60,7 +61,7 @@ describe('Form.List.NoStyle', () => {
       "'users.1.first' is required",
     );
 
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 });

--- a/components/form/__tests__/list.test.tsx
+++ b/components/form/__tests__/list.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, beforeEach, afterAll, it, vi } from 'vitest';
 import React from 'react';
 import type { FormListFieldData, FormListOperation } from '..';
 import Form from '..';
@@ -41,12 +42,12 @@ describe('Form.List', () => {
 
   beforeEach(() => {
     document.body.innerHTML = '';
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   const testList = (
@@ -119,7 +120,7 @@ describe('Form.List', () => {
       fireEvent.click(wrapper.querySelector(className)!);
     }
 
-    const onFinish = jest.fn().mockImplementation(() => {});
+    const onFinish = vi.fn().mockImplementation(() => {});
 
     const { container } = render(
       <Form
@@ -216,7 +217,7 @@ describe('Form.List', () => {
   });
 
   it('no warning when reset in validate', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Demo = () => {
       const [form] = Form.useForm();

--- a/components/form/__tests__/ref.test.tsx
+++ b/components/form/__tests__/ref.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '../../../tests/utils';
 import Form from '..';
@@ -68,7 +69,7 @@ describe('Form.Ref', () => {
   };
 
   it('should ref work', () => {
-    const onRef = jest.fn();
+    const onRef = vi.fn();
     const { container, rerender } = render(<Test onRef={onRef} show />);
 
     fireEvent.click(container.querySelector('.ref-item')!);

--- a/components/form/__tests__/type.test.tsx
+++ b/components/form/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React, { useEffect, useRef } from 'react';
 import type { FormInstance } from '..';
 import Form from '..';

--- a/components/grid/__tests__/cached-row-context.test.tsx
+++ b/components/grid/__tests__/cached-row-context.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest';
 import React, { memo, useContext } from 'react';
 import Row from '../row';
 import RowContext from '../RowContext';

--- a/components/grid/__tests__/gap.test.tsx
+++ b/components/grid/__tests__/gap.test.tsx
@@ -1,9 +1,10 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { Col, Row } from '..';
 import { render, screen } from '../../../tests/utils';
 
-jest.mock('../../_util/styleChecker', () => ({
+vi.mock('../../_util/styleChecker', () => ({
   canUseDocElement: () => true,
   isStyleSupport: () => true,
   detectFlexGapSupported: () => true,
@@ -33,7 +34,7 @@ describe('Grid.Gap', () => {
   });
 
   it('not break ssr', () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Demo = () => (
       <Row gutter={[16, 8]}>

--- a/components/grid/__tests__/image.test.ts
+++ b/components/grid/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Grid image', () => {

--- a/components/grid/__tests__/index.test.tsx
+++ b/components/grid/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { Col, Row } from '..';
@@ -7,8 +8,8 @@ import { fireEvent, render } from '../../../tests/utils';
 import useBreakpoint from '../hooks/useBreakpoint';
 
 // Mock for `responsiveObserve` to test `unsubscribe` call
-jest.mock('../../_util/responsiveObserver', () => {
-  const modules = jest.requireActual('../../_util/responsiveObserver');
+vi.mock('../../_util/responsiveObserver', () => {
+  const modules = vi.requireActual('../../_util/responsiveObserver');
   const originHook = modules.default;
 
   const useMockResponsiveObserver = (...args: any[]) => {
@@ -75,13 +76,13 @@ describe('Grid', () => {
   });
 
   it('when typeof gutter is object array in large screen', () => {
-    jest.spyOn(window, 'matchMedia').mockImplementation(
+    vi.spyOn(window, 'matchMedia').mockImplementation(
       (query) =>
         ({
           addListener: (cb: (e: { matches: boolean }) => void) => {
             cb({ matches: query === '(min-width: 1200px)' });
           },
-          removeListener: jest.fn(),
+          removeListener: vi.fn(),
           matches: query === '(min-width: 1200px)',
         }) as any,
     );
@@ -141,14 +142,14 @@ describe('Grid', () => {
   // By jsdom mock, actual jsdom not implemented matchMedia
   // https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
   it('should work with useBreakpoint', () => {
-    const matchMediaSpy = jest.spyOn(window, 'matchMedia');
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia');
     matchMediaSpy.mockImplementation(
       (query) =>
         ({
           addListener: (cb: (e: { matches: boolean }) => void) => {
             cb({ matches: query === '(max-width: 575px)' });
           },
-          removeListener: jest.fn(),
+          removeListener: vi.fn(),
           matches: query === '(max-width: 575px)',
         }) as any,
     );
@@ -172,14 +173,14 @@ describe('Grid', () => {
   });
 
   it('should align by responsive align prop', () => {
-    const matchMediaSpy = jest.spyOn(window, 'matchMedia');
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia');
     matchMediaSpy.mockImplementation(
       (query) =>
         ({
           addListener: (cb: (e: { matches: boolean }) => void) => {
             cb({ matches: query === '(max-width: 575px)' });
           },
-          removeListener: jest.fn(),
+          removeListener: vi.fn(),
           matches: query === '(max-width: 575px)',
         }) as any,
     );
@@ -192,14 +193,14 @@ describe('Grid', () => {
   });
 
   it('should justify by responsive justify prop', () => {
-    const matchMediaSpy = jest.spyOn(window, 'matchMedia');
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia');
     matchMediaSpy.mockImplementation(
       (query) =>
         ({
           addListener: (cb: (e: { matches: boolean }) => void) => {
             cb({ matches: query === '(max-width: 575px)' });
           },
-          removeListener: jest.fn(),
+          removeListener: vi.fn(),
           matches: query === '(max-width: 575px)',
         }) as any,
     );

--- a/components/grid/__tests__/server.test.tsx
+++ b/components/grid/__tests__/server.test.tsx
@@ -1,8 +1,9 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { Col, Row } from '..';
 import { render } from '../../../tests/utils';
 
-jest.mock('rc-util/lib/Dom/canUseDom', () => () => false);
+vi.mock('rc-util/lib/Dom/canUseDom', () => () => false);
 
 describe('Grid.Server', () => {
   it('use compatible gap logic', () => {

--- a/components/icon/__tests__/image.test.ts
+++ b/components/icon/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Icon image', () => {

--- a/components/icon/__tests__/index.test.tsx
+++ b/components/icon/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Icon from '..';
 import { render } from '../../../tests/utils';
@@ -10,7 +11,7 @@ describe('Icon', () => {
   });
 
   it('should throw Error', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Icon />);
     expect(errSpy).toHaveBeenCalledWith('Warning: [antd: Icon] Empty Icon');
     errSpy.mockRestore();

--- a/components/image/__tests__/image.test.ts
+++ b/components/image/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Image image', () => {

--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Image from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -89,7 +90,7 @@ describe('Image', () => {
     expect(baseElement.querySelector('.container')?.children.length).not.toBe(0);
   });
   it('Preview forceRender props', async () => {
-    const onLoadCb = jest.fn();
+    const onLoadCb = vi.fn();
     const PreviewImage: React.FC = () => (
       <Image
         preview={{

--- a/components/input-number/__tests__/image.test.ts
+++ b/components/input-number/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('InputNumber image', () => {

--- a/components/input-number/__tests__/index.test.tsx
+++ b/components/input-number/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 import InputNumber from '..';
@@ -13,14 +14,14 @@ describe('InputNumber', () => {
 
   // https://github.com/ant-design/ant-design/issues/13896
   it('should return null when blur a empty input number', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(<InputNumber defaultValue="1" onChange={onChange} />);
     fireEvent.change(container.querySelector('input')!, { target: { value: '' } });
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
   it('should call onStep when press up or down button', () => {
-    const onStep = jest.fn();
+    const onStep = vi.fn();
     const { container } = render(<InputNumber defaultValue={1} onStep={onStep} />);
     fireEvent.mouseDown(container.querySelector('.ant-input-number-handler-up')!);
     expect(onStep).toHaveBeenCalledTimes(1);

--- a/components/input-number/__tests__/prefix.test.tsx
+++ b/components/input-number/__tests__/prefix.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { forwardRef } from 'react';
 import InputNumber from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -17,7 +18,7 @@ describe('prefix', () => {
   it('should trigger focus when prefix is clicked', () => {
     const { container } = render(<InputNumber prefix={<i>123</i>} />);
 
-    const mockFocus = jest.spyOn(container.querySelector('input')!, 'focus');
+    const mockFocus = vi.spyOn(container.querySelector('input')!, 'focus');
     fireEvent.mouseUp(container.querySelector('i')!);
     expect(mockFocus).toHaveBeenCalled();
   });

--- a/components/input/__tests__/Password.test.tsx
+++ b/components/input/__tests__/Password.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { InputRef } from '..';
 import Input from '..';
@@ -14,7 +15,7 @@ describe('Input.Password', () => {
 
   it('should get input element from ref', () => {
     const ref = React.createRef<InputRef>();
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
 
     const { container } = render(<Input.Password onSelect={onSelect} ref={ref} />);
     expect(ref.current?.input instanceof HTMLInputElement).toBe(true);
@@ -71,17 +72,17 @@ describe('Input.Password', () => {
 
   // https://github.com/ant-design/ant-design/issues/20541
   it('should not show value attribute in input element', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Input.Password />);
     fireEvent.change(container.querySelector('input')!, { target: { value: 'value' } });
-    jest.runAllTimers();
+    vi.runAllTimers();
     expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   // https://github.com/ant-design/ant-design/issues/24526
   it('should not show value attribute in input element after blur it', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Input.Password />);
     fireEvent.change(container.querySelector('input')!, { target: { value: 'value' } });
     await waitFakeTimer();
@@ -92,8 +93,8 @@ describe('Input.Password', () => {
     fireEvent.focus(container.querySelector('input')!);
     await waitFakeTimer();
     expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   // https://github.com/ant-design/ant-design/issues/20541
@@ -107,16 +108,16 @@ describe('Input.Password', () => {
 
   // https://github.com/ant-design/ant-design/pull/20544#issuecomment-569861679
   it('should not contain value attribute in input element with defaultValue', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Input.Password defaultValue="value" />);
     await waitFakeTimer();
     expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should not show value attribute in input element after toggle visibility', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Input.Password />);
     fireEvent.change(container.querySelector('input')!, { target: { value: 'value' } });
     await waitFakeTimer();
@@ -127,8 +128,8 @@ describe('Input.Password', () => {
     fireEvent.click(container.querySelector('.ant-input-password-icon')!);
     await waitFakeTimer();
     expect(container.querySelector('input')?.getAttribute('value')).toBeFalsy();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should control password visible', () => {
@@ -139,7 +140,7 @@ describe('Input.Password', () => {
   });
 
   it('should call onPasswordVisibleChange when visible is changed', () => {
-    const handlePasswordVisibleChange = jest.fn();
+    const handlePasswordVisibleChange = vi.fn();
     const { container, rerender } = render(
       <Input.Password visibilityToggle={{ onVisibleChange: handlePasswordVisibleChange }} />,
     );

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import focusTest from '../../../tests/shared/focusTest';
@@ -39,7 +40,7 @@ describe('Input.Search', () => {
   });
 
   it('should disable search icon when disabled prop is true', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(
       <Search defaultValue="search text" onSearch={onSearch} disabled />,
     );
@@ -48,7 +49,7 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when click search icon', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(<Search defaultValue="search text" onSearch={onSearch} />);
     fireEvent.click(container.querySelector('button')!);
     expect(onSearch).toHaveBeenCalledTimes(1);
@@ -56,7 +57,7 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when click search button', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(
       <Search defaultValue="search text" enterButton onSearch={onSearch} />,
     );
@@ -66,7 +67,7 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when click search button with text', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(
       <Search defaultValue="search text" enterButton="button text" onSearch={onSearch} />,
     );
@@ -76,7 +77,7 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when click search button with customize button', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(
       <Search
         defaultValue="search text"
@@ -90,8 +91,8 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when click search button of native', () => {
-    const onSearch = jest.fn();
-    const onButtonClick = jest.fn();
+    const onSearch = vi.fn();
+    const onButtonClick = vi.fn();
     const { container } = render(
       <Search
         defaultValue="search text"
@@ -110,7 +111,7 @@ describe('Input.Search', () => {
   });
 
   it('should trigger onSearch when press enter', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(<Search defaultValue="search text" onSearch={onSearch} />);
     fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
     expect(onSearch).toHaveBeenCalledTimes(1);
@@ -119,7 +120,7 @@ describe('Input.Search', () => {
 
   // https://github.com/ant-design/ant-design/issues/34844
   it('should not trigger onSearch when press enter using chinese inputting method', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(<Search defaultValue="search text" onSearch={onSearch} />);
     fireEvent.compositionStart(container.querySelector('input')!);
     fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
@@ -144,8 +145,8 @@ describe('Input.Search', () => {
 
   // https://github.com/ant-design/ant-design/issues/18729
   it('should trigger onSearch when click clear icon', () => {
-    const onSearch = jest.fn();
-    const onChange = jest.fn();
+    const onSearch = vi.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Search allowClear defaultValue="value" onSearch={onSearch} onChange={onChange} />,
     );
@@ -162,7 +163,7 @@ describe('Input.Search', () => {
   });
 
   it('should not trigger onSearch when press enter while loading', () => {
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(<Search loading onSearch={onSearch} />);
     fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
     expect(onSearch).not.toHaveBeenCalled();
@@ -199,7 +200,7 @@ describe('Input.Search', () => {
   });
 
   it('not crash when use function ref', () => {
-    const ref = jest.fn();
+    const ref = vi.fn();
     const { container } = render(<Search ref={ref} enterButton />);
     expect(() => {
       fireEvent.mouseDown(container.querySelector('button')!);

--- a/components/input/__tests__/focus.test.tsx
+++ b/components/input/__tests__/focus.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import Input from '..';
@@ -14,8 +15,8 @@ describe('Input.Focus', () => {
   let setSelectionRange: ReturnType<typeof jest.fn>;
 
   beforeEach(() => {
-    focus = jest.fn();
-    setSelectionRange = jest.fn();
+    focus = vi.fn();
+    setSelectionRange = vi.fn();
     inputSpy = spyElementPrototypes(HTMLInputElement, {
       focus,
       setSelectionRange,

--- a/components/input/__tests__/image.test.ts
+++ b/components/input/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Input image', () => {

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { fireEvent, render } from '../../../tests/utils';
@@ -11,7 +12,7 @@ import { resetWarned } from '../../_util/warning';
 import { triggerFocus } from '../Input';
 
 describe('Input', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -79,7 +80,7 @@ describe('Input', () => {
   describe('click focus', () => {
     it('click outside should also get focus', () => {
       const { container } = render(<Input suffix={<span className="test-suffix" />} />);
-      const onFocus = jest.spyOn(container.querySelector('input')!, 'focus');
+      const onFocus = vi.spyOn(container.querySelector('input')!, 'focus');
       fireEvent.click(container.querySelector('.test-suffix')!);
       expect(onFocus).toHaveBeenCalled();
     });
@@ -100,7 +101,7 @@ describe('Input', () => {
         />,
       );
 
-      const onFocus = jest.spyOn(container.querySelector('input')!, 'focus');
+      const onFocus = vi.spyOn(container.querySelector('input')!, 'focus');
       fireEvent.mouseDown(document.querySelector('.popup')!);
       fireEvent.mouseUp(document.querySelector('.popup')!);
 
@@ -379,7 +380,7 @@ describe('Input allowClear', () => {
 
   // https://github.com/ant-design/ant-design/issues/31200
   it('should not lost focus when clear input', () => {
-    const onBlur = jest.fn();
+    const onBlur = vi.fn();
     const { container, unmount } = render(
       <Input allowClear defaultValue="value" onBlur={onBlur} />,
       {

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import type { ChangeEventHandler, TextareaHTMLAttributes } from 'react';
 import React, { useState } from 'react';
@@ -29,13 +30,13 @@ describe('TextArea', () => {
   });
 
   it('should auto calculate height according to content length', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const ref = React.createRef<TextAreaRef>();
 
-    const onInternalAutoSize = jest.fn();
+    const onInternalAutoSize = vi.fn();
     const genTextArea = (props = {}) => (
       <TextArea
         value=""
@@ -65,13 +66,13 @@ describe('TextArea', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
 
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should support onPressEnter and onKeyDown', () => {
-    const fakeHandleKeyDown = jest.fn();
-    const fakeHandlePressEnter = jest.fn();
+    const fakeHandleKeyDown = vi.fn();
+    const fakeHandlePressEnter = vi.fn();
     const { container } = render(
       <TextArea onKeyDown={fakeHandleKeyDown} onPressEnter={fakeHandlePressEnter} />,
     );
@@ -115,7 +116,7 @@ describe('TextArea', () => {
     });
 
     it('should exceed maxLength when use IME', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
 
       const { container } = render(<TextArea maxLength={1} onChange={onChange} />);
       fireEvent.compositionStart(container.querySelector('textarea')!);
@@ -132,7 +133,7 @@ describe('TextArea', () => {
 
     // 字符输入
     it('should not cut off string when cursor position is not at the end', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container } = render(
         <TextArea maxLength={6} defaultValue="123456" onChange={onChange} />,
       );
@@ -148,7 +149,7 @@ describe('TextArea', () => {
     // 拼音输入
     // 1. 光标位于最后，且当前字符数未达到6个，若选中的字符 + 原字符的长度超过6个，则将最终的字符按照maxlength截断
     it('when the input method is pinyin and the cursor is at the end, should use maxLength to crop', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container } = render(
         <TextArea maxLength={6} defaultValue="1234" onChange={onChange} />,
       );
@@ -171,7 +172,7 @@ describe('TextArea', () => {
 
     // 2. 光标位于中间或开头，且当前字符数未达到6个，若选中的字符 + 原字符的长度超过6个，则显示原有字符
     it('when the input method is Pinyin and the cursor is in the middle, should display the original string', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container } = render(
         <TextArea maxLength={6} defaultValue="1234" onChange={onChange} />,
       );
@@ -194,8 +195,8 @@ describe('TextArea', () => {
   });
 
   it('handleKeyDown', () => {
-    const onPressEnter = jest.fn();
-    const onKeyDown = jest.fn();
+    const onPressEnter = vi.fn();
+    const onKeyDown = vi.fn();
     const { container } = render(
       <TextArea onPressEnter={onPressEnter} onKeyDown={onKeyDown} aria-label="textarea" />,
     );
@@ -206,8 +207,8 @@ describe('TextArea', () => {
   });
 
   it('should trigger onResize', async () => {
-    jest.useFakeTimers();
-    const onResize = jest.fn();
+    vi.useFakeTimers();
+    const onResize = vi.fn();
     const ref = React.createRef<TextAreaRef>();
     const { container } = render(<TextArea ref={ref} onResize={onResize} autoSize />);
     await waitFakeTimer();
@@ -219,8 +220,8 @@ describe('TextArea', () => {
       expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
     );
 
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should disabled trigger onResize', async () => {
@@ -432,7 +433,7 @@ describe('TextArea allowClear', () => {
   });
 
   it('scroll to bottom when autoSize', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const ref = React.createRef<TextAreaRef>();
     const { container, unmount } = render(<Input.TextArea ref={ref} autoSize />, {
       container: document.body,
@@ -441,18 +442,15 @@ describe('TextArea allowClear', () => {
     fireEvent.focus(container.querySelector('textarea')!);
     container.querySelector('textarea')?.focus();
 
-    const setSelectionRangeFn = jest.spyOn(
-      container.querySelector('textarea')!,
-      'setSelectionRange',
-    );
+    const setSelectionRangeFn = vi.spyOn(container.querySelector('textarea')!, 'setSelectionRange');
     fireEvent.input(container.querySelector('textarea')!, { target: { value: '\n1' } });
     const target = ref.current?.resizableTextArea?.textArea!;
     triggerResize(target);
     await waitFakeTimer();
     expect(setSelectionRangeFn).toHaveBeenCalled();
     unmount();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   // https://github.com/ant-design/ant-design/issues/26308
@@ -462,7 +460,7 @@ describe('TextArea allowClear', () => {
   });
 
   it('onChange event should return HTMLTextAreaElement', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(<Input.TextArea onChange={onChange} allowClear />);
 
     function isNativeElement() {
@@ -515,7 +513,7 @@ describe('TextArea allowClear', () => {
 
   // https://github.com/ant-design/ant-design/issues/31200
   it('should not lost focus when clear input', () => {
-    const onBlur = jest.fn();
+    const onBlur = vi.fn();
     const { container, unmount } = render(
       <TextArea allowClear defaultValue="value" onBlur={onBlur} />,
       {
@@ -553,7 +551,7 @@ describe('TextArea allowClear', () => {
   });
 
   it('should focus when clearBtn is clicked in controlled case', () => {
-    const handleFocus = jest.fn();
+    const handleFocus = vi.fn();
 
     const textareaSpy = spyElementPrototypes(HTMLTextAreaElement, {
       focus: handleFocus,

--- a/components/input/__tests__/type.test.tsx
+++ b/components/input/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Input from '..';
 import { render } from '../../../tests/utils';

--- a/components/layout/__tests__/dynamic-breakpoint.test.tsx
+++ b/components/layout/__tests__/dynamic-breakpoint.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import Sider from '../Sider';
 import { render, fireEvent } from '../../../tests/utils';
@@ -21,9 +22,9 @@ const Content = () => {
 };
 
 it('Dynamic breakpoint in Sider component', () => {
-  const add = jest.fn();
-  const remove = jest.fn();
-  const newMatch = jest.spyOn(window, 'matchMedia').mockReturnValue({
+  const add = vi.fn();
+  const remove = vi.fn();
+  const newMatch = vi.spyOn(window, 'matchMedia').mockReturnValue({
     matches: true,
     addEventListener: add,
     removeEventListener: remove,
@@ -45,5 +46,5 @@ it('Dynamic breakpoint in Sider component', () => {
   expect(add.mock.calls).toHaveLength(originCallTimes + 1);
   expect(remove.mock.calls).toHaveLength(originCallTimes);
 
-  jest.restoreAllMocks();
+  vi.restoreAllMocks();
 });

--- a/components/layout/__tests__/image.test.ts
+++ b/components/layout/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Layout image', () => {

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, afterEach, afterAll, vi } from 'vitest';
 import { UserOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
@@ -132,7 +133,7 @@ describe('Layout', () => {
 
     describe('should collapsible', () => {
       it('uncontrolled', () => {
-        const onCollapse = jest.fn();
+        const onCollapse = vi.fn();
 
         const { container } = render(
           <Layout>
@@ -214,7 +215,7 @@ describe('Layout', () => {
   });
 
   it('render correct with Tooltip', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(
       <Sider collapsible collapsed={false}>
         <Menu mode="inline">
@@ -228,7 +229,7 @@ describe('Layout', () => {
 
     fireEvent.mouseEnter(container.querySelector('.ant-menu-item')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tooltip-inner').length).toBeFalsy();
     rerender(
@@ -243,16 +244,16 @@ describe('Layout', () => {
     );
     fireEvent.mouseEnter(container.querySelector('.ant-menu-item')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tooltip-inner').length).toBeTruthy();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 });
 
 describe('Sider', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -263,7 +264,7 @@ describe('Sider', () => {
   });
 
   it('should trigger onBreakpoint', async () => {
-    const onBreakpoint = jest.fn();
+    const onBreakpoint = vi.fn();
 
     render(
       <Sider breakpoint="md" onBreakpoint={onBreakpoint}>
@@ -322,7 +323,7 @@ describe('Sider', () => {
 
     it(`should get ${tag} element from ref`, () => {
       const ref = React.createRef<HTMLDivElement>();
-      const onSelect = jest.fn();
+      const onSelect = vi.fn();
       const Component = ComponentMap[tag];
       render(
         <Component onSelect={onSelect} ref={ref}>

--- a/components/layout/__tests__/token.test.tsx
+++ b/components/layout/__tests__/token.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Layout from '..';
 import { render } from '../../../tests/utils';

--- a/components/layout/__tests__/warning.test.tsx
+++ b/components/layout/__tests__/warning.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Layout from '..';
 import { render } from '../../../tests/utils';
@@ -19,7 +20,7 @@ describe('Layout.Warning', () => {
        * If you accidentally passed it from a parent component,
        * remove it from the DOM element.
        */
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const Component = ComponentMap[tag];
       render(<Component>{tag}</Component>);

--- a/components/list/__tests__/Item.test.tsx
+++ b/components/list/__tests__/Item.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React, { useEffect } from 'react';
 import List from '..';
 import { pureRender, render } from '../../../tests/utils';

--- a/components/list/__tests__/empty.test.tsx
+++ b/components/list/__tests__/empty.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import List from '..';
 import { render } from '../../../tests/utils';

--- a/components/list/__tests__/image.test.ts
+++ b/components/list/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('List image', () => {

--- a/components/list/__tests__/index.test.tsx
+++ b/components/list/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import type { ListProps } from '..';
 import List from '..';

--- a/components/list/__tests__/loading.test.tsx
+++ b/components/list/__tests__/loading.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { LoadingOutlined } from '@ant-design/icons';
 import React from 'react';
 import { render } from '../../../tests/utils';

--- a/components/list/__tests__/pagination.test.tsx
+++ b/components/list/__tests__/pagination.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { ListProps } from '..';
 import List from '..';
@@ -77,7 +78,7 @@ describe('List.pagination', () => {
   });
 
   it('fires change event', () => {
-    const handlePaginationChange = jest.fn();
+    const handlePaginationChange = vi.fn();
     const { container: wrapper } = render(
       createList({
         pagination: {
@@ -166,7 +167,7 @@ describe('List.pagination', () => {
   // https://github.com/ant-design/ant-design/issues/24913
   // https://github.com/ant-design/ant-design/issues/24501
   it('should onChange called when pageSize change', () => {
-    const handlePaginationChange = jest.fn();
+    const handlePaginationChange = vi.fn();
     const handlePageSizeChange = () => {};
     const { container: wrapper } = render(
       createList({

--- a/components/locale/__tests__/cached-context.test.tsx
+++ b/components/locale/__tests__/cached-context.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest';
 import React, { memo, useContext } from 'react';
 import { fireEvent, pureRender } from '../../../tests/utils';
 import LocaleProvider from '..';

--- a/components/locale/__tests__/config.test.tsx
+++ b/components/locale/__tests__/config.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useEffect } from 'react';
 import { Modal } from '../..';
 import { waitFakeTimer, render, fireEvent } from '../../../tests/utils';
@@ -15,7 +16,7 @@ const Demo: React.FC<{ type: string }> = ({ type }) => {
 
 describe('Locale Provider demo', () => {
   it('change type', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
     const BasicExample: React.FC = () => {
       const [type, setType] = React.useState<string>('');
@@ -52,6 +53,6 @@ describe('Locale Provider demo', () => {
 
     expect(document.body.querySelectorAll('.ant-btn-primary span')[0]?.textContent).toBe('确 定');
     Modal.destroyAll();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 });

--- a/components/locale/__tests__/index.test.tsx
+++ b/components/locale/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
 /* eslint-disable react/no-multi-comp */
 import dayjs from 'dayjs';
 import 'dayjs/locale/ar';

--- a/components/mentions/__tests__/image.test.ts
+++ b/components/mentions/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Mentions image', () => {

--- a/components/mentions/__tests__/index.test.tsx
+++ b/components/mentions/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import Mentions, { Option } from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -36,11 +37,11 @@ function simulateInput(wrapper: ReturnType<typeof render>, text: string, keyEven
 
 describe('Mentions', () => {
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('getMentions', () => {
@@ -52,8 +53,8 @@ describe('Mentions', () => {
   });
 
   it('focus', () => {
-    const onFocus = jest.fn();
-    const onBlur = jest.fn();
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
 
     const { container } = render(<Mentions onFocus={onFocus} onBlur={onBlur} />);
     fireEvent.focus(container.querySelector('textarea')!);
@@ -61,7 +62,7 @@ describe('Mentions', () => {
     expect(onFocus).toHaveBeenCalled();
     fireEvent.blur(container.querySelector('textarea')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-mentions')).not.toHaveClass('ant-mentions-focused');
     expect(onBlur).toHaveBeenCalled();
@@ -86,7 +87,7 @@ describe('Mentions', () => {
   });
 
   it('warning if use Mentions.Option', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(
       <Mentions style={{ width: '100%' }} defaultValue="@afc163">
         <Option value="afc163">afc163</Option>
@@ -112,7 +113,7 @@ describe('Mentions', () => {
     fireEvent.mouseEnter(container.querySelector('li.ant-mentions-dropdown-menu-item:last-child')!);
     fireEvent.focus(container.querySelector('textarea')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(
       wrapper.container.querySelector('.ant-mentions-dropdown-menu-item-active')?.textContent,

--- a/components/menu/__tests__/cached-context.test.tsx
+++ b/components/menu/__tests__/cached-context.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest';
 import React, { memo, useContext } from 'react';
 import Menu from '../index';
 import MenuContext from '../MenuContext';

--- a/components/menu/__tests__/image.test.ts
+++ b/components/menu/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Menu image', () => {

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, beforeEach, afterEach, it, vi } from 'vitest';
 import {
   AppstoreOutlined,
   InboxOutlined,
@@ -28,7 +29,7 @@ describe('Menu', () => {
   function triggerAllTimer() {
     for (let i = 0; i < 10; i += 1) {
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
     }
   }
@@ -86,12 +87,12 @@ describe('Menu', () => {
   // window.cancelAnimationFrame = window.clearTimeout;
 
   beforeEach(() => {
-    jest.useFakeTimers();
-    jest.clearAllTimers();
+    vi.useFakeTimers();
+    vi.clearAllTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   mountTest(() => (
@@ -361,7 +362,7 @@ describe('Menu', () => {
         );
 
         act(() => {
-          jest.runAllTimers();
+          vi.runAllTimers();
         });
 
         expect(container.querySelector('ul.ant-menu-root')).toHaveClass('ant-menu-dark');
@@ -384,7 +385,7 @@ describe('Menu', () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     // just expect no error emit
   });
@@ -431,7 +432,7 @@ describe('Menu', () => {
     rerender(<Demo inlineCollapsed />);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('ul.ant-menu-root')).toHaveClass('ant-menu-vertical');
@@ -441,7 +442,7 @@ describe('Menu', () => {
     rerender(<Demo inlineCollapsed={false} />);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('ul.ant-menu-sub')).toHaveClass('ant-menu-inline');
@@ -468,13 +469,13 @@ describe('Menu', () => {
 
     rerender(<Demo inlineCollapsed />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     const transitionEndEvent = new Event('transitionend');
     fireEvent(container.querySelector('ul')!, transitionEndEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     fireEvent.mouseEnter(container.querySelector('.ant-menu-submenu-title')!);
@@ -565,8 +566,8 @@ describe('Menu', () => {
         motionDeadline: 1,
       };
 
-      const onOpenChange = jest.fn();
-      const onEnterEnd = jest.spyOn(cloneMotion, 'onEnterEnd');
+      const onOpenChange = vi.fn();
+      const onEnterEnd = vi.spyOn(cloneMotion, 'onEnterEnd');
 
       const { container } = render(
         <Menu mode="inline" motion={cloneMotion} onOpenChange={onOpenChange}>
@@ -731,7 +732,7 @@ describe('Menu', () => {
   });
 
   it('onMouseEnter should work', () => {
-    const onMouseEnter = jest.fn();
+    const onMouseEnter = vi.fn();
     const { container } = render(
       <Menu onMouseEnter={onMouseEnter} defaultSelectedKeys={['test1']}>
         <Menu.Item key="test1">Navigation One</Menu.Item>
@@ -761,7 +762,7 @@ describe('Menu', () => {
 
     fireEvent.mouseEnter(container.querySelector('li.ant-menu-item')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelectorAll('.ant-tooltip-inner').length).toBe(0);
@@ -801,7 +802,7 @@ describe('Menu', () => {
   });
 
   it('not title if not collapsed', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(
       <Menu mode="inline" inlineCollapsed={false}>
         <Menu.Item key="1" icon={<PieChartOutlined />}>
@@ -811,18 +812,18 @@ describe('Menu', () => {
     );
     fireEvent.mouseEnter(container.querySelector('.ant-menu-item')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelectorAll('.ant-tooltip-inner').length).toBeFalsy();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('props#onOpen and props#onClose do not warn anymore', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const onOpen = jest.fn();
-    const onClose = jest.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
     const Demo: React.FC = () => {
       const menuProps = useMemo<MenuProps>(() => ({ onOpen, onClose }) as MenuProps, []);
       return (
@@ -857,7 +858,7 @@ describe('Menu', () => {
   // https://github.com/ant-design/ant-design/issues/18825
   // https://github.com/ant-design/ant-design/issues/8587
   it('should keep selectedKeys in state when collapsed to 0px', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const Demo: React.FC<MenuProps> = (props) => {
       const menuProps = useMemo<MenuProps>(() => ({ collapsedWidth: 0 }) as MenuProps, []);
       return (
@@ -885,14 +886,14 @@ describe('Menu', () => {
 
     rerender(<Demo inlineCollapsed />);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('li.ant-menu-item-selected')?.textContent).toBe('O');
 
     rerender(<Demo inlineCollapsed={false} />);
 
     expect(container.querySelector('li.ant-menu-item-selected')?.textContent).toBe('Option 2');
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('Menu.Item with icon children auto wrap span', () => {
@@ -913,7 +914,7 @@ describe('Menu', () => {
 
   // https://github.com/ant-design/ant-design/issues/23755
   it('should trigger onOpenChange when collapse inline menu', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     function App() {
       const [inlineCollapsed, setInlineCollapsed] = useState(false);
       return (
@@ -1040,7 +1041,7 @@ describe('Menu', () => {
   });
 
   it('should not warning deprecated message when items={undefined}', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Menu items={undefined} />);
     expect(errorSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('`children` will be removed in next major version'),

--- a/components/menu/__tests__/type.test.tsx
+++ b/components/menu/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Menu from '..';
 

--- a/components/message/__tests__/config.test.tsx
+++ b/components/message/__tests__/config.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { act } from '../../../tests/utils';
 import message, { actWrapper } from '..';
 import ConfigProvider from '../../config-provider';
@@ -9,7 +10,7 @@ describe('message.config', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -17,7 +18,7 @@ describe('message.config', () => {
     message.destroy();
     await triggerMotionEnd();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -104,13 +105,13 @@ describe('message.config', () => {
     expect(document.querySelectorAll('.ant-message-notice')).toHaveLength(1);
 
     act(() => {
-      jest.advanceTimersByTime(4000);
+      vi.advanceTimersByTime(4000);
     });
 
     expect(document.querySelectorAll('.ant-message-notice')).toHaveLength(1);
 
     act(() => {
-      jest.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
     });
 
     await triggerMotionEnd('.ant-message-notice');

--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -8,11 +9,11 @@ import { fireEvent, render } from '../../../tests/utils';
 
 describe('message.hooks', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should work', () => {
@@ -230,7 +231,7 @@ describe('message.hooks', () => {
   });
 
   it('warning if user call update in render', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Demo = () => {
       const [api, holder] = message.useMessage();

--- a/components/message/__tests__/image.test.ts
+++ b/components/message/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Message image', () => {

--- a/components/message/__tests__/immediately.test.tsx
+++ b/components/message/__tests__/immediately.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import message, { actWrapper, actDestroy } from '..';
 import { act } from '../../../tests/utils';
 import { awaitPromise, triggerMotionEnd } from './util';
@@ -9,7 +10,7 @@ describe('call close immediately', () => {
 
   beforeEach(() => {
     actDestroy();
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -18,10 +19,10 @@ describe('call close immediately', () => {
     await triggerMotionEnd();
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });

--- a/components/message/__tests__/index.test.tsx
+++ b/components/message/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { SmileOutlined } from '@ant-design/icons';
 import message, { actWrapper } from '..';
@@ -10,7 +11,7 @@ describe('message', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -19,10 +20,10 @@ describe('message', () => {
     await triggerMotionEnd();
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -81,7 +82,7 @@ describe('message', () => {
   });
 
   it('should not need to use duration argument when using the onClose arguments', async () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const close = message.info('whatever', onClose);
 
     await awaitPromise();
@@ -93,25 +94,25 @@ describe('message', () => {
   });
 
   it('should have the default duration when using the onClose arguments', async () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
 
     message.info('whatever', onClose);
     await awaitPromise();
 
     act(() => {
-      jest.advanceTimersByTime(2500);
+      vi.advanceTimersByTime(2500);
     });
 
     expect(document.querySelector('.ant-message-move-up-leave')).toBeFalsy();
 
     act(() => {
-      jest.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(1000);
     });
     expect(document.querySelector('.ant-message-move-up-leave')).toBeTruthy();
   });
 
   it('trigger onClick method', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     message.info({
       onClick,
       duration: 0,
@@ -127,17 +128,17 @@ describe('message', () => {
   });
 
   it('should be called like promise', async () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     message.info('whatever').then(onClose);
     await awaitPromise();
 
     act(() => {
-      jest.advanceTimersByTime(2500);
+      vi.advanceTimersByTime(2500);
     });
     expect(onClose).not.toHaveBeenCalled();
 
     act(() => {
-      jest.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(1000);
     });
     await waitFakeTimer(); // Wait to let event loop run
     expect(onClose).toHaveBeenCalled();
@@ -200,7 +201,7 @@ describe('message', () => {
 
     expect(document.querySelectorAll('.ant-message-notice')).toHaveLength(1);
     act(() => {
-      jest.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(1500);
     });
 
     expect(document.querySelectorAll('.ant-message-notice')).toHaveLength(1);
@@ -225,7 +226,7 @@ describe('message', () => {
     expect(document.querySelectorAll('.ant-message-notice')).toHaveLength(1);
 
     act(() => {
-      jest.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(1500);
     });
     expect(document.querySelectorAll('.ant-message-move-up-leave')).toHaveLength(1);
   });

--- a/components/message/__tests__/static-warning.test.tsx
+++ b/components/message/__tests__/static-warning.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import message, { actWrapper } from '..';
 import { act, render, waitFakeTimer } from '../../../tests/utils';
@@ -10,7 +11,7 @@ describe('message static warning', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -18,14 +19,14 @@ describe('message static warning', () => {
     message.destroy();
     await triggerMotionEnd();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
 
   // Follow test need keep order
   it('no warning', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     message.success({
       content: <div className="bamboo" />,
@@ -39,7 +40,7 @@ describe('message static warning', () => {
   });
 
   it('warning if use theme', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<ConfigProvider theme={{}} />);
 
     message.success({

--- a/components/message/__tests__/type.test.tsx
+++ b/components/message/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import message, { actWrapper } from '..';
 import { act } from '../../../tests/utils';
 import { awaitPromise, triggerMotionEnd } from './util';
@@ -8,7 +9,7 @@ describe('message.typescript', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -16,7 +17,7 @@ describe('message.typescript', () => {
     message.destroy();
     await triggerMotionEnd();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -27,7 +28,7 @@ describe('message.typescript', () => {
   });
 
   it('promise with one arguments', async () => {
-    const filled = jest.fn();
+    const filled = vi.fn();
 
     message.success('yes!!!').then(filled);
 
@@ -37,8 +38,8 @@ describe('message.typescript', () => {
   });
 
   it('promise two arguments', async () => {
-    const filled = jest.fn();
-    const rejected = jest.fn();
+    const filled = vi.fn();
+    const rejected = vi.fn();
 
     message.success('yes!!!').then(filled, rejected);
 

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useEffect } from 'react';
 import type { ModalProps } from '..';
 import Modal from '..';
@@ -6,7 +7,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 
-jest.mock('rc-util/lib/Portal');
+vi.mock('rc-util/lib/Portal');
 
 const ModalTester: React.FC<ModalProps> = (props) => {
   const [open, setOpen] = React.useState(false);
@@ -44,14 +45,14 @@ describe('Modal', () => {
   });
 
   it('onCancel should be called', () => {
-    const onCancel = jest.fn();
+    const onCancel = vi.fn();
     render(<Modal open onCancel={onCancel} />);
     fireEvent.click(document.body.querySelectorAll('.ant-btn')[0]);
     expect(onCancel).toHaveBeenCalled();
   });
 
   it('onOk should be called', () => {
-    const onOk = jest.fn();
+    const onOk = vi.fn();
     render(<Modal open onOk={onOk} />);
     const btns = document.body.querySelectorAll('.ant-btn');
     fireEvent.click(btns[btns.length - 1]);
@@ -105,7 +106,7 @@ describe('Modal', () => {
 
   it('deprecated warning', () => {
     resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<Modal visible />);
     expect(errSpy).toHaveBeenCalledWith(

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, afterAll, it, expect, vi } from 'vitest';
 import { SmileOutlined } from '@ant-design/icons';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
@@ -16,13 +17,13 @@ import destroyFns from '../destroyFns';
 
 const { confirm } = Modal;
 
-jest.mock('rc-motion');
+vi.mock('rc-motion');
 
 (global as any).injectPromise = false;
 (global as any).rejectPromise = null;
 
-jest.mock('../../_util/ActionButton', () => {
-  const ActionButton = jest.requireActual('../../_util/ActionButton').default;
+vi.mock('../../_util/ActionButton', () => {
+  const ActionButton = vi.requireActual('../../_util/ActionButton').default;
   return (props: any) => {
     const { actionFn } = props;
     let mockActionFn: any = actionFn;
@@ -80,7 +81,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   // });
   // jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => window.clearTimeout(id));
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   /* eslint-disable no-console */
   // Hack error to remove act warning
@@ -96,7 +97,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   /* eslint-enable */
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     (global as any).injectPromise = false;
     (global as any).rejectPromise = null;
   });
@@ -107,11 +108,11 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     await waitFakeTimer();
     document.body.innerHTML = '';
-    jest.clearAllTimers();
+    vi.clearAllTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     errorSpy.mockRestore();
   });
 
@@ -138,8 +139,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('trigger onCancel once when click on cancel button', async () => {
-    const onCancel = jest.fn();
-    const onOk = jest.fn();
+    const onCancel = vi.fn();
+    const onOk = vi.fn();
     await open({
       onCancel,
       onOk,
@@ -151,8 +152,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('trigger onOk once when click on ok button', async () => {
-    const onCancel = jest.fn();
-    const onOk = jest.fn();
+    const onCancel = vi.fn();
+    const onOk = vi.fn();
     await open({
       onCancel,
       onOk,
@@ -180,7 +181,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should close confirm modal when press ESC', async () => {
-    const onCancel = jest.fn();
+    const onCancel = vi.fn();
     Modal.confirm({
       title: 'title',
       content: 'content',
@@ -202,7 +203,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   it('should not fire twice onOk when button is pressed twice', async () => {
     let resolveFn: VoidFunction;
-    const onOk = jest.fn(
+    const onOk = vi.fn(
       () =>
         new Promise<void>((resolve) => {
           resolveFn = resolve;
@@ -304,7 +305,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should close confirm modal when click cancel button', async () => {
-    const onCancel = jest.fn();
+    const onCancel = vi.fn();
     Modal.confirm({
       // test legacy visible
       visible: true,
@@ -321,7 +322,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should close confirm modal when click close button', async () => {
-    const onCancel = jest.fn();
+    const onCancel = vi.fn();
     Modal.confirm({
       title: 'title',
       content: 'content',
@@ -488,7 +489,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
       // Render modal
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       instances.push(instance);
@@ -499,14 +500,14 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
       act(() => {
         instance.destroy();
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(destroyFns.length).toBe(length - index - 1);
     });
   });
 
   it('should warning when pass a string as icon props', async () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     confirm({
       content: 'some descriptions',
       icon: 'ab',
@@ -529,7 +530,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('icon can be null to hide icon', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     confirm({
       title: 'some title',
       content: 'some descriptions',
@@ -544,11 +545,11 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       document.querySelector('.ant-modal-confirm-body')!.querySelector('.anticon'),
     ).toBeFalsy();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('ok button should trigger onOk once when click it many times quickly', async () => {
-    const onOk = jest.fn();
+    const onOk = vi.fn();
     await open({ onOk });
 
     $$('.ant-btn-primary')[0].click();
@@ -558,7 +559,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   // https://github.com/ant-design/ant-design/issues/23358
   it('ok button should trigger onOk multiple times when onOk has close argument', async () => {
-    const onOk = jest.fn();
+    const onOk = vi.fn();
     await open({
       onOk(close?: any) {
         onOk();
@@ -625,7 +626,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('trigger afterClose once when click on cancel button', async () => {
-    const afterClose = jest.fn();
+    const afterClose = vi.fn();
     await open({
       afterClose,
     });
@@ -637,7 +638,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('trigger afterClose once when click on ok button', async () => {
-    const afterClose = jest.fn();
+    const afterClose = vi.fn();
     await open({
       afterClose,
     });
@@ -659,7 +660,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   describe('the callback close should be a method when onCancel has a close parameter', () => {
     (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the close icon to trigger ${type} onCancel`, async () => {
-        const mock = jest.fn();
+        const mock = vi.fn();
 
         Modal[type]?.({
           closable: true,
@@ -680,7 +681,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`press ESC to trigger ${type} onCancel`, async () => {
-        const mock = jest.fn();
+        const mock = vi.fn();
 
         Modal[type]?.({
           keyboard: true,
@@ -703,7 +704,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the mask to trigger ${type} onCancel`, async () => {
-        const mock = jest.fn();
+        const mock = vi.fn();
 
         Modal[type]?.({
           maskClosable: true,
@@ -726,7 +727,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('confirm modal click Cancel button close callback is a function', async () => {
-    const mock = jest.fn();
+    const mock = vi.fn();
 
     Modal.confirm({
       onCancel: (close) => mock(close),
@@ -758,8 +759,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   // https://github.com/ant-design/ant-design/issues/37461
   it('Update should closable', async () => {
     resetWarned();
-    jest.useFakeTimers();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const modal = Modal.confirm({});
 
@@ -776,7 +777,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     expect($$('.ant-modal-confirm-confirm')).toHaveLength(0);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
     errSpy.mockRestore();
   });
 

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import KeyCode from 'rc-util/lib/KeyCode';
@@ -11,8 +12,8 @@ import ConfigProvider from '../../config-provider';
 import Input from '../../input';
 import type { ModalFunc } from '../confirm';
 
-jest.mock('rc-util/lib/Portal');
-jest.mock('rc-motion');
+vi.mock('rc-util/lib/Portal');
+vi.mock('rc-motion');
 
 describe('Modal.hook', () => {
   // Inject CSSMotion to replace with No transition support
@@ -23,7 +24,7 @@ describe('Modal.hook', () => {
   });
 
   it('hooks support context', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const Context = React.createContext('light');
     let instance: ReturnType<ModalFunc>;
 
@@ -65,11 +66,11 @@ describe('Modal.hook', () => {
     // Destroy
     act(() => {
       instance.destroy();
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(document.body.querySelectorAll('Modal')).toHaveLength(0);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('destroyAll works with contextHolder', () => {
@@ -110,7 +111,7 @@ describe('Modal.hook', () => {
   });
 
   it('context support config direction', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const Demo = () => {
       const [modal, contextHolder] = Modal.useModal();
       return (
@@ -234,9 +235,9 @@ describe('Modal.hook', () => {
   });
 
   it('the callback close should be a method when onCancel has a close parameter', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
-    const mockFn = jest.fn();
+    const mockFn = vi.fn();
 
     const Demo = () => {
       const [modal, contextHolder] = Modal.useModal();
@@ -330,7 +331,7 @@ describe('Modal.hook', () => {
 
     expect(mockFn.mock.calls).toEqual(Array.from({ length: 5 }, () => [expect.any(Function)]));
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('not block origin ConfigProvider config', () => {
@@ -352,7 +353,7 @@ describe('Modal.hook', () => {
   });
 
   it('it should call forwarded afterClose', () => {
-    const afterClose = jest.fn();
+    const afterClose = vi.fn();
     const Demo = () => {
       const [modal, contextHolder] = Modal.useModal();
       React.useEffect(() => {

--- a/components/modal/__tests__/image.test.ts
+++ b/components/modal/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Modal image', () => {

--- a/components/modal/__tests__/static-warning.test.tsx
+++ b/components/modal/__tests__/static-warning.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import Modal from '..';
 import { render, waitFakeTimer } from '../../../tests/utils';
@@ -6,7 +7,7 @@ import { resetWarned } from '../../_util/warning';
 
 describe('Modal.confirm warning', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     resetWarned();
   });
 
@@ -15,12 +16,12 @@ describe('Modal.confirm warning', () => {
 
     await waitFakeTimer();
     document.body.innerHTML = '';
-    jest.clearAllTimers();
+    vi.clearAllTimers();
   });
 
   // Follow test need keep order
   it('no warning', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     Modal.confirm({
       content: <div className="bamboo" />,
     });
@@ -32,7 +33,7 @@ describe('Modal.confirm warning', () => {
   });
 
   it('warning if use theme', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<ConfigProvider theme={{}} />);
 
     Modal.confirm({

--- a/components/modal/__tests__/type.test.tsx
+++ b/components/modal/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Modal from '..';
 

--- a/components/notification/__tests__/config.test.tsx
+++ b/components/notification/__tests__/config.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import notification, { actWrapper } from '..';
 import { act } from '../../../tests/utils';
 import { awaitPromise, triggerMotionEnd } from './util';
@@ -8,7 +9,7 @@ describe('notification.config', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -21,7 +22,7 @@ describe('notification.config', () => {
       getContainer: null,
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -44,7 +45,7 @@ describe('notification.config', () => {
 
       act(() => {
         // One frame is 16ms
-        jest.advanceTimersByTime(100);
+        vi.advanceTimersByTime(100);
       });
 
       // eslint-disable-next-line no-await-in-loop
@@ -64,7 +65,7 @@ describe('notification.config', () => {
 
     act(() => {
       // One frame is 16ms
-      jest.advanceTimersByTime(100);
+      vi.advanceTimersByTime(100);
     });
     await triggerMotionEnd(false);
 
@@ -74,10 +75,10 @@ describe('notification.config', () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     await triggerMotionEnd(false);

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent, pureRender } from '../../../tests/utils';
 import notification from '..';
@@ -5,11 +6,11 @@ import ConfigProvider from '../../config-provider';
 
 describe('notification.hooks', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should work', () => {
@@ -127,7 +128,7 @@ describe('notification.hooks', () => {
     });
 
     it('warning if user call update in render', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const Demo = () => {
         const [api, holder] = notification.useNotification();

--- a/components/notification/__tests__/image.test.ts
+++ b/components/notification/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Notification image', () => {

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { UserOutlined } from '@ant-design/icons';
 import notification, { actWrapper } from '..';
@@ -11,7 +12,7 @@ describe('notification', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -24,7 +25,7 @@ describe('notification', () => {
       getContainer: null,
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -44,7 +45,7 @@ describe('notification', () => {
     await awaitPromise();
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(document.querySelectorAll('.additional-holder')).toHaveLength(1);
@@ -195,7 +196,7 @@ describe('notification', () => {
   });
 
   it('trigger onClick', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
 
     notification.open({
       message: 'Notification Title',

--- a/components/notification/__tests__/placement.test.tsx
+++ b/components/notification/__tests__/placement.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import notification, { actWrapper } from '..';
 import { act, fireEvent } from '../../../tests/utils';
 import type { ArgsProps, GlobalConfigProps } from '../interface';
@@ -27,7 +28,7 @@ describe('Notification.placement', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -40,7 +41,7 @@ describe('Notification.placement', () => {
       getContainer: null,
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
@@ -150,7 +151,7 @@ describe('Notification.placement', () => {
 
       // Leave motion
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       document.querySelectorAll('.ant-notification-notice').forEach((ele) => {
         fireEvent.animationEnd(ele);

--- a/components/notification/__tests__/static-warning.test.tsx
+++ b/components/notification/__tests__/static-warning.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import notification, { actWrapper } from '..';
 import { act, render, waitFakeTimer } from '../../../tests/utils';
@@ -10,7 +11,7 @@ describe('notification static warning', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(async () => {
@@ -18,14 +19,14 @@ describe('notification static warning', () => {
     notification.destroy();
     await triggerMotionEnd();
 
-    jest.useRealTimers();
+    vi.useRealTimers();
 
     await awaitPromise();
   });
 
   // Follow test need keep order
   it('no warning', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     notification.open({
       message: <div className="bamboo" />,
@@ -39,7 +40,7 @@ describe('notification static warning', () => {
   });
 
   it('warning if use theme', async () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<ConfigProvider theme={{}} />);
 
     notification.open({

--- a/components/pagination/__tests__/image.test.ts
+++ b/components/pagination/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Pagination image', () => {

--- a/components/pagination/__tests__/index.test.tsx
+++ b/components/pagination/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { OptionFC } from 'rc-select/lib/Option';
 import type { PaginationProps } from '..';
@@ -36,8 +37,8 @@ describe('Pagination', () => {
   // https://github.com/ant-design/ant-design/issues/24913
   // https://github.com/ant-design/ant-design/issues/24501
   it('should onChange called when pageSize change', () => {
-    const onChange = jest.fn();
-    const onShowSizeChange = jest.fn();
+    const onChange = vi.fn();
+    const onShowSizeChange = vi.fn();
     const { container } = render(
       <Pagination
         defaultCurrent={1}

--- a/components/pagination/__tests__/simple.test.tsx
+++ b/components/pagination/__tests__/simple.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Pagination from '..';
 import { render } from '../../../tests/utils';

--- a/components/popconfirm/__tests__/image.test.ts
+++ b/components/popconfirm/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Popconfirm image', () => {

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import Popconfirm from '..';
@@ -22,16 +23,16 @@ describe('Popconfirm', () => {
   });
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should popup Popconfirm dialog', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
 
     const wrapper = render(
       <Popconfirm
@@ -98,7 +99,7 @@ describe('Popconfirm', () => {
   });
 
   it('should be controlled by open', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const popconfirm = render(
       <Popconfirm title="code">
         <span>show me your code</span>
@@ -123,16 +124,16 @@ describe('Popconfirm', () => {
       </Popconfirm>,
     );
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(popconfirm.container.querySelector('.ant-popover')).not.toBe(null);
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should trigger onConfirm and onCancel', async () => {
-    const confirm = jest.fn();
-    const cancel = jest.fn();
-    const onOpenChange = jest.fn((_, e) => {
+    const confirm = vi.fn();
+    const cancel = vi.fn();
+    const onOpenChange = vi.fn((_, e) => {
       e?.persist?.();
     });
     const popconfirm = render(
@@ -161,7 +162,7 @@ describe('Popconfirm', () => {
       new Promise((res) => {
         setTimeout(res, 300);
       });
-    const onOpenChange = jest.fn((_, e) => {
+    const onOpenChange = vi.fn((_, e) => {
       e?.persist?.();
     });
     const popconfirm = render(
@@ -230,7 +231,7 @@ describe('Popconfirm', () => {
   });
 
   it('should be closed by pressing ESC', () => {
-    const onOpenChange = jest.fn((_, e) => {
+    const onOpenChange = vi.fn((_, e) => {
       e?.persist?.();
     });
     const wrapper = render(
@@ -246,7 +247,7 @@ describe('Popconfirm', () => {
   });
 
   it('should not warn memory leaking if setState in async callback', async () => {
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const Test = () => {
       const [show, setShow] = React.useState(true);

--- a/components/popconfirm/__tests__/type.test.tsx
+++ b/components/popconfirm/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Popconfirm from '..';
 

--- a/components/popover/__tests__/image.test.ts
+++ b/components/popover/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Popover image', () => {

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Popover from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -66,9 +67,9 @@ describe('Popover', () => {
   });
 
   it('props#overlay do not warn anymore', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const overlay = jest.fn();
+    const overlay = vi.fn();
     render(
       <Popover content="console.log('hello world')" title="code" trigger="click">
         <span>show me your code</span>

--- a/components/progress/__tests__/image.test.ts
+++ b/components/progress/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Progress image', () => {

--- a/components/progress/__tests__/index.test.tsx
+++ b/components/progress/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import type { ProgressProps } from '..';
 import Progress from '..';
@@ -168,7 +169,7 @@ describe('Progress', () => {
 
   // https://github.com/ant-design/ant-design/pull/15951#discussion_r273062969
   it('should show success status when status is invalid', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container: wrapper } = render(
       <Progress percent={100} status={'invalid' as ProgressProps['status']} />,
     );
@@ -226,14 +227,14 @@ describe('Progress', () => {
   });
 
   it('should warning if use `progress` in success', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress percent={60} success={{ progress: 30 }} />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] `success.progress` is deprecated. Please use `success.percent` instead.',
     );
   });
   it('should warnning if use `width` prop', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress percent={60} width={100} />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] `width` is deprecated. Please use `size` instead.',
@@ -241,7 +242,7 @@ describe('Progress', () => {
   });
 
   it('should warnning if use `strokeWidth` prop in type Line', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress percent={60} strokeWidth={10} />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] `strokeWidth` is deprecated. Please use `size` instead.',
@@ -249,7 +250,7 @@ describe('Progress', () => {
   });
 
   it('should warning if use `progress` in success in type Circle', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress percent={60} success={{ progress: 30 }} type="circle" />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] `success.progress` is deprecated. Please use `success.percent` instead.',
@@ -257,7 +258,7 @@ describe('Progress', () => {
   });
 
   it('should warnning if pass number[] into `size` in type Circle', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress size={[60, 20]} type="circle" />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] Type "circle" and "dashbord" do not accept array as `size`, please use number or preset size instead.',
@@ -265,7 +266,7 @@ describe('Progress', () => {
   });
 
   it('should warnning if pass number[] into `size` in type dashboard', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Progress size={[60, 20]} type="dashboard" />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Progress] Type "circle" and "dashbord" do not accept array as `size`, please use number or preset size instead.',

--- a/components/qrcode/__tests__/image.test.ts
+++ b/components/qrcode/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('QRCode image', () => {

--- a/components/qrcode/__tests__/index.test.tsx
+++ b/components/qrcode/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React, { useState } from 'react';
 import QRCode from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -20,7 +21,7 @@ describe('QRCode test', () => {
   });
 
   it('should render `null` and console Error when value not exist', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(<QRCode value={undefined as unknown as string} />);
     expect(container.firstChild).toBe(null);
     expect(container.firstChild).toMatchSnapshot();
@@ -45,7 +46,7 @@ describe('QRCode test', () => {
   });
 
   it('support refresh', () => {
-    const refresh = jest.fn();
+    const refresh = vi.fn();
     const { container } = render(<QRCode value="test" status="expired" onRefresh={refresh} />);
     fireEvent.click(
       container
@@ -81,7 +82,7 @@ describe('QRCode test', () => {
   });
 
   it('should console Error when icon exist && errorLevel is `L`', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<QRCode value="test" icon="test" errorLevel="L" />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: QRCode] ErrorLevel `L` is not recommended to be used with `icon`, for scanning result would be affected by low level.',

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { RefAttributes } from 'react';
 import type { RadioGroupProps } from '..';
@@ -25,8 +26,8 @@ describe('Radio Group', () => {
   }
 
   it('responses hover events', () => {
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
 
     const { container } = render(
       <Radio.Group onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
@@ -42,7 +43,7 @@ describe('Radio Group', () => {
   });
 
   it('fire change events when value changes', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(
       createRadioGroup({
@@ -63,8 +64,8 @@ describe('Radio Group', () => {
   });
 
   it('both of radio and radioGroup will trigger onchange event when they exists', () => {
-    const onChange = jest.fn();
-    const onChangeRadioGroup = jest.fn();
+    const onChange = vi.fn();
+    const onChangeRadioGroup = vi.fn();
 
     const RadioGroup: React.FC<
       RadioGroupProps & { onChangeRadioGroup: RadioGroupProps['onChange'] }
@@ -95,7 +96,7 @@ describe('Radio Group', () => {
   });
 
   it('Trigger onChange when both of radioButton and radioGroup exists', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const RadioGroup: React.FC<RadioGroupProps> = (props) => (
       <Radio.Group {...props}>
@@ -115,7 +116,7 @@ describe('Radio Group', () => {
   });
 
   it('should only trigger once when in group with options', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const options = [{ label: 'Bamboo', value: 'Bamboo' }];
     const { container } = render(<Radio.Group options={options} onChange={onChange} />);
 
@@ -124,7 +125,7 @@ describe('Radio Group', () => {
   });
 
   it("won't fire change events when value not changes", () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(
       createRadioGroup({
@@ -198,7 +199,7 @@ describe('Radio Group', () => {
   });
 
   it('Radio type should not be override', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Radio.Group onChange={onChange}>
         <Radio value={1} type="1">
@@ -242,8 +243,8 @@ describe('Radio Group', () => {
   });
 
   it('onBlur & onFocus should work', () => {
-    const handleBlur = jest.fn();
-    const handleFocus = jest.fn();
+    const handleBlur = vi.fn();
+    const handleFocus = vi.fn();
     const { container } = render(
       <Radio.Group options={['1', '2', '3']} onBlur={handleBlur} onFocus={handleFocus} />,
     );

--- a/components/radio/__tests__/image.test.ts
+++ b/components/radio/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Radio image', () => {

--- a/components/radio/__tests__/radio-button.test.tsx
+++ b/components/radio/__tests__/radio-button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import type { RefAttributes } from 'react';
 import React from 'react';
 import type { RadioGroupProps } from '..';
@@ -20,8 +21,8 @@ describe('Radio Button', () => {
   });
 
   it('responses hover events', () => {
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
 
     const { container } = render(
       <Button onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />,
@@ -47,8 +48,8 @@ describe('Radio Group', () => {
   }
 
   it('responses hover events', () => {
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
 
     const { container } = render(
       <Radio.Group onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
@@ -64,7 +65,7 @@ describe('Radio Group', () => {
   });
 
   it('fire change events when value changes', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(createRadioGroup({ onChange }));
 
@@ -77,8 +78,8 @@ describe('Radio Group', () => {
   });
 
   it('both of radio and radioGroup will trigger onchange event when they exists', () => {
-    const onChange = jest.fn();
-    const onChangeRadioGroup = jest.fn();
+    const onChange = vi.fn();
+    const onChangeRadioGroup = vi.fn();
 
     const { container } = render(
       <Radio.Group onChange={onChangeRadioGroup}>
@@ -102,7 +103,7 @@ describe('Radio Group', () => {
   });
 
   it('Trigger onChange when both of Button and radioGroup exists', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(
       <Radio.Group onChange={onChange}>
@@ -126,7 +127,7 @@ describe('Radio Group', () => {
   });
 
   it('should only trigger once when in group with options', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const options = [{ label: 'Bamboo', value: 'Bamboo' }];
     const { container } = render(<Radio.Group options={options} onChange={onChange} />);
 
@@ -135,7 +136,7 @@ describe('Radio Group', () => {
   });
 
   it("won't fire change events when value not changes", () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container, rerender } = render(
       createRadioGroup({
@@ -197,7 +198,7 @@ describe('Radio Group', () => {
   });
 
   it('Radio type should not be override', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Radio.Group onChange={onChange}>
         <Radio value={1} type="1">

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Radio, { Button, Group } from '..';
 import Form from '../../form';
@@ -23,8 +24,8 @@ describe('Radio', () => {
   });
 
   it('responses hover events', () => {
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
 
     const { container } = render(<Radio onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />);
 

--- a/components/rate/__tests__/image.test.ts
+++ b/components/rate/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Rate image', () => {

--- a/components/rate/__tests__/index.test.ts
+++ b/components/rate/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import Rate from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';

--- a/components/result/__tests__/image.test.ts
+++ b/components/result/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Result image', () => {

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Result from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -55,7 +56,7 @@ describe('Result', () => {
   });
 
   it('should warning when pass a string as icon props', () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<Result title="404" icon="ab" />);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/components/result/__tests__/type.test.tsx
+++ b/components/result/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Result from '..';
 

--- a/components/segmented/__tests__/image.test.ts
+++ b/components/segmented/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Segmented image', () => {

--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { expect, describe, beforeAll, afterAll, it, vi } from 'vitest';
 import { AppstoreOutlined, BarsOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 
@@ -9,8 +10,8 @@ import type { SegmentedValue } from '../index';
 import Segmented from '../index';
 
 // Make CSSMotion working without transition
-jest.mock('rc-motion/lib/util/motion', () => ({
-  ...jest.requireActual('rc-motion/lib/util/motion'),
+vi.mock('rc-motion/lib/util/motion', () => ({
+  ...vi.requireActual('rc-motion/lib/util/motion'),
   supportTransition: false,
 }));
 
@@ -34,11 +35,11 @@ describe('Segmented', () => {
   rtlTest(Segmented);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('render empty segmented', () => {
@@ -87,7 +88,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with string options', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented options={['Daily', 'Weekly', 'Monthly']} onChange={handleValueChange} />,
     );
@@ -107,7 +108,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with numeric options', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented options={[1, 2, 3, 4, 5]} onChange={(value) => handleValueChange(value)} />,
     );
@@ -121,7 +122,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with mixed options', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented
         options={['Daily', { label: 'Weekly', value: 'Weekly' }, 'Monthly']}
@@ -138,7 +139,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with options: disabled', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented
         options={['Daily', { label: 'Weekly', value: 'Weekly', disabled: true }, 'Monthly']}
@@ -166,7 +167,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented: disabled', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented
         disabled
@@ -238,7 +239,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with options null/undefined', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented
         options={[null, undefined, ''] as any}
@@ -253,7 +254,7 @@ describe('Segmented', () => {
   });
 
   it('render segmented with thumb', () => {
-    const handleValueChange = jest.fn();
+    const handleValueChange = vi.fn();
     const { asFragment, container } = render(
       <Segmented
         options={['Map', 'Transit', 'Satellite']}

--- a/components/select/__tests__/image.test.ts
+++ b/components/select/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Select image', () => {

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import { CloseOutlined } from '@ant-design/icons';
 import type { SelectProps } from '..';
@@ -18,16 +19,16 @@ describe('Select', () => {
   function toggleOpen(container: ReturnType<typeof render>['container']): void {
     fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
   }
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should have default notFoundContent', () => {
@@ -64,7 +65,7 @@ describe('Select', () => {
   });
 
   it('should be controlled by open prop', () => {
-    const onDropdownVisibleChange = jest.fn();
+    const onDropdownVisibleChange = vi.fn();
     const TestComponent: React.FC = () => {
       const [open, setOpen] = React.useState(false);
       const handleChange: SelectProps['onDropdownVisibleChange'] = (value) => {
@@ -85,7 +86,7 @@ describe('Select', () => {
   });
 
   it('should show search icon when showSearch and open', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(
       <Select showSearch>
         <Option value="1">1</Option>
@@ -119,7 +120,7 @@ describe('Select', () => {
         </Select>,
       );
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(asFragment().firstChild).toMatchSnapshot();
     });
@@ -138,7 +139,7 @@ describe('Select', () => {
     it('dropdownClassName', () => {
       resetWarned();
 
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const { container } = render(<Select dropdownClassName="legacy" open />);
       expect(errSpy).toHaveBeenCalledWith(
         'Warning: [antd: Select] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',

--- a/components/skeleton/__tests__/image.test.ts
+++ b/components/skeleton/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Skeleton image', () => {

--- a/components/skeleton/__tests__/index.test.tsx
+++ b/components/skeleton/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import Skeleton from '..';
 import mountTest from '../../../tests/shared/mountTest';

--- a/components/slider/__tests__/image.test.ts
+++ b/components/slider/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Slider image', () => {

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import Slider from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -13,9 +14,9 @@ function tooltipProps(): TooltipProps {
   return (global as any).tooltipProps;
 }
 
-jest.mock('../../tooltip', () => {
-  const ReactReal = jest.requireActual('react');
-  const Tooltip = jest.requireActual('../../tooltip');
+vi.mock('../../tooltip', () => {
+  const ReactReal = vi.requireActual('react');
+  const Tooltip = vi.requireActual('../../tooltip');
   const TooltipComponent = Tooltip.default;
   return ReactReal.forwardRef((props: TooltipProps, ref: any) => {
     (global as any).tooltipProps = props;
@@ -29,12 +30,12 @@ describe('Slider', () => {
   focusTest(Slider);
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should show tooltip when hovering slider handler', () => {
@@ -136,9 +137,9 @@ describe('Slider', () => {
   it('should keepAlign by calling forceAlign', async () => {
     const ref = React.createRef<any>();
     render(<SliderTooltip title="30" open ref={ref} />);
-    ref.current.forceAlign = jest.fn();
+    ref.current.forceAlign = vi.fn();
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(ref.current.forceAlign).toHaveBeenCalled();
   });
@@ -158,7 +159,7 @@ describe('Slider', () => {
 
     const TSSlider = Slider as any;
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container, rerender } = render(<TSSlider tooltipPrefixCls="xxx" />);
     expect(errSpy).toHaveBeenCalledWith(
@@ -190,7 +191,7 @@ describe('Slider', () => {
     holder.id = 'holder';
     document.body.appendChild(holder);
 
-    const getTooltipPopupContainer = jest.fn(() => container);
+    const getTooltipPopupContainer = vi.fn(() => container);
 
     rerender(
       <TSSlider
@@ -203,7 +204,7 @@ describe('Slider', () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(getTooltipPopupContainer).toHaveBeenCalled();

--- a/components/slider/__tests__/type.test.tsx
+++ b/components/slider/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Slider from '..';
 

--- a/components/space/__tests__/gap.test.tsx
+++ b/components/space/__tests__/gap.test.tsx
@@ -1,8 +1,9 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Space from '..';
 import { render } from '../../../tests/utils';
 
-jest.mock('../../_util/styleChecker', () => ({
+vi.mock('../../_util/styleChecker', () => ({
   canUseDocElement: () => true,
   isStyleSupport: () => true,
   detectFlexGapSupported: () => true,

--- a/components/space/__tests__/image.test.ts
+++ b/components/space/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Space image', () => {

--- a/components/space/__tests__/index.test.tsx
+++ b/components/space/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 /* eslint-disable no-console */
 import React, { useState } from 'react';
 import Space from '..';
@@ -181,7 +182,7 @@ describe('Space', () => {
 
   // https://github.com/ant-design/ant-design/issues/35305
   it('should not throw duplicated key warning', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(
       <Space>
         <div key="1" />

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /* eslint-disable no-console */
 import React from 'react';
 import Space from '..';

--- a/components/spin/__tests__/delay.test.tsx
+++ b/components/spin/__tests__/delay.test.tsx
@@ -1,12 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { debounce } from 'throttle-debounce';
 import Spin from '..';
 import { waitFakeTimer } from '../../../tests/utils';
 
-jest.mock('throttle-debounce');
+vi.mock('throttle-debounce');
 (debounce as jest.Mock).mockImplementation((...args: any[]) =>
-  jest.requireActual('throttle-debounce').debounce(...args),
+  vi.requireActual('throttle-debounce').debounce(...args),
 );
 
 describe('delay spinning', () => {
@@ -18,7 +19,7 @@ describe('delay spinning', () => {
   });
 
   it('should render when delay is init set', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Spin spinning delay={100} />);
 
     expect(container.querySelector('.ant-spin-spinning')).toBeFalsy();
@@ -27,13 +28,13 @@ describe('delay spinning', () => {
 
     expect(container.querySelector('.ant-spin-spinning')).toBeTruthy();
 
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should cancel debounce function when unmount', () => {
-    const debouncedFn = jest.fn();
-    const cancel = jest.fn();
+    const debouncedFn = vi.fn();
+    const cancel = vi.fn();
     (debouncedFn as any).cancel = cancel;
     (debounce as jest.Mock).mockReturnValueOnce(debouncedFn);
     const { unmount } = render(<Spin spinning delay={100} />);
@@ -44,7 +45,7 @@ describe('delay spinning', () => {
   });
 
   it('should close immediately', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(<Spin spinning delay={500} />);
 
     await waitFakeTimer();

--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { waitFakeTimer } from '../../../tests/utils';
@@ -26,14 +27,14 @@ describe('Spin', () => {
   });
 
   it('should be controlled by spinning', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(<Spin spinning={false} />);
     expect(container.querySelector('.ant-spin-spinning')).toBeFalsy();
     rerender(<Spin spinning />);
     await waitFakeTimer();
     expect(container.querySelector('.ant-spin-spinning')).toBeTruthy();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('if indicator set null should not be render default indicator', () => {

--- a/components/statistic/__tests__/image.test.ts
+++ b/components/statistic/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Statistic image', () => {

--- a/components/statistic/__tests__/index.test.tsx
+++ b/components/statistic/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import MockDate from 'mockdate';
 import React from 'react';
@@ -26,7 +27,7 @@ describe('Statistic', () => {
   });
 
   it('customize formatter', () => {
-    const formatter = jest.fn(() => 93);
+    const formatter = vi.fn(() => 93);
     const { container } = render(<Statistic value={1128} formatter={formatter} />);
     expect(formatter).toHaveBeenCalledWith(1128);
     expect(container.querySelector('.ant-statistic-content-value')!.textContent).toEqual('93');
@@ -102,9 +103,9 @@ describe('Statistic', () => {
     });
 
     it('time going', async () => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
       const now = Date.now() + 1000;
-      const onFinish = jest.fn();
+      const onFinish = vi.fn();
 
       const { unmount } = render(<Statistic.Countdown value={now} onFinish={onFinish} />);
 
@@ -112,13 +113,13 @@ describe('Statistic', () => {
 
       unmount();
       expect(onFinish).not.toHaveBeenCalled();
-      jest.clearAllTimers();
-      jest.useRealTimers();
+      vi.clearAllTimers();
+      vi.useRealTimers();
     });
 
     it('responses hover events', () => {
-      const onMouseEnter = jest.fn();
-      const onMouseLeave = jest.fn();
+      const onMouseEnter = vi.fn();
+      const onMouseLeave = vi.fn();
       const { container } = render(
         <Statistic onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />,
       );
@@ -129,8 +130,8 @@ describe('Statistic', () => {
     });
 
     it('responses hover events for Countdown', () => {
-      const onMouseEnter = jest.fn();
-      const onMouseLeave = jest.fn();
+      const onMouseEnter = vi.fn();
+      const onMouseLeave = vi.fn();
       const { container } = render(
         <Statistic.Countdown onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} />,
       );
@@ -142,7 +143,7 @@ describe('Statistic', () => {
 
     describe('time onchange', () => {
       it("called if time has't passed", async () => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
         const deadline = Date.now() + 10 * 1000;
         let remainingTime;
 
@@ -153,29 +154,29 @@ describe('Statistic', () => {
         // container.update();
         await waitFakeTimer(100);
         expect(remainingTime).toBeGreaterThan(0);
-        jest.clearAllTimers();
-        jest.useRealTimers();
+        vi.clearAllTimers();
+        vi.useRealTimers();
       });
     });
 
     describe('time finished', () => {
       it('not call if time already passed', () => {
         const now = Date.now() - 1000;
-        const onFinish = jest.fn();
+        const onFinish = vi.fn();
         render(<Statistic.Countdown value={now} onFinish={onFinish} />);
 
         expect(onFinish).not.toHaveBeenCalled();
       });
 
       it('called if finished', async () => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
         const now = Date.now() + 10;
-        const onFinish = jest.fn();
+        const onFinish = vi.fn();
         render(<Statistic.Countdown value={now} onFinish={onFinish} />);
         await waitFakeTimer();
         expect(onFinish).toHaveBeenCalled();
-        jest.clearAllTimers();
-        jest.useRealTimers();
+        vi.clearAllTimers();
+        vi.useRealTimers();
       });
     });
   });

--- a/components/steps/__tests__/image.test.ts
+++ b/components/steps/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Steps image', () => {

--- a/components/steps/__tests__/index.test.tsx
+++ b/components/steps/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Steps from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -91,7 +92,7 @@ describe('Steps', () => {
 
   it('deprecated warning', () => {
     resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(
       <Steps>

--- a/components/switch/__tests__/image.test.ts
+++ b/components/switch/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Switch image', () => {

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Switch from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -6,7 +7,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 
-jest.mock('rc-util/lib/Dom/isVisible', () => {
+vi.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => true;
   return mockFn;
 });
@@ -17,21 +18,21 @@ describe('Switch', () => {
   rtlTest(Switch);
 
   it('should has click wave effect', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Switch />);
     fireEvent.click(container.querySelector('.ant-switch')!);
     act(() => {
-      jest.advanceTimersByTime(100);
+      vi.advanceTimersByTime(100);
     });
     expect(document.querySelector('.ant-wave')).toBeTruthy();
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('warning if set `value`', () => {
     resetWarned();
 
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const props = { value: true } as any;
     render(<Switch {...props} />);
     expect(errorSpy).toHaveBeenCalledWith(

--- a/components/switch/__tests__/wave.test.tsx
+++ b/components/switch/__tests__/wave.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import Switch from '..';
 import { waitFakeTimer, render, fireEvent } from '../../../tests/utils';
@@ -12,7 +13,7 @@ describe('click wave effect', () => {
   }
 
   it('should have click wave effect', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container } = render(<Switch />);
     await click(container);
     await click(container);
@@ -24,7 +25,7 @@ describe('click wave effect', () => {
     const event = new Event('animationend');
     Object.assign(event, { animationName: 'fadeEffect' });
     container.querySelector('.ant-switch')!.dispatchEvent(event);
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 });

--- a/components/table/__tests__/Table.expand.test.tsx
+++ b/components/table/__tests__/Table.expand.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import Table from '..';

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, test, vi } from 'vitest';
 /* eslint-disable no-unsafe-optional-chaining */
 /* eslint-disable react/no-multi-comp */
 import React, { useEffect, useState } from 'react';
@@ -79,18 +80,18 @@ describe('Table.filter', () => {
   function refreshTimer() {
     for (let i = 0; i < 3; i += 1) {
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
     }
   }
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('not show filter icon when undefined', () => {
@@ -134,7 +135,7 @@ describe('Table.filter', () => {
   });
 
   it('renders empty menu correctly', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
       createTable({
         columns: [
@@ -149,7 +150,7 @@ describe('Table.filter', () => {
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('.ant-empty')).toBeTruthy();
@@ -354,10 +355,10 @@ describe('Table.filter', () => {
 
   it('fires change event when visible change', () => {
     resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const onFilterDropdownOpenChange = jest.fn();
-    const onFilterDropdownVisibleChange = jest.fn();
+    const onFilterDropdownOpenChange = vi.fn();
+    const onFilterDropdownVisibleChange = vi.fn();
     const { container } = render(
       createTable({
         columns: [
@@ -578,7 +579,7 @@ describe('Table.filter', () => {
 
   //  Warning: An update to Item ran an effect, but was not wrapped in act(...).
   it('fires change event', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(createTable({ onChange: handleChange }));
     fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
     fireEvent.click(container.querySelectorAll('.ant-dropdown-menu-item')[0]);
@@ -595,7 +596,7 @@ describe('Table.filter', () => {
   });
 
   it('fires pagination change event', async () => {
-    const onPaginationChange = jest.fn();
+    const onPaginationChange = vi.fn();
     const { container } = render(createTable({ pagination: { onChange: onPaginationChange } }));
     fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
     fireEvent.click(container.querySelectorAll('.ant-dropdown-menu-item')[0]);
@@ -604,7 +605,7 @@ describe('Table.filter', () => {
   });
 
   it('should not fire change event when close filterDropdown without changing anything', async () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(createTable({ onChange: handleChange }));
 
     fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
@@ -613,7 +614,7 @@ describe('Table.filter', () => {
   });
 
   it('should not fire change event when close a filtered filterDropdown without changing anything', async () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(
       createTable({
         onChange: handleChange,
@@ -631,7 +632,7 @@ describe('Table.filter', () => {
   });
 
   it('three levels menu', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const filters = [
       { text: 'Upper', value: 'Upper' },
       { text: 'Lower', value: 'Lower' },
@@ -714,7 +715,7 @@ describe('Table.filter', () => {
       ['Bamboo', false],
     ].forEach(([text, value]) => {
       it(`${typeof value} type`, async () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
         const filters = [{ text, value }];
         const { container } = render(
           createTable({
@@ -855,7 +856,7 @@ describe('Table.filter', () => {
 
   // Warning: An update to Item ran an effect, but was not wrapped in act(...).
   it('confirm filter when dropdown hidden', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(
       createTable({
         columns: [
@@ -991,7 +992,7 @@ describe('Table.filter', () => {
 
   // https://github.com/ant-design/ant-design/issues/17833
   it('should not trigger onChange when blurring custom filterDropdown', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const filterDropdown = ({ setSelectedKeys }: FilterDropdownProps) => (
       <input onChange={(e) => setSelectedKeys([e.target.value])} />
     );
@@ -1015,7 +1016,7 @@ describe('Table.filter', () => {
   });
 
   it('should trigger onChange with correct params if defines custom filterDropdown', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const filterDropdown = ({ setSelectedKeys, confirm }: FilterDropdownProps) => (
       <div>
         <input onChange={(e) => setSelectedKeys([e.target.value])} />
@@ -1051,7 +1052,7 @@ describe('Table.filter', () => {
 
   it('should work as expected with complex custom filterDropdown', () => {
     let renderSelectedKeys = null;
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const filterDropdown = ({ setSelectedKeys, selectedKeys, confirm }: FilterDropdownProps) => {
       renderSelectedKeys = selectedKeys;
@@ -1137,7 +1138,7 @@ describe('Table.filter', () => {
 
   // https://github.com/ant-design/ant-design/issues/17089
   it('not crash when dynamic change filter', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const Test: React.FC<{ filters?: ColumnFilterItem[] }> = ({ filters }) => (
       <Table
@@ -1196,7 +1197,7 @@ describe('Table.filter', () => {
   });
 
   it('should support getPopupContainer', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
 
     render(
       createTable({
@@ -1213,7 +1214,7 @@ describe('Table.filter', () => {
   });
 
   it('should support getPopupContainer from ConfigProvider', () => {
-    const getPopupContainer = jest.fn((node) => node.parentNode);
+    const getPopupContainer = vi.fn((node) => node.parentNode);
 
     render(
       <ConfigProvider getPopupContainer={getPopupContainer}>
@@ -1231,7 +1232,7 @@ describe('Table.filter', () => {
   });
 
   it('pass visible prop to filterDropdown', () => {
-    const filterDropdownMock = jest.fn().mockReturnValue(<span>test</span>);
+    const filterDropdownMock = vi.fn().mockReturnValue(<span>test</span>);
     const filterDropdown = (...args: any[]) => filterDropdownMock(...args);
 
     const Test = () => (
@@ -1251,7 +1252,7 @@ describe('Table.filter', () => {
   });
 
   it('visible prop of filterDropdown changes on click', () => {
-    const filterDropdownMock = jest.fn().mockReturnValue(<span>test</span>);
+    const filterDropdownMock = vi.fn().mockReturnValue(<span>test</span>);
     const filterDropdown = (...args: any[]) => filterDropdownMock(...args);
 
     const Test: React.FC = () => (
@@ -1279,7 +1280,7 @@ describe('Table.filter', () => {
   });
 
   it('should reset pagination after filter', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(
       createTable({
         onChange: handleChange,
@@ -1308,7 +1309,7 @@ describe('Table.filter', () => {
   });
 
   it('should keep pagination current after filter', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(
       createTable({
         onChange: handleChange,
@@ -1353,7 +1354,7 @@ describe('Table.filter', () => {
 
   // https://github.com/ant-design/ant-design/issues/20854
   it('Not cache for onChange state', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       <Table
@@ -1526,7 +1527,7 @@ describe('Table.filter', () => {
   });
 
   it('with onFilter', () => {
-    const onFilter = jest.fn((value, record) => record.key === value);
+    const onFilter = vi.fn((value, record) => record.key === value);
     const columns = [{ dataIndex: 'key', filteredValue: [5], onFilter }];
     const testData = [{ key: 1 }, { key: 3 }, { key: 5 }];
     const { container } = render(<Table columns={columns} dataSource={testData} />);
@@ -1578,7 +1579,7 @@ describe('Table.filter', () => {
   });
 
   it('should not trigger onChange when filters is empty', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const Test: React.FC<{ filters?: ColumnFilterItem[] }> = ({ filters }) => (
       <Table
         onChange={onChange}
@@ -1656,7 +1657,7 @@ describe('Table.filter', () => {
 
   //  Warning: An update to Item ran an effect, but was not wrapped in act(...).
   it('should pagination.current be 1 after filtering', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const columns = [
       {
         title: 'Name',
@@ -1708,7 +1709,7 @@ describe('Table.filter', () => {
 
   // https://github.com/ant-design/ant-design/issues/30454
   it('should not trigger onFilterDropdownOpenChange when call confirm({ closeDropdown: false })', () => {
-    const onFilterDropdownOpenChange = jest.fn();
+    const onFilterDropdownOpenChange = vi.fn();
     const { container } = render(
       createTable({
         columns: [
@@ -2002,7 +2003,7 @@ describe('Table.filter', () => {
 
   describe('filter tree mode', () => {
     it('supports filter tree', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [
@@ -2015,14 +2016,14 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-tree').length).toBe(1);
       expect(container.querySelectorAll('.ant-tree-checkbox').length).toBe(5);
     });
 
     it('supports search input in filter tree', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [
@@ -2036,7 +2037,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-tree').length).toBe(1);
       expect(container.querySelectorAll('.ant-input').length).toBe(1);
@@ -2044,7 +2045,7 @@ describe('Table.filter', () => {
     });
 
     it('supports search input in filter menu', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [{ ...column, filterSearch: true }],
@@ -2052,7 +2053,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-search').length).toBe(1);
       expect(container.querySelectorAll('.ant-input').length).toBe(1);
@@ -2060,7 +2061,7 @@ describe('Table.filter', () => {
     });
 
     it('should skip search when filters[0].text is ReactNode', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container, unmount } = render(
         createTable({
           columns: [
@@ -2088,7 +2089,7 @@ describe('Table.filter', () => {
 
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-search').length).toBe(1);
       expect(container.querySelectorAll('.ant-input').length).toBe(1);
@@ -2100,7 +2101,7 @@ describe('Table.filter', () => {
     });
 
     it('should supports filterSearch has type of function', () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container, unmount } = render(
         createTable({
           columns: [
@@ -2118,7 +2119,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-search').length).toBe(1);
       expect(container.querySelectorAll('.ant-input').length).toBe(1);
@@ -2131,7 +2132,7 @@ describe('Table.filter', () => {
     });
 
     it('should supports filterSearch has type of function when filterMode is tree', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [
@@ -2151,7 +2152,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-tree').length).toBe(1);
       expect(container.querySelectorAll('.ant-input').length).toBe(1);
@@ -2160,7 +2161,7 @@ describe('Table.filter', () => {
     });
 
     it('supports check all items', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [{ ...column, filterMode: 'tree', filterSearch: true }],
@@ -2168,7 +2169,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-checkall').length).toBe(1);
       expect(container.querySelector('.ant-table-filter-dropdown-checkall')?.textContent).toBe(
@@ -2186,7 +2187,7 @@ describe('Table.filter', () => {
     });
 
     it('supports check item by selecting it', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [
@@ -2200,7 +2201,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelectorAll('.ant-table-filter-dropdown-checkall').length).toBe(1);
       expect(container.querySelector('.ant-table-filter-dropdown-checkall')?.textContent).toBe(
@@ -2221,7 +2222,7 @@ describe('Table.filter', () => {
     });
 
     it('select-all checkbox should change when all items are selected', () => {
-      jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
       const { container } = render(
         createTable({
           columns: [
@@ -2238,7 +2239,7 @@ describe('Table.filter', () => {
       );
       fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       fireEvent.click(container.querySelectorAll('.ant-tree-node-content-wrapper')[0]);
       fireEvent.click(container.querySelectorAll('.ant-tree-node-content-wrapper')[1]);
@@ -2252,7 +2253,7 @@ describe('Table.filter', () => {
   });
 
   it('filterMultiple is false - check item', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const { container } = render(
       createTable({
         columns: [{ ...column, filterMode: 'tree', filterMultiple: false }],
@@ -2261,7 +2262,7 @@ describe('Table.filter', () => {
 
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tree-checkbox').length).toBe(5);
     expect(container.querySelector('.ant-table-filter-dropdown-checkall')).toBe(null);
@@ -2293,7 +2294,7 @@ describe('Table.filter', () => {
   });
 
   it('filterMultiple is false - select item', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const { container } = render(
       createTable({
         columns: [
@@ -2307,7 +2308,7 @@ describe('Table.filter', () => {
     );
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelectorAll('.ant-tree-checkbox').length).toBe(5);
@@ -2339,7 +2340,7 @@ describe('Table.filter', () => {
   });
 
   it('should select children when select parent', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const { container } = render(
       createTable({
         columns: [
@@ -2364,7 +2365,7 @@ describe('Table.filter', () => {
     );
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     // check parentnode
 
@@ -2473,7 +2474,7 @@ describe('Table.filter', () => {
   });
 
   it('filterDropdown should support filterResetToDefaultFilteredValue', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     const columnFilter: ColumnGroupType<any> | ColumnType<any> = {
       ...column,
@@ -2489,7 +2490,7 @@ describe('Table.filter', () => {
     );
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tree-checkbox-checked').length).toBe(1);
 
@@ -2511,7 +2512,7 @@ describe('Table.filter', () => {
 
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.click(container.querySelector('.ant-table-filter-dropdown-checkall')!);
     expect(container.querySelectorAll('.ant-tree-checkbox-checked').length).toBe(5);
@@ -2521,7 +2522,7 @@ describe('Table.filter', () => {
   });
 
   it('filterDropdown should not override customize Menu selectable', () => {
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
 
     const { container } = render(
       createTable({
@@ -2549,7 +2550,7 @@ describe('Table.filter', () => {
     // Open Filter
     fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     // Click Item
@@ -2563,7 +2564,7 @@ describe('Table.filter', () => {
 
     beforeEach(() => {
       resetWarned();
-      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       errorSpy.mockReset();
     });
 
@@ -2688,7 +2689,7 @@ describe('Table.filter', () => {
   });
 
   it('title render function support `filter`', () => {
-    const title = jest.fn(() => 'RenderTitle');
+    const title = vi.fn(() => 'RenderTitle');
     const { container } = render(
       createTable({
         columns: [
@@ -2709,8 +2710,8 @@ describe('Table.filter', () => {
     );
   });
   it('should be hidden and not commit when call close()', () => {
-    const onFilterDropdownOpenChange = jest.fn();
-    const onFilter = jest.fn();
+    const onFilterDropdownOpenChange = vi.fn();
+    const onFilter = vi.fn();
     const { container } = render(
       createTable({
         columns: [

--- a/components/table/__tests__/Table.order.test.tsx
+++ b/components/table/__tests__/Table.order.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { TableProps } from '..';
 import Table from '..';
@@ -8,7 +9,7 @@ describe('Table.order', () => {
   window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16);
   window.cancelAnimationFrame = window.clearTimeout;
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();

--- a/components/table/__tests__/Table.pagination.test.tsx
+++ b/components/table/__tests__/Table.pagination.test.tsx
@@ -1,5 +1,6 @@
+import { describe, it, expect, vi } from 'vitest';
 /* eslint-disable import/first */
-jest.mock('../../_util/scrollTo');
+vi.mock('../../_util/scrollTo');
 
 import React from 'react';
 import type { TablePaginationConfig, TableProps } from '..';
@@ -154,8 +155,8 @@ describe('Table.pagination', () => {
   });
 
   it('fires change event', () => {
-    const handleChange = jest.fn();
-    const handlePaginationChange = jest.fn();
+    const handleChange = vi.fn();
+    const handlePaginationChange = vi.fn();
     const noop = () => {};
     const { container } = render(
       createTable({
@@ -233,8 +234,8 @@ describe('Table.pagination', () => {
 
   // https://github.com/ant-design/ant-design/issues/24913
   it('should called onChange when pageSize change', () => {
-    const onChange = jest.fn();
-    const onShowSizeChange = jest.fn();
+    const onChange = vi.fn();
+    const onShowSizeChange = vi.fn();
     const { container } = render(
       createTable({
         pagination: { current: 1, pageSize: 10, total: 200, onChange, onShowSizeChange },
@@ -265,8 +266,8 @@ describe('Table.pagination', () => {
 
   // https://github.com/ant-design/ant-design/issues/29175
   it('should change page to max page count when pageSize change without pagination.total', () => {
-    const onChange = jest.fn();
-    const onShowSizeChange = jest.fn();
+    const onChange = vi.fn();
+    const onShowSizeChange = vi.fn();
     const { container } = render(
       createTable({
         pagination: {
@@ -289,8 +290,8 @@ describe('Table.pagination', () => {
   });
 
   it('should change page to max page count when pageSize change with pagination.total', () => {
-    const onChange = jest.fn();
-    const onShowSizeChange = jest.fn();
+    const onChange = vi.fn();
+    const onShowSizeChange = vi.fn();
     const total = 20000;
     const { container } = render(
       createTable({
@@ -317,8 +318,8 @@ describe('Table.pagination', () => {
 
   // https://github.com/ant-design/ant-design/issues/29175
   it('should not change page to max page if current is not greater max page when pageSize change', () => {
-    const onChange = jest.fn();
-    const onShowSizeChange = jest.fn();
+    const onChange = vi.fn();
+    const onShowSizeChange = vi.fn();
     const { container } = render(
       createTable({
         pagination: {
@@ -337,7 +338,7 @@ describe('Table.pagination', () => {
   });
 
   it('should reset current to max page when data length is cut', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container, rerender } = render(
       createTable({
         pagination: {
@@ -423,8 +424,8 @@ describe('Table.pagination', () => {
   });
 
   it('ajax render should keep display by the dataSource', () => {
-    const onChange = jest.fn();
-    const onPaginationChange = jest.fn();
+    const onChange = vi.fn();
+    const onPaginationChange = vi.fn();
 
     const { container } = render(
       createTable({
@@ -464,9 +465,9 @@ describe('Table.pagination', () => {
   });
 
   it('onShowSizeChange should trigger once', () => {
-    jest.useFakeTimers();
-    const onShowSizeChange = jest.fn();
-    const onChange = jest.fn();
+    vi.useFakeTimers();
+    const onShowSizeChange = vi.fn();
+    const onChange = vi.fn();
     const { container } = render(
       createTable({
         pagination: {
@@ -481,14 +482,14 @@ describe('Table.pagination', () => {
     fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
     //  resolve Warning: An update to Align ran an effect, but was not wrapped in act(...)
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-select-item-option').length).toBe(4);
     fireEvent.click(container.querySelectorAll('.ant-select-item-option')[3]);
     expect(onShowSizeChange).toHaveBeenCalledTimes(1);
     expect(onShowSizeChange).toHaveBeenLastCalledWith(1, 100);
     expect(onChange).toHaveBeenCalled();
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should support current in pagination', () => {
@@ -537,7 +538,7 @@ describe('Table.pagination', () => {
   });
 
   it('should call onChange when change pagination size', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       createTable({
         pagination: {
@@ -554,7 +555,7 @@ describe('Table.pagination', () => {
 
   it('dynamic warning', () => {
     resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const dynamicData = [];
     for (let i = 0; i < 15; i += 1) {

--- a/components/table/__tests__/Table.rowSelection.test.tsx
+++ b/components/table/__tests__/Table.rowSelection.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { TableProps } from '..';
 import Table from '..';
@@ -10,7 +11,7 @@ describe('Table.rowSelection', () => {
   window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16);
   window.cancelAnimationFrame = window.clearTimeout;
 
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -207,10 +208,10 @@ describe('Table.rowSelection', () => {
 
   it('fires change & select events', () => {
     const order: string[] = [];
-    const handleChange = jest.fn().mockImplementation(() => {
+    const handleChange = vi.fn().mockImplementation(() => {
       order.push('onChange');
     });
-    const handleSelect = jest.fn().mockImplementation(() => {
+    const handleSelect = vi.fn().mockImplementation(() => {
       order.push('onSelect');
     });
     const rowSelection = {
@@ -234,13 +235,13 @@ describe('Table.rowSelection', () => {
 
   it('fires selectMulti event', () => {
     const order: string[] = [];
-    const handleSelectMulti = jest.fn().mockImplementation(() => {
+    const handleSelectMulti = vi.fn().mockImplementation(() => {
       order.push('onSelectMultiple');
     });
-    const handleSelect = jest.fn().mockImplementation(() => {
+    const handleSelect = vi.fn().mockImplementation(() => {
       order.push('onSelect');
     });
-    const handleChange = jest.fn().mockImplementation(() => {
+    const handleChange = vi.fn().mockImplementation(() => {
       order.push('onChange');
     });
     const rowSelection = {
@@ -294,8 +295,8 @@ describe('Table.rowSelection', () => {
   });
 
   it('reset last select key after performing select and bulk operations', async () => {
-    jest.useFakeTimers();
-    const onChange = jest.fn();
+    vi.useFakeTimers();
+    const onChange = vi.fn();
 
     const { container, baseElement } = render(
       createTable({
@@ -353,7 +354,7 @@ describe('Table.rowSelection', () => {
     // Reset last select key when bulk operations
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     fireEvent.click(baseElement.querySelector('li.ant-dropdown-menu-item')!);
     expect(onChange).toHaveBeenLastCalledWith([]);
@@ -362,15 +363,15 @@ describe('Table.rowSelection', () => {
     });
     expect(onChange).toHaveBeenLastCalledWith([0]);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('fires selectAll event', () => {
     const order: string[] = [];
-    const handleSelectAll = jest.fn().mockImplementation(() => {
+    const handleSelectAll = vi.fn().mockImplementation(() => {
       order.push('onSelectAll');
     });
-    const handleChange = jest.fn().mockImplementation(() => {
+    const handleChange = vi.fn().mockImplementation(() => {
       order.push('onChange');
     });
     const rowSelection = {
@@ -391,8 +392,8 @@ describe('Table.rowSelection', () => {
   });
 
   it('works with selectAll option inside selection menu', () => {
-    jest.useFakeTimers();
-    const handleChange = jest.fn();
+    vi.useFakeTimers();
+    const handleChange = vi.fn();
     const rowSelection = {
       onChange: handleChange,
       selections: true,
@@ -402,7 +403,7 @@ describe('Table.rowSelection', () => {
     // Open
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     fireEvent.click(container.querySelectorAll('.ant-dropdown-menu-item')[0]);
@@ -411,27 +412,27 @@ describe('Table.rowSelection', () => {
   });
 
   it('render with default selection correctly', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const rowSelection = {
       selections: true,
     };
     const { container } = render(createTable({ rowSelection }));
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('.ant-dropdown')).toMatchSnapshot();
   });
 
   it('fires selectInvert event', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
     const order: string[] = [];
-    const handleSelectInvert = jest.fn().mockImplementation(() => {
+    const handleSelectInvert = vi.fn().mockImplementation(() => {
       order.push('onSelectInvert');
     });
-    const handleChange = jest.fn().mockImplementation(() => {
+    const handleChange = vi.fn().mockImplementation(() => {
       order.push('onChange');
     });
     const rowSelection = {
@@ -446,7 +447,7 @@ describe('Table.rowSelection', () => {
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     fireEvent.click(container.querySelectorAll('li.ant-dropdown-menu-item')[1]);
@@ -454,16 +455,16 @@ describe('Table.rowSelection', () => {
     expect(handleSelectInvert).toHaveBeenCalledWith([1, 2, 3]);
     expect(order).toEqual(['onChange', 'onSelectInvert', 'onChange']);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('fires selectNone event', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const order: string[] = [];
-    const handleChange = jest.fn().mockImplementation(() => {
+    const handleChange = vi.fn().mockImplementation(() => {
       order.push('onChange');
     });
-    const handleSelectNone = jest.fn().mockImplementation(() => {
+    const handleSelectNone = vi.fn().mockImplementation(() => {
       order.push('onSelectNone');
     });
     const rowSelection = {
@@ -477,7 +478,7 @@ describe('Table.rowSelection', () => {
     // Open
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     const dropdownMenuItems = container.querySelectorAll('.ant-dropdown-menu-item');
     fireEvent.click(dropdownMenuItems[dropdownMenuItems.length - 1]);
@@ -487,9 +488,9 @@ describe('Table.rowSelection', () => {
   });
 
   it('fires selection event', () => {
-    jest.useFakeTimers();
-    const handleSelectOdd = jest.fn();
-    const handleSelectEven = jest.fn();
+    vi.useFakeTimers();
+    const handleSelectOdd = vi.fn();
+    const handleSelectEven = vi.fn();
     const rowSelection = {
       selections: [
         Table.SELECTION_ALL,
@@ -511,7 +512,7 @@ describe('Table.rowSelection', () => {
     // Open
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     const dropdownMenuItems = container.querySelectorAll('.ant-dropdown-menu-item');
@@ -535,8 +536,8 @@ describe('Table.rowSelection', () => {
     const getCheckboxProps = (record: any) => record;
 
     it('SELECTION_ALL', () => {
-      jest.useFakeTimers();
-      const onChange = jest.fn();
+      vi.useFakeTimers();
+      const onChange = vi.fn();
       const { container } = render(
         createTable({
           dataSource: presetData,
@@ -552,7 +553,7 @@ describe('Table.rowSelection', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       fireEvent.click(container.querySelector('li.ant-dropdown-menu-item')!);
@@ -560,8 +561,8 @@ describe('Table.rowSelection', () => {
     });
 
     it('SELECTION_INVERT', () => {
-      jest.useFakeTimers();
-      const onChange = jest.fn();
+      vi.useFakeTimers();
+      const onChange = vi.fn();
       const { container } = render(
         createTable({
           dataSource: presetData,
@@ -577,7 +578,7 @@ describe('Table.rowSelection', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       fireEvent.click(container.querySelector('li.ant-dropdown-menu-item')!);
@@ -586,8 +587,8 @@ describe('Table.rowSelection', () => {
     });
 
     it('SELECTION_NONE', () => {
-      jest.useFakeTimers();
-      const onChange = jest.fn();
+      vi.useFakeTimers();
+      const onChange = vi.fn();
       const { container } = render(
         createTable({
           dataSource: presetData,
@@ -603,7 +604,7 @@ describe('Table.rowSelection', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
 
       fireEvent.click(container.querySelector('li.ant-dropdown-menu-item')!);
@@ -621,9 +622,9 @@ describe('Table.rowSelection', () => {
   });
 
   it('handle custom selection onSelect correctly when hide default selection options', () => {
-    jest.useFakeTimers();
-    const handleSelectOdd = jest.fn();
-    const handleSelectEven = jest.fn();
+    vi.useFakeTimers();
+    const handleSelectOdd = vi.fn();
+    const handleSelectEven = vi.fn();
     const rowSelection = {
       selections: [
         {
@@ -643,7 +644,7 @@ describe('Table.rowSelection', () => {
     // Open
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     const dropdownMenuItems = container.querySelectorAll('li.ant-dropdown-menu-item');
@@ -881,7 +882,7 @@ describe('Table.rowSelection', () => {
       },
     ];
 
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const rowSelection = {
       onChange,
     };
@@ -969,7 +970,7 @@ describe('Table.rowSelection', () => {
 
   // https://github.com/ant-design/ant-design/issues/16614
   it('should get selectedRows correctly when set childrenColumnName', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const newData = [
       {
         key: 1,
@@ -1147,7 +1148,7 @@ describe('Table.rowSelection', () => {
   });
 
   it('should onRowClick not called when checkbox clicked', () => {
-    const onRowClick = jest.fn();
+    const onRowClick = vi.fn();
 
     const { container } = render(
       createTable({
@@ -1166,17 +1167,17 @@ describe('Table.rowSelection', () => {
     const rowSelection = {
       selections: true,
     };
-    const getPopupContainer = jest.fn((node) => node);
+    const getPopupContainer = vi.fn((node) => node);
     const { container } = render(
       createTable({
         rowSelection,
         getPopupContainer,
       }),
     );
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.firstChild).toMatchSnapshot();
     expect(getPopupContainer).toHaveBeenCalled();
@@ -1193,16 +1194,16 @@ describe('Table.rowSelection', () => {
         })}
       </ConfigProvider>,
     );
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('Table selection should check', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Table
         dataSource={[{ name: 'light', sub: [{ name: 'bamboo' }] }]}
@@ -1258,7 +1259,7 @@ describe('Table.rowSelection', () => {
     ];
     describe('supports checkStrictly', () => {
       it('use data entity key', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
 
         const table = createTable({
           dataSource: dataWithChildren,
@@ -1284,7 +1285,7 @@ describe('Table.rowSelection', () => {
         expect(onChange.mock.calls[1][0]).toEqual([4, 5]);
       });
       it('use function rowkey', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
         const table = createTable({
           dataSource: dataWithChildren,
           defaultExpandAllRows: true,
@@ -1324,7 +1325,7 @@ describe('Table.rowSelection', () => {
         expect(onChange.mock.calls[1][0]).toEqual(['Jerry Jack', 'Jerry Lucy']);
       });
       it('use string rowkey', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
         const table = createTable({
           dataSource: dataWithChildren,
           defaultExpandAllRows: true,
@@ -1378,7 +1379,7 @@ describe('Table.rowSelection', () => {
         expect(getIndeterminateSelection(container)).toEqual([3]);
       });
       it('works with disabled checkbox', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
 
         const table = createTable({
           dataSource: dataWithChildren,
@@ -1410,7 +1411,7 @@ describe('Table.rowSelection', () => {
         expect(onChange.mock.calls[2][0]).toEqual([9]);
       });
       it('works with disabled checkbox and function rowkey', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
 
         const table = createTable({
           dataSource: dataWithChildren,
@@ -1451,7 +1452,7 @@ describe('Table.rowSelection', () => {
         expect(onChange.mock.calls[2][0]).toEqual(['Jerry Tom Tom']);
       });
       it('works with disabled checkbox and string rowkey', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
 
         const table = createTable({
           dataSource: dataWithChildren,
@@ -1493,7 +1494,7 @@ describe('Table.rowSelection', () => {
       });
 
       it('should support `childrenColumnName`', () => {
-        const onChange = jest.fn();
+        const onChange = vi.fn();
 
         const table = createTable({
           dataSource: [
@@ -1547,7 +1548,7 @@ describe('Table.rowSelection', () => {
 
   describe('cache with selected keys', () => {
     it('default not cache', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container, rerender } = render(
         <Table
           dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
@@ -1566,7 +1567,7 @@ describe('Table.rowSelection', () => {
     });
 
     it('cache with preserveSelectedRowKeys', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container, rerender } = render(
         <Table
           dataSource={[{ name: 'light' }, { name: 'bamboo' }]}
@@ -1594,7 +1595,7 @@ describe('Table.rowSelection', () => {
     });
 
     it('works with receive selectedRowKeys from [] to undefined', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const dataSource = [{ name: 'Jack' }];
       const { container, rerender } = render(
         <Table
@@ -1617,7 +1618,7 @@ describe('Table.rowSelection', () => {
     });
 
     it('works with selectionType radio receive selectedRowKeys from [] to undefined', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const dataSource = [{ name: 'Jack' }];
       const { container, rerender } = render(
         <Table
@@ -1640,7 +1641,7 @@ describe('Table.rowSelection', () => {
 
     it('selectedRows ant selectedKeys should keep sync in initial state', () => {
       const dataSource = [{ name: 'Jack' }, { name: 'Tom' }, { name: 'Lucy' }, { name: 'John' }];
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const rowSelection = {
         preserveSelectedRowKeys: true,
         onChange,

--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import type { ColumnType, TableProps } from '..';
@@ -232,7 +233,7 @@ describe('Table.sorter', () => {
   });
 
   it('fires change event', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(createTable({ onChange: handleChange }));
 
     // ascent
@@ -260,13 +261,13 @@ describe('Table.sorter', () => {
 
   it('hover header show sorter tooltip', () => {
     // tooltip has delay
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(createTable());
 
     // default show sorter tooltip
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
@@ -276,7 +277,7 @@ describe('Table.sorter', () => {
     rerender(createTable({ showSorterTooltip: false }));
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeFalsy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
@@ -287,7 +288,7 @@ describe('Table.sorter', () => {
     );
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
@@ -301,7 +302,7 @@ describe('Table.sorter', () => {
     );
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeFalsy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
@@ -309,14 +310,14 @@ describe('Table.sorter', () => {
 
   it('should show correct tooltip when showSorterTooltip is an object', () => {
     // basically copied from 'hover header show sorter tooltip'
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(
       createTable({ showSorterTooltip: { placement: 'bottom', title: 'static title' } }),
     );
 
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
@@ -324,7 +325,7 @@ describe('Table.sorter', () => {
     // Root to false
     rerender(createTable({ showSorterTooltip: false }));
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeFalsy();
 
@@ -337,7 +338,7 @@ describe('Table.sorter', () => {
     );
     fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
@@ -350,7 +351,7 @@ describe('Table.sorter', () => {
       }),
     );
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelector('.ant-tooltip-open')).toBeFalsy();
   });
@@ -701,8 +702,8 @@ describe('Table.sorter', () => {
   });
 
   it('pagination back', () => {
-    const onPageChange = jest.fn();
-    const onChange = jest.fn();
+    const onPageChange = vi.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       createTable({
@@ -726,7 +727,7 @@ describe('Table.sorter', () => {
   });
 
   it('should support onHeaderCell in sort column', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <Table columns={[{ title: 'title', onHeaderCell: () => ({ onClick }), sorter: true }]} />,
     );
@@ -943,7 +944,7 @@ describe('Table.sorter', () => {
       },
     ];
 
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const dataProp = { data: groupData };
     const { container } = render(
       <Table columns={groupColumns} {...dataProp} onChange={onChange} />,
@@ -1036,7 +1037,7 @@ describe('Table.sorter', () => {
       },
     ];
 
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       <Table columns={columns} dataSource={tableData} onChange={onChange} />,

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterAll, it, expect, vi } from 'vitest';
 import { ConfigProvider } from 'antd';
 import React, { useRef } from 'react';
 import type { TableProps } from '..';
@@ -12,7 +13,7 @@ describe('Table', () => {
   mountTest(Table);
   rtlTest(Table);
 
-  const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterAll(() => {
     warnSpy.mockRestore();
@@ -71,7 +72,7 @@ describe('Table', () => {
   });
 
   it('loading with Spin', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const loading = {
       spinning: false,
       delay: 500,
@@ -86,21 +87,21 @@ describe('Table', () => {
     await waitFakeTimer();
     rerender(<Table loading />);
     expect(container.querySelectorAll('.ant-spin')).toHaveLength(1);
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   // https://github.com/ant-design/ant-design/issues/22733
   it('support loading tip', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container, rerender } = render(<Table loading={{ tip: 'loading...' }} />);
     await waitFakeTimer();
     rerender(
       <Table loading={{ tip: 'loading...', loading: true } as TableProps<any>['loading']} />,
     );
     expect(container.querySelectorAll('.ant-spin')).toHaveLength(1);
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('props#columnsPageRange and props#columnsPageSize do not warn anymore', () => {
@@ -109,8 +110,8 @@ describe('Table', () => {
       { key: '2', age: 42 },
     ];
 
-    const columnsPageRange = jest.fn();
-    const columnsPageSize = jest.fn();
+    const columnsPageRange = vi.fn();
+    const columnsPageSize = vi.fn();
     const props = { columnsPageRange, columnsPageSize };
     render(
       <Table dataSource={data} rowKey="key" {...props}>
@@ -127,7 +128,7 @@ describe('Table', () => {
   });
 
   it('support onHeaderCell', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(
       <Table columns={[{ title: 'title', onHeaderCell: () => ({ onClick }) }]} />,
     );
@@ -164,7 +165,7 @@ describe('Table', () => {
 
   it('prevent touch event', () => {
     // prevent touch event, 原来的用例感觉是少了 touchmove 调用判断
-    const touchmove = jest.fn();
+    const touchmove = vi.fn();
     const { container } = render(
       <Table
         columns={[

--- a/components/table/__tests__/empty.test.tsx
+++ b/components/table/__tests__/empty.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import React from 'react';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import type { ColumnsType } from '..';

--- a/components/table/__tests__/image.test.ts
+++ b/components/table/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Table image', () => {

--- a/components/table/__tests__/type.test.tsx
+++ b/components/table/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import type { ColumnProps } from '..';
 import type { TreeColumnFilterItem } from '../hooks/useFilter/FilterDropdown';

--- a/components/tabs/__tests__/animated.test.tsx
+++ b/components/tabs/__tests__/animated.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { renderHook } from '../../../tests/utils';
 import useAnimateConfig from '../hooks/useAnimateConfig';
 

--- a/components/tabs/__tests__/image.test.ts
+++ b/components/tabs/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tabs image', () => {

--- a/components/tabs/__tests__/index.test.tsx
+++ b/components/tabs/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
 import React from 'react';
 import Tabs from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -24,7 +25,7 @@ describe('Tabs', () => {
     let wrapper: ReturnType<typeof render>['container'];
 
     beforeEach(() => {
-      handleEdit = jest.fn();
+      handleEdit = vi.fn();
       const { container } = render(
         <Tabs type="editable-card" onEdit={handleEdit}>
           <TabPane tab="foo" key="1">
@@ -80,7 +81,7 @@ describe('Tabs', () => {
   });
 
   it('warning for onNextClick', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const onNextClick = { onNextClick() {} } as any;
     render(<Tabs {...onNextClick} />);
     expect(errorSpy).toHaveBeenCalledWith(
@@ -110,7 +111,7 @@ describe('Tabs', () => {
 
   it('deprecated warning', () => {
     resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(
       <Tabs>

--- a/components/tag/__tests__/image.test.ts
+++ b/components/tag/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tag image', () => {

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import { Simulate } from 'react-dom/test-utils';
 
@@ -10,14 +11,14 @@ import { act, render, fireEvent } from '../../../tests/utils';
 
 (global as any).isVisible = true;
 
-jest.mock('rc-util/lib/Dom/isVisible', () => {
+vi.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => (global as any).isVisible;
   return mockFn;
 });
 
 function waitRaf() {
   act(() => {
-    jest.advanceTimersByTime(100);
+    vi.advanceTimersByTime(100);
   });
 }
 
@@ -28,22 +29,22 @@ describe('Tag', () => {
   rtlTest(Tag.CheckableTag);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should be closable', () => {
-    const onClose = jest.fn();
+    const onClose = vi.fn();
     const { container } = render(<Tag closable onClose={onClose} />);
     expect(container.querySelectorAll('.anticon-close').length).toBe(1);
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
     fireEvent.click(container.querySelectorAll('.anticon-close')[0]);
     expect(onClose).toHaveBeenCalled();
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(0);
   });
@@ -57,13 +58,13 @@ describe('Tag', () => {
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
     fireEvent.click(container.querySelectorAll('.anticon-close')[0]);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
   });
 
   it('should trigger onClick', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<Tag onClick={onClick} />);
     const target = container.querySelectorAll('.ant-tag')[0];
     Simulate.click(target);
@@ -81,7 +82,7 @@ describe('Tag', () => {
   });
 
   it('should trigger onClick on CheckableTag', () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     const { container } = render(<Tag.CheckableTag checked={false} onClick={onClick} />);
     const target = container.querySelectorAll('.ant-tag')[0];
     Simulate.click(target);
@@ -100,8 +101,8 @@ describe('Tag', () => {
 
   // https://github.com/ant-design/ant-design/issues/20344
   it('should not trigger onClick when click close icon', () => {
-    const onClose = jest.fn();
-    const onClick = jest.fn();
+    const onClose = vi.fn();
+    const onClick = vi.fn();
     const { container } = render(<Tag closable onClose={onClose} onClick={onClick} />);
     fireEvent.click(container.querySelectorAll('.anticon-close')[0]);
     expect(onClose).toHaveBeenCalled();
@@ -110,7 +111,7 @@ describe('Tag', () => {
 
   it('deprecated warning', () => {
     resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(<Tag visible={false} />);
     expect(errSpy).toHaveBeenCalledWith(
@@ -128,13 +129,13 @@ describe('Tag', () => {
 
       rerender(<Tag visible={false} />);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelector('.ant-tag-hidden')).toBeTruthy();
 
       rerender(<Tag visible />);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelector('.ant-tag-hidden')).toBeFalsy();
     });
@@ -145,13 +146,13 @@ describe('Tag', () => {
 
       rerender(<Tag visible />);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelector('.ant-tag-hidden')).toBeFalsy();
 
       rerender(<Tag visible={false} />);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(container.querySelector('.ant-tag-hidden')).toBeTruthy();
     });
@@ -159,7 +160,7 @@ describe('Tag', () => {
 
   describe('CheckableTag', () => {
     it('support onChange', () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const { container } = render(<Tag.CheckableTag checked={false} onChange={onChange} />);
       fireEvent.click(container.querySelectorAll('.ant-tag')[0]);
       expect(onChange).toHaveBeenCalledWith(true);

--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { Theme } from '@ant-design/cssinjs';
 import * as React from 'react';
 import genRadius from '../themes/shared/genRadius';

--- a/components/theme/__tests__/util.test.tsx
+++ b/components/theme/__tests__/util.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import getAlphaColor from '../util/getAlphaColor';
 
 describe('util', () => {

--- a/components/time-picker/__tests__/image.test.ts
+++ b/components/time-picker/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('TimePicker image', () => {

--- a/components/time-picker/__tests__/index.test.tsx
+++ b/components/time-picker/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import React from 'react';
@@ -11,7 +12,7 @@ import { render } from '../../../tests/utils';
 dayjs.extend(customParseFormat);
 
 describe('TimePicker', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();

--- a/components/time-picker/__tests__/type.test.tsx
+++ b/components/time-picker/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import TimePicker from '..';
 

--- a/components/timeline/__tests__/image.test.ts
+++ b/components/timeline/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Timeline image', () => {

--- a/components/timeline/__tests__/index.test.tsx
+++ b/components/timeline/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import type { TimelineProps } from '..';
 import TimeLine from '..';
@@ -31,7 +32,7 @@ describe('TimeLine', () => {
 
   describe('render TimeLine.Item', () => {
     it('TimeLine.Item  should correctly', () => {
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const { container } = render(
         <TimeLine reverse>

--- a/components/tooltip/__tests__/image.test.ts
+++ b/components/tooltip/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tooltip image', () => {

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, beforeAll, it, expect, vi } from 'vitest';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -20,11 +21,11 @@ describe('Tooltip', () => {
   mountTest(Tooltip);
   rtlTest(Tooltip);
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
   afterEach(() => {
-    jest.useRealTimers();
-    jest.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllTimers();
   });
 
   beforeAll(() => {
@@ -34,7 +35,7 @@ describe('Tooltip', () => {
   });
 
   it('check `onOpenChange` arguments', async () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const ref = React.createRef<any>();
 
     const { container, rerender } = render(
@@ -116,7 +117,7 @@ describe('Tooltip', () => {
   });
 
   it('should hide when mouse leave native disabled button', async () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const ref = React.createRef<any>();
 
     const { container } = render(
@@ -152,7 +153,7 @@ describe('Tooltip', () => {
   describe('should hide when mouse leave antd disabled component', () => {
     function testComponent(name: string, Component: typeof Button | typeof Switch) {
       it(name, async () => {
-        const onOpenChange = jest.fn();
+        const onOpenChange = vi.fn();
         const ref = React.createRef<any>();
         const { container } = render(
           <Tooltip
@@ -205,7 +206,7 @@ describe('Tooltip', () => {
   });
 
   it('should warn for arrowPointAtCenter', async () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(
       <Tooltip
@@ -243,7 +244,7 @@ describe('Tooltip', () => {
   });
 
   it('should works for date picker', async () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const ref = React.createRef<any>();
 
     const { container } = render(
@@ -269,7 +270,7 @@ describe('Tooltip', () => {
   });
 
   it('should works for input group', async () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const ref = React.createRef<any>();
     const { container } = render(
       <Tooltip title="hello" onOpenChange={onOpenChange} ref={ref}>
@@ -412,7 +413,7 @@ describe('Tooltip', () => {
   });
 
   it('should work with loading switch', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <Tooltip
         title="loading tips"
@@ -431,7 +432,7 @@ describe('Tooltip', () => {
   });
 
   it('should work with disabled Radio', () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const { container } = render(
       <Tooltip
         title="loading tips"
@@ -450,7 +451,7 @@ describe('Tooltip', () => {
   });
 
   it('should work with Fragment children', async () => {
-    const onOpenChange = jest.fn();
+    const onOpenChange = vi.fn();
     const ref = React.createRef<any>();
 
     const { container } = render(
@@ -484,7 +485,7 @@ describe('Tooltip', () => {
 
   it('deprecated warning', async () => {
     resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     // defaultVisible
     const { container, rerender } = render(
@@ -541,8 +542,8 @@ describe('Tooltip', () => {
     );
 
     // Event Trigger
-    const onVisibleChange = jest.fn();
-    const afterVisibleChange = jest.fn();
+    const onVisibleChange = vi.fn();
+    const afterVisibleChange = vi.fn();
     rerender(
       <Tooltip
         visible
@@ -594,11 +595,11 @@ describe('Tooltip', () => {
 
   it('use ref.current.forcePopupAlign', async () => {
     const ref = React.createRef<any>();
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Tooltip open ref={ref} />);
     act(() => {
       ref.current.forcePopupAlign();
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
     expect(error).toHaveBeenCalled();
     error.mockRestore();

--- a/components/tooltip/__tests__/type.test.tsx
+++ b/components/tooltip/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import * as React from 'react';
 import Tooltip from '..';
 

--- a/components/tour/__tests__/image.test.ts
+++ b/components/tour/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tooltip tour', () => {

--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 /* eslint-disable react/no-unstable-nested-components */
 import React, { useEffect, useRef } from 'react';
 import Tour from '..';
@@ -54,8 +55,8 @@ describe('Tour', () => {
   });
 
   it('steps props indicatorsRender', () => {
-    const onClickMock = jest.fn();
-    const indicatorsRenderMock = jest.fn();
+    const onClickMock = vi.fn();
+    const indicatorsRenderMock = vi.fn();
     const App: React.FC = () => {
       const coverBtnRef = useRef<HTMLButtonElement>(null);
       return (

--- a/components/transfer/__tests__/customize.test.tsx
+++ b/components/transfer/__tests__/customize.test.tsx
@@ -1,10 +1,11 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render } from '../../../tests/utils';
 import type { TransferProps } from '../index';
 import Transfer from '../index';
 
 describe('Transfer.Customize', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -15,7 +16,7 @@ describe('Transfer.Customize', () => {
   });
 
   it('props#body does not work anymore', () => {
-    const body = jest.fn();
+    const body = vi.fn();
     const props = { body } as TransferProps<any>;
     render(<Transfer {...props} />);
     expect(errorSpy).not.toHaveBeenCalled();

--- a/components/transfer/__tests__/dropdown.test.tsx
+++ b/components/transfer/__tests__/dropdown.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 /* eslint no-use-before-define: "off" */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -46,36 +47,36 @@ describe('Transfer.Dropdown', () => {
   }
 
   it('select all', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
-    const onSelectChange = jest.fn();
+    const onSelectChange = vi.fn();
     const { container } = render(<Transfer {...listProps} onSelectChange={onSelectChange} />);
 
     fireEvent.mouseEnter(container.querySelector('.ant-transfer-list-header-dropdown')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     clickItem(container, 0);
     expect(onSelectChange).toHaveBeenCalledWith(['b', 'c', 'd', 'e'], []);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('select current page', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
-    const onSelectChange = jest.fn();
+    const onSelectChange = vi.fn();
     const { container } = render(<Transfer {...listProps} onSelectChange={onSelectChange} />);
     fireEvent.mouseEnter(container.querySelector('.ant-transfer-list-header-dropdown')!);
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     clickItem(container, 1);
     expect(onSelectChange).toHaveBeenCalledWith(['b', 'c', 'd'], []);
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('should hide checkbox and dropdown icon when showSelectAll={false}', () => {
@@ -97,19 +98,19 @@ describe('Transfer.Dropdown', () => {
       },
     ].forEach(({ name, props, index, keys }) => {
       it(name, () => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
 
-        const onSelectChange = jest.fn();
+        const onSelectChange = vi.fn();
         const { container } = render(<Transfer {...props} onSelectChange={onSelectChange} />);
         fireEvent.mouseEnter(container.querySelector('.ant-transfer-list-header-dropdown')!);
         act(() => {
-          jest.runAllTimers();
+          vi.runAllTimers();
         });
 
         clickItem(container, index);
         expect(onSelectChange).toHaveBeenCalledWith(keys, []);
 
-        jest.useRealTimers();
+        vi.useRealTimers();
       });
     });
   });
@@ -120,9 +121,9 @@ describe('Transfer.Dropdown', () => {
       { name: 'without pagination', props: { ...listProps, pagination: null as any } },
     ].forEach(({ name, props }) => {
       it(name, () => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
 
-        const onChange = jest.fn();
+        const onChange = vi.fn();
         const { container } = render(
           <Transfer {...props} targetKeys={['b', 'c']} oneWay onChange={onChange} />,
         );
@@ -130,13 +131,13 @@ describe('Transfer.Dropdown', () => {
         // Right dropdown
         fireEvent.mouseEnter(container.querySelectorAll('.ant-transfer-list-header-dropdown')[1]!);
         act(() => {
-          jest.runAllTimers();
+          vi.runAllTimers();
         });
 
         clickItem(container, 0);
         expect(onChange).toHaveBeenCalledWith([], 'left', ['b', 'c']);
 
-        jest.useRealTimers();
+        vi.useRealTimers();
       });
     });
   });

--- a/components/transfer/__tests__/image.test.ts
+++ b/components/transfer/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Transfer image', () => {

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
 import type { SelectAllLabel, TransferProps } from '..';
@@ -5,7 +6,7 @@ import Transfer from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 
-const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 const listCommonProps: {
   dataSource: { key: string; title: string; disabled?: boolean }[];
@@ -83,14 +84,14 @@ describe('Transfer', () => {
   });
 
   it('should move selected keys to corresponding list', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(<Transfer {...listCommonProps} onChange={handleChange} />);
     fireEvent.click(container.querySelector('.ant-transfer-operation')?.querySelector('button')!); // move selected keys to right list
     expect(handleChange).toHaveBeenCalledWith(['a', 'b'], 'right', ['a']);
   });
 
   it('should move selected keys to left list', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(
       <Transfer
         {...listCommonProps}
@@ -106,14 +107,14 @@ describe('Transfer', () => {
   });
 
   it('should move selected keys expect disabled to corresponding list', () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const { container } = render(<Transfer {...listDisabledProps} onChange={handleChange} />);
     fireEvent.click(container.querySelector('.ant-transfer-operation')?.querySelector('button')!); // move selected keys to right list
     expect(handleChange).toHaveBeenCalledWith(['b'], 'right', ['b']);
   });
 
   it('should uncheck checkbox when click on checked item', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { getByTitle } = render(
       <Transfer
         {...listCommonProps}
@@ -126,7 +127,7 @@ describe('Transfer', () => {
   });
 
   it('should check checkbox when click on unchecked item', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { getByText } = render(
       <Transfer
         {...listCommonProps}
@@ -139,7 +140,7 @@ describe('Transfer', () => {
   });
 
   it('should not check checkbox when component disabled', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { getByText } = render(
       <Transfer
         {...listCommonProps}
@@ -153,7 +154,7 @@ describe('Transfer', () => {
   });
 
   it('should not check checkbox when click on disabled item', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { getByText } = render(
       <Transfer
         {...listCommonProps}
@@ -167,7 +168,7 @@ describe('Transfer', () => {
   });
 
   it('should check all item when click on check all', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { container } = render(
       <Transfer {...listCommonProps} onSelectChange={handleSelectChange} />,
     );
@@ -183,7 +184,7 @@ describe('Transfer', () => {
   });
 
   it('should uncheck all item when click on uncheck all', () => {
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { container } = render(
       <Transfer {...listCommonProps} onSelectChange={handleSelectChange} />,
     );
@@ -308,7 +309,7 @@ describe('Transfer', () => {
     const filterOption: TransferProps<any>['filterOption'] = (inputValue, option) =>
       option.description.includes(inputValue);
     const renderFunc: TransferProps<any>['render'] = (item) => item.title;
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { container, getByTitle } = render(
       <Transfer
         {...searchTransferProps}
@@ -333,7 +334,7 @@ describe('Transfer', () => {
     const filterOption: TransferProps<any>['filterOption'] = (inputValue, option) =>
       option.description.includes(inputValue);
     const renderFunc: TransferProps<any>['render'] = (item) => item.title;
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const TransferDemo = () => {
       const [selectedKeys, setSelectedKeys] = useState<string[]>(searchTransferProps.selectedKeys);
       const handleSelectChange: TransferProps<any>['onSelectChange'] = (
@@ -373,7 +374,7 @@ describe('Transfer', () => {
     const newProps = { ...listCommonProps };
     delete newProps.targetKeys;
     delete newProps.selectedKeys;
-    const handleSelectChange = jest.fn();
+    const handleSelectChange = vi.fn();
     const { container, getByText } = render(
       <Transfer
         {...newProps}
@@ -472,7 +473,7 @@ describe('Transfer', () => {
   });
 
   it('should support onScroll', () => {
-    const onScroll = jest.fn();
+    const onScroll = vi.fn();
     const { container } = render(<Transfer {...listCommonProps} onScroll={onScroll} />);
 
     fireEvent.scroll(
@@ -574,7 +575,7 @@ describe('Transfer', () => {
   });
 
   it('remove by click icon', () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(<Transfer {...listCommonProps} onChange={onChange} oneWay />);
     fireEvent.click(container.querySelectorAll('.ant-transfer-list-content-item-remove')[0]);
     expect(onChange).toHaveBeenCalledWith([], 'left', ['b']);

--- a/components/transfer/__tests__/list.test.tsx
+++ b/components/transfer/__tests__/list.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import type { KeyWiseTransferItem } from '..';
 import type { TransferListProps } from '../list';

--- a/components/transfer/__tests__/search.test.tsx
+++ b/components/transfer/__tests__/search.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, afterAll, it, expect, vi } from 'vitest';
 import { render as testLibRender } from '@testing-library/react';
 import React from 'react';
 import { fireEvent, render } from '../../../tests/utils';
@@ -5,7 +6,7 @@ import Transfer from '../index';
 import Search from '../search';
 
 describe('Transfer.Search', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   const dataSource = [
     {
@@ -41,9 +42,9 @@ describe('Transfer.Search', () => {
   });
 
   it('onSearch', () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
 
-    const onSearch = jest.fn();
+    const onSearch = vi.fn();
     const { container } = render(
       <Transfer
         dataSource={dataSource}
@@ -60,11 +61,11 @@ describe('Transfer.Search', () => {
     onSearch.mockReset();
     fireEvent.click(container.querySelectorAll('.ant-input-clear-icon').item(0));
     expect(onSearch).toHaveBeenCalledWith('left', '');
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('legacy props#onSearchChange does not work anymore', () => {
-    const onSearchChange = jest.fn();
+    const onSearchChange = vi.fn();
     const props = { onSearchChange };
     const { container } = render(<Transfer render={(item) => item.title!} {...props} showSearch />);
     fireEvent.change(container.querySelector('.ant-input')!, { target: { value: 'a' } });
@@ -74,7 +75,7 @@ describe('Transfer.Search', () => {
 
   // https://github.com/ant-design/ant-design/issues/26208
   it('typing space should trigger filterOption', () => {
-    const filterOption = jest.fn();
+    const filterOption = vi.fn();
 
     // We use origin testing lib here since StrictMode will render multiple times
     const { container } = testLibRender(

--- a/components/tree-select/__tests__/image.test.ts
+++ b/components/tree-select/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('TreeSelect image', () => {

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render } from '../../../tests/utils';
 import TreeSelect, { TreeNode } from '..';
@@ -56,7 +57,7 @@ describe('TreeSelect', () => {
   it('legacy dropdownClassName', () => {
     resetWarned();
 
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(<TreeSelect dropdownClassName="legacy" open />);
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: TreeSelect] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import debounce from 'lodash/debounce';
 import type { Key } from 'react';
@@ -10,7 +11,7 @@ import type { TreeProps } from '../index';
 
 const { DirectoryTree, TreeNode } = Tree;
 
-jest.mock('lodash/debounce');
+vi.mock('lodash/debounce');
 
 describe('Directory Tree', () => {
   mountTest(Tree);
@@ -22,11 +23,11 @@ describe('Directory Tree', () => {
   (debounce as any).mockImplementation((fn: () => void) => fn);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     (debounce as any).mockRestore();
   });
 
@@ -47,43 +48,43 @@ describe('Directory Tree', () => {
 
   describe('expand', () => {
     it('click', () => {
-      const onExpand = jest.fn();
+      const onExpand = vi.fn();
       const { container } = render(createTree({ onExpand }));
 
       fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(onExpand).toHaveBeenCalledWith(['0-0'], expect.anything());
       onExpand.mockReset();
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(onExpand).toHaveBeenCalledWith([], expect.anything());
     });
 
     it('double click', () => {
-      const onExpand = jest.fn();
+      const onExpand = vi.fn();
       const { container } = render(createTree({ expandAction: 'doubleClick', onExpand }));
 
       fireEvent.doubleClick(container.querySelector('.ant-tree-node-content-wrapper')!);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(onExpand).toHaveBeenCalledWith(['0-0'], expect.anything());
       onExpand.mockReset();
 
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       fireEvent.doubleClick(container.querySelector('.ant-tree-node-content-wrapper')!);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       expect(onExpand).toHaveBeenCalledWith([], expect.anything());
     });
@@ -104,14 +105,14 @@ describe('Directory Tree', () => {
         const { container, asFragment } = render(<StateDirTree expandAction="click" />);
 
         fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!);
-        jest.runAllTimers();
+        vi.runAllTimers();
         expect(asFragment().firstChild).toMatchSnapshot();
       });
       it('doubleClick', () => {
         const { container, asFragment } = render(<StateDirTree expandAction="doubleClick" />);
 
         fireEvent.doubleClick(container.querySelector('.ant-tree-node-content-wrapper')!);
-        jest.runAllTimers();
+        vi.runAllTimers();
         expect(asFragment().firstChild).toMatchSnapshot();
       });
     });
@@ -154,7 +155,7 @@ describe('Directory Tree', () => {
   it('expandedKeys update', () => {
     const { rerender, asFragment } = render(createTree());
     rerender(createTree({ expandedKeys: ['0-1'] }));
-    jest.runAllTimers();
+    vi.runAllTimers();
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
@@ -165,7 +166,7 @@ describe('Directory Tree', () => {
   });
 
   it('group select', () => {
-    const onSelect = jest.fn();
+    const onSelect = vi.fn();
     const { container, asFragment } = render(
       createTree({
         defaultExpandAll: true,
@@ -203,15 +204,15 @@ describe('Directory Tree', () => {
   });
 
   it('onDoubleClick', () => {
-    const onDoubleClick = jest.fn();
+    const onDoubleClick = vi.fn();
     const { container } = render(createTree({ onDoubleClick }));
     fireEvent.doubleClick(container.querySelector('.ant-tree-node-content-wrapper')!);
     expect(onDoubleClick).toHaveBeenCalled();
   });
 
   it('should not expand tree now when pressing ctrl', () => {
-    const onExpand = jest.fn();
-    const onSelect = jest.fn();
+    const onExpand = vi.fn();
+    const onSelect = vi.fn();
     const { container } = render(createTree({ onExpand, onSelect }));
     fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!, { ctrlKey: true });
     expect(onExpand).not.toHaveBeenCalled();
@@ -222,8 +223,8 @@ describe('Directory Tree', () => {
   });
 
   it('should not expand tree now when click leaf node', () => {
-    const onExpand = jest.fn();
-    const onSelect = jest.fn();
+    const onExpand = vi.fn();
+    const onSelect = vi.fn();
     const { container } = render(
       createTree({
         onExpand,

--- a/components/tree/__tests__/dropIndicator.test.tsx
+++ b/components/tree/__tests__/dropIndicator.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { render } from '../../../tests/utils';
 import dropIndicatorRender, { offset } from '../utils/dropIndicator';
 

--- a/components/tree/__tests__/image.test.ts
+++ b/components/tree/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Tree image', () => {

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, screen } from '../../../tests/utils';
 import Tree from '../index';
@@ -174,13 +175,13 @@ describe('Tree', () => {
     });
 
     it('nodeDraggable', () => {
-      const nodeDraggable = jest.fn(() => false);
+      const nodeDraggable = vi.fn(() => false);
       render(<Tree treeData={dragTreeData} draggable={{ nodeDraggable }} />);
       expect(nodeDraggable).toHaveBeenCalledWith(dragTreeData[0]);
     });
 
     it('nodeDraggable func', () => {
-      const nodeDraggable = jest.fn(() => false);
+      const nodeDraggable = vi.fn(() => false);
       render(<Tree treeData={dragTreeData} draggable={nodeDraggable} />);
       expect(nodeDraggable).toHaveBeenCalledWith(dragTreeData[0]);
     });

--- a/components/tree/__tests__/type.test.tsx
+++ b/components/tree/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import type { BasicDataNode } from 'rc-tree';
 import * as React from 'react';
 import { render } from '../../../tests/utils';

--- a/components/tree/__tests__/util.test.tsx
+++ b/components/tree/__tests__/util.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { calcRangeKeys } from '../utils/dictUtil';

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -1,3 +1,4 @@
+import { describe, afterEach, it, expect, vi } from 'vitest';
 import { LikeOutlined, SmileOutlined } from '@ant-design/icons';
 import * as copyObj from 'copy-to-clipboard';
 import React from 'react';
@@ -6,7 +7,7 @@ import { fireEvent, render, waitFor, act } from '../../../tests/utils';
 import Base from '../Base';
 
 describe('Typography copy', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   afterEach(() => {
     errorSpy.mockReset();
@@ -32,7 +33,7 @@ describe('Typography copy', () => {
         tooltipLength?: number;
       }) {
         it(name, async () => {
-          jest.useFakeTimers();
+          vi.useFakeTimers();
           const { container: wrapper, unmount } = render(
             <Base component="p" copyable={{ icon, tooltips }}>
               test copy
@@ -48,7 +49,7 @@ describe('Typography copy', () => {
           }
 
           fireEvent.mouseEnter(wrapper.querySelectorAll('.ant-typography-copy')[0]);
-          jest.runAllTimers();
+          vi.runAllTimers();
 
           if (tooltipTexts[0] !== undefined) {
             await waitFor(() => {
@@ -65,7 +66,7 @@ describe('Typography copy', () => {
           }
 
           fireEvent.click(wrapper.querySelectorAll('.ant-typography-copy')[0]);
-          jest.useRealTimers();
+          vi.useRealTimers();
           if (iconClassNames[1] !== undefined) {
             expect(wrapper.querySelector(iconClassNames[1])).not.toBeNull();
           }
@@ -86,14 +87,14 @@ describe('Typography copy', () => {
             );
           }
 
-          jest.useFakeTimers();
+          vi.useFakeTimers();
           fireEvent.click(wrapper.querySelectorAll('.ant-typography-copy')[0]);
           act(() => {
-            jest.runAllTimers();
+            vi.runAllTimers();
           });
 
           unmount();
-          jest.useRealTimers();
+          vi.useRealTimers();
         });
       }
 
@@ -209,7 +210,7 @@ describe('Typography copy', () => {
     });
 
     it('copy click event stopPropagation', () => {
-      const onDivClick = jest.fn();
+      const onDivClick = vi.fn();
       const { container: wrapper } = render(
         <div onClick={onDivClick}>
           <Base component="p" copyable>
@@ -235,8 +236,8 @@ describe('Typography copy', () => {
     });
 
     it('copy to clipboard', () => {
-      jest.useFakeTimers();
-      const spy = jest.spyOn(copyObj, 'default');
+      vi.useFakeTimers();
+      const spy = vi.spyOn(copyObj, 'default');
       const originText = 'origin text.';
       const nextText = 'next text.';
       const Test = () => {
@@ -257,12 +258,12 @@ describe('Typography copy', () => {
       fireEvent.click(copyBtn);
       expect(spy.mock.calls[0][0]).toEqual(originText);
       act(() => {
-        jest.runAllTimers();
+        vi.runAllTimers();
       });
       spy.mockReset();
       fireEvent.click(copyBtn);
       expect(spy.mock.calls[0][0]).toEqual(nextText);
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
   });
 });

--- a/components/typography/__tests__/editable.test.tsx
+++ b/components/typography/__tests__/editable.test.tsx
@@ -1,17 +1,18 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import { fireEvent, render } from '../../../tests/utils';
 import Base from '../Base';
 
-jest.mock('copy-to-clipboard');
+vi.mock('copy-to-clipboard');
 
-jest.mock('../../_util/styleChecker', () => ({
+vi.mock('../../_util/styleChecker', () => ({
   isStyleSupport: () => true,
 }));
 
 describe('Typography.Editable', () => {
   const LINE_STR_COUNT = 20;
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   let mockRectSpy: ReturnType<typeof spyElementPrototypes>;
 
   beforeAll(() => {

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterEach, afterAll, it, expect, vi } from 'vitest';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -5,21 +6,21 @@ import { fireEvent, render, waitFakeTimer, triggerResize, waitFor } from '../../
 import type { EllipsisConfig } from '../Base';
 import Base from '../Base';
 
-jest.mock('copy-to-clipboard');
+vi.mock('copy-to-clipboard');
 
-jest.mock('../../_util/styleChecker', () => ({
+vi.mock('../../_util/styleChecker', () => ({
   isStyleSupport: () => true,
 }));
 
 describe('Typography.Ellipsis', () => {
   const LINE_STR_COUNT = 20;
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   let mockRectSpy: ReturnType<typeof spyElementPrototypes>;
   let getWidthTimes = 0;
   let computeSpy: jest.SpyInstance<CSSStyleDeclaration>;
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     mockRectSpy = spyElementPrototypes(HTMLElement, {
       offsetHeight: {
         get() {
@@ -43,7 +44,7 @@ describe('Typography.Ellipsis', () => {
       },
     });
 
-    computeSpy = jest
+    computeSpy = vi
       .spyOn(window, 'getComputedStyle')
       .mockImplementation(() => ({ fontSize: 12 }) as unknown as CSSStyleDeclaration);
   });
@@ -54,7 +55,7 @@ describe('Typography.Ellipsis', () => {
   });
 
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     errorSpy.mockRestore();
     mockRectSpy.mockRestore();
     computeSpy.mockRestore();
@@ -65,7 +66,7 @@ describe('Typography.Ellipsis', () => {
 
   it('should trigger update', async () => {
     const ref = React.createRef<HTMLElement>();
-    const onEllipsis = jest.fn();
+    const onEllipsis = vi.fn();
     const { container, rerender, unmount } = render(
       <Base ellipsis={{ onEllipsis }} component="p" editable ref={ref}>
         {fullStr}
@@ -128,7 +129,7 @@ describe('Typography.Ellipsis', () => {
         Ant Design, a design language for background applications, is refined by
         Ant UED Team.`;
     const ref = React.createRef<HTMLElement>();
-    const onEllipsis = jest.fn();
+    const onEllipsis = vi.fn();
     const { container: wrapper, unmount } = render(
       <Base ellipsis={{ onEllipsis }} component="p" editable ref={ref}>
         {parenthesesStr}
@@ -222,7 +223,7 @@ describe('Typography.Ellipsis', () => {
   });
 
   it('should expandable work', async () => {
-    const onExpand = jest.fn();
+    const onExpand = vi.fn();
     const { container: wrapper } = render(
       <Base ellipsis={{ expandable: true, onExpand }} component="p" copyable editable>
         {fullStr}
@@ -255,8 +256,8 @@ describe('Typography.Ellipsis', () => {
       const originIntersectionObserver = global.IntersectionObserver;
 
       let elementChangeCallback: () => void;
-      const observeFn = jest.fn();
-      const disconnectFn = jest.fn();
+      const observeFn = vi.fn();
+      const disconnectFn = vi.fn();
 
       (global as any).IntersectionObserver = class MockIntersectionObserver {
         constructor(callback: () => IntersectionObserverCallback) {

--- a/components/typography/__tests__/enter-key-callback.test.tsx
+++ b/components/typography/__tests__/enter-key-callback.test.tsx
@@ -1,11 +1,12 @@
+import { test, expect, vi } from 'vitest';
 import KeyCode from 'rc-util/lib/KeyCode';
 import React from 'react';
 import { fireEvent, render } from '../../../tests/utils';
 import Paragraph from '../Paragraph';
 
 test('Callback on enter key is triggered', () => {
-  const onEditStart = jest.fn();
-  const onCopy = jest.fn();
+  const onEditStart = vi.fn();
+  const onCopy = vi.fn();
 
   const { container: wrapper } = render(
     <Paragraph
@@ -20,13 +21,13 @@ test('Callback on enter key is triggered', () => {
     </Paragraph>,
   );
   const timer: any = 9527;
-  jest.spyOn(window, 'setTimeout').mockReturnValue(timer);
-  jest.spyOn(window, 'clearTimeout');
+  vi.spyOn(window, 'setTimeout').mockReturnValue(timer);
+  vi.spyOn(window, 'clearTimeout');
   // must copy first, because editing button will hide copy button
   fireEvent.keyUp(wrapper.querySelectorAll('.ant-typography-copy')[0], { keyCode: KeyCode.ENTER });
   fireEvent.keyUp(wrapper.querySelectorAll('.anticon-edit')[0], { keyCode: KeyCode.ENTER });
 
   expect(onEditStart.mock.calls.length).toBe(1);
   expect(onCopy.mock.calls.length).toBe(1);
-  jest.restoreAllMocks();
+  vi.restoreAllMocks();
 });

--- a/components/typography/__tests__/image.test.ts
+++ b/components/typography/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Typography image', () => {

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterEach, afterAll, it, expect, vi } from 'vitest';
 import { CheckOutlined, HighlightOutlined, LikeOutlined, SmileOutlined } from '@ant-design/icons';
 import copy from 'copy-to-clipboard';
 import KeyCode from 'rc-util/lib/KeyCode';
@@ -14,7 +15,7 @@ import type { TitleProps } from '../Title';
 import Title from '../Title';
 import Typography from '../Typography';
 
-jest.mock('copy-to-clipboard');
+vi.mock('copy-to-clipboard');
 
 describe('Typography', () => {
   mountTest(Paragraph);
@@ -28,7 +29,7 @@ describe('Typography', () => {
   rtlTest(Link);
 
   const LINE_STR_COUNT = 20;
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   // Mock offsetHeight
   const originOffsetHeight = Object.getOwnPropertyDescriptor(
@@ -36,7 +37,7 @@ describe('Typography', () => {
     'offsetHeight',
   )?.get;
 
-  const mockGetBoundingClientRect = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+  const mockGetBoundingClientRect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
 
   beforeAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
@@ -105,8 +106,8 @@ describe('Typography', () => {
         format?: 'text/plain' | 'text/html',
       ): void {
         it(name, async () => {
-          jest.useFakeTimers();
-          const onCopy = jest.fn();
+          vi.useFakeTimers();
+          const onCopy = vi.fn();
           const { container, unmount } = render(
             <Base component="p" copyable={{ text, onCopy, icon, tooltips, format }}>
               test copy
@@ -122,7 +123,7 @@ describe('Typography', () => {
           // Mouse enter to show tooltip
           fireEvent.mouseEnter(container.querySelector('.ant-typography-copy')!);
           act(() => {
-            jest.advanceTimersByTime(10000);
+            vi.advanceTimersByTime(10000);
           });
 
           if (tooltips === undefined || tooltips === true) {
@@ -184,8 +185,8 @@ describe('Typography', () => {
           expect(container.querySelector(copiedIcon)).toBeFalsy();
 
           unmount();
-          jest.clearAllTimers();
-          jest.useRealTimers();
+          vi.clearAllTimers();
+          vi.useRealTimers();
         });
       }
 
@@ -246,9 +247,9 @@ describe('Typography', () => {
         expectFunc?: (callback: jest.Mock) => void,
       ) {
         it(name, async () => {
-          jest.useFakeTimers();
-          const onStart = jest.fn();
-          const onChange = jest.fn();
+          vi.useFakeTimers();
+          const onStart = vi.fn();
+          const onChange = vi.fn();
 
           const className = 'test';
           const style = { padding: 'unset' };
@@ -276,7 +277,7 @@ describe('Typography', () => {
             }
             fireEvent.mouseEnter(wrapper.querySelectorAll('.ant-typography-edit')[0]);
             act(() => {
-              jest.runAllTimers();
+              vi.runAllTimers();
             });
 
             if (tooltip === undefined || tooltip === true) {
@@ -389,7 +390,7 @@ describe('Typography', () => {
       testStep({ name: 'trigger by both icon and text', triggerType: ['icon', 'text'] });
 
       it('should trigger onEnd when type Enter', () => {
-        const onEnd = jest.fn();
+        const onEnd = vi.fn();
         const { container: wrapper } = render(<Paragraph editable={{ onEnd }}>Bamboo</Paragraph>);
         fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
         fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ENTER });
@@ -398,7 +399,7 @@ describe('Typography', () => {
       });
 
       it('should trigger onStart when type Start', () => {
-        const onStart = jest.fn();
+        const onStart = vi.fn();
         const { container: wrapper } = render(<Paragraph editable={{ onStart }}>Bamboo</Paragraph>);
         fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
         fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.A });
@@ -407,7 +408,7 @@ describe('Typography', () => {
       });
 
       it('should trigger onCancel when type ESC', () => {
-        const onCancel = jest.fn();
+        const onCancel = vi.fn();
         const { container: wrapper } = render(
           <Paragraph editable={{ onCancel }}>Bamboo</Paragraph>,
         );

--- a/components/typography/__tests__/prefixCls.test.tsx
+++ b/components/typography/__tests__/prefixCls.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { render } from '../../../tests/utils';
 

--- a/components/upload/__tests__/dragger.test.tsx
+++ b/components/upload/__tests__/dragger.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 /* eslint-disable react/no-string-refs, react/prefer-es6-class */
 import React from 'react';
 import Upload from '..';
@@ -12,7 +13,7 @@ describe('Upload.Dragger', () => {
   afterEach(() => teardown());
 
   it('support drag file with over style', async () => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     const { container: wrapper } = render(
       <Upload.Dragger action="http://upload.com">
         <div />
@@ -26,18 +27,18 @@ describe('Upload.Dragger', () => {
     });
 
     act(() => {
-      jest.runAllTimers();
+      vi.runAllTimers();
     });
 
     await waitFor(() => {
       expect(wrapper.querySelector('.ant-upload-drag')).toHaveClass('ant-upload-drag-hover');
     });
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it('support onDrop when files are dropped onto upload area', async () => {
-    const onDrop = jest.fn();
+    const onDrop = vi.fn();
     const { container: wrapper } = render(
       <Upload.Dragger onDrop={onDrop}>
         <div />

--- a/components/upload/__tests__/image.test.ts
+++ b/components/upload/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Upload image', () => {

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import React from 'react';
 import type { UploadProps } from '..';
 import Upload from '..';

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, beforeEach, afterAll, afterEach, it, expect, vi } from 'vitest';
 import { produce } from 'immer';
 import { cloneDeep } from 'lodash';
 import type { UploadRequestOption } from 'rc-upload/lib/interface';
@@ -19,14 +20,14 @@ describe('Upload', () => {
   rtlTest(Upload);
 
   beforeAll(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
   });
   beforeEach(() => setup());
   afterAll(() => {
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
   afterEach(() => {
-    jest.clearAllTimers();
+    vi.clearAllTimers();
     return teardown();
   });
 
@@ -54,8 +55,8 @@ describe('Upload', () => {
   });
 
   it('return promise in beforeUpload', async () => {
-    const data = jest.fn();
-    const done = jest.fn();
+    const data = vi.fn();
+    const done = vi.fn();
     const props: UploadProps = {
       action: 'http://upload.com',
       beforeUpload: () =>
@@ -84,7 +85,7 @@ describe('Upload', () => {
   });
 
   it('beforeUpload can be falsy', async () => {
-    const done = jest.fn();
+    const done = vi.fn();
     const props: UploadProps = {
       action: 'http://upload.com',
       beforeUpload: () => false,
@@ -109,8 +110,8 @@ describe('Upload', () => {
   });
 
   it('upload promise return file in beforeUpload', async () => {
-    const done = jest.fn();
-    const data = jest.fn();
+    const done = vi.fn();
+    const data = vi.fn();
     const props: UploadProps = {
       action: 'http://upload.com',
       beforeUpload: (file) =>
@@ -155,7 +156,7 @@ describe('Upload', () => {
     const mockFile = new File(['foo'], 'foo.png', {
       type: 'image/png',
     });
-    const data = jest.fn();
+    const data = vi.fn();
     const props: UploadProps = {
       action: 'http://upload.com',
       fileList,
@@ -181,7 +182,7 @@ describe('Upload', () => {
   });
 
   it('should not stop upload when return value of beforeUpload is not false', (done) => {
-    const data = jest.fn();
+    const data = vi.fn();
     const props = {
       action: 'http://upload.com',
       beforeUpload() {},
@@ -426,7 +427,7 @@ describe('Upload', () => {
   });
 
   it('should stop remove when return value of onRemove is false', async () => {
-    const mockRemove = jest.fn(() => false);
+    const mockRemove = vi.fn(() => false);
     const props: UploadProps = {
       onRemove: mockRemove,
       fileList: [
@@ -466,7 +467,7 @@ describe('Upload', () => {
         expect(file.status).toBe('uploading');
         removePromise = resolve;
       });
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container } = render(
       <Upload
@@ -488,7 +489,7 @@ describe('Upload', () => {
   });
 
   it('should not stop download when return use onDownload', async () => {
-    const mockRemove = jest.fn(() => false);
+    const mockRemove = vi.fn(() => false);
     const props: UploadProps = {
       onRemove: mockRemove,
       showUploadList: {
@@ -582,7 +583,7 @@ describe('Upload', () => {
   it('warning if set `value`', () => {
     resetWarned();
     const value = { value: [] } as any;
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<Upload {...value} />);
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Upload] `value` is not a valid prop, do you mean `fileList`?',
@@ -605,9 +606,9 @@ describe('Upload', () => {
 
   // https://github.com/ant-design/ant-design/issues/25077
   it('should support events', () => {
-    const onClick = jest.fn();
-    const onMouseEnter = jest.fn();
-    const onMouseLeave = jest.fn();
+    const onClick = vi.fn();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
     const props = { onClick, onMouseEnter, onMouseLeave };
     const { container: wrapper } = render(
       <Upload {...props}>
@@ -624,10 +625,10 @@ describe('Upload', () => {
 
   // https://github.com/ant-design/ant-design/issues/26427
   it('should sync file list with control mode', async () => {
-    const done = jest.fn();
+    const done = vi.fn();
     let callTimes = 0;
 
-    const customRequest = jest.fn(async (options) => {
+    const customRequest = vi.fn(async (options) => {
       // stop here to make sure new fileList has been set and passed to Upload
       // eslint-disable-next-line no-promise-executor-return
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -690,7 +691,7 @@ describe('Upload', () => {
 
   describe('maxCount', () => {
     it('replace when only 1', async () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const fileList = [
         {
           uid: 'bar',
@@ -728,7 +729,7 @@ describe('Upload', () => {
     });
 
     it('maxCount > 1', async () => {
-      const onChange = jest.fn();
+      const onChange = vi.fn();
       const fileList = [
         {
           uid: 'bar',
@@ -789,7 +790,7 @@ describe('Upload', () => {
   });
 
   it('Proxy should support deepClone', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const { container: wrapper } = render(
       <Upload onChange={onChange}>
@@ -846,7 +847,7 @@ describe('Upload', () => {
   // https://github.com/ant-design/ant-design/issues/30390
   // IE11 Does not support the File constructor
   it('should not break in IE if beforeUpload returns false', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Upload beforeUpload={() => false} fileList={[]} onChange={onChange} />,
     );
@@ -854,7 +855,7 @@ describe('Upload', () => {
       throw new TypeError("Object doesn't support this action");
     };
 
-    const spyIE = jest.spyOn(global, 'File').mockImplementationOnce(fileConstructor);
+    const spyIE = vi.spyOn(global, 'File').mockImplementationOnce(fileConstructor);
     fireEvent.change(container.querySelector('input')!, {
       target: { files: [{ file: 'foo.png' }] },
     });
@@ -907,7 +908,7 @@ describe('Upload', () => {
     let info1: UploadRequestOption;
     let info2: UploadRequestOption;
 
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const { container } = render(
       <Upload
         customRequest={(info) => {
@@ -950,7 +951,7 @@ describe('Upload', () => {
     const mockFile1 = new File(['bamboo'], 'bamboo.png', { type: 'image/png' });
     const mockFile2 = new File(['light'], 'light.png', { type: 'image/png' });
 
-    const customRequest = jest.fn(async (options) => {
+    const customRequest = vi.fn(async (options) => {
       // stop here to make sure new fileList has been set and passed to Upload
       // eslint-disable-next-line no-promise-executor-return
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, beforeAll, afterAll, it, expect, test, vi } from 'vitest';
 import React from 'react';
 import Upload from '..';
 import { act, fireEvent, render, waitFakeTimer, waitFor } from '../../../tests/utils';
@@ -34,40 +35,40 @@ describe('Upload List', () => {
 
   // jsdom not support `createObjectURL` yet. Let's handle this.
   const originCreateObjectURL = window.URL.createObjectURL;
-  window.URL.createObjectURL = jest.fn(() => '');
+  window.URL.createObjectURL = vi.fn(() => '');
 
   // Mock dom
   let size = { width: 0, height: 0 };
   function setSize(width: number, height: number) {
     size = { width, height };
   }
-  const mockWidthGet = jest.spyOn(Image.prototype, 'width', 'get');
-  const mockHeightGet = jest.spyOn(Image.prototype, 'height', 'get');
-  const mockSrcSet = jest.spyOn(Image.prototype, 'src', 'set');
+  const mockWidthGet = vi.spyOn(Image.prototype, 'width', 'get');
+  const mockHeightGet = vi.spyOn(Image.prototype, 'height', 'get');
+  const mockSrcSet = vi.spyOn(Image.prototype, 'src', 'set');
 
   let drawImageCallback: jest.Mock | null = null;
   function hookDrawImageCall(callback: jest.Mock) {
     drawImageCallback = callback;
   }
-  const mockGetCanvasContext = jest.spyOn(HTMLCanvasElement.prototype, 'getContext');
-  const mockToDataURL = jest.spyOn(HTMLCanvasElement.prototype, 'toDataURL');
+  const mockGetCanvasContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext');
+  const mockToDataURL = vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL');
 
   // HTMLCanvasElement.prototype
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     return setup();
   });
   afterEach(() => {
     teardown();
     drawImageCallback = null;
-    jest.clearAllTimers();
-    jest.useRealTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   let open: jest.MockInstance<any, any[]>;
   beforeAll(() => {
-    open = jest.spyOn(window, 'open').mockImplementation(() => null);
+    open = vi.spyOn(window, 'open').mockImplementation(() => null);
     mockWidthGet.mockImplementation(() => size.width);
     mockHeightGet.mockImplementation(() => size.height);
     mockSrcSet.mockImplementation(function fn() {
@@ -157,7 +158,7 @@ describe('Upload List', () => {
   });
 
   it('should be uploading when upload a file', async () => {
-    const done = jest.fn();
+    const done = vi.fn();
     let wrapper: ReturnType<typeof render>;
     let latestFileList: UploadFile<any>[] | null = null;
     const onChange: UploadProps['onChange'] = async ({ file, fileList: eventFileList }) => {
@@ -192,7 +193,7 @@ describe('Upload List', () => {
   });
 
   it('handle error', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
 
     const {
       container: wrapper,
@@ -237,7 +238,7 @@ describe('Upload List', () => {
   });
 
   it('does concat fileList when beforeUpload returns false', async () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const ref = React.createRef<any>();
     const { container: wrapper, unmount } = render(
       <Upload
@@ -319,7 +320,7 @@ describe('Upload List', () => {
   });
 
   it('should support onPreview', () => {
-    const handlePreview = jest.fn();
+    const handlePreview = vi.fn();
     const { container: wrapper, unmount } = render(
       <Upload listType="picture-card" defaultFileList={fileList} onPreview={handlePreview}>
         <button type="button">upload</button>
@@ -334,8 +335,8 @@ describe('Upload List', () => {
   });
 
   it('should support onRemove', async () => {
-    const handleRemove = jest.fn();
-    const handleChange = jest.fn();
+    const handleRemove = vi.fn();
+    const handleChange = vi.fn();
     const { container: wrapper, unmount } = render(
       <Upload
         listType="picture-card"
@@ -357,7 +358,7 @@ describe('Upload List', () => {
   });
 
   it('should support onDownload', async () => {
-    const handleDownload = jest.fn();
+    const handleDownload = vi.fn();
     const { container: wrapper, unmount } = render(
       <Upload
         listType="picture-card"
@@ -414,10 +415,10 @@ describe('Upload List', () => {
     ].forEach(({ width, height, name }) => {
       it(name, async () => {
         setSize(width, height);
-        const onDrawImage = jest.fn();
+        const onDrawImage = vi.fn();
         hookDrawImageCall(onDrawImage);
 
-        const handlePreview = jest.fn();
+        const handlePreview = vi.fn();
         const newFileList: UploadProps['fileList'] = [...fileList];
         const newFile = {
           ...fileList[0],
@@ -577,9 +578,9 @@ describe('Upload List', () => {
   });
 
   it('should support custom onClick in custom icon', async () => {
-    const handleRemove = jest.fn();
-    const handleChange = jest.fn();
-    const myClick = jest.fn();
+    const handleRemove = vi.fn();
+    const handleChange = vi.fn();
+    const myClick = vi.fn();
     const { container: wrapper, unmount } = render(
       <Upload
         listType="picture-card"
@@ -743,7 +744,7 @@ describe('Upload List', () => {
 
   it('previewFile should work correctly', async () => {
     const items = [{ uid: 'upload-list-item', url: '' }];
-    const previewFunc = jest.fn(previewImage);
+    const previewFunc = vi.fn(previewImage);
     const { container: wrapper, unmount } = render(
       <Upload
         fileList={items as UploadProps['fileList']}
@@ -767,7 +768,7 @@ describe('Upload List', () => {
   });
 
   it('downloadFile should work correctly', async () => {
-    const downloadFunc = jest.fn();
+    const downloadFunc = vi.fn();
     const items = [{ uid: 'upload-list-item', name: 'test', url: '', status: 'done' }];
     const { container: wrapper, unmount } = render(
       <UploadList
@@ -835,7 +836,7 @@ describe('Upload List', () => {
   });
 
   it('onPreview should be called, when url exists', () => {
-    const onPreview = jest.fn();
+    const onPreview = vi.fn();
     const items = [{ thumbUrl: 'thumbUrl', url: 'url', uid: 'upload-list-item' }];
     const {
       container: wrapper,
@@ -872,7 +873,7 @@ describe('Upload List', () => {
       type: 'image/png',
     });
 
-    const previewFunc = jest.fn(previewImage);
+    const previewFunc = vi.fn(previewImage);
 
     const { unmount } = render(
       <Upload
@@ -901,7 +902,7 @@ describe('Upload List', () => {
       { type: 'image/svg+xml' },
     );
 
-    const previewFunc = jest.fn(previewImage);
+    const previewFunc = vi.fn(previewImage);
 
     const { unmount } = render(
       <Upload
@@ -925,7 +926,7 @@ describe('Upload List', () => {
     const mockFile = new File([''], 'foo.7z', {
       type: 'application/x-7z-compressed',
     });
-    const previewFunc = jest.fn(previewImage);
+    const previewFunc = vi.fn(previewImage);
 
     const { unmount } = render(
       <Upload
@@ -950,7 +951,7 @@ describe('Upload List', () => {
     function test(name: string, renderInstance: () => File | Blob) {
       it(name, async () => {
         const mockThumbnail = 'mock-image';
-        const previewFile = jest.fn(() => Promise.resolve(mockThumbnail));
+        const previewFile = vi.fn(() => Promise.resolve(mockThumbnail));
         const file = {
           ...fileList?.[0],
           originFileObj: renderInstance(),
@@ -1005,7 +1006,7 @@ describe('Upload List', () => {
       unmount();
     });
     it('should render <img /> when custom imageUrl return true', () => {
-      const isImageUrl = jest.fn(() => true);
+      const isImageUrl = vi.fn(() => true);
       const { container: wrapper, unmount } = render(
         <Upload
           listType="picture-card"
@@ -1021,7 +1022,7 @@ describe('Upload List', () => {
       unmount();
     });
     it('should not render <img /> when custom imageUrl return false', () => {
-      const isImageUrl = jest.fn(() => false);
+      const isImageUrl = vi.fn(() => false);
       const { container: wrapper, unmount } = render(
         <Upload
           listType="picture-card"
@@ -1043,7 +1044,7 @@ describe('Upload List', () => {
       const thumbUrl =
         'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
       let wrapper: ReturnType<typeof render>;
-      const onChange = jest.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
+      const onChange = vi.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
         ({ fileList: files }) => {
           const newFileList = files?.map<UploadFile<any>>((item) => ({ ...item, thumbUrl }));
 
@@ -1099,7 +1100,7 @@ describe('Upload List', () => {
       (global as any).testName =
         'should not render <img /> when upload non-image file without thumbUrl in onChange';
       let wrapper: ReturnType<typeof render>;
-      const onChange = jest.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
+      const onChange = vi.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
         ({ fileList: files }) => {
           wrapper.rerender(
             <Upload
@@ -1140,11 +1141,11 @@ describe('Upload List', () => {
   });
 
   it('[deprecated] should support transformFile', (done) => {
-    jest.useRealTimers();
+    vi.useRealTimers();
     let wrapper: ReturnType<typeof render>;
     let lastFile: UploadFile;
 
-    const handleTransformFile = jest.fn();
+    const handleTransformFile = vi.fn();
     const onChange: UploadProps['onChange'] = ({ file }) => {
       if (file.status === 'done') {
         expect(file).not.toBe(lastFile);
@@ -1261,9 +1262,9 @@ describe('Upload List', () => {
   });
 
   it('itemRender', () => {
-    const onDownload = jest.fn();
-    const onRemove = jest.fn();
-    const onPreview = jest.fn();
+    const onDownload = vi.fn();
+    const onRemove = vi.fn();
+    const onPreview = vi.fn();
     const itemRender: UploadListProps['itemRender'] = (_, file, currFileList, actions) => {
       const { name, status, uid, url } = file;
       const index = currFileList.indexOf(file);
@@ -1311,7 +1312,7 @@ describe('Upload List', () => {
   });
 
   it('LIST_IGNORE should not add in list', async () => {
-    const beforeUpload = jest.fn(() => Upload.LIST_IGNORE);
+    const beforeUpload = vi.fn(() => Upload.LIST_IGNORE);
     const { container: wrapper, unmount } = render(<Upload beforeUpload={beforeUpload} />);
 
     fireEvent.change(wrapper.querySelector('input')!, {
@@ -1513,7 +1514,7 @@ describe('Upload List', () => {
 
   // https://github.com/ant-design/ant-design/issues/36286
   it('remove should keep origin className', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     const list = [
       {
         uid: '0',

--- a/components/watermark/__tests__/image.test.ts
+++ b/components/watermark/__tests__/image.test.ts
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Watermark image', () => {

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, beforeAll, afterAll, it, expect, vi } from 'vitest';
 import React from 'react';
 import Watermark from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -8,7 +9,7 @@ describe('Watermark', () => {
   mountTest(Watermark);
   rtlTest(Watermark);
 
-  const mockSrcSet = jest.spyOn(Image.prototype, 'src', 'set');
+  const mockSrcSet = vi.spyOn(Image.prototype, 'src', 'set');
 
   beforeAll(() => {
     mockSrcSet.mockImplementation(function fn() {

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "typedoc": "^0.24.0",
     "typescript": "~5.0.2",
     "vanilla-jsoneditor": "^0.17.1",
+    "vitest": "^0.30.1",
     "webpack-bundle-analyzer": "^4.1.0",
     "xhr-mock": "^2.4.1",
     "yaml-front-matter": "^4.0.0"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c6a775</samp>

This pull request migrates the test suite of the `ant-design/ant-design` repository from using the `jest` library to using the `vitest` library. This is part of a larger effort to switch from `create-react-app` to Vite as the build tool for web development. The pull request updates various test files in the `components` directory to import `vitest` and replace `jest` functions with their `vitest` equivalents.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c6a775</samp>

*  Replace `jest` with `vitest` for testing components ([link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-374c121fcb187c07e4e5ab706a9f1c9c41fea3cb08ef3f0274fa95ca19156ffdR1)-[link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474R1))
*  Use `vitest` API functions for mocking, spying, creating mock functions, and using fake timers ([link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-c22baca52dc03e566ee482381b5e5cc99fe3efe008af8453a331e16798fa0e89L8-R9), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-c22baca52dc03e566ee482381b5e5cc99fe3efe008af8453a331e16798fa0e89L20-R21), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-bbc68d987dc8cdec9e238440977486d4232c6a1dd62ac0ef9fc28bb37aec2ae3L10-R11), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-bbc68d987dc8cdec9e238440977486d4232c6a1dd62ac0ef9fc28bb37aec2ae3L21-R22), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-bbc68d987dc8cdec9e238440977486d4232c6a1dd62ac0ef9fc28bb37aec2ae3L33-R34), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-bbc68d987dc8cdec9e238440977486d4232c6a1dd62ac0ef9fc28bb37aec2ae3L45-R46), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-bcc58e35c96166d551e0be1a18ec08b55ea3e4bf54765a97732a8197a5a46473L14-R15), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-04b8b144d5c02a0be4077411d6c8eb36915ec198e4edb44c92a29c18f1a14366L16-R26), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-04b8b144d5c02a0be4077411d6c8eb36915ec198e4edb44c92a29c18f1a14366L39-R40), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b9315a880f72df16b8162e240562c751ac9046cd7cfe65a89c46f86c7e56a382L13-R26), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b9315a880f72df16b8162e240562c751ac9046cd7cfe65a89c46f86c7e56a382L38-R39), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b9315a880f72df16b8162e240562c751ac9046cd7cfe65a89c46f86c7e56a382L109-R110), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b9315a880f72df16b8162e240562c751ac9046cd7cfe65a89c46f86c7e56a382L130-R131), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-8c9e315b1b1a56abf2d7913f769e9f5ed3b3b2223e522dfe935c1181b35235c6L13-R14), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L8-R9), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L32-R37), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L47-R48), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L69-R70), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L26-R27), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L46-R52), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L63-R65), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L115-R116), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L251-R252), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L18-R27), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L39-R40), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L79-R80), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L109-R110), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L127-R128))
*  Update test cases for `components/affix/__tests__/Affix.test.tsx` and `components/alert/__tests__/index.test.tsx` to use `vitest` API functions ([link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L26-R27)-[link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-05af79f3eabcfa0384ed2166c3819fa85c66dc0a842682fc8e3542b9774220c2L251-R252), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L18-R27)-[link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474L127-R128))
*  Add image tests for `components/affix` and `components/alert` using `vitest` ([link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-321e41937b4642c6540e45932723f029d478329f491529af1bf04accd6a22540R1), [link](https://github.com/ant-design/ant-design/pull/41814/files?diff=unified&w=0#diff-630a93b029484f41a16e22dfdb1c3976adf404ab5443ad044513c9ce85296b68R1))
