### PR TITLE
fix: FloatButton findDOMNode is deprecated in StrictMode.

### DIFF
--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -14,7 +14,9 @@ import useStyle from './style';
 
 export type { ScrollNumberProps } from './ScrollNumber';
 
-type CompoundedComponent = React.FC<BadgeProps> & {
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  BadgeProps & React.RefAttributes<HTMLSpanElement>
+> & {
   Ribbon: typeof Ribbon;
 };
 
@@ -40,25 +42,26 @@ export interface BadgeProps {
   children?: React.ReactNode;
 }
 
-const Badge: CompoundedComponent = ({
-  prefixCls: customizePrefixCls,
-  scrollNumberPrefixCls: customizeScrollNumberPrefixCls,
-  children,
-  status,
-  text,
-  color,
-  count = null,
-  overflowCount = 99,
-  dot = false,
-  size = 'default',
-  title,
-  offset,
-  style,
-  className,
-  rootClassName,
-  showZero = false,
-  ...restProps
-}) => {
+const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps> = (props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    scrollNumberPrefixCls: customizeScrollNumberPrefixCls,
+    children,
+    status,
+    text,
+    color,
+    count = null,
+    overflowCount = 99,
+    dot = false,
+    size = 'default',
+    title,
+    offset,
+    style,
+    className,
+    rootClassName,
+    showZero = false,
+    ...restProps
+  } = props;
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('badge', customizePrefixCls);
 
@@ -191,7 +194,7 @@ const Badge: CompoundedComponent = ({
   }
 
   return wrapSSR(
-    <span {...restProps} className={badgeClassName}>
+    <span ref={ref} {...restProps} className={badgeClassName}>
       {children}
       <CSSMotion
         visible={!isHidden}
@@ -199,7 +202,7 @@ const Badge: CompoundedComponent = ({
         motionAppear={false}
         motionDeadline={1000}
       >
-        {({ className: motionClassName, ref }) => {
+        {({ className: motionClassName, ref: scrollNumberRef }) => {
           const scrollNumberPrefixCls = getPrefixCls(
             'scroll-number',
             customizeScrollNumberPrefixCls,
@@ -233,7 +236,7 @@ const Badge: CompoundedComponent = ({
               title={titleNode}
               style={scrollNumberStyle}
               key="scrollNumber"
-              ref={ref}
+              ref={scrollNumberRef}
             >
               {displayNode}
             </ScrollNumber>
@@ -244,6 +247,8 @@ const Badge: CompoundedComponent = ({
     </span>,
   );
 };
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(InternalBadge) as CompoundedComponent;
 
 Badge.Ribbon = Ribbon;
 

--- a/components/float-button/demo/basic.tsx
+++ b/components/float-button/demo/basic.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { FloatButton } from 'antd';
 
-const App: React.FC = () => (
-  <React.StrictMode>
-    <FloatButton onClick={() => console.log('click')} />
-  </React.StrictMode>
-);
+const App: React.FC = () => <FloatButton onClick={() => console.log('click')} />;
 
 export default App;

--- a/components/float-button/demo/basic.tsx
+++ b/components/float-button/demo/basic.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { FloatButton } from 'antd';
 
-const App: React.FC = () => <FloatButton onClick={() => console.log('click')} />;
+const App: React.FC = () => (
+  <React.StrictMode>
+    <FloatButton onClick={() => console.log('click')} />
+  </React.StrictMode>
+);
 
 export default App;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix FloatButton warning: findDOMNode is deprecated in StrictMode.         |
| 🇨🇳 Chinese |    修复 FloatButton  警告: findDOMNode is deprecated in StrictMode.       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 579c9d4</samp>

This pull request refactors the `Badge` component to support ref forwarding and adds a `Ribbon` sub-component. It also wraps the new `FloatButton` component with `React.StrictMode` in the demo file to detect potential issues. These changes improve the accessibility, usability, and quality of the components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 579c9d4</samp>

*  Change the type of the `Badge` component to use `React.ForwardRefExoticComponent` and implement forwarding refs to the root `<span>` element ([link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L17-R19), [link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L43-R64), [link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L194-R197))
* Rename the `ref` prop of the `CSSMotion` and `ScrollNumber` components to `scrollNumberRef` and pass it to the child function of the `CSSMotion` component ([link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L202-R205), [link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L236-R239))
* Export the `Badge` component as a compounded component with a `Ribbon` property ([link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391R251-R252))
* Wrap the `FloatButton` component with `React.StrictMode` in the `components/float-button/demo/basic.tsx` file ([link](https://github.com/ant-design/ant-design/pull/41833/files?diff=unified&w=0#diff-65dc763437b8c6198be51fdb630441c362dc1d9191468c99fef09b41d78b3425L4-R8))
