### PR TITLE
feat: table columnTitle renderProps

### DIFF
--- a/components/table/demo/row-selection.tsx
+++ b/components/table/demo/row-selection.tsx
@@ -54,6 +54,14 @@ const data: DataType[] = [
 
 // rowSelection object indicates the need for row selection
 const rowSelection = {
+  columnTitle: (checkboxNode: React.ReactNode) => (
+    <div>
+      {React.cloneElement(checkboxNode! as unknown as React.ReactElement, {
+        'data-testid': 'selection-checkbox',
+      })}
+    </div>
+  ),
+  columnWidth: 100,
   onChange: (selectedRowKeys: React.Key[], selectedRows: DataType[]) => {
     console.log(`selectedRowKeys: ${selectedRowKeys}`, 'selectedRows: ', selectedRows);
   },

--- a/components/table/demo/row-selection.tsx
+++ b/components/table/demo/row-selection.tsx
@@ -54,14 +54,6 @@ const data: DataType[] = [
 
 // rowSelection object indicates the need for row selection
 const rowSelection = {
-  columnTitle: (checkboxNode: React.ReactNode) => (
-    <div>
-      {React.cloneElement(checkboxNode! as unknown as React.ReactElement, {
-        'data-testid': 'selection-checkbox',
-      })}
-    </div>
-  ),
-  columnWidth: 100,
   onChange: (selectedRowKeys: React.Key[], selectedRows: DataType[]) => {
     console.log(`selectedRowKeys: ${selectedRowKeys}`, 'selectedRows: ', selectedRows);
   },

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -404,6 +404,7 @@ const useSelection = <RecordType extends AnyObject = any>(
       // ===================== Render =====================
       // Title Cell
       let title: React.ReactNode;
+      let columnTitleCheckbox: React.ReactNode;
       if (selectionType !== 'radio') {
         let customizeSelections: React.ReactNode;
         if (mergedSelections) {
@@ -448,22 +449,26 @@ const useSelection = <RecordType extends AnyObject = any>(
         const allDisabledSomeChecked =
           allDisabled && allDisabledData.some(({ checked }) => checked);
 
+        columnTitleCheckbox = (
+          <Checkbox
+            checked={
+              !allDisabled ? !!flattedData.length && checkedCurrentAll : allDisabledAndChecked
+            }
+            indeterminate={
+              !allDisabled
+                ? !checkedCurrentAll && checkedCurrentSome
+                : !allDisabledAndChecked && allDisabledSomeChecked
+            }
+            onChange={onSelectAllChange}
+            disabled={flattedData.length === 0 || allDisabled}
+            aria-label={customizeSelections ? 'Custom selection' : 'Select all'}
+            skipGroup
+          />
+        );
+
         title = !hideSelectAll && (
           <div className={`${prefixCls}-selection`}>
-            <Checkbox
-              checked={
-                !allDisabled ? !!flattedData.length && checkedCurrentAll : allDisabledAndChecked
-              }
-              indeterminate={
-                !allDisabled
-                  ? !checkedCurrentAll && checkedCurrentSome
-                  : !allDisabledAndChecked && allDisabledSomeChecked
-              }
-              onChange={onSelectAllChange}
-              disabled={flattedData.length === 0 || allDisabled}
-              aria-label={customizeSelections ? 'Custom selection' : 'Select all'}
-              skipGroup
-            />
+            {columnTitleCheckbox}
             {customizeSelections}
           </div>
         );
@@ -691,12 +696,22 @@ const useSelection = <RecordType extends AnyObject = any>(
         [`${prefixCls}-selection-col-with-dropdown`]: selections && selectionType === 'checkbox',
       });
 
+      const renderColumnTitle = () => {
+        if (!rowSelection?.columnTitle) {
+          return title;
+        }
+        if (typeof rowSelection.columnTitle === 'function') {
+          return rowSelection.columnTitle(columnTitleCheckbox);
+        }
+        return rowSelection.columnTitle;
+      };
+
       // Replace with real selection column
       const selectionColumn = {
         fixed: mergedFixed,
         width: selectionColWidth,
         className: `${prefixCls}-selection-column`,
-        title: rowSelection.columnTitle || title,
+        title: renderColumnTitle(),
         render: renderSelectionCell,
         [INTERNAL_COL_DEFINE]: { className: columnCls },
       };

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -247,7 +247,7 @@ Properties for row selection.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | checkStrictly | Check table row precisely; parent row and children rows are not associated | boolean | true | 4.4.0 |
-| columnTitle | Set the title of the selection column | ReactNode | - |  |
+| columnTitle | Set the title of the selection column | ReactNode \| (originalNode: ReactNode) => ReactNode | - |  |
 | columnWidth | Set the width of the selection column | string \| number | `32px` |  |
 | fixed | Fixed selection column on the left | boolean | - |  |
 | getCheckboxProps | Get Checkbox or Radio props | function(record) | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -249,7 +249,7 @@ const columns = [
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | checkStrictly | checkable 状态下节点选择完全受控（父子数据选中状态不再关联） | boolean | true | 4.4.0 |
-| columnTitle | 自定义列表选择框标题 | ReactNode | - |  |
+| columnTitle | 自定义列表选择框标题 | ReactNode \| (originalNode: ReactNode) => ReactNode | - |  |
 | columnWidth | 自定义列表选择框宽度 | string \| number | `32px` |  |
 | fixed | 把选择框列固定在左边 | boolean | - |  |
 | getCheckboxProps | 选择框的默认属性配置 | function(record) | - |  |

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -190,7 +190,7 @@ export interface TableRowSelection<T> {
   hideSelectAll?: boolean;
   fixed?: FixedType;
   columnWidth?: string | number;
-  columnTitle?: string | React.ReactNode;
+  columnTitle?: string | React.ReactNode | ((checkboxNode: React.ReactNode) => React.ReactNode);
   checkStrictly?: boolean;
   renderCell?: (
     value: boolean,


### PR DESCRIPTION
[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   update table rowSelection columnTitle renderProps with original CheckboxNode     |
| 🇨🇳 中文 |   更新 table rowSelection columnTitle 属性，增加 columnTitle renderProps , 可返回原节点      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

table 的 columnTitle 原先只能够使用 ReactNode,  如果直接返回ReactNode 就不能用全选按钮，目前支持使用方法返回ReactNode,  可以使用全选按钮， 关联issue  

#33176 

https://github.com/ant-design/ant-design/issues/33176

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af1c56c</samp>

*  Add a new property `columnTitle` to the `rowSelection` object that allows customizing the selection column title with a function or a node ([link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-699a9403a8783b5b108057bc0314e3d47ab1bb0ca96b521531e7d3a3ff60fb42R57-R64), [link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25R699-R708), [link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9L250-R250), [link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209L252-R252), [link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9L193-R193))
*  Separate the checkbox node from the rest of the title node in the `useSelection` hook and store it in a new variable `columnTitleCheckbox` ([link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25R407), [link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L451-R471))
*  Call the `columnTitle` function with the `columnTitleCheckbox` node or return the `columnTitle` node or the default `title` node in a new function `renderColumnTitle` in the `useSelection` hook ([link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25R699-R708))
*  Replace the `title` property of the selection column with the `renderColumnTitle` function call in the `useSelection` hook ([link](https://github.com/ant-design/ant-design/pull/41837/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L699-R714))