### PR TITLE
fix:checkbox默认选中与原生标签表现不一致

### DIFF
--- a/components/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Checkbox rtl render component should be rendered correctly in RTL direc
     <input
       class="ant-checkbox-input"
       type="checkbox"
-      value=""
     />
     <span
       class="ant-checkbox-inner"

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -159,6 +159,49 @@ Array [
 ]
 `;
 
+exports[`renders ./components/checkbox/demo/debug-defalutChecked.md extend context correctly 1`] = `
+Array [
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox"
+    >
+      <input
+        class="ant-checkbox-input"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      checked 值为undefined
+    </span>
+  </label>,
+  <br />,
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      checked 值为 true
+    </span>
+  </label>,
+]
+`;
+
 exports[`renders ./components/checkbox/demo/debug-line.md extend context correctly 1`] = `
 <div>
   <div
@@ -359,6 +402,26 @@ exports[`renders ./components/checkbox/demo/debug-line.md extend context correct
       </span>
     </label>
   </div>
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        name="ceshikk"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      Aligned stable
+    </span>
+  </label>
 </div>
 `;
 

--- a/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.ts.snap
@@ -159,6 +159,49 @@ Array [
 ]
 `;
 
+exports[`renders ./components/checkbox/demo/debug-defalutChecked.md correctly 1`] = `
+Array [
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox"
+    >
+      <input
+        class="ant-checkbox-input"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      checked 值为undefined
+    </span>
+  </label>,
+  <br />,
+  <label
+    class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      checked 值为 true
+    </span>
+  </label>,
+]
+`;
+
 exports[`renders ./components/checkbox/demo/debug-line.md correctly 1`] = `
 <div>
   <div
@@ -359,6 +402,26 @@ exports[`renders ./components/checkbox/demo/debug-line.md correctly 1`] = `
       </span>
     </label>
   </div>
+  <label
+    class="ant-checkbox-wrapper"
+  >
+    <span
+      class="ant-checkbox ant-checkbox-checked"
+    >
+      <input
+        checked=""
+        class="ant-checkbox-input"
+        name="ceshikk"
+        type="checkbox"
+      />
+      <span
+        class="ant-checkbox-inner"
+      />
+    </span>
+    <span>
+      Aligned stable
+    </span>
+  </label>
 </div>
 `;
 

--- a/components/checkbox/demo/debug-defalutChecked.md
+++ b/components/checkbox/demo/debug-defalutChecked.md
@@ -1,0 +1,34 @@
+---
+order: 1
+title:
+  zh-CN: defaultChecked
+  en-US: defaultChecked
+debug: true
+---
+
+## zh-CN
+
+defaultChecked is true
+
+## en-US
+
+defaultChecked is true
+
+```tsx
+import { Checkbox } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => (
+  <>
+    <Checkbox checked={undefined} defaultChecked={true}>
+      checked 值为undefined
+    </Checkbox>
+    <br />
+    <Checkbox checked defaultChecked={true}>
+      checked 值为 true
+    </Checkbox>
+  </>
+);
+
+export default App;
+```

--- a/components/checkbox/demo/debug-line.md
+++ b/components/checkbox/demo/debug-line.md
@@ -60,6 +60,9 @@ const App: React.FC = () => (
       <div>Bamboo</div>
       <Radio value="little">Little</Radio>
     </div>
+    <Checkbox checked={undefined} defaultChecked={true} name="ceshikk">
+      Aligned stable
+    </Checkbox>
   </div>
 );
 

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -12091,7 +12091,6 @@ exports[`ConfigProvider components Checkbox configProvider 1`] = `
       <input
         class="config-checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="config-checkbox-inner"
@@ -12118,7 +12117,6 @@ exports[`ConfigProvider components Checkbox configProvider componentDisabled 1`]
         class="config-checkbox-input"
         disabled=""
         type="checkbox"
-        value=""
       />
       <span
         class="config-checkbox-inner"
@@ -12144,7 +12142,6 @@ exports[`ConfigProvider components Checkbox configProvider componentSize large 1
       <input
         class="config-checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="config-checkbox-inner"
@@ -12170,7 +12167,6 @@ exports[`ConfigProvider components Checkbox configProvider componentSize middle 
       <input
         class="config-checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="config-checkbox-inner"
@@ -12196,7 +12192,6 @@ exports[`ConfigProvider components Checkbox configProvider virtual and dropdownM
       <input
         class="ant-checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="ant-checkbox-inner"
@@ -12222,7 +12217,6 @@ exports[`ConfigProvider components Checkbox normal 1`] = `
       <input
         class="ant-checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="ant-checkbox-inner"
@@ -12248,7 +12242,6 @@ exports[`ConfigProvider components Checkbox prefixCls 1`] = `
       <input
         class="prefix-Checkbox-input"
         type="checkbox"
-        value=""
       />
       <span
         class="prefix-Checkbox-inner"
@@ -22392,7 +22385,6 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
           checked=""
           class="config-radio-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-inner"
@@ -22416,7 +22408,6 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
           checked=""
           class="config-radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-button-inner"
@@ -22446,7 +22437,6 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
           class="config-radio-input"
           disabled=""
           type="radio"
-          value=""
         />
         <span
           class="config-radio-inner"
@@ -22471,7 +22461,6 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
           class="config-radio-button-input"
           disabled=""
           type="radio"
-          value=""
         />
         <span
           class="config-radio-button-inner"
@@ -22500,7 +22489,6 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
           checked=""
           class="config-radio-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-inner"
@@ -22524,7 +22512,6 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
           checked=""
           class="config-radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-button-inner"
@@ -22553,7 +22540,6 @@ exports[`ConfigProvider components Radio configProvider componentSize middle 1`]
           checked=""
           class="config-radio-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-inner"
@@ -22577,7 +22563,6 @@ exports[`ConfigProvider components Radio configProvider componentSize middle 1`]
           checked=""
           class="config-radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="config-radio-button-inner"
@@ -22606,7 +22591,6 @@ exports[`ConfigProvider components Radio configProvider virtual and dropdownMatc
           checked=""
           class="ant-radio-input"
           type="radio"
-          value=""
         />
         <span
           class="ant-radio-inner"
@@ -22630,7 +22614,6 @@ exports[`ConfigProvider components Radio configProvider virtual and dropdownMatc
           checked=""
           class="ant-radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="ant-radio-button-inner"
@@ -22659,7 +22642,6 @@ exports[`ConfigProvider components Radio normal 1`] = `
           checked=""
           class="ant-radio-input"
           type="radio"
-          value=""
         />
         <span
           class="ant-radio-inner"
@@ -22683,7 +22665,6 @@ exports[`ConfigProvider components Radio normal 1`] = `
           checked=""
           class="ant-radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="ant-radio-button-inner"
@@ -22712,7 +22693,6 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
           checked=""
           class="prefix-Radio-input"
           type="radio"
-          value=""
         />
         <span
           class="prefix-Radio-inner"
@@ -22736,7 +22716,6 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
           checked=""
           class="prefix-Radio-button-input"
           type="radio"
-          value=""
         />
         <span
           class="prefix-Radio-button-inner"
@@ -27098,7 +27077,6 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                                       <input
                                         class="config-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="config-checkbox-inner"
@@ -27405,7 +27383,6 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                                         class="config-checkbox-input"
                                         disabled=""
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="config-checkbox-inner"
@@ -27712,7 +27689,6 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                                       <input
                                         class="config-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="config-checkbox-inner"
@@ -28018,7 +27994,6 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                                       <input
                                         class="config-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="config-checkbox-inner"
@@ -28324,7 +28299,6 @@ exports[`ConfigProvider components Table configProvider virtual and dropdownMatc
                                       <input
                                         class="ant-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="ant-checkbox-inner"
@@ -28630,7 +28604,6 @@ exports[`ConfigProvider components Table normal 1`] = `
                                       <input
                                         class="ant-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="ant-checkbox-inner"
@@ -28936,7 +28909,6 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                                       <input
                                         class="ant-checkbox-input"
                                         type="checkbox"
-                                        value=""
                                       />
                                       <span
                                         class="ant-checkbox-inner"
@@ -38751,7 +38723,6 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -38911,7 +38882,6 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39025,7 +38995,6 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
             class="config-checkbox-input"
             disabled=""
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39186,7 +39155,6 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
             class="config-checkbox-input"
             disabled=""
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39299,7 +39267,6 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39459,7 +39426,6 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39572,7 +39538,6 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39732,7 +39697,6 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
           <input
             class="config-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="config-checkbox-inner"
@@ -39845,7 +39809,6 @@ exports[`ConfigProvider components Transfer configProvider virtual and dropdownM
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -40005,7 +39968,6 @@ exports[`ConfigProvider components Transfer configProvider virtual and dropdownM
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -40118,7 +40080,6 @@ exports[`ConfigProvider components Transfer normal 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -40278,7 +40239,6 @@ exports[`ConfigProvider components Transfer normal 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -40391,7 +40351,6 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -40551,7 +40510,6 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -138,7 +138,6 @@ exports[`Form form should support disabled 1`] = `
                   disabled=""
                   id="disabled"
                   type="checkbox"
-                  value=""
                 />
                 <span
                   class="ant-checkbox-inner"

--- a/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Radio Button rtl render component should be rendered correctly in RTL d
     <input
       class="ant-radio-button-input"
       type="radio"
-      value=""
     />
     <span
       class="ant-radio-button-inner"
@@ -29,7 +28,6 @@ exports[`Radio Button should render correctly 1`] = `
     <input
       class="ant-radio-button-input"
       type="radio"
-      value=""
     />
     <span
       class="ant-radio-button-inner"

--- a/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Radio rtl render component should be rendered correctly in RTL directio
     <input
       class="ant-radio-input"
       type="radio"
-      value=""
     />
     <span
       class="ant-radio-inner"
@@ -35,7 +34,6 @@ exports[`Radio rtl render component should be rendered correctly in RTL directio
     <input
       class="ant-radio-button-input"
       type="radio"
-      value=""
     />
     <span
       class="ant-radio-button-inner"
@@ -54,7 +52,6 @@ exports[`Radio should render correctly 1`] = `
     <input
       class="ant-radio-input"
       type="radio"
-      value=""
     />
     <span
       class="ant-radio-inner"

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -580,7 +580,6 @@ exports[`Table.filter renders menu correctly 1`] = `
             <input
               class="ant-checkbox-input"
               type="checkbox"
-              value=""
             />
             <span
               class="ant-checkbox-inner"
@@ -610,7 +609,6 @@ exports[`Table.filter renders menu correctly 1`] = `
             <input
               class="ant-checkbox-input"
               type="checkbox"
-              value=""
             />
             <span
               class="ant-checkbox-inner"
@@ -722,7 +720,6 @@ exports[`Table.filter renders radio filter correctly 1`] = `
             <input
               class="ant-radio-input"
               type="radio"
-              value=""
             />
             <span
               class="ant-radio-inner"
@@ -752,7 +749,6 @@ exports[`Table.filter renders radio filter correctly 1`] = `
             <input
               class="ant-radio-input"
               type="radio"
-              value=""
             />
             <span
               class="ant-radio-inner"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
@@ -56,7 +56,6 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                             aria-label="Select all"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -133,7 +132,6 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -175,7 +173,6 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -217,7 +214,6 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -259,7 +255,6 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -411,7 +406,6 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                             aria-label="Select all"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -469,7 +463,6 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -500,7 +493,6 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -531,7 +523,6 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -562,7 +553,6 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -714,7 +704,6 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                             aria-label="Select all"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -773,7 +762,6 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -805,7 +793,6 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -837,7 +824,6 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -869,7 +855,6 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1075,7 +1060,6 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                             aria-label="Custom selection"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -1194,7 +1178,6 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1224,7 +1207,6 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1254,7 +1236,6 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1284,7 +1265,6 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1434,7 +1414,6 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                             aria-label="Custom selection"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -1553,7 +1532,6 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1583,7 +1561,6 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1613,7 +1590,6 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1643,7 +1619,6 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1793,7 +1768,6 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                             aria-label="Select all"
                             class="ant-checkbox-input"
                             type="checkbox"
-                            value=""
                           />
                           <span
                             class="ant-checkbox-inner"
@@ -1828,7 +1802,6 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1858,7 +1831,6 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1888,7 +1860,6 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"
@@ -1918,7 +1889,6 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                         <input
                           class="ant-checkbox-input"
                           type="checkbox"
-                          value=""
                         />
                         <span
                           class="ant-checkbox-inner"

--- a/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -179,7 +178,6 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -293,7 +291,6 @@ exports[`Transfer should render correctly 1`] = `
             checked=""
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -348,7 +345,6 @@ exports[`Transfer should render correctly 1`] = `
                 checked=""
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -372,7 +368,6 @@ exports[`Transfer should render correctly 1`] = `
                 class="ant-checkbox-input"
                 disabled=""
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -454,7 +449,6 @@ exports[`Transfer should render correctly 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -508,7 +502,6 @@ exports[`Transfer should render correctly 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -544,7 +537,6 @@ exports[`Transfer should show sorted targetKey 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -599,7 +591,6 @@ exports[`Transfer should show sorted targetKey 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -684,7 +675,6 @@ exports[`Transfer should show sorted targetKey 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -739,7 +729,6 @@ exports[`Transfer should show sorted targetKey 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -765,7 +754,6 @@ exports[`Transfer should show sorted targetKey 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -803,7 +791,6 @@ exports[`Transfer should support render value and label in item 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -858,7 +845,6 @@ exports[`Transfer should support render value and label in item 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -943,7 +929,6 @@ exports[`Transfer should support render value and label in item 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -1056,7 +1041,6 @@ exports[`immutable data dataSource is frozen 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"
@@ -1110,7 +1094,6 @@ exports[`immutable data dataSource is frozen 1`] = `
               <input
                 class="ant-checkbox-input"
                 type="checkbox"
-                value=""
               />
               <span
                 class="ant-checkbox-inner"
@@ -1193,7 +1176,6 @@ exports[`immutable data dataSource is frozen 1`] = `
           <input
             class="ant-checkbox-input"
             type="checkbox"
-            value=""
           />
           <span
             class="ant-checkbox-inner"

--- a/components/transfer/__tests__/__snapshots__/list.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/list.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Transfer.List should render correctly 1`] = `
           aria-checked="mixed"
           class="ant-checkbox-input"
           type="checkbox"
-          value=""
         />
         <span
           class="ant-checkbox-inner"
@@ -71,7 +70,6 @@ exports[`Transfer.List should render correctly 1`] = `
               checked=""
               class="ant-checkbox-input"
               type="checkbox"
-              value=""
             />
             <span
               class="ant-checkbox-inner"
@@ -94,7 +92,6 @@ exports[`Transfer.List should render correctly 1`] = `
             <input
               class="ant-checkbox-input"
               type="checkbox"
-              value=""
             />
             <span
               class="ant-checkbox-inner"
@@ -118,7 +115,6 @@ exports[`Transfer.List should render correctly 1`] = `
               class="ant-checkbox-input"
               disabled=""
               type="checkbox"
-              value=""
             />
             <span
               class="ant-checkbox-inner"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
     "rc-cascader": "~3.7.0",
-    "rc-checkbox": "~2.3.0",
+    "rc-checkbox": "~3.0.0",
     "rc-collapse": "~3.4.2",
     "rc-dialog": "~9.0.2",
     "rc-drawer": "~6.1.0",


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix: https://github.com/ant-design/ant-design/issues/35130

### 💡 需求背景和解决方案

1. 当 CheckBox 中checked 属性值为 undefined,defaultChecked 值为 true ,该 checkbox 应该被选中。但实际情况未选中
2. 通过升级 rc-checkbox解决

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Upgraded the version of rc-checkbox. When the checked attribute passed in is undefined, the previous version will get checked='', and the current version will not display this attribute directly        |
| 🇨🇳 中文 | 升级了rc-checkbox的版本。当传入的checked属性为undefined时,上版本会得到 checked='',现版本会直接不显示该属性   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf6e9cd</samp>

Add new debug demos and update dependency for Checkbox component. The changes include two new demo files with the `debug` flag set to `true`, and a major version upgrade of the `rc-checkbox` library in the `package.json` file.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf6e9cd</samp>

* Upgrade the rc-checkbox dependency to 3.0.0 ([link](https://github.com/ant-design/ant-design/pull/41845/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L128-R128)), which may introduce breaking changes or new features for the Checkbox component and its related components