### PR TITLE
fix: arrow compatible

### DIFF
--- a/components/style/roundedArrow.ts
+++ b/components/style/roundedArrow.ts
@@ -24,6 +24,7 @@ export const roundedArrow = (
   const fy = ay;
 
   const shadowWidth = unitWidth * Math.sqrt(2) + outerRadius * (Math.sqrt(2) - 2);
+  const polygonOffset = outerRadius * (Math.sqrt(2) - 1);
 
   return {
     pointerEvents: 'none',
@@ -38,7 +39,15 @@ export const roundedArrow = (
       width,
       height: width / 2,
       background: bgColor,
-      clipPath: `path('M ${ax} ${ay} A ${outerRadius} ${outerRadius} 0 0 0 ${bx} ${by} L ${cx} ${cy} A ${innerRadius} ${innerRadius} 0 0 1 ${dx} ${dy} L ${ex} ${ey} A ${outerRadius} ${outerRadius} 0 0 0 ${fx} ${fy} Z')`,
+      clipPath: {
+        _multi_value_: true,
+        value: [
+          `polygon(${polygonOffset}px 100%, 50% ${polygonOffset}px, ${
+            2 * unitWidth - polygonOffset
+          }px 100%, ${polygonOffset}px 100%)`,
+          `path('M ${ax} ${ay} A ${outerRadius} ${outerRadius} 0 0 0 ${bx} ${by} L ${cx} ${cy} A ${innerRadius} ${innerRadius} 0 0 1 ${dx} ${dy} L ${ex} ${ey} A ${outerRadius} ${outerRadius} 0 0 0 ${fx} ${fy} Z')`,
+        ],
+      },
       content: '""',
     },
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^7.0.0",
-    "@ant-design/cssinjs": "^1.7.1",
+    "@ant-design/cssinjs": "^1.9.0",
     "@ant-design/icons": "^5.0.0",
     "@ant-design/react-slick": "~1.0.0",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
不支持 path 的时候 fallback 到 polygon
![image](https://user-images.githubusercontent.com/27722486/232949077-f5455ebc-6ba7-4f6d-9268-47def7866d4d.png)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Arrow element support more old browsers which do not support `clip-path: path()`.        |
| 🇨🇳 Chinese |   箭头元素兼容旧版本不支持 `clip-path: path()` 的浏览器。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e39e91</samp>

This pull request improves the compatibility and styling of the rounded arrow component in Safari. It modifies the `components/style/roundedArrow.ts` file and updates the `@ant-design/cssinjs` dependency in `package.json`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e39e91</samp>

*  Add a variable `polygonOffset` to calculate the offset of the polygon shape for clipping the rounded arrow in Safari ([link](https://github.com/ant-design/ant-design/pull/41872/files?diff=unified&w=0#diff-00c9b8ad872ab0d8e21637b999ef0a5e9a27ba23c76c92a99c2db67011fdc66cR27))
*  Use the `_multi_value_` flag to set different values for the `clipPath` property of the pseudo-element that creates the rounded arrow, depending on the browser ([link](https://github.com/ant-design/ant-design/pull/41872/files?diff=unified&w=0#diff-00c9b8ad872ab0d8e21637b999ef0a5e9a27ba23c76c92a99c2db67011fdc66cL41-R50))
*  Update the dependency version of `@ant-design/cssinjs` to support the `_multi_value_` feature in `package.json` ([link](https://github.com/ant-design/ant-design/pull/41872/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L111-R111))
