### PR TITLE
fix: dynamic useApp CP theme

### DIFF
--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -1,5 +1,5 @@
 // deps-lint-skip-all
-import { Keyframes } from '@ant-design/cssinjs';
+import { CSSObject, Keyframes } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -67,6 +67,40 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     },
   });
 
+  const noticeStyle: CSSObject = {
+    padding: paddingXS,
+    textAlign: 'center',
+
+    [`${componentCls}-custom-content > ${iconCls}`]: {
+      verticalAlign: 'text-bottom',
+      marginInlineEnd: marginXS, // affected by ltr or rtl
+      fontSize: fontSizeLG,
+    },
+
+    [`${noticeCls}-content`]: {
+      display: 'inline-block',
+      padding: messageNoticeContentPadding,
+      background: colorBgElevated,
+      borderRadius: borderRadiusLG,
+      boxShadow,
+      pointerEvents: 'all',
+    },
+
+    [`${componentCls}-success > ${iconCls}`]: {
+      color: colorSuccess,
+    },
+    [`${componentCls}-error > ${iconCls}`]: {
+      color: colorError,
+    },
+    [`${componentCls}-warning > ${iconCls}`]: {
+      color: colorWarning,
+    },
+    [`${componentCls}-info > ${iconCls},
+      ${componentCls}-loading > ${iconCls}`]: {
+      color: colorInfo,
+    },
+  };
+
   return [
     // ============================ Holder ============================
     {
@@ -119,38 +153,7 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     {
       [componentCls]: {
         [noticeCls]: {
-          padding: paddingXS,
-          textAlign: 'center',
-
-          [`${componentCls}-custom-content > ${iconCls}`]: {
-            verticalAlign: 'text-bottom',
-            marginInlineEnd: marginXS, // affected by ltr or rtl
-            fontSize: fontSizeLG,
-          },
-
-          [`${noticeCls}-content`]: {
-            display: 'inline-block',
-            padding: messageNoticeContentPadding,
-            background: colorBgElevated,
-            borderRadius: borderRadiusLG,
-            boxShadow,
-            pointerEvents: 'all',
-          },
-
-          [`${componentCls}-success > ${iconCls}`]: {
-            color: colorSuccess,
-          },
-          [`${componentCls}-error > ${iconCls}`]: {
-            color: colorError,
-          },
-          [`${componentCls}-warning > ${iconCls}`]: {
-            color: colorWarning,
-          },
-          [`
-        ${componentCls}-info > ${iconCls},
-        ${componentCls}-loading > ${iconCls}`]: {
-            color: colorInfo,
-          },
+          ...noticeStyle,
         },
       },
     },
@@ -158,6 +161,7 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     // ============================= Pure =============================
     {
       [`${componentCls}-notice-pure-panel`]: {
+        ...noticeStyle,
         padding: 0,
         textAlign: 'start',
       },

--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -1,8 +1,8 @@
 // deps-lint-skip-all
 import { Keyframes } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { resetComponent } from '../../style';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -37,6 +37,8 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     // Custom token
     messageNoticeContentPadding,
   } = token;
+
+  const noticeCls = `${componentCls}-notice`;
 
   const messageMoveIn = new Keyframes('MessageMoveIn', {
     '0%': {
@@ -115,38 +117,40 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
 
     // ============================ Notice ============================
     {
-      [`${componentCls}-notice`]: {
-        padding: paddingXS,
-        textAlign: 'center',
+      [componentCls]: {
+        [noticeCls]: {
+          padding: paddingXS,
+          textAlign: 'center',
 
-        [`${componentCls}-custom-content > ${iconCls}`]: {
-          verticalAlign: 'text-bottom',
-          marginInlineEnd: marginXS, // affected by ltr or rtl
-          fontSize: fontSizeLG,
-        },
+          [`${componentCls}-custom-content > ${iconCls}`]: {
+            verticalAlign: 'text-bottom',
+            marginInlineEnd: marginXS, // affected by ltr or rtl
+            fontSize: fontSizeLG,
+          },
 
-        [`${componentCls}-notice-content`]: {
-          display: 'inline-block',
-          padding: messageNoticeContentPadding,
-          background: colorBgElevated,
-          borderRadius: borderRadiusLG,
-          boxShadow,
-          pointerEvents: 'all',
-        },
+          [`${noticeCls}-content`]: {
+            display: 'inline-block',
+            padding: messageNoticeContentPadding,
+            background: colorBgElevated,
+            borderRadius: borderRadiusLG,
+            boxShadow,
+            pointerEvents: 'all',
+          },
 
-        [`${componentCls}-success > ${iconCls}`]: {
-          color: colorSuccess,
-        },
-        [`${componentCls}-error > ${iconCls}`]: {
-          color: colorError,
-        },
-        [`${componentCls}-warning > ${iconCls}`]: {
-          color: colorWarning,
-        },
-        [`
+          [`${componentCls}-success > ${iconCls}`]: {
+            color: colorSuccess,
+          },
+          [`${componentCls}-error > ${iconCls}`]: {
+            color: colorError,
+          },
+          [`${componentCls}-warning > ${iconCls}`]: {
+            color: colorWarning,
+          },
+          [`
         ${componentCls}-info > ${iconCls},
         ${componentCls}-loading > ${iconCls}`]: {
-          color: colorInfo,
+            color: colorInfo,
+          },
         },
       },
     },

--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -1,5 +1,6 @@
 // deps-lint-skip-all
-import { CSSObject, Keyframes } from '@ant-design/cssinjs';
+import type { CSSObject } from '@ant-design/cssinjs';
+import { Keyframes } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -1,4 +1,5 @@
-import { CSSObject, Keyframes } from '@ant-design/cssinjs';
+import type { CSSObject } from '@ant-design/cssinjs';
+import { Keyframes } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -1,4 +1,4 @@
-import { Keyframes } from '@ant-design/cssinjs';
+import { CSSObject, Keyframes } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -82,6 +82,100 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
     },
   });
 
+  const noticeStyle: CSSObject = {
+    position: 'relative',
+    width,
+    maxWidth: `calc(100vw - ${notificationMarginEdge * 2}px)`,
+    marginBottom: notificationMarginBottom,
+    marginInlineStart: 'auto',
+    padding: notificationPadding,
+    overflow: 'hidden',
+    lineHeight,
+    wordWrap: 'break-word',
+    background: notificationBg,
+    borderRadius: borderRadiusLG,
+    boxShadow,
+
+    [`${componentCls}-close-icon`]: {
+      fontSize,
+      cursor: 'pointer',
+    },
+
+    [`${noticeCls}-message`]: {
+      marginBottom: token.marginXS,
+      color: colorTextHeading,
+      fontSize: fontSizeLG,
+      lineHeight: token.lineHeightLG,
+    },
+
+    [`${noticeCls}-description`]: {
+      fontSize,
+    },
+
+    [`&${noticeCls}-closable ${noticeCls}-message`]: {
+      paddingInlineEnd: token.paddingLG,
+    },
+
+    [`${noticeCls}-with-icon ${noticeCls}-message`]: {
+      marginBottom: token.marginXS,
+      marginInlineStart: token.marginSM + notificationIconSize,
+      fontSize: fontSizeLG,
+    },
+
+    [`${noticeCls}-with-icon ${noticeCls}-description`]: {
+      marginInlineStart: token.marginSM + notificationIconSize,
+      fontSize,
+    },
+
+    // Icon & color style in different selector level
+    // https://github.com/ant-design/ant-design/issues/16503
+    // https://github.com/ant-design/ant-design/issues/15512
+    [`${noticeCls}-icon`]: {
+      position: 'absolute',
+      fontSize: notificationIconSize,
+      lineHeight: 0,
+
+      // icon-font
+      [`&-success${iconCls}`]: {
+        color: colorSuccess,
+      },
+      [`&-info${iconCls}`]: {
+        color: colorInfo,
+      },
+      [`&-warning${iconCls}`]: {
+        color: colorWarning,
+      },
+      [`&-error${iconCls}`]: {
+        color: colorError,
+      },
+    },
+
+    [`${noticeCls}-close`]: {
+      position: 'absolute',
+      top: token.notificationPaddingVertical,
+      insetInlineEnd: token.notificationPaddingHorizontal,
+      color: token.colorIcon,
+      outline: 'none',
+      width: token.notificationCloseButtonSize,
+      height: token.notificationCloseButtonSize,
+      borderRadius: token.borderRadiusSM,
+      transition: `background-color ${token.motionDurationMid}, color ${token.motionDurationMid}`,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+
+      '&:hover': {
+        color: token.colorIconHover,
+        backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
+      },
+    },
+
+    [`${noticeCls}-btn`]: {
+      float: 'right',
+      marginTop: token.marginSM,
+    },
+  };
+
   return [
     // ============================ Holder ============================
     {
@@ -155,97 +249,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
     {
       [componentCls]: {
         [noticeCls]: {
-          position: 'relative',
-          width,
-          maxWidth: `calc(100vw - ${notificationMarginEdge * 2}px)`,
-          marginBottom: notificationMarginBottom,
-          marginInlineStart: 'auto',
-          padding: notificationPadding,
-          overflow: 'hidden',
-          lineHeight,
-          wordWrap: 'break-word',
-          background: notificationBg,
-          borderRadius: borderRadiusLG,
-          boxShadow,
-
-          [`${componentCls}-close-icon`]: {
-            fontSize,
-            cursor: 'pointer',
-          },
-
-          [`${noticeCls}-message`]: {
-            marginBottom: token.marginXS,
-            color: colorTextHeading,
-            fontSize: fontSizeLG,
-            lineHeight: token.lineHeightLG,
-          },
-
-          [`${noticeCls}-description`]: {
-            fontSize,
-          },
-
-          [`&${noticeCls}-closable ${noticeCls}-message`]: {
-            paddingInlineEnd: token.paddingLG,
-          },
-
-          [`${noticeCls}-with-icon ${noticeCls}-message`]: {
-            marginBottom: token.marginXS,
-            marginInlineStart: token.marginSM + notificationIconSize,
-            fontSize: fontSizeLG,
-          },
-
-          [`${noticeCls}-with-icon ${noticeCls}-description`]: {
-            marginInlineStart: token.marginSM + notificationIconSize,
-            fontSize,
-          },
-
-          // Icon & color style in different selector level
-          // https://github.com/ant-design/ant-design/issues/16503
-          // https://github.com/ant-design/ant-design/issues/15512
-          [`${noticeCls}-icon`]: {
-            position: 'absolute',
-            fontSize: notificationIconSize,
-            lineHeight: 0,
-
-            // icon-font
-            [`&-success${iconCls}`]: {
-              color: colorSuccess,
-            },
-            [`&-info${iconCls}`]: {
-              color: colorInfo,
-            },
-            [`&-warning${iconCls}`]: {
-              color: colorWarning,
-            },
-            [`&-error${iconCls}`]: {
-              color: colorError,
-            },
-          },
-
-          [`${noticeCls}-close`]: {
-            position: 'absolute',
-            top: token.notificationPaddingVertical,
-            insetInlineEnd: token.notificationPaddingHorizontal,
-            color: token.colorIcon,
-            outline: 'none',
-            width: token.notificationCloseButtonSize,
-            height: token.notificationCloseButtonSize,
-            borderRadius: token.borderRadiusSM,
-            transition: `background-color ${token.motionDurationMid}, color ${token.motionDurationMid}`,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-
-            '&:hover': {
-              color: token.colorIconHover,
-              backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
-            },
-          },
-
-          [`${noticeCls}-btn`]: {
-            float: 'right',
-            marginTop: token.marginSM,
-          },
+          ...noticeStyle,
         },
       },
     },
@@ -253,6 +257,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
     // ============================= Pure =============================
     {
       [`${noticeCls}-pure-panel`]: {
+        ...noticeStyle,
         margin: 0,
       },
     },

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -1,8 +1,8 @@
 import { Keyframes } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genNotificationPlacementStyle from './placement';
-import { resetComponent } from '../../style';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -97,13 +97,13 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
         },
 
         [`&${componentCls}-top, &${componentCls}-bottom`]: {
-          [`${componentCls}-notice`]: {
+          [noticeCls]: {
             marginInline: 'auto auto',
           },
         },
 
         [`&${componentCls}-topLeft, &${componentCls}-bottomLeft`]: {
-          [`${componentCls}-notice`]: {
+          [noticeCls]: {
             marginInlineEnd: 'auto',
             marginInlineStart: 0,
           },
@@ -144,7 +144,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
         '&-rtl': {
           direction: 'rtl',
 
-          [`${componentCls}-notice-btn`]: {
+          [`${noticeCls}-btn`]: {
             float: 'left',
           },
         },
@@ -153,97 +153,99 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 
     // ============================ Notice ============================
     {
-      [noticeCls]: {
-        position: 'relative',
-        width,
-        maxWidth: `calc(100vw - ${notificationMarginEdge * 2}px)`,
-        marginBottom: notificationMarginBottom,
-        marginInlineStart: 'auto',
-        padding: notificationPadding,
-        overflow: 'hidden',
-        lineHeight,
-        wordWrap: 'break-word',
-        background: notificationBg,
-        borderRadius: borderRadiusLG,
-        boxShadow,
+      [componentCls]: {
+        [noticeCls]: {
+          position: 'relative',
+          width,
+          maxWidth: `calc(100vw - ${notificationMarginEdge * 2}px)`,
+          marginBottom: notificationMarginBottom,
+          marginInlineStart: 'auto',
+          padding: notificationPadding,
+          overflow: 'hidden',
+          lineHeight,
+          wordWrap: 'break-word',
+          background: notificationBg,
+          borderRadius: borderRadiusLG,
+          boxShadow,
 
-        [`${componentCls}-close-icon`]: {
-          fontSize,
-          cursor: 'pointer',
-        },
-
-        [`${noticeCls}-message`]: {
-          marginBottom: token.marginXS,
-          color: colorTextHeading,
-          fontSize: fontSizeLG,
-          lineHeight: token.lineHeightLG,
-        },
-
-        [`${noticeCls}-description`]: {
-          fontSize,
-        },
-
-        [`&${noticeCls}-closable ${noticeCls}-message`]: {
-          paddingInlineEnd: token.paddingLG,
-        },
-
-        [`${noticeCls}-with-icon ${noticeCls}-message`]: {
-          marginBottom: token.marginXS,
-          marginInlineStart: token.marginSM + notificationIconSize,
-          fontSize: fontSizeLG,
-        },
-
-        [`${noticeCls}-with-icon ${noticeCls}-description`]: {
-          marginInlineStart: token.marginSM + notificationIconSize,
-          fontSize,
-        },
-
-        // Icon & color style in different selector level
-        // https://github.com/ant-design/ant-design/issues/16503
-        // https://github.com/ant-design/ant-design/issues/15512
-        [`${noticeCls}-icon`]: {
-          position: 'absolute',
-          fontSize: notificationIconSize,
-          lineHeight: 0,
-
-          // icon-font
-          [`&-success${iconCls}`]: {
-            color: colorSuccess,
+          [`${componentCls}-close-icon`]: {
+            fontSize,
+            cursor: 'pointer',
           },
-          [`&-info${iconCls}`]: {
-            color: colorInfo,
-          },
-          [`&-warning${iconCls}`]: {
-            color: colorWarning,
-          },
-          [`&-error${iconCls}`]: {
-            color: colorError,
-          },
-        },
 
-        [`${noticeCls}-close`]: {
-          position: 'absolute',
-          top: token.notificationPaddingVertical,
-          insetInlineEnd: token.notificationPaddingHorizontal,
-          color: token.colorIcon,
-          outline: 'none',
-          width: token.notificationCloseButtonSize,
-          height: token.notificationCloseButtonSize,
-          borderRadius: token.borderRadiusSM,
-          transition: `background-color ${token.motionDurationMid}, color ${token.motionDurationMid}`,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-
-          '&:hover': {
-            color: token.colorIconHover,
-            backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
+          [`${noticeCls}-message`]: {
+            marginBottom: token.marginXS,
+            color: colorTextHeading,
+            fontSize: fontSizeLG,
+            lineHeight: token.lineHeightLG,
           },
-        },
 
-        [`${noticeCls}-btn`]: {
-          float: 'right',
-          marginTop: token.marginSM,
+          [`${noticeCls}-description`]: {
+            fontSize,
+          },
+
+          [`&${noticeCls}-closable ${noticeCls}-message`]: {
+            paddingInlineEnd: token.paddingLG,
+          },
+
+          [`${noticeCls}-with-icon ${noticeCls}-message`]: {
+            marginBottom: token.marginXS,
+            marginInlineStart: token.marginSM + notificationIconSize,
+            fontSize: fontSizeLG,
+          },
+
+          [`${noticeCls}-with-icon ${noticeCls}-description`]: {
+            marginInlineStart: token.marginSM + notificationIconSize,
+            fontSize,
+          },
+
+          // Icon & color style in different selector level
+          // https://github.com/ant-design/ant-design/issues/16503
+          // https://github.com/ant-design/ant-design/issues/15512
+          [`${noticeCls}-icon`]: {
+            position: 'absolute',
+            fontSize: notificationIconSize,
+            lineHeight: 0,
+
+            // icon-font
+            [`&-success${iconCls}`]: {
+              color: colorSuccess,
+            },
+            [`&-info${iconCls}`]: {
+              color: colorInfo,
+            },
+            [`&-warning${iconCls}`]: {
+              color: colorWarning,
+            },
+            [`&-error${iconCls}`]: {
+              color: colorError,
+            },
+          },
+
+          [`${noticeCls}-close`]: {
+            position: 'absolute',
+            top: token.notificationPaddingVertical,
+            insetInlineEnd: token.notificationPaddingHorizontal,
+            color: token.colorIcon,
+            outline: 'none',
+            width: token.notificationCloseButtonSize,
+            height: token.notificationCloseButtonSize,
+            borderRadius: token.borderRadiusSM,
+            transition: `background-color ${token.motionDurationMid}, color ${token.motionDurationMid}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+
+            '&:hover': {
+              color: token.colorIconHover,
+              backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
+            },
+          },
+
+          [`${noticeCls}-btn`]: {
+            float: 'right',
+            marginTop: token.marginSM,
+          },
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #41885

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Message hooks icon style not follow dynamic theme token.       |
| 🇨🇳 Chinese |   修复 Message hooks 的图标样式不跟随动态主题 token 切换的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4f021a</samp>

Refactored the CSS code for the message and notification components by extracting common styles and class names into variables. This made the code more consistent, readable, and easy to modify.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4f021a</samp>

*  Refactor the import order and the type of CSSObject to match the code style and the usage of the cssinjs library ([link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL2-R5), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL1-R5))
*  Define the noticeCls variable to store the class name of the message and notification notice components, and use it instead of the hard-coded class names to avoid typos and make the code more maintainable ([link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR41-R42), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL100-R194), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL106-R200), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL147-R241))
*  Define the noticeStyle object to store the common CSS properties of the message and notification notice components, such as padding, background, border, and icon styles, and spread it into the selectors to avoid repeating the same properties and simplify the code ([link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR70-R103), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL118-R157), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR164), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fR85-R178), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL156-R253), [link](https://github.com/ant-design/ant-design/pull/41899/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fR260))
