### PR TITLE
fix: DatePicker PurePanel placement

### DIFF
--- a/components/date-picker/index.ts
+++ b/components/date-picker/index.ts
@@ -2,11 +2,12 @@ import type { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import genPurePanel from '../_util/PurePanel';
 import type {
+  RangePickerProps as BaseRangePickerProps,
   PickerDateProps,
   PickerProps,
-  RangePickerProps as BaseRangePickerProps,
 } from './generatePicker';
 import generatePicker from './generatePicker';
+import { transPlacement2DropdownAlign } from './util';
 
 export type DatePickerProps = PickerProps<Dayjs>;
 export type MonthPickerProps = Omit<PickerDateProps<Dayjs>, 'picker'>;
@@ -15,11 +16,23 @@ export type RangePickerProps = BaseRangePickerProps<Dayjs>;
 
 const DatePicker = generatePicker<Dayjs>(dayjsGenerateConfig);
 
+function postPureProps(props: DatePickerProps) {
+  const dropdownAlign = transPlacement2DropdownAlign(props.direction, props.placement);
+
+  dropdownAlign.overflow!.adjustY = false;
+  dropdownAlign.overflow!.adjustX = false;
+
+  return {
+    ...props,
+    dropdownAlign,
+  };
+}
+
 // We don't care debug panel
 /* istanbul ignore next */
-const PurePanel = genPurePanel(DatePicker, 'picker');
+const PurePanel = genPurePanel(DatePicker, 'picker', null, postPureProps);
 (DatePicker as any)._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
-const PureRangePanel = genPurePanel(DatePicker.RangePicker, 'picker');
+const PureRangePanel = genPurePanel(DatePicker.RangePicker, 'picker', null, postPureProps);
 (DatePicker as any)._InternalRangePanelDoNotUseOrYouWillBeFired = PureRangePanel;
 
 export default DatePicker as typeof DatePicker & {

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -2,6 +2,7 @@ import type { PickerMode } from 'rc-picker/lib/interface';
 import type { DirectionType } from '../config-provider';
 import type { SelectCommonPlacement } from '../_util/motion';
 import type { PickerLocale } from './generatePicker';
+import { AlignType } from '@rc-component/trigger';
 
 export function getPlaceholder(
   locale: PickerLocale,
@@ -60,7 +61,7 @@ export function getRangePlaceholder(
 export function transPlacement2DropdownAlign(
   direction: DirectionType,
   placement?: SelectCommonPlacement,
-) {
+): AlignType {
   const overflow = {
     adjustX: 1,
     adjustY: 1,

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -1,8 +1,8 @@
+import type { AlignType } from '@rc-component/trigger';
 import type { PickerMode } from 'rc-picker/lib/interface';
-import type { DirectionType } from '../config-provider';
 import type { SelectCommonPlacement } from '../_util/motion';
+import type { DirectionType } from '../config-provider';
 import type { PickerLocale } from './generatePicker';
-import { AlignType } from '@rc-component/trigger';
 
 export function getPlaceholder(
   locale: PickerLocale,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |       -    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acf6829</samp>

This pull request enhances the `PurePanel` component to allow customizing the props of its children, and fixes the alignment of the date picker panel with the input. It also refactors the `transPlacement2DropdownAlign` function to use a consistent type for the dropdown alignment.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at acf6829</samp>

*  Add `postProps` parameter to `genPurePanel` function to customize props for different components ([link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6L14-R19), [link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6R62-R76), [link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6L78-R96))
*  Use `postProps` function to add `dropdownAlign` prop to `DatePicker` and `RangePicker` based on `placement` and `direction` props ([link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-78eb7aa1662e48dc14665cbcead280795a60503742024dd031b87311186be5eeL5-R10), [link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-78eb7aa1662e48dc14665cbcead280795a60503742024dd031b87311186be5eeL18-R35), [link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-64d79cd59dfc100bce2821bc07efac6651fb728fd8473b730597a06dd0815dceR5), [link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-64d79cd59dfc100bce2821bc07efac6651fb728fd8473b730597a06dd0815dceL63-R64))
*  Import `AlignType` type from `@rc-component/trigger` to match the expected type for `dropdownAlign` prop ([link](https://github.com/ant-design/ant-design/pull/41901/files?diff=unified&w=0#diff-64d79cd59dfc100bce2821bc07efac6651fb728fd8473b730597a06dd0815dceR5))
