### PR TITLE
fix(Transfer): Dropdown is hidden & `showSizeChanger` not work

### DIFF
--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -73,6 +73,19 @@ const searchTransferProps = {
   targetKeys: ['3', '4'],
 };
 
+const generateData = (n = 20) => {
+  const data = [];
+  for (let i = 0; i < n; i++) {
+    data.push({
+      key: `${i}`,
+      title: `content${i}`,
+      description: `description of content${i}`,
+      chosen: false,
+    });
+  }
+  return data;
+};
+
 describe('Transfer', () => {
   mountTest(Transfer);
   rtlTest(Transfer);
@@ -594,6 +607,32 @@ describe('Transfer', () => {
         />,
       );
       await waitFor(() => expect(getAllByTitle('1/1')).toHaveLength(2));
+    });
+
+    it('should support change pageSize', () => {
+      const dataSource = generateData();
+      const { container } = render(
+        <Transfer dataSource={dataSource} pagination={{ showSizeChanger: true, simple: false }} />,
+      );
+
+      fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
+      fireEvent.click(container.querySelectorAll('.ant-select-item-option')[1]);
+      expect(container.querySelectorAll('.ant-transfer-list-content-item').length).toBe(20);
+    });
+
+    it('should be used first when pagination has pagesize', () => {
+      const dataSource = generateData(30);
+
+      const { container } = render(
+        <Transfer
+          dataSource={dataSource}
+          pagination={{ showSizeChanger: true, simple: false, pageSize: 20 }}
+        />,
+      );
+
+      fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
+      fireEvent.click(container.querySelectorAll('.ant-select-item-option')[2]);
+      expect(container.querySelectorAll('.ant-transfer-list-content-item').length).toBe(20);
     });
   });
 

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -110,7 +110,6 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
   } = props;
 
   const [filterValue, setFilterValue] = useState<string>('');
-
   const listBodyRef = useRef<ListBodyRef<RecordType>>({});
 
   const internalHandleFilter = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -101,6 +101,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     marginXS,
     paddingSM,
     lineType,
+    antCls,
     iconCls,
     motionDurationSlow,
     controlItemBgHover,
@@ -174,8 +175,9 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       display: 'flex',
       flex: 'auto',
       flexDirection: 'column',
-      overflow: 'hidden',
       fontSize: token.fontSize,
+      // https://blog.csdn.net/qq449245884/article/details/107373672/
+      minHeight: 0,
 
       '&-search-wrapper': {
         position: 'relative',
@@ -262,6 +264,10 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       padding: `${token.paddingXS}px 0`,
       textAlign: 'end',
       borderTop: `${lineWidth}px ${lineType} ${colorSplit}`,
+
+      [`${antCls}-pagination-options`]: {
+        paddingInlineEnd: token.paddingXS,
+      },
     },
 
     '&-body-not-found': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41790
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
在当前的 `Transfer` 组件中，如果设置了 `pagination={{ showSizeChanger: true, simple: false }}` ，那么会出现切换分页数量的下拉按钮被隐藏的情况：
<img width="359" alt="image" src="https://user-images.githubusercontent.com/112228030/233337186-46665c51-df11-4bcc-8d77-0ffd86779bb0.png">
解决被隐藏问题并添加右边距（之前贴边）后，如下图：
<img width="362" alt="image" src="https://user-images.githubusercontent.com/112228030/233337513-f1e13e07-1f8c-43f8-a8aa-f56e4da2cffb.png">
根据 https://github.com/ant-design/ant-design/issues/41790#issuecomment-1507831602，发现 `Transfer` 组件内部的 `Pagination` 没有绑定 `showSizeChanger` 方法，因此添加上对应方法。


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix Pagination Dropdown is hidden & `showSizeChanger` not work           |
| 🇨🇳 Chinese | 修复分页下拉按钮被隐藏以及 `showSizeChanger` 方法无效          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff72fad</samp>

Added pagination support for the `Transfer` component, allowing users to select and change the page size of the transfer list. Updated the test cases, the `TransferList` and `ListBody` components, and the style file to handle the pagination functionality.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff72fad</samp>

*  Add `pageSize` and `onPageSizeChange` props to `TransferList` and `ListBody` components to enable changing the number of items per page in the transfer component ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415L113-R113), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415R204-R207), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415R232), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cL17-R21), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cL56-R72), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cR113-R116))
*  Modify `parsePagination` function to accept an optional `pageSize` parameter and use it to slice the render items according to the current page number and page size ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cL25-R27), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cL84-R87), [link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cL92-R99))
*  Add `onShowSizeChange` prop to `Pagination` component to trigger the `onPageSizeChange` callback and reset the current page number when the user selects a different page size ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-2234478f9c4d5f6c74fa4089e1f1ac4f7813fc5d971297a37959055c8eb85d6cR113-R116))
*  Add `generateData` function to `index.test.tsx` to create mock data items for testing the transfer component with pagination ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-4c216b8afeb5629f3befe0a7945c5f6f492158195855764e91524049a0462296R76-R88))
*  Add test case for changing the page size in the transfer component and verify the correct number of items per page ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-4c216b8afeb5629f3befe0a7945c5f6f492158195855764e91524049a0462296R587-R597))
*  Add `antCls` parameter to `genTransferListStyle` function in `style/index.ts` to access the ant design class name for the transfer list component ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbR106))
*  Add `minHeight` property to the transfer list style to fix a flexbox bug that causes the list body to overflow the list container when the page size is larger than the number of items ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL174-R177))
*  Add `paddingInlineEnd` property to the pagination options style to add some spacing between the page size changer and the pagination buttons ([link](https://github.com/ant-design/ant-design/pull/41906/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbR264-R267))
