### PR TITLE
style(Tree): Checkbox and title do not align

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -63,9 +63,16 @@ type TreeToken = DerivativeToken & {
 };
 
 export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => {
-  const { treeCls, treeNodeCls, treeNodePadding, treeTitleHeight } = token;
-
-  const treeCheckBoxMarginVertical = (treeTitleHeight - token.fontSizeLG) / 2;
+  const {
+    treeCls,
+    treeNodeCls,
+    controlInteractiveSize: checkboxSize,
+    treeNodePadding,
+    treeTitleHeight,
+  } = token;
+  // Ref: https://github.com/ant-design/ant-design/issues/41564
+  const checkBoxOffset = (token.lineHeight * token.fontSize) / 2 - checkboxSize / 2;
+  const treeCheckBoxMarginVertical = (treeTitleHeight - token.fontSizeLG) / 2 - checkBoxOffset;
   const treeCheckBoxMarginHorizontal = token.paddingXS;
 
   return {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41914

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
在 https://github.com/ant-design/ant-design/pull/41566/files#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efR83 新增样式会主动进行偏移，但是在 Tree 组件中的 checkbox 具有额外的 margin， 因此导致 checkbox 和 title 没有对齐，这里将原先 `marginBlockStart` 的距离减去 checkbox 偏移的距离来解决 checkbox 和 title 没有对齐。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix checkbox and title do not align            |
| 🇨🇳 Chinese | 修复 checkbox 和标题没有对齐           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 989cd9b</samp>

Fixed checkbox misalignment in tree component by renaming and using a new variable for checkbox size and offset in `components/tree/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 989cd9b</samp>

*  Rename and destructure `controlInteractiveSize` to `checkboxSize` for clarity ([link](https://github.com/ant-design/ant-design/pull/41920/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L66-R75))
*  Introduce `checkBoxOffset` to calculate the vertical offset of the checkbox based on font size and line height ([link](https://github.com/ant-design/ant-design/pull/41920/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L66-R75))
*  Adjust `treeCheckBoxMarginVertical` to account for the offset and fix checkbox misalignment ([link](https://github.com/ant-design/ant-design/pull/41920/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L66-R75))
