### PR TITLE
fix(tree): Draggable tree title is not aligned when the text is wrapped

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -170,6 +170,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
         '&-draggable': {
           [`${treeCls}-draggable-icon`]: {
+            // https://github.com/ant-design/ant-design/issues/41915
+            flexShrink: 0,
             width: treeTitleHeight,
             lineHeight: `${treeTitleHeight}px`,
             textAlign: 'center',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41915

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
问题是由于 flex 布局下的子元素的宽度失效，因此设置 `flexShrink: 0` 来解决该问题, 修复前后对比，
修复前：
![image](https://user-images.githubusercontent.com/112228030/233655570-f52ff9e2-2c2c-49d9-9181-cc06d542deaf.png)

修复后：
![image](https://user-images.githubusercontent.com/112228030/233655903-33ee8f30-0b07-45bc-adb3-3eabe3b2936f.png)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix Draggable tree title is not aligned when the text is wrapped            |
| 🇨🇳 Chinese | 修复可拖拽树文本换行时其标题不对齐            |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 780f096</samp>

Fix tree node text overlap with switcher icon by adding `flexShrink: 0` to node style in `components/tree/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 780f096</samp>

*  Prevent tree node from shrinking when container is too small ([link](https://github.com/ant-design/ant-design/pull/41928/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010R173-R174))
