### PR TITLE
fix: popover width on the screen side

### DIFF
--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -15,6 +15,7 @@
   top: 0;
   left: 0;
   z-index: @zindex-popover;
+  max-width: 100%;
   font-weight: normal;
   white-space: normal;
   text-align: left;
@@ -86,6 +87,7 @@
 
   &-inner-content {
     width: max-content;
+    max-width: 100%;
     padding: @padding-sm @popover-padding-horizontal;
     color: @popover-color;
   }

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -85,6 +85,7 @@
   }
 
   &-inner-content {
+    width: max-content;
     padding: @padding-sm @popover-padding-horizontal;
     color: @popover-color;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #41921

### 💡 Background and solution

4.x 后期 Popover 图标换成了 flex 布局，导致宽度放置会塌缩。v5 换了 `trigger` 计算方式不同，因而不需要在 v5 patch。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Popover width collapse when show on the screen edge.        |
| 🇨🇳 Chinese |    修复 Popover 在屏幕边缘时宽度塌缩的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe64d51</samp>

Improve responsiveness and layout of `popover` and `popover-content` components. Add `width` and `max-width` properties to prevent overflow and cutoff issues.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe64d51</samp>

* Limit the width of the popover and its content to the width of its container ([link](https://github.com/ant-design/ant-design/pull/41953/files?diff=unified&w=0#diff-fe80c5b599638edd09552f7dc17f380ddfbbbbd33690688f99fcddb516590071R18), [link](https://github.com/ant-design/ant-design/pull/41953/files?diff=unified&w=0#diff-fe80c5b599638edd09552f7dc17f380ddfbbbbd33690688f99fcddb516590071R89-R90))
