### PR TITLE
fix: Carousel GoTo is ignored if animation is in progress

### DIFF
--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -139,4 +139,33 @@ describe('Carousel', () => {
       expect(container.querySelector('.slick-dots')).toHaveClass('customDots');
     });
   });
+
+  it('should not wait for the animation', async () => {
+    const ref = React.createRef<CarouselRef>();
+    render(
+      <Carousel ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>,
+    );
+    const { prev, next, goTo } = ref.current || {};
+    expect(typeof prev).toBe('function');
+    expect(typeof next).toBe('function');
+    expect(typeof goTo).toBe('function');
+    expect(ref.current?.innerSlider.state.currentSlide).toBe(0);
+    ref.current?.goTo(1);
+    ref.current?.goTo(2);
+    ref.current?.goTo(1);
+    await waitFakeTimer();
+    expect(ref.current?.innerSlider.state.currentSlide).toBe(1);
+    ref.current?.prev();
+    ref.current?.next();
+    ref.current?.next();
+    await waitFakeTimer();
+    expect(ref.current?.innerSlider.state.currentSlide).toBe(2);
+    ref.current?.prev();
+    await waitFakeTimer();
+    expect(ref.current?.innerSlider.state.currentSlide).toBe(1);
+  });
 });

--- a/components/carousel/index.en-US.md
+++ b/components/carousel/index.en-US.md
@@ -31,6 +31,7 @@ A carousel component. Scales with its container.
 | autoplay | Whether to scroll automatically | boolean | false |  |
 | dotPosition | The position of the dots, which can be one of `top` `bottom` `left` `right` | string | `bottom` |  |
 | dots | Whether to show the dots at the bottom of the gallery, `object` for `dotsClass` and any others | boolean \| { className?: string } | true |  |
+| waitForAnimate | Whether to wait for the animation when switching | boolean | false |  |
 | easing | Transition interpolation function name | string | `linear` |  |
 | effect | Transition effect | `scrollx` \| `fade` | `scrollx` |  |
 | afterChange | Callback function called after the current index changes | (current: number) => void | - |  |

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -18,6 +18,7 @@ export interface CarouselProps extends Omit<Settings, 'dots' | 'dotsClass'> {
   dotPosition?: DotPosition;
   children?: React.ReactNode;
   dots?: boolean | { className?: string };
+  waitForAnimate?: boolean;
 }
 
 export interface CarouselRef {
@@ -34,6 +35,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
       dots = true,
       arrows = false,
       draggable = false,
+      waitForAnimate = false,
       dotPosition = 'bottom',
       vertical = dotPosition === 'left' || dotPosition === 'right',
       rootClassName,
@@ -109,6 +111,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
           dotsClass={dsClass}
           arrows={arrows}
           draggable={draggable}
+          waitForAnimate={waitForAnimate}
         />
       </div>,
     );

--- a/components/carousel/index.zh-CN.md
+++ b/components/carousel/index.zh-CN.md
@@ -32,6 +32,7 @@ demo:
 | autoplay | 是否自动切换 | boolean | false |  |
 | dotPosition | 面板指示点位置，可选 `top` `bottom` `left` `right` | string | `bottom` |  |
 | dots | 是否显示面板指示点，如果为 `object` 则同时可以指定 `dotsClass` 或者 | boolean \| { className?: string } | true |  |
+| waitForAnimate | 是否等待切换动画 | boolean | false |  |
 | easing | 动画效果 | string | `linear` |  |
 | effect | 动画效果函数 | `scrollx` \| `fade` | `scrollx` |  |
 | afterChange | 切换面板的回调 | (current: number) => void | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

1. fix #32293

### 💡 Background and solution

- Carousel GoTo is ignored if animation is in progress.
   -  By setting the ```waitForAnimate = false``` by default, it won't wait the animation and thus perform GoTo mostly.
   - refer to @theGOTOguy and @afc163 

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      add waitForAnimate in Carousel     |
| 🇨🇳 Chinese |    在 Carousel 组件中添加"waitForAnimate" 属性    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e44a86</samp>

Add a new prop `waitForAnimate` to the `Carousel` component and document it in both English and Chinese. This prop allows users to control the slide switching animation behavior.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e44a86</samp>

*  Add a new prop `waitForAnimate` to the Carousel component that controls whether the component waits for the animation to finish when switching slides ([link](https://github.com/ant-design/ant-design/pull/41969/files?diff=unified&w=0#diff-1c7149c47863e64c7c50329eb74007c831fe6de5311ca65b52a6d691c8227bb5R34), [link](https://github.com/ant-design/ant-design/pull/41969/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR21), [link](https://github.com/ant-design/ant-design/pull/41969/files?diff=unified&w=0#diff-571c29e796a3a85fdd7797d5f7732f3b1f0fc65908889f05deccd8e44ff298c3R35))
* Set the default value of `waitForAnimate` to `false` in the `Carousel` component function in `index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41969/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR38))
* Forward the `waitForAnimate` prop to the underlying `rc-carousel` component in `index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41969/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR114))
