### PR TITLE
feat: validated should be reset when trigger reset event

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -20625,14 +20625,35 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
           <div
             class="ant-form-item-control-input-content"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              type="submit"
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center"
             >
-              <span>
-                Submit
-              </span>
-            </button>
+              <div
+                class="ant-space-item"
+                style="margin-right: 8px;"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  class="ant-btn ant-btn-default"
+                  type="reset"
+                >
+                  <span>
+                    reset
+                  </span>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -9505,14 +9505,35 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
           <div
             class="ant-form-item-control-input-content"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              type="submit"
+            <div
+              class="ant-space ant-space-horizontal ant-space-align-center"
             >
-              <span>
-                Submit
-              </span>
-            </button>
+              <div
+                class="ant-space-item"
+                style="margin-right:8px"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <button
+                  class="ant-btn ant-btn-default"
+                  type="reset"
+                >
+                  <span>
+                    reset
+                  </span>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/form/demo/validate-other.tsx
+++ b/components/form/demo/validate-other.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { InboxOutlined, UploadOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -11,9 +10,11 @@ import {
   Row,
   Select,
   Slider,
+  Space,
   Switch,
   Upload,
 } from 'antd';
+import React from 'react';
 
 const { Option } = Select;
 
@@ -181,9 +182,12 @@ const App: React.FC = () => (
     </Form.Item>
 
     <Form.Item wrapperCol={{ span: 12, offset: 6 }}>
-      <Button type="primary" htmlType="submit">
-        Submit
-      </Button>
+      <Space>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+        <Button htmlType="reset">reset</Button>
+      </Space>
     </Form.Item>
   </Form>
 );

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "rc-dialog": "~9.1.0",
     "rc-drawer": "~6.1.1",
     "rc-dropdown": "~4.0.0",
-    "rc-field-form": "~1.29.0",
+    "rc-field-form": "~1.30.0",
     "rc-image": "~5.16.0",
     "rc-input": "~1.0.4",
     "rc-input-number": "~7.4.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/41966
- fix https://github.com/ant-design/ant-design/issues/41053

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Resolve issue about the feedback icon was not reset after a reset event had been triggered <br />  - Fixed inaccurate data collected by onValuesChange |
| 🇨🇳 Chinese |  - 修复触发重置事件后反馈图标未重置的问题  <br /> - 修复 onValuesChange 收集到的数据不准确的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a3f75a</samp>

Updated `rc-field-form` dependency and improved form demo. The changes enhance the functionality and appearance of the form component and its examples.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a3f75a</samp>

* Update rc-field-form dependency to 1.30.0 for form validation and management ([link](https://github.com/ant-design/ant-design/pull/41976/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L129-R129))
* Add Space component to import and wrap submit and reset buttons for better layout ([link](https://github.com/ant-design/ant-design/pull/41976/files?diff=unified&w=0#diff-60162065407f047d6fa0b6cb87e9524b8e80bab29b205a4678517644a564cde8L14-R17), [link](https://github.com/ant-design/ant-design/pull/41976/files?diff=unified&w=0#diff-60162065407f047d6fa0b6cb87e9524b8e80bab29b205a4678517644a564cde8L184-R190))
* Add reset button to `validate-other.tsx` demo to clear form fields ([link](https://github.com/ant-design/ant-design/pull/41976/files?diff=unified&w=0#diff-60162065407f047d6fa0b6cb87e9524b8e80bab29b205a4678517644a564cde8L184-R190))
* Remove unnecessary React import from `validate-other.tsx` ([link](https://github.com/ant-design/ant-design/pull/41976/files?diff=unified&w=0#diff-60162065407f047d6fa0b6cb87e9524b8e80bab29b205a4678517644a564cde8L1))
