### PR TITLE
fix: Adds aria-* to TreeSelect

### DIFF
--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -68,15 +68,13 @@ describe('TreeSelect', () => {
 
   it('support aria-label', async () => {
     const { container } = render(
-      <TreeSelect treeIcon open>
-        <TreeNode
-          value="parent 1"
-          treeData={[{ value: 'parent 1', title: 'parnet 1', 'aria-label': 'label' }]}
-        />
-      </TreeSelect>,
+      <TreeSelect
+        open
+        treeData={[{ value: 'parent 1', title: 'parnet 1', 'aria-label': 'label' }]}
+      />,
     );
     expect(
-      container.querySelector('ant-select-tree-node-content-wrapper')?.getAttribute('aria-label'),
+      container.querySelector('.ant-select-tree-treenode-leaf-last')?.getAttribute('aria-label'),
     ).toBe('label');
   });
 });

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -65,4 +65,18 @@ describe('TreeSelect', () => {
 
     errSpy.mockRestore();
   });
+
+  it('support aria-label', async () => {
+    const { container } = render(
+      <TreeSelect treeIcon open>
+        <TreeNode
+          value="parent 1"
+          treeData={[{ value: 'parent 1', title: 'parnet 1', 'aria-label': 'label' }]}
+        />
+      </TreeSelect>,
+    );
+    expect(
+      container.querySelector('ant-select-tree-node-content-wrapper')?.getAttribute('aria-label'),
+    ).toBe('label');
+  });
 });

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -66,7 +66,7 @@ describe('TreeSelect', () => {
     errSpy.mockRestore();
   });
 
-  it('support aria-label', async () => {
+  it('support aria-*', async () => {
     const { container } = render(
       <TreeSelect
         open

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -64,7 +64,7 @@ export interface TreeSelectProps<
   status?: InputStatus;
   switcherIcon?: SwitcherIcon | RcTreeSelectProps<ValueType, OptionType>['switcherIcon'];
   rootClassName?: string;
-  [key: `aria-${string}`]: string | boolean | number | undefined;
+  [key: `aria-${string}`]: React.AriaAttributes[keyof React.AriaAttributes];
 }
 
 const InternalTreeSelect = <

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -64,6 +64,7 @@ export interface TreeSelectProps<
   status?: InputStatus;
   switcherIcon?: SwitcherIcon | RcTreeSelectProps<ValueType, OptionType>['switcherIcon'];
   rootClassName?: string;
+  ['aria-label']?: string;
 }
 
 const InternalTreeSelect = <
@@ -71,6 +72,7 @@ const InternalTreeSelect = <
   OptionType extends BaseOptionType | DefaultOptionType = BaseOptionType,
 >(
   {
+    'aria-label': ariaLabel,
     prefixCls: customizePrefixCls,
     size: customizeSize,
     disabled: customDisabled,
@@ -256,6 +258,7 @@ const InternalTreeSelect = <
       )}
       showArrow={hasFeedback || mergedShowArrow}
       treeExpandAction={treeExpandAction}
+      aria-label={ariaLabel}
     />
   );
 

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -64,7 +64,7 @@ export interface TreeSelectProps<
   status?: InputStatus;
   switcherIcon?: SwitcherIcon | RcTreeSelectProps<ValueType, OptionType>['switcherIcon'];
   rootClassName?: string;
-  ['aria-label']?: string;
+  [key: `aria-${string}`]: string | boolean | number | undefined;
 }
 
 const InternalTreeSelect = <
@@ -72,7 +72,6 @@ const InternalTreeSelect = <
   OptionType extends BaseOptionType | DefaultOptionType = BaseOptionType,
 >(
   {
-    'aria-label': ariaLabel,
     prefixCls: customizePrefixCls,
     size: customizeSize,
     disabled: customDisabled,
@@ -258,7 +257,6 @@ const InternalTreeSelect = <
       )}
       showArrow={hasFeedback || mergedShowArrow}
       treeExpandAction={treeExpandAction}
-      aria-label={ariaLabel}
     />
   );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

1. close #40055

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adds aria-* to TreeSelect      |
| 🇨🇳 Chinese |      添加 aria-* 到 TreeSelect     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b2bbea</samp>

This pull request enhances the accessibility of the `TreeSelect` component by adding the `aria-label` prop, which allows users to specify custom labels for the tree nodes. It also adds a test case to verify the functionality of the new prop.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b2bbea</samp>

*  Add `aria-label` prop to `TreeSelect` component to support accessibility labels ([link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR67), [link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR75), [link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR261), [link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-d4c24db61ead898cb9be2edaa49ab821f7fc94aad2b3ebdd14723614d742aebcR68-R79))
  * Define `aria-label` prop in `TreeSelectProps` interface in `components/tree-select/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR67))
  * Assign `aria-label` prop to `ariaLabel` variable in `InternalTreeSelect` function in `components/tree-select/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR75))
  * Pass `ariaLabel` variable to `rc-tree-select` component in `InternalTreeSelect` function in `components/tree-select/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-f4ebf787ec0bc13112f49b0d9a2df0bfa73f8ea80cec9a6c92d311e120fa6ffeR261))
  * Add test case to check `aria-label` prop in `components/tree-select/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/41978/files?diff=unified&w=0#diff-d4c24db61ead898cb9be2edaa49ab821f7fc94aad2b3ebdd14723614d742aebcR68-R79))
