### PR TITLE
style: fix Table border and radius issues

### DIFF
--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -39,6 +39,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         // ============================ Content ============================
         [`> ${componentCls}-container`]: {
           borderInlineStart: tableBorder,
+          borderTop: tableBorder,
 
           [`
             > ${componentCls}-content,
@@ -50,6 +51,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
               // ============================= Cell =============================
               [`
                 > thead > tr > th,
+                > thead > tr > td,
                 > tbody > tr > th,
                 > tbody > tr > td,
                 > tfoot > tr > th,
@@ -102,15 +104,6 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
               },
             },
           },
-
-          [`
-            > ${componentCls}-content,
-            > ${componentCls}-header
-          `]: {
-            '> table': {
-              borderTop: tableBorder,
-            },
-          },
         },
 
         // ============================ Scroll ============================
@@ -158,6 +151,10 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         '&-scrollbar:not([rowspan])': {
           boxShadow: `0 ${token.lineWidth}px 0 ${token.lineWidth}px ${token.tableHeaderBg}`,
         },
+      },
+
+      [`${componentCls}-bordered ${componentCls}-cell-scrollbar`]: {
+        borderInlineEnd: tableBorder,
       },
     },
   };

--- a/components/table/style/radius.ts
+++ b/components/table/style/radius.ts
@@ -17,17 +17,13 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           borderStartEndRadius: 0,
 
           // https://github.com/ant-design/ant-design/issues/41975
-          [`${componentCls}-header`]: {
+          [`${componentCls}-header, table`]: {
             borderRadius: 0,
           },
 
-          table: {
-            borderRadius: 0,
-
-            '> thead > tr:first-child': {
-              'th:first-child, th:last-child, td:first-child, td:last-child': {
-                borderRadius: 0,
-              },
+          'table > thead > tr:first-child': {
+            'th:first-child, th:last-child, td:first-child, td:last-child': {
+              borderRadius: 0,
             },
           },
         },

--- a/components/table/style/radius.ts
+++ b/components/table/style/radius.ts
@@ -16,15 +16,16 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           borderStartStartRadius: 0,
           borderStartEndRadius: 0,
 
+          // https://github.com/ant-design/ant-design/issues/41975
+          [`${componentCls}-header`]: {
+            borderRadius: 0,
+          },
+
           table: {
             borderRadius: 0,
 
             '> thead > tr:first-child': {
-              'th:first-child': {
-                borderRadius: 0,
-              },
-
-              'th:last-child': {
+              'th:first-child, th:last-child, td:first-child, td:last-child': {
                 borderRadius: 0,
               },
             },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/41975

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
修复一系列表格样式细节问题。

- [x] 右边丢边框。
<img width="102" alt="图片" src="https://user-images.githubusercontent.com/507615/234246458-7b1c5b3d-a983-4e1a-9cd9-3336d82dbf3e.png">

- [x] 左上角圆角边框样式异常。
<img width="121" alt="图片" src="https://user-images.githubusercontent.com/507615/234246591-8528dee4-bbfc-484b-a8f1-509b2814016c.png">

- [x] 可展开列头缺少边框。
<img width="275" alt="图片" src="https://user-images.githubusercontent.com/507615/234246681-ceda885d-a1b2-49a0-ab60-b6a54f3651f8.png">

- [x] 带标题的 Table 列头左上角圆角问题。https://github.com/ant-design/ant-design/issues/41975
<img width="221" alt="图片" src="https://user-images.githubusercontent.com/507615/234246942-dfbc6639-2f71-47ae-9264-4fc1d898d457.png">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix miIIions of Table border and radius styling issues.         |
| 🇨🇳 Chinese | 修复 Table 一系列边框和圆角的样式细节问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb140f8</samp>

This pull request improves the appearance of `bordered` and `radius` table styles by fixing some border and border-radius bugs. It also refactors the style files to consolidate the related styles in `bordered.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb140f8</samp>

*  Fix table border styles when bordered prop is true ([link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR42), [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR54), [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedL105-L113), [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR155-R158), [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-b12ced1b5a8e3d92028e94a37af829fa284362fad0900262a089dd77ec7bb47cL19-R30))
  - Add `border-top` to `table` element to create consistent top border for scrollable and fixed header tables (`components/table/style/bordered.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR42))
  - Apply same `border` style to table header cells as table body cells (`components/table/style/bordered.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR54))
  - Remove redundant `border-top` from table content and header elements to avoid double border effect (`components/table/style/bordered.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedL105-L113))
  - Add `border-inline-end` to table cell scrollbar element to create consistent right border for scrollable and fixed header or column tables (`components/table/style/bordered.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-af9a50095f1ce23e8cabb4de4623f4b2e62fd9942a8b26e3c0084df3baef1fedR155-R158))
  - Modify `border-radius` for table header and cells to match table body and apply to both first and last cells of each row (`components/table/style/bordered.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-b12ced1b5a8e3d92028e94a37af829fa284362fad0900262a089dd77ec7bb47cL19-R30))
  - Move `border-radius` style from `radius.ts` to `bordered.ts` since it only applies when bordered prop is true (`components/table/style/radius.ts`, [link](https://github.com/ant-design/ant-design/pull/41985/files?diff=unified&w=0#diff-b12ced1b5a8e3d92028e94a37af829fa284362fad0900262a089dd77ec7bb47cL19-R30))
