### PR TITLE
chore: use `composeRef(ref, internalRef)` replace `ref || internalRef`

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable react/button-has-type */
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
-import * as React from 'react';
+import { composeRef } from 'rc-util/lib/ref';
+import React, {
+  Children,
+  createRef,
+  forwardRef,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import warning from '../_util/warning';
 import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
@@ -110,48 +119,30 @@ const InternalButton: React.ForwardRefRenderFunction<
     ...rest
   } = props;
 
-  const { getPrefixCls, autoInsertSpaceInButton, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, autoInsertSpaceInButton, direction } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('btn', customizePrefixCls);
 
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
-  const size = React.useContext(SizeContext);
-  const disabled = React.useContext(DisabledContext);
+  const size = useContext(SizeContext);
+  const disabled = useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
 
-  const groupSize = React.useContext(GroupSizeContext);
-  const loadingOrDelay = React.useMemo<LoadingConfigType>(
-    () => getLoadingConfig(loading),
-    [loading],
-  );
-  const [innerLoading, setLoading] = React.useState<Loading>(loadingOrDelay.loading);
-  const [hasTwoCNChar, setHasTwoCNChar] = React.useState(false);
+  const groupSize = useContext(GroupSizeContext);
 
-  const internalRef = React.createRef<HTMLAnchorElement | HTMLButtonElement>();
+  const loadingOrDelay = useMemo<LoadingConfigType>(() => getLoadingConfig(loading), [loading]);
 
-  const buttonRef = (ref as React.RefObject<any>) || internalRef;
+  const [innerLoading, setLoading] = useState<Loading>(loadingOrDelay.loading);
+  const [hasTwoCNChar, setHasTwoCNChar] = useState(false);
 
-  const isNeedInserted = () =>
-    React.Children.count(children) === 1 && !icon && !isUnBorderedButtonType(type);
+  const internalRef = createRef<HTMLButtonElement | HTMLAnchorElement>();
 
-  const fixTwoCNChar = () => {
-    // FIXME: for HOC usage like <FormatMessage />
-    if (!buttonRef || !buttonRef.current || autoInsertSpaceInButton === false) {
-      return;
-    }
-    const buttonText = buttonRef.current.textContent;
-    if (isNeedInserted() && isTwoCNChar(buttonText)) {
-      if (!hasTwoCNChar) {
-        setHasTwoCNChar(true);
-      }
-    } else if (hasTwoCNChar) {
-      setHasTwoCNChar(false);
-    }
-  };
+  const buttonRef = composeRef(ref, internalRef);
 
-  React.useEffect(() => {
+  const needInserted = Children.count(children) === 1 && !icon && !isUnBorderedButtonType(type);
+
+  useEffect(() => {
     let delayTimer: NodeJS.Timer | null = null;
-
     if (loadingOrDelay.delay > 0) {
       delayTimer = setTimeout(() => {
         delayTimer = null;
@@ -171,7 +162,20 @@ const InternalButton: React.ForwardRefRenderFunction<
     return cleanupTimer;
   }, [loadingOrDelay]);
 
-  React.useEffect(fixTwoCNChar, [buttonRef]);
+  useEffect(() => {
+    // FIXME: for HOC usage like <FormatMessage />
+    if (!buttonRef || !(buttonRef as any).current || autoInsertSpaceInButton === false) {
+      return;
+    }
+    const buttonText = (buttonRef as any).current.textContent;
+    if (needInserted && isTwoCNChar(buttonText)) {
+      if (!hasTwoCNChar) {
+        setHasTwoCNChar(true);
+      }
+    } else if (hasTwoCNChar) {
+      setHasTwoCNChar(false);
+    }
+  }, [buttonRef]);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) => {
     const { onClick } = props;
@@ -237,13 +241,16 @@ const InternalButton: React.ForwardRefRenderFunction<
     );
 
   const kids =
-    children || children === 0
-      ? spaceChildren(children, isNeedInserted() && autoInsertSpace)
-      : null;
+    children || children === 0 ? spaceChildren(children, needInserted && autoInsertSpace) : null;
 
   if (linkButtonRestProps.href !== undefined) {
     return wrapSSR(
-      <a {...linkButtonRestProps} className={classes} onClick={handleClick} ref={buttonRef}>
+      <a
+        {...linkButtonRestProps}
+        className={classes}
+        onClick={handleClick}
+        ref={buttonRef as React.Ref<HTMLAnchorElement>}
+      >
         {iconNode}
         {kids}
       </a>,
@@ -257,7 +264,7 @@ const InternalButton: React.ForwardRefRenderFunction<
       className={classes}
       onClick={handleClick}
       disabled={mergedDisabled}
-      ref={buttonRef}
+      ref={buttonRef as React.Ref<HTMLButtonElement>}
     >
       {iconNode}
       {kids}
@@ -271,7 +278,7 @@ const InternalButton: React.ForwardRefRenderFunction<
   return wrapSSR(buttonNode);
 };
 
-const Button = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
   InternalButton,
 ) as CompoundedComponent;
 

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -133,7 +133,8 @@ const InternalButton: React.ForwardRefRenderFunction<
   const loadingOrDelay = useMemo<LoadingConfigType>(() => getLoadingConfig(loading), [loading]);
 
   const [innerLoading, setLoading] = useState<Loading>(loadingOrDelay.loading);
-  const [hasTwoCNChar, setHasTwoCNChar] = useState(false);
+
+  const [hasTwoCNChar, setHasTwoCNChar] = useState<boolean>(false);
 
   const internalRef = createRef<HTMLButtonElement | HTMLAnchorElement>();
 
@@ -257,7 +258,7 @@ const InternalButton: React.ForwardRefRenderFunction<
     );
   }
 
-  const buttonNode = (
+  let buttonNode = (
     <button
       {...(rest as NativeButtonProps)}
       type={htmlType}
@@ -271,11 +272,11 @@ const InternalButton: React.ForwardRefRenderFunction<
     </button>
   );
 
-  if (isUnBorderedButtonType(type)) {
-    return wrapSSR(buttonNode);
+  if (!isUnBorderedButtonType(type)) {
+    buttonNode = <Wave disabled={!!innerLoading}>{buttonNode}</Wave>;
   }
 
-  return wrapSSR(<Wave disabled={!!innerLoading}>{buttonNode}</Wave>);
+  return wrapSSR(buttonNode);
 };
 
 const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -257,7 +257,7 @@ const InternalButton: React.ForwardRefRenderFunction<
     );
   }
 
-  let buttonNode = (
+  const buttonNode = (
     <button
       {...(rest as NativeButtonProps)}
       type={htmlType}
@@ -271,11 +271,11 @@ const InternalButton: React.ForwardRefRenderFunction<
     </button>
   );
 
-  if (!isUnBorderedButtonType(type)) {
-    buttonNode = <Wave disabled={!!innerLoading}>{buttonNode}</Wave>;
+  if (isUnBorderedButtonType(type)) {
+    return wrapSSR(buttonNode);
   }
 
-  return wrapSSR(buttonNode);
+  return wrapSSR(<Wave disabled={!!innerLoading}>{buttonNode}</Wave>);
 };
 
 const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: use `composeRef(ref, internalRef)` replace `ref || internalRef` |
| 🇨🇳 Chinese | 代码优化，无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3e0742</samp>

Refactor `Button` component to use named React imports, `composeRef`, and fix TypeScript errors. Optimize `fixTwoCNChar` function.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3e0742</samp>

*  Use named imports for React and its hooks and utilities, and add `composeRef` utility to combine forwarded and internal refs ([link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L4-R13), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L113-R145), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L174-R178), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L274-R281))
*  Change ref types to `any` or `React.Ref<HTMLElement>` to avoid TypeScript errors ([link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L113-R145), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L174-R178), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L240-R253), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L260-R267))
*  Rename `isNeedInserted` to `needInserted` and make it a constant instead of a function ([link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L113-R145), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L174-R178), [link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L240-R253))
*  Move `fixTwoCNChar` function to a `useEffect` hook to avoid unnecessary calls and dependencies ([link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L174-R178))
*  Use `useMemo` instead of `React.useMemo` to follow the named imports convention ([link](https://github.com/ant-design/ant-design/pull/42036/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L113-R145))
