### PR TITLE
feat: Card Component Token

### DIFF
--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -130,6 +130,135 @@ exports[`renders components/card/demo/border-less.tsx extend context correctly 1
 </div>
 `;
 
+exports[`renders components/card/demo/component-token.tsx extend context correctly 1`] = `
+Array [
+  <div
+    class="ant-card ant-card-bordered"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Card title
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <div
+        class="ant-card ant-card-bordered ant-card-type-inner"
+      >
+        <div
+          class="ant-card-head"
+        >
+          <div
+            class="ant-card-head-wrapper"
+          >
+            <div
+              class="ant-card-head-title"
+            >
+              Inner Card title
+            </div>
+            <div
+              class="ant-card-extra"
+            >
+              <a
+                href="#"
+              >
+                More
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-card-body"
+        >
+          Inner Card content
+        </div>
+      </div>
+      <div
+        class="ant-card ant-card-bordered ant-card-type-inner"
+        style="margin-top: 16px;"
+      >
+        <div
+          class="ant-card-head"
+        >
+          <div
+            class="ant-card-head-wrapper"
+          >
+            <div
+              class="ant-card-head-title"
+            >
+              Inner Card title
+            </div>
+            <div
+              class="ant-card-extra"
+            >
+              <a
+                href="#"
+              >
+                More
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-card-body"
+        >
+          Inner Card content
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-card ant-card-bordered ant-card-small"
+    style="width: 300px;"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Small size card
+        </div>
+        <div
+          class="ant-card-extra"
+        >
+          <a
+            href="#"
+          >
+            More
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/card/demo/flexible-content.tsx extend context correctly 1`] = `
 <div
   class="ant-card ant-card-bordered ant-card-hoverable"

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -133,7 +133,7 @@ exports[`renders components/card/demo/border-less.tsx extend context correctly 1
 exports[`renders components/card/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <div
-    class="ant-card ant-card-bordered"
+    class="ant-card ant-card-bordered ant-card-contain-tabs"
   >
     <div
       class="ant-card-head"
@@ -146,75 +146,224 @@ Array [
         >
           Card title
         </div>
+        <div
+          class="ant-card-extra"
+        >
+          More
+        </div>
+      </div>
+      <div
+        class="ant-tabs ant-tabs-top ant-tabs-large ant-card-head-tabs"
+      >
+        <div
+          class="ant-tabs-nav"
+          role="tablist"
+        >
+          <div
+            class="ant-tabs-nav-wrap"
+          >
+            <div
+              class="ant-tabs-nav-list"
+              style="transform: translate(0px, 0px);"
+            >
+              <div
+                class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="tab1"
+              >
+                <div
+                  aria-controls="rc-tabs-test-panel-tab1"
+                  aria-selected="true"
+                  class="ant-tabs-tab-btn"
+                  id="rc-tabs-test-tab-tab1"
+                  role="tab"
+                  tabindex="0"
+                >
+                  tab1
+                </div>
+              </div>
+              <div
+                class="ant-tabs-tab"
+                data-node-key="tab2"
+              >
+                <div
+                  aria-controls="rc-tabs-test-panel-tab2"
+                  aria-selected="false"
+                  class="ant-tabs-tab-btn"
+                  id="rc-tabs-test-tab-tab2"
+                  role="tab"
+                  tabindex="0"
+                >
+                  tab2
+                </div>
+              </div>
+              <div
+                class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+              />
+            </div>
+          </div>
+          <div
+            class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          >
+            <button
+              aria-controls="rc-tabs-test-more-popup"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-hidden="true"
+              class="ant-tabs-nav-more"
+              id="rc-tabs-test-more"
+              style="visibility: hidden; order: 1;"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="ellipsis"
+                class="anticon anticon-ellipsis"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="ellipsis"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <ul
+                aria-label="expanded dropdown"
+                class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+                data-menu-list="true"
+                id="rc-tabs-test-more-popup"
+                role="listbox"
+                tabindex="-1"
+              />
+              <div
+                aria-hidden="true"
+                style="display: none;"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-tabs-content-holder"
+        >
+          <div
+            class="ant-tabs-content ant-tabs-content-top"
+          >
+            <div
+              aria-hidden="false"
+              aria-labelledby="rc-tabs-test-tab-tab1"
+              class="ant-tabs-tabpane ant-tabs-tabpane-active"
+              id="rc-tabs-test-panel-tab1"
+              role="tabpanel"
+              tabindex="0"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div
       class="ant-card-body"
     >
-      <div
-        class="ant-card ant-card-bordered ant-card-type-inner"
-      >
-        <div
-          class="ant-card-head"
-        >
-          <div
-            class="ant-card-head-wrapper"
-          >
-            <div
-              class="ant-card-head-title"
-            >
-              Inner Card title
-            </div>
-            <div
-              class="ant-card-extra"
-            >
-              <a
-                href="#"
-              >
-                More
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ant-card-body"
-        >
-          Inner Card content
-        </div>
-      </div>
-      <div
-        class="ant-card ant-card-bordered ant-card-type-inner"
-        style="margin-top: 16px;"
-      >
-        <div
-          class="ant-card-head"
-        >
-          <div
-            class="ant-card-head-wrapper"
-          >
-            <div
-              class="ant-card-head-title"
-            >
-              Inner Card title
-            </div>
-            <div
-              class="ant-card-extra"
-            >
-              <a
-                href="#"
-              >
-                More
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ant-card-body"
-        >
-          Inner Card content
-        </div>
-      </div>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
     </div>
+    <ul
+      class="ant-card-actions"
+    >
+      <li
+        style="width: 33.333333333333336%;"
+      >
+        <span>
+          <span
+            aria-label="setting"
+            class="anticon anticon-setting"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="setting"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+      <li
+        style="width: 33.333333333333336%;"
+      >
+        <span>
+          <span
+            aria-label="edit"
+            class="anticon anticon-edit"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="edit"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+      <li
+        style="width: 33.333333333333336%;"
+      >
+        <span>
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+    </ul>
   </div>,
   <div
     class="ant-card ant-card-bordered ant-card-small"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -130,6 +130,135 @@ exports[`renders components/card/demo/border-less.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/card/demo/component-token.tsx correctly 1`] = `
+Array [
+  <div
+    class="ant-card ant-card-bordered"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Card title
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <div
+        class="ant-card ant-card-bordered ant-card-type-inner"
+      >
+        <div
+          class="ant-card-head"
+        >
+          <div
+            class="ant-card-head-wrapper"
+          >
+            <div
+              class="ant-card-head-title"
+            >
+              Inner Card title
+            </div>
+            <div
+              class="ant-card-extra"
+            >
+              <a
+                href="#"
+              >
+                More
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-card-body"
+        >
+          Inner Card content
+        </div>
+      </div>
+      <div
+        class="ant-card ant-card-bordered ant-card-type-inner"
+        style="margin-top:16px"
+      >
+        <div
+          class="ant-card-head"
+        >
+          <div
+            class="ant-card-head-wrapper"
+          >
+            <div
+              class="ant-card-head-title"
+            >
+              Inner Card title
+            </div>
+            <div
+              class="ant-card-extra"
+            >
+              <a
+                href="#"
+              >
+                More
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-card-body"
+        >
+          Inner Card content
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-card ant-card-bordered ant-card-small"
+    style="width:300px"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Small size card
+        </div>
+        <div
+          class="ant-card-extra"
+        >
+          <a
+            href="#"
+          >
+            More
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/card/demo/flexible-content.tsx correctly 1`] = `
 <div
   class="ant-card ant-card-bordered ant-card-hoverable"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -133,7 +133,7 @@ exports[`renders components/card/demo/border-less.tsx correctly 1`] = `
 exports[`renders components/card/demo/component-token.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-card ant-card-bordered"
+    class="ant-card ant-card-bordered ant-card-contain-tabs"
   >
     <div
       class="ant-card-head"
@@ -146,75 +146,201 @@ Array [
         >
           Card title
         </div>
+        <div
+          class="ant-card-extra"
+        >
+          More
+        </div>
+      </div>
+      <div
+        class="ant-tabs ant-tabs-top ant-tabs-large ant-card-head-tabs"
+      >
+        <div
+          class="ant-tabs-nav"
+          role="tablist"
+        >
+          <div
+            class="ant-tabs-nav-wrap"
+          >
+            <div
+              class="ant-tabs-nav-list"
+              style="transform:translate(0px, 0px)"
+            >
+              <div
+                class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="tab1"
+              >
+                <div
+                  aria-selected="true"
+                  class="ant-tabs-tab-btn"
+                  role="tab"
+                  tabindex="0"
+                >
+                  tab1
+                </div>
+              </div>
+              <div
+                class="ant-tabs-tab"
+                data-node-key="tab2"
+              >
+                <div
+                  aria-selected="false"
+                  class="ant-tabs-tab-btn"
+                  role="tab"
+                  tabindex="0"
+                >
+                  tab2
+                </div>
+              </div>
+              <div
+                class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+              />
+            </div>
+          </div>
+          <div
+            class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          >
+            <button
+              aria-controls="null-more-popup"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-hidden="true"
+              class="ant-tabs-nav-more"
+              id="null-more"
+              style="visibility:hidden;order:1"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="ellipsis"
+                class="anticon anticon-ellipsis"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="ellipsis"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="ant-tabs-content-holder"
+        >
+          <div
+            class="ant-tabs-content ant-tabs-content-top"
+          >
+            <div
+              aria-hidden="false"
+              class="ant-tabs-tabpane ant-tabs-tabpane-active"
+              role="tabpanel"
+              tabindex="0"
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div
       class="ant-card-body"
     >
-      <div
-        class="ant-card ant-card-bordered ant-card-type-inner"
-      >
-        <div
-          class="ant-card-head"
-        >
-          <div
-            class="ant-card-head-wrapper"
-          >
-            <div
-              class="ant-card-head-title"
-            >
-              Inner Card title
-            </div>
-            <div
-              class="ant-card-extra"
-            >
-              <a
-                href="#"
-              >
-                More
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ant-card-body"
-        >
-          Inner Card content
-        </div>
-      </div>
-      <div
-        class="ant-card ant-card-bordered ant-card-type-inner"
-        style="margin-top:16px"
-      >
-        <div
-          class="ant-card-head"
-        >
-          <div
-            class="ant-card-head-wrapper"
-          >
-            <div
-              class="ant-card-head-title"
-            >
-              Inner Card title
-            </div>
-            <div
-              class="ant-card-extra"
-            >
-              <a
-                href="#"
-              >
-                More
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ant-card-body"
-        >
-          Inner Card content
-        </div>
-      </div>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
+      <p>
+        Card content
+      </p>
     </div>
+    <ul
+      class="ant-card-actions"
+    >
+      <li
+        style="width:33.333333333333336%"
+      >
+        <span>
+          <span
+            aria-label="setting"
+            class="anticon anticon-setting"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="setting"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+      <li
+        style="width:33.333333333333336%"
+      >
+        <span>
+          <span
+            aria-label="edit"
+            class="anticon anticon-edit"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="edit"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+      <li
+        style="width:33.333333333333336%"
+      >
+        <span>
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </li>
+    </ul>
   </div>,
   <div
     class="ant-card ant-card-bordered ant-card-small"

--- a/components/card/demo/component-token.md
+++ b/components/card/demo/component-token.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Component Token Debug.
+
+## en-US
+
+Component Token Debug.

--- a/components/card/demo/component-token.tsx
+++ b/components/card/demo/component-token.tsx
@@ -1,3 +1,4 @@
+import { EditOutlined, EllipsisOutlined, SettingOutlined } from '@ant-design/icons';
 import { Card, ConfigProvider } from 'antd';
 import React from 'react';
 
@@ -6,41 +7,41 @@ export default () => (
     theme={{
       components: {
         Card: {
-          headPadding: 20,
-          innerHeadPadding: 20,
-          cardPaddingSM: 16,
-          headHeight: 36,
-          headHeightSM: 26,
-          cardPaddingBase: 6,
-          cardPaddingBaseSm: 4,
-          cardShadow: '0 0 1px red',
-          actionsLiMargin: `14px 0`,
-          tabsMarginBottom: 20,
-          actionsIconSize: 20,
-          headColor: 'red',
-          headBackground: '#eee',
-          headFontSize: 22,
-          headFontSizeSm: 16,
-          actionsBackground: '#afb321',
-          cardBackground: '#342bab',
-          cardRadius: 6,
-          headExtraColor: '#f6f1ed',
+          headerBg: '#e6f4ff',
+          headerFontSize: 20,
+          headerFontSizeSM: 20,
+          headerHeight: 60,
+          headerHeightSM: 60,
+          actionsBg: '#e6f4ff',
+          actionsLiMargin: `2px 0`,
+          tabsMarginBottom: 0,
+          extraColor: 'rgba(0,0,0,0.25)',
         },
       },
     }}
   >
-    <Card title="Card title">
-      <Card type="inner" title="Inner Card title" extra={<a href="#">More</a>}>
-        Inner Card content
-      </Card>
-      <Card
-        style={{ marginTop: 16 }}
-        type="inner"
-        title="Inner Card title"
-        extra={<a href="#">More</a>}
-      >
-        Inner Card content
-      </Card>
+    <Card
+      title="Card title"
+      actions={[
+        <SettingOutlined key="setting" />,
+        <EditOutlined key="edit" />,
+        <EllipsisOutlined key="ellipsis" />,
+      ]}
+      extra="More"
+      tabList={[
+        {
+          key: 'tab1',
+          label: 'tab1',
+        },
+        {
+          key: 'tab2',
+          label: 'tab2',
+        },
+      ]}
+    >
+      <p>Card content</p>
+      <p>Card content</p>
+      <p>Card content</p>
     </Card>
     <Card size="small" title="Small size card" extra={<a href="#">More</a>} style={{ width: 300 }}>
       <p>Card content</p>

--- a/components/card/demo/component-token.tsx
+++ b/components/card/demo/component-token.tsx
@@ -1,0 +1,51 @@
+import { Card, ConfigProvider } from 'antd';
+import React from 'react';
+
+export default () => (
+  <ConfigProvider
+    theme={{
+      components: {
+        Card: {
+          headPadding: 20,
+          innerHeadPadding: 20,
+          cardPaddingSM: 16,
+          headHeight: 36,
+          headHeightSM: 26,
+          cardPaddingBase: 6,
+          cardPaddingBaseSm: 4,
+          cardShadow: '0 0 1px red',
+          actionsLiMargin: `14px 0`,
+          tabsMarginBottom: 20,
+          actionsIconSize: 20,
+          headColor: 'red',
+          headBackground: '#eee',
+          headFontSize: 22,
+          headFontSizeSm: 16,
+          actionsBackground: '#afb321',
+          cardBackground: '#342bab',
+          cardRadius: 6,
+          headExtraColor: '#f6f1ed',
+        },
+      },
+    }}
+  >
+    <Card title="Card title">
+      <Card type="inner" title="Inner Card title" extra={<a href="#">More</a>}>
+        Inner Card content
+      </Card>
+      <Card
+        style={{ marginTop: 16 }}
+        type="inner"
+        title="Inner Card title"
+        extra={<a href="#">More</a>}
+      >
+        Inner Card content
+      </Card>
+    </Card>
+    <Card size="small" title="Small size card" extra={<a href="#">More</a>} style={{ width: 300 }}>
+      <p>Card content</p>
+      <p>Card content</p>
+      <p>Card content</p>
+    </Card>
+  </ConfigProvider>
+);

--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -25,6 +25,7 @@ A card can be used to display content related to a single subject. The content c
 <code src="./demo/inner.tsx">Inner card</code>
 <code src="./demo/tabs.tsx">With tabs</code>
 <code src="./demo/meta.tsx">Support more content configuration</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API
 

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -26,6 +26,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*a-8zR6rrupgAAA
 <code src="./demo/inner.tsx">内部卡片</code>
 <code src="./demo/tabs.tsx">带页签的卡片</code>
 <code src="./demo/meta.tsx">支持更多内容配置</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -1,20 +1,26 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 
+import { clearFix, resetComponent, textEllipsis } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { clearFix, resetComponent, textEllipsis } from '../../style';
 
-export interface ComponentToken {}
+export interface ComponentToken {
+  headerBg: string;
+  headerFontSize: number;
+  headerFontSizeSM: number;
+  headerHeight: number;
+  headerHeightSM: number;
+  actionsBg: string;
+  actionsLiMargin: string;
+  tabsMarginBottom: number;
+  extraColor: string;
+}
 
 interface CardToken extends FullToken<'Card'> {
-  cardHeadHeight: number;
-  cardHeadHeightSM: number;
   cardShadow: string;
   cardHeadPadding: number;
   cardPaddingSM: number;
   cardPaddingBase: number;
-  cardHeadTabsMarginBottom: number;
-  cardActionsLiMargin: string;
   cardActionsIconSize: number;
 }
 
@@ -22,19 +28,19 @@ interface CardToken extends FullToken<'Card'> {
 
 // ============================== Head ==============================
 const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { antCls, componentCls, cardHeadHeight, cardPaddingBase, cardHeadTabsMarginBottom } = token;
+  const { antCls, componentCls, headerHeight, cardPaddingBase, tabsMarginBottom } = token;
 
   return {
     display: 'flex',
     justifyContent: 'center',
     flexDirection: 'column',
-    minHeight: cardHeadHeight,
+    minHeight: headerHeight,
     marginBottom: -1, // Fix card grid overflow bug: https://gw.alipayobjects.com/zos/rmsportal/XonYxBikwpgbqIQBeuhk.png
     padding: `0 ${cardPaddingBase}px`,
     color: token.colorTextHeading,
     fontWeight: token.fontWeightStrong,
-    fontSize: token.fontSizeLG,
-    background: 'transparent',
+    fontSize: token.headerFontSize,
+    background: token.headerBg,
     borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorBorderSecondary}`,
     borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
 
@@ -63,7 +69,7 @@ const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
     [`${antCls}-tabs-top`]: {
       clear: 'both',
-      marginBottom: cardHeadTabsMarginBottom,
+      marginBottom: tabsMarginBottom,
       color: token.colorText,
       fontWeight: 'normal',
       fontSize: token.fontSize,
@@ -102,20 +108,26 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Actions ==============================
 const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, iconCls, cardActionsLiMargin, cardActionsIconSize, colorBorderSecondary } =
-    token;
+  const {
+    componentCls,
+    iconCls,
+    actionsLiMargin,
+    cardActionsIconSize,
+    colorBorderSecondary,
+    actionsBg,
+  } = token;
   return {
     margin: 0,
     padding: 0,
     listStyle: 'none',
-    background: token.colorBgContainer,
+    background: actionsBg,
     borderTop: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
     display: 'flex',
     borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px `,
     ...clearFix(),
 
     '& > li': {
-      margin: cardActionsLiMargin,
+      margin: actionsLiMargin,
       color: token.colorTextDescription,
       textAlign: 'center',
 
@@ -231,6 +243,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     colorBorderSecondary,
     boxShadowTertiary,
     cardPaddingBase,
+    extraColor,
   } = token;
 
   return {
@@ -250,7 +263,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       [`${componentCls}-extra`]: {
         // https://stackoverflow.com/a/22429853/3040605
         marginInlineStart: 'auto',
-        color: '',
+        color: extraColor,
         fontWeight: 'normal',
         fontSize: token.fontSize,
       },
@@ -332,14 +345,14 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Size ==============================
 const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, cardPaddingSM, cardHeadHeightSM } = token;
+  const { componentCls, cardPaddingSM, headerHeightSM, headerFontSizeSM } = token;
 
   return {
     [`${componentCls}-small`]: {
       [`> ${componentCls}-head`]: {
-        minHeight: cardHeadHeightSM,
+        minHeight: headerHeightSM,
         padding: `0 ${cardPaddingSM}px`,
-        fontSize: token.fontSize,
+        fontSize: headerFontSizeSM,
 
         [`> ${componentCls}-head-wrapper`]: {
           [`> ${componentCls}-extra`]: {
@@ -355,7 +368,7 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-small${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
-          minHeight: cardHeadHeightSM,
+          minHeight: headerHeightSM,
           paddingTop: 0,
           display: 'flex',
           alignItems: 'center',
@@ -366,24 +379,34 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Card', (token) => {
-  const cardToken = mergeToken<CardToken>(token, {
-    cardShadow: token.boxShadowCard,
-    cardHeadHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
-    cardHeadHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
-    cardHeadPadding: token.padding,
-    cardPaddingBase: token.paddingLG,
-    cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
-    cardActionsLiMargin: `${token.paddingSM}px 0`,
-    cardActionsIconSize: token.fontSize,
-    cardPaddingSM: 12, // Fixed padding.
-  });
+export default genComponentStyleHook(
+  'Card',
+  (token) => {
+    const cardToken = mergeToken<CardToken>(token, {
+      cardShadow: token.boxShadowCard,
+      cardHeadPadding: token.padding,
+      cardPaddingBase: token.paddingLG,
+      cardActionsIconSize: token.fontSize,
+      cardPaddingSM: 12, // Fixed padding.
+    });
 
-  return [
-    // Style
-    genCardStyle(cardToken),
+    return [
+      // Style
+      genCardStyle(cardToken),
 
-    // Size
-    genCardSizeStyle(cardToken),
-  ];
-});
+      // Size
+      genCardSizeStyle(cardToken),
+    ];
+  },
+  (token) => ({
+    headerBg: 'transparent',
+    headerFontSize: token.fontSizeLG,
+    headerFontSizeSM: token.fontSize,
+    headerHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
+    headerHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
+    actionsBg: token.colorBgContainer,
+    actionsLiMargin: `${token.paddingSM}px 0`,
+    tabsMarginBottom: -token.padding - token.lineWidth,
+    extraColor: token.colorText,
+  }),
+);

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -24,7 +24,6 @@ export interface ComponentToken {
   cardRadius: number;
   cardHeadExtraColor: string;
   cardInnerHeadPadding: number;
-  cardSkeletonBg: string;
 }
 
 interface CardToken extends FullToken<'Card'> {}
@@ -113,7 +112,8 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Actions ==============================
 const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, iconCls, cardActionsLiMargin, fontSize, colorBorderSecondary } = token;
+  const { componentCls, iconCls, cardActionsLiMargin, cardActionsIconSize, colorBorderSecondary } =
+    token;
   return {
     margin: 0,
     padding: 0,
@@ -155,8 +155,8 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         },
 
         [`> ${iconCls}`]: {
-          fontSize,
-          lineHeight: `${fontSize * token.lineHeight}px`,
+          fontSize: cardActionsIconSize,
+          lineHeight: `${cardActionsIconSize * token.lineHeight}px`,
         },
       },
 
@@ -409,6 +409,5 @@ export default genComponentStyleHook(
     cardBackground: token.colorBgContainer,
     cardRadius: token.borderRadius,
     cardHeadExtraColor: token.colorText,
-    cardSkeletonBg: '#cfd8dc', // todo Fixed
   }),
 );

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -1,22 +1,21 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 
+import { clearFix, resetComponent, textEllipsis } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { clearFix, resetComponent, textEllipsis } from '../../style';
 
-export interface ComponentToken {}
-
-interface CardToken extends FullToken<'Card'> {
-  cardHeadHeight: number;
-  cardHeadHeightSM: number;
-  cardShadow: string;
+export interface ComponentToken {
   cardHeadPadding: number;
   cardPaddingSM: number;
+  cardHeadHeight: number;
+  cardHeadHeightSM: number;
   cardPaddingBase: number;
-  cardHeadTabsMarginBottom: number;
+  cardShadow: string;
   cardActionsLiMargin: string;
-  cardActionsIconSize: number;
+  cardHeadTabsMarginBottom: number;
 }
+
+interface CardToken extends FullToken<'Card'> {}
 
 // ============================== Styles ==============================
 
@@ -102,8 +101,7 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Actions ==============================
 const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, iconCls, cardActionsLiMargin, cardActionsIconSize, colorBorderSecondary } =
-    token;
+  const { componentCls, iconCls, cardActionsLiMargin, fontSize, colorBorderSecondary } = token;
   return {
     margin: 0,
     padding: 0,
@@ -122,7 +120,7 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       '> span': {
         position: 'relative',
         display: 'block',
-        minWidth: token.cardActionsIconSize * 2,
+        minWidth: token.fontSize * 2,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         cursor: 'pointer',
@@ -145,8 +143,8 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         },
 
         [`> ${iconCls}`]: {
-          fontSize: cardActionsIconSize,
-          lineHeight: `${cardActionsIconSize * token.lineHeight}px`,
+          fontSize,
+          lineHeight: `${fontSize * token.lineHeight}px`,
         },
       },
 
@@ -366,24 +364,27 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Card', (token) => {
-  const cardToken = mergeToken<CardToken>(token, {
-    cardShadow: token.boxShadowCard,
+export default genComponentStyleHook(
+  'Card',
+  (token) => {
+    const cardToken = mergeToken<CardToken>(token);
+
+    return [
+      // Style
+      genCardStyle(cardToken),
+
+      // Size
+      genCardSizeStyle(cardToken),
+    ];
+  },
+  (token) => ({
+    cardHeadPadding: token.padding,
+    cardPaddingSM: 12, // Fixed padding.
     cardHeadHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
     cardHeadHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
-    cardHeadPadding: token.padding,
     cardPaddingBase: token.paddingLG,
-    cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
+    cardShadow: token.boxShadowCard,
     cardActionsLiMargin: `${token.paddingSM}px 0`,
-    cardActionsIconSize: token.fontSize,
-    cardPaddingSM: 12, // Fixed padding.
-  });
-
-  return [
-    // Style
-    genCardStyle(cardToken),
-
-    // Size
-    genCardSizeStyle(cardToken),
-  ];
-});
+    cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
+  }),
+);

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -1,44 +1,34 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 
-import { clearFix, resetComponent, textEllipsis } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import { clearFix, resetComponent, textEllipsis } from '../../style';
 
-export interface ComponentToken {
-  headPadding: number;
-  cardPaddingSM: number;
-  headHeight: number;
-  headHeightSM: number;
-  cardPaddingBase: number;
-  cardPaddingBaseSm: number;
+export interface ComponentToken {}
+
+interface CardToken extends FullToken<'Card'> {
+  cardHeadHeight: number;
+  cardHeadHeightSM: number;
   cardShadow: string;
-  actionsLiMargin: string;
-  tabsMarginBottom: number;
-  actionsIconSize: number;
-  headColor: string;
-  headBackground: string;
-  headFontSize: number;
-  headFontSizeSm: number;
-  actionsBackground: string;
-  cardBackground: string;
-  cardRadius: number;
-  headExtraColor: string;
-  innerHeadPadding: number;
+  cardHeadPadding: number;
+  cardPaddingSM: number;
+  cardPaddingBase: number;
+  cardHeadTabsMarginBottom: number;
+  cardActionsLiMargin: string;
+  cardActionsIconSize: number;
 }
-
-interface CardToken extends FullToken<'Card'> {}
 
 // ============================== Styles ==============================
 
 // ============================== Head ==============================
 const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { antCls, componentCls, headHeight, cardPaddingBase, tabsMarginBottom } = token;
+  const { antCls, componentCls, cardHeadHeight, cardPaddingBase, cardHeadTabsMarginBottom } = token;
 
   return {
     display: 'flex',
     justifyContent: 'center',
     flexDirection: 'column',
-    minHeight: headHeight,
+    minHeight: cardHeadHeight,
     marginBottom: -1, // Fix card grid overflow bug: https://gw.alipayobjects.com/zos/rmsportal/XonYxBikwpgbqIQBeuhk.png
     padding: `0 ${cardPaddingBase}px`,
     color: token.colorTextHeading,
@@ -73,7 +63,7 @@ const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
     [`${antCls}-tabs-top`]: {
       clear: 'both',
-      marginBottom: tabsMarginBottom,
+      marginBottom: cardHeadTabsMarginBottom,
       color: token.colorText,
       fontWeight: 'normal',
       fontSize: token.fontSize,
@@ -112,7 +102,8 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Actions ==============================
 const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, iconCls, actionsLiMargin, actionsIconSize, colorBorderSecondary } = token;
+  const { componentCls, iconCls, cardActionsLiMargin, cardActionsIconSize, colorBorderSecondary } =
+    token;
   return {
     margin: 0,
     padding: 0,
@@ -124,14 +115,14 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     ...clearFix(),
 
     '& > li': {
-      margin: actionsLiMargin,
+      margin: cardActionsLiMargin,
       color: token.colorTextDescription,
       textAlign: 'center',
 
       '> span': {
         position: 'relative',
         display: 'block',
-        minWidth: token.actionsIconSize * 2,
+        minWidth: token.cardActionsIconSize * 2,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         cursor: 'pointer',
@@ -154,8 +145,8 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         },
 
         [`> ${iconCls}`]: {
-          fontSize: actionsIconSize,
-          lineHeight: `${actionsIconSize * token.lineHeight}px`,
+          fontSize: cardActionsIconSize,
+          lineHeight: `${cardActionsIconSize * token.lineHeight}px`,
         },
       },
 
@@ -236,7 +227,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     antCls,
     componentCls,
     cardShadow,
-    headPadding,
+    cardHeadPadding,
     colorBorderSecondary,
     boxShadowTertiary,
     cardPaddingBase,
@@ -324,7 +315,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
-          paddingTop: headPadding,
+          paddingTop: cardHeadPadding,
         },
       },
     },
@@ -341,12 +332,12 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Size ==============================
 const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, cardPaddingSM, headHeightSM } = token;
+  const { componentCls, cardPaddingSM, cardHeadHeightSM } = token;
 
   return {
     [`${componentCls}-small`]: {
       [`> ${componentCls}-head`]: {
-        minHeight: headHeightSM,
+        minHeight: cardHeadHeightSM,
         padding: `0 ${cardPaddingSM}px`,
         fontSize: token.fontSize,
 
@@ -364,7 +355,7 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-small${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
-          minHeight: headHeightSM,
+          minHeight: cardHeadHeightSM,
           paddingTop: 0,
           display: 'flex',
           alignItems: 'center',
@@ -375,38 +366,24 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook(
-  'Card',
-  (token) => {
-    const cardToken = mergeToken<CardToken>(token);
-    console.log('tokenboxShadowCard', token.boxShadowCard);
-    return [
-      // Style
-      genCardStyle(cardToken),
-
-      // Size
-      genCardSizeStyle(cardToken),
-    ];
-  },
-  (token) => ({
-    headPadding: token.padding,
-    innerHeadPadding: 12, // Fixed padding.
-    cardPaddingSM: 12, // Fixed padding.
-    headHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
-    headHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
-    cardPaddingBase: token.paddingLG,
-    cardPaddingBaseSm: token.paddingLG / 2,
+export default genComponentStyleHook('Card', (token) => {
+  const cardToken = mergeToken<CardToken>(token, {
     cardShadow: token.boxShadowCard,
-    actionsLiMargin: `${token.paddingSM}px 0`,
-    tabsMarginBottom: -token.padding - token.lineWidth,
-    actionsIconSize: token.fontSize,
-    headColor: token.colorText,
-    headBackground: 'transparent',
-    headFontSize: token.fontSizeLG,
-    headFontSizeSm: token.fontSize,
-    actionsBackground: token.colorBgContainer,
-    cardBackground: token.colorBgContainer,
-    cardRadius: token.borderRadius,
-    headExtraColor: token.colorText,
-  }),
-);
+    cardHeadHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
+    cardHeadHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
+    cardHeadPadding: token.padding,
+    cardPaddingBase: token.paddingLG,
+    cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
+    cardActionsLiMargin: `${token.paddingSM}px 0`,
+    cardActionsIconSize: token.fontSize,
+    cardPaddingSM: 12, // Fixed padding.
+  });
+
+  return [
+    // Style
+    genCardStyle(cardToken),
+
+    // Size
+    genCardSizeStyle(cardToken),
+  ];
+});

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -5,25 +5,25 @@ import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
-  cardHeadPadding: number;
+  headPadding: number;
   cardPaddingSM: number;
-  cardHeadHeight: number;
-  cardHeadHeightSM: number;
+  headHeight: number;
+  headHeightSM: number;
   cardPaddingBase: number;
   cardPaddingBaseSm: number;
   cardShadow: string;
-  cardActionsLiMargin: string;
-  cardHeadTabsMarginBottom: number;
-  cardActionsIconSize: number;
-  cardHeadColor: string;
-  cardHeadBackground: string;
-  cardHeadFontSize: number;
-  cardHeadFontSizeSm: number;
-  cardActionsBackground: string;
+  actionsLiMargin: string;
+  tabsMarginBottom: number;
+  actionsIconSize: number;
+  headColor: string;
+  headBackground: string;
+  headFontSize: number;
+  headFontSizeSm: number;
+  actionsBackground: string;
   cardBackground: string;
   cardRadius: number;
-  cardHeadExtraColor: string;
-  cardInnerHeadPadding: number;
+  headExtraColor: string;
+  innerHeadPadding: number;
 }
 
 interface CardToken extends FullToken<'Card'> {}
@@ -32,13 +32,13 @@ interface CardToken extends FullToken<'Card'> {}
 
 // ============================== Head ==============================
 const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { antCls, componentCls, cardHeadHeight, cardPaddingBase, cardHeadTabsMarginBottom } = token;
+  const { antCls, componentCls, headHeight, cardPaddingBase, tabsMarginBottom } = token;
 
   return {
     display: 'flex',
     justifyContent: 'center',
     flexDirection: 'column',
-    minHeight: cardHeadHeight,
+    minHeight: headHeight,
     marginBottom: -1, // Fix card grid overflow bug: https://gw.alipayobjects.com/zos/rmsportal/XonYxBikwpgbqIQBeuhk.png
     padding: `0 ${cardPaddingBase}px`,
     color: token.colorTextHeading,
@@ -73,7 +73,7 @@ const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
     [`${antCls}-tabs-top`]: {
       clear: 'both',
-      marginBottom: cardHeadTabsMarginBottom,
+      marginBottom: tabsMarginBottom,
       color: token.colorText,
       fontWeight: 'normal',
       fontSize: token.fontSize,
@@ -112,8 +112,7 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Actions ==============================
 const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, iconCls, cardActionsLiMargin, cardActionsIconSize, colorBorderSecondary } =
-    token;
+  const { componentCls, iconCls, actionsLiMargin, actionsIconSize, colorBorderSecondary } = token;
   return {
     margin: 0,
     padding: 0,
@@ -125,14 +124,14 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     ...clearFix(),
 
     '& > li': {
-      margin: cardActionsLiMargin,
+      margin: actionsLiMargin,
       color: token.colorTextDescription,
       textAlign: 'center',
 
       '> span': {
         position: 'relative',
         display: 'block',
-        minWidth: token.cardActionsIconSize * 2,
+        minWidth: token.actionsIconSize * 2,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         cursor: 'pointer',
@@ -155,8 +154,8 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         },
 
         [`> ${iconCls}`]: {
-          fontSize: cardActionsIconSize,
-          lineHeight: `${cardActionsIconSize * token.lineHeight}px`,
+          fontSize: actionsIconSize,
+          lineHeight: `${actionsIconSize * token.lineHeight}px`,
         },
       },
 
@@ -237,7 +236,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     antCls,
     componentCls,
     cardShadow,
-    cardHeadPadding,
+    headPadding,
     colorBorderSecondary,
     boxShadowTertiary,
     cardPaddingBase,
@@ -325,7 +324,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
-          paddingTop: cardHeadPadding,
+          paddingTop: headPadding,
         },
       },
     },
@@ -342,12 +341,12 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Size ==============================
 const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
-  const { componentCls, cardPaddingSM, cardHeadHeightSM } = token;
+  const { componentCls, cardPaddingSM, headHeightSM } = token;
 
   return {
     [`${componentCls}-small`]: {
       [`> ${componentCls}-head`]: {
-        minHeight: cardHeadHeightSM,
+        minHeight: headHeightSM,
         padding: `0 ${cardPaddingSM}px`,
         fontSize: token.fontSize,
 
@@ -365,7 +364,7 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-small${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
-          minHeight: cardHeadHeightSM,
+          minHeight: headHeightSM,
           paddingTop: 0,
           display: 'flex',
           alignItems: 'center',
@@ -380,7 +379,7 @@ export default genComponentStyleHook(
   'Card',
   (token) => {
     const cardToken = mergeToken<CardToken>(token);
-
+    console.log('tokenboxShadowCard', token.boxShadowCard);
     return [
       // Style
       genCardStyle(cardToken),
@@ -390,24 +389,24 @@ export default genComponentStyleHook(
     ];
   },
   (token) => ({
-    cardHeadPadding: token.padding,
-    cardInnerHeadPadding: 12, // Fixed padding.
+    headPadding: token.padding,
+    innerHeadPadding: 12, // Fixed padding.
     cardPaddingSM: 12, // Fixed padding.
-    cardHeadHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
-    cardHeadHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
+    headHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
+    headHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
     cardPaddingBase: token.paddingLG,
     cardPaddingBaseSm: token.paddingLG / 2,
     cardShadow: token.boxShadowCard,
-    cardActionsLiMargin: `${token.paddingSM}px 0`,
-    cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
-    cardActionsIconSize: token.fontSize,
-    cardHeadColor: token.colorText,
-    cardHeadBackground: 'transparent',
-    cardHeadFontSize: token.fontSizeLG,
-    cardHeadFontSizeSm: token.fontSize,
-    cardActionsBackground: token.colorBgContainer,
+    actionsLiMargin: `${token.paddingSM}px 0`,
+    tabsMarginBottom: -token.padding - token.lineWidth,
+    actionsIconSize: token.fontSize,
+    headColor: token.colorText,
+    headBackground: 'transparent',
+    headFontSize: token.fontSizeLG,
+    headFontSizeSm: token.fontSize,
+    actionsBackground: token.colorBgContainer,
     cardBackground: token.colorBgContainer,
     cardRadius: token.borderRadius,
-    cardHeadExtraColor: token.colorText,
+    headExtraColor: token.colorText,
   }),
 );

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -10,9 +10,21 @@ export interface ComponentToken {
   cardHeadHeight: number;
   cardHeadHeightSM: number;
   cardPaddingBase: number;
+  cardPaddingBaseSm: number;
   cardShadow: string;
   cardActionsLiMargin: string;
   cardHeadTabsMarginBottom: number;
+  cardActionsIconSize: number;
+  cardHeadColor: string;
+  cardHeadBackground: string;
+  cardHeadFontSize: number;
+  cardHeadFontSizeSm: number;
+  cardActionsBackground: string;
+  cardBackground: string;
+  cardRadius: number;
+  cardHeadExtraColor: string;
+  cardInnerHeadPadding: number;
+  cardSkeletonBg: string;
 }
 
 interface CardToken extends FullToken<'Card'> {}
@@ -120,7 +132,7 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       '> span': {
         position: 'relative',
         display: 'block',
-        minWidth: token.fontSize * 2,
+        minWidth: token.cardActionsIconSize * 2,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         cursor: 'pointer',
@@ -379,12 +391,24 @@ export default genComponentStyleHook(
   },
   (token) => ({
     cardHeadPadding: token.padding,
+    cardInnerHeadPadding: 12, // Fixed padding.
     cardPaddingSM: 12, // Fixed padding.
     cardHeadHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
     cardHeadHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
     cardPaddingBase: token.paddingLG,
+    cardPaddingBaseSm: token.paddingLG / 2,
     cardShadow: token.boxShadowCard,
     cardActionsLiMargin: `${token.paddingSM}px 0`,
     cardHeadTabsMarginBottom: -token.padding - token.lineWidth,
+    cardActionsIconSize: token.fontSize,
+    cardHeadColor: token.colorText,
+    cardHeadBackground: 'transparent',
+    cardHeadFontSize: token.fontSizeLG,
+    cardHeadFontSizeSm: token.fontSize,
+    cardActionsBackground: token.colorBgContainer,
+    cardBackground: token.colorBgContainer,
+    cardRadius: token.borderRadius,
+    cardHeadExtraColor: token.colorText,
+    cardSkeletonBg: '#cfd8dc', // todo Fixed
   }),
 );

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -78,25 +78,25 @@ This document contains the correspondence between all the less variables related
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | `cardHeadColor` | - |
-| `@card-head-background` | `cardHeadBackground` | - |
-| `@card-head-font-size` | `cardHeadFontSize` | - |
-| `@card-head-font-size-sm` | `cardHeadFontSizeSm` | - |
-| `@card-head-padding` | `cardHeadPadding` | - |
+| `@card-head-color` | `headColor` | - |
+| `@card-head-background` | `headBackground` | - |
+| `@card-head-font-size` | `headFontSize` | - |
+| `@card-head-font-size-sm` | `headFontSizeSm` | - |
+| `@card-head-padding` | `headPadding` | - |
 | `@card-head-padding-sm` | `cardPaddingSM` | - |
-| `@card-head-height` | `cardHeadHeight` | - |
-| `@card-head-height-sm` | `cardHeadHeightSM` | - |
-| `@card-inner-head-padding` | `cardInnerHeadPadding` | - |
+| `@card-head-height` | `headHeight` | - |
+| `@card-head-height-sm` | `headHeightSM` | - |
+| `@card-inner-head-padding` | `innerHeadPadding` | - |
 | `@card-padding-base` | `cardPaddingBase` | - |
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
-| `@card-actions-background` | `cardActionsBackground` | - |
-| `@card-actions-li-margin` | `cardActionsLiMargin` | - |
+| `@card-actions-background` | `actionsBackground` | - |
+| `@card-actions-li-margin` | `actionsLiMargin` | - |
 | `@card-skeleton-bg` | - | Deprecated for style change |
 | `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
 | `@card-radius` | `cardRadius` | - |
-| `@card-head-tabs-margin-bottom` | `cardHeadTabsMarginBottom` | - |
-| `@card-head-extra-color` | `cardHeadExtraColor` | - |
+| `@card-head-tabs-margin-bottom` | `tabsMarginBottom` | - |
+| `@card-head-extra-color` | `headExtraColor` | - |
 
 ## Carousel
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -78,25 +78,25 @@ This document contains the correspondence between all the less variables related
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | `headColor` | - |
-| `@card-head-background` | `headBackground` | - |
-| `@card-head-font-size` | `headFontSize` | - |
-| `@card-head-font-size-sm` | `headFontSizeSm` | - |
-| `@card-head-padding` | `headPadding` | - |
-| `@card-head-padding-sm` | `cardPaddingSM` | - |
-| `@card-head-height` | `headHeight` | - |
-| `@card-head-height-sm` | `headHeightSM` | - |
-| `@card-inner-head-padding` | `innerHeadPadding` | - |
+| `@card-head-color` | `colorTextHeading` | Global Token |
+| `@card-head-background` | `headerBg` | - |
+| `@card-head-font-size` | `headerFontSize` | - |
+| `@card-head-font-size-sm` | `headerFontSizeSM` | - |
+| `@card-head-padding` | - | Deprecated |
+| `@card-head-padding-sm` | - | Deprecated |
+| `@card-head-height` | `headerHeight` | - |
+| `@card-head-height-sm` | `headerHeightSM` | - |
+| `@card-inner-head-padding` | - | Deprecated |
 | `@card-padding-base` | `cardPaddingBase` | - |
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
 | `@card-actions-background` | `actionsBackground` | - |
 | `@card-actions-li-margin` | `actionsLiMargin` | - |
-| `@card-skeleton-bg` | - | Deprecated for style change |
-| `@card-background` | `cardBackground` | - |
-| `@card-shadow` | `cardShadow` | - |
-| `@card-radius` | `cardRadius` | - |
+| `@card-skeleton-bg` | - | Deprecated in favor of internal Skeleton |
+| `@card-background` | `colorBgContainer` | Global Token |
+| `@card-shadow` | - | Could be modified by `className` or `style` directly |
+| `@card-radius` | `borderRadiusLG` | Global Token |
 | `@card-head-tabs-margin-bottom` | `tabsMarginBottom` | - |
-| `@card-head-extra-color` | `headExtraColor` | - |
+| `@card-head-extra-color` | `extraColor` | - |
 
 ## Carousel
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -82,18 +82,18 @@ This document contains the correspondence between all the less variables related
 | `@card-head-background` | - | Deprecated for style change |
 | `@card-head-font-size` | - | Deprecated for style change |
 | `@card-head-font-size-sm` | - | Deprecated for style change |
-| `@card-head-padding` | - | Deprecated for style change |
-| `@card-head-padding-sm` | - | Deprecated for style change |
-| `@card-head-height` | - | Deprecated for style change |
-| `@card-head-height-sm` | - | Deprecated for style change |
+| `@card-head-padding` | `cardHeadPadding` | - |
+| `@card-head-padding-sm` | `cardPaddingSM` | - |
+| `@card-head-height` | `cardHeadHeight` | - |
+| `@card-head-height-sm` | `cardHeadHeightSM` | - |
 | `@card-inner-head-padding` | - | Deprecated for style change |
-| `@card-padding-base` | - | Deprecated for style change |
+| `@card-padding-base` | `cardPaddingBase` | - |
 | `@card-padding-base-sm` | - | Deprecated for style change |
 | `@card-actions-background` | - | Deprecated for style change |
-| `@card-actions-li-margin` | - | Deprecated for style change |
+| `@card-actions-li-margin` | `cardActionsLiMargin` | - |
 | `@card-skeleton-bg` | - | Deprecated for style change |
 | `@card-background` | - | Deprecated for style change |
-| `@card-shadow` | - | Deprecated for style change |
+| `@card-shadow` | `cardShadow` | - |
 | `@card-radius` | - | Deprecated for style change |
 | `@card-head-tabs-margin-bottom` | - | Deprecated for style change |
 | `@card-head-extra-color` | - | Deprecated for style change |

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -91,7 +91,7 @@ This document contains the correspondence between all the less variables related
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
 | `@card-actions-background` | `cardActionsBackground` | - |
 | `@card-actions-li-margin` | `cardActionsLiMargin` | - |
-| `@card-skeleton-bg` | `cardSkeletonBg` | - |
+| `@card-skeleton-bg` | - | Deprecated for style change |
 | `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
 | `@card-radius` | `cardRadius` | - |

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -78,25 +78,25 @@ This document contains the correspondence between all the less variables related
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | - | Deprecated for style change |
-| `@card-head-background` | - | Deprecated for style change |
-| `@card-head-font-size` | - | Deprecated for style change |
-| `@card-head-font-size-sm` | - | Deprecated for style change |
+| `@card-head-color` | `cardHeadColor` | - |
+| `@card-head-background` | `cardHeadBackground` | - |
+| `@card-head-font-size` | `cardHeadFontSize` | - |
+| `@card-head-font-size-sm` | `cardHeadFontSizeSm` | - |
 | `@card-head-padding` | `cardHeadPadding` | - |
 | `@card-head-padding-sm` | `cardPaddingSM` | - |
 | `@card-head-height` | `cardHeadHeight` | - |
 | `@card-head-height-sm` | `cardHeadHeightSM` | - |
-| `@card-inner-head-padding` | - | Deprecated for style change |
+| `@card-inner-head-padding` | `cardInnerHeadPadding` | - |
 | `@card-padding-base` | `cardPaddingBase` | - |
-| `@card-padding-base-sm` | - | Deprecated for style change |
-| `@card-actions-background` | - | Deprecated for style change |
+| `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
+| `@card-actions-background` | `cardActionsBackground` | - |
 | `@card-actions-li-margin` | `cardActionsLiMargin` | - |
-| `@card-skeleton-bg` | - | Deprecated for style change |
-| `@card-background` | - | Deprecated for style change |
+| `@card-skeleton-bg` | `cardSkeletonBg` | - |
+| `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
-| `@card-radius` | - | Deprecated for style change |
-| `@card-head-tabs-margin-bottom` | - | Deprecated for style change |
-| `@card-head-extra-color` | - | Deprecated for style change |
+| `@card-radius` | `cardRadius` | - |
+| `@card-head-tabs-margin-bottom` | `cardHeadTabsMarginBottom` | - |
+| `@card-head-extra-color` | `cardHeadExtraColor` | - |
 
 ## Carousel
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -73,7 +73,30 @@ This document contains the correspondence between all the less variables related
 | `@calendar-full-bg` | `fullBg` | - |
 | `@calendar-full-panel-bg` | `fullPanelBg` | - |
 
-<!-- ### Card -->
+### Card
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@card-head-color` | - | Deprecated for style change |
+| `@card-head-background` | - | Deprecated for style change |
+| `@card-head-font-size` | - | Deprecated for style change |
+| `@card-head-font-size-sm` | - | Deprecated for style change |
+| `@card-head-padding` | - | Deprecated for style change |
+| `@card-head-padding-sm` | - | Deprecated for style change |
+| `@card-head-height` | - | Deprecated for style change |
+| `@card-head-height-sm` | - | Deprecated for style change |
+| `@card-inner-head-padding` | - | Deprecated for style change |
+| `@card-padding-base` | - | Deprecated for style change |
+| `@card-padding-base-sm` | - | Deprecated for style change |
+| `@card-actions-background` | - | Deprecated for style change |
+| `@card-actions-li-margin` | - | Deprecated for style change |
+| `@card-skeleton-bg` | - | Deprecated for style change |
+| `@card-background` | - | Deprecated for style change |
+| `@card-shadow` | - | Deprecated for style change |
+| `@card-radius` | - | Deprecated for style change |
+| `@card-head-tabs-margin-bottom` | - | Deprecated for style change |
+| `@card-head-extra-color` | - | Deprecated for style change |
 
 ## Carousel
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -78,25 +78,25 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | - | Deprecated for style change |
-| `@card-head-background` | - | Deprecated for style change |
-| `@card-head-font-size` | - | Deprecated for style change |
-| `@card-head-font-size-sm` | - | Deprecated for style change |
-| `@card-head-padding` | - | Deprecated for style change |
-| `@card-head-padding-sm` | - | Deprecated for style change |
-| `@card-head-height` | - | Deprecated for style change |
-| `@card-head-height-sm` | - | Deprecated for style change |
-| `@card-inner-head-padding` | - | Deprecated for style change |
-| `@card-padding-base` | - | Deprecated for style change |
-| `@card-padding-base-sm` | - | Deprecated for style change |
-| `@card-actions-background` | - | Deprecated for style change |
-| `@card-actions-li-margin` | - | Deprecated for style change |
-| `@card-skeleton-bg` | - | Deprecated for style change |
-| `@card-background` | - | Deprecated for style change |
-| `@card-shadow` | - | Deprecated for style change |
-| `@card-radius` | - | Deprecated for style change |
-| `@card-head-tabs-margin-bottom` | - | Deprecated for style change |
-| `@card-head-extra-color` | - | Deprecated for style change |
+| `@card-head-color` | - | 由于样式变化已废弃 |
+| `@card-head-background` | - | 由于样式变化已废弃 |
+| `@card-head-font-size` | - | 由于样式变化已废弃 |
+| `@card-head-font-size-sm` | - | 由于样式变化已废弃 |
+| `@card-head-padding` | `cardHeadPadding` | - |
+| `@card-head-padding-sm` | `cardPaddingSM` | - |
+| `@card-head-height` | `cardHeadHeight` | - |
+| `@card-head-height-sm` | `cardHeadHeightSM` | - |
+| `@card-inner-head-padding` | - | 由于样式变化已废弃 |
+| `@card-padding-base` | `cardPaddingBase` | - |
+| `@card-padding-base-sm` | - | 由于样式变化已废弃 |
+| `@card-actions-background` | - | 由于样式变化已废弃 |
+| `@card-actions-li-margin` | `cardActionsLiMargin` | - |
+| `@card-skeleton-bg` | - | 由于样式变化已废弃 |
+| `@card-background` | - | 由于样式变化已废弃 |
+| `@card-shadow` | `cardShadow` | - |
+| `@card-radius` | - | 由于样式变化已废弃 |
+| `@card-head-tabs-margin-bottom` | - | 由于样式变化已废弃 |
+| `@card-head-extra-color` | - | 由于样式变化已废弃 |
 
 ### Carousel 走马灯
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -78,25 +78,25 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | `cardHeadColor` | - |
-| `@card-head-background` | `cardHeadBackground` | - |
-| `@card-head-font-size` | `cardHeadFontSize` | - |
-| `@card-head-font-size-sm` | `cardHeadFontSizeSm` | - |
-| `@card-head-padding` | `cardHeadPadding` | - |
+| `@card-head-color` | `headColor` | - |
+| `@card-head-background` | `headBackground` | - |
+| `@card-head-font-size` | `headFontSize` | - |
+| `@card-head-font-size-sm` | `headFontSizeSm` | - |
+| `@card-head-padding` | `headPadding` | - |
 | `@card-head-padding-sm` | `cardPaddingSM` | - |
-| `@card-head-height` | `cardHeadHeight` | - |
-| `@card-head-height-sm` | `cardHeadHeightSM` | - |
-| `@card-inner-head-padding` | `cardInnerHeadPadding` | - |
+| `@card-head-height` | `headHeight` | - |
+| `@card-head-height-sm` | `headHeightSM` | - |
+| `@card-inner-head-padding` | `innerHeadPadding` | - |
 | `@card-padding-base` | `cardPaddingBase` | - |
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
-| `@card-actions-background` | `cardActionsBackground` | - |
-| `@card-actions-li-margin` | `cardActionsLiMargin` | - |
+| `@card-actions-background` | `actionsBackground` | - |
+| `@card-actions-li-margin` | `actionsLiMargin` | - |
 | `@card-skeleton-bg` | - | 由于样式变化已废弃 |
 | `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
 | `@card-radius` | `cardRadius` | - |
-| `@card-head-tabs-margin-bottom` | `cardHeadTabsMarginBottom` | - |
-| `@card-head-extra-color` | `cardHeadExtraColor` | - |
+| `@card-head-tabs-margin-bottom` | `tabsMarginBottom` | - |
+| `@card-head-extra-color` | `headExtraColor` | - |
 
 ### Carousel 走马灯
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -78,25 +78,25 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | `headColor` | - |
-| `@card-head-background` | `headBackground` | - |
-| `@card-head-font-size` | `headFontSize` | - |
-| `@card-head-font-size-sm` | `headFontSizeSm` | - |
-| `@card-head-padding` | `headPadding` | - |
-| `@card-head-padding-sm` | `cardPaddingSM` | - |
-| `@card-head-height` | `headHeight` | - |
-| `@card-head-height-sm` | `headHeightSM` | - |
-| `@card-inner-head-padding` | `innerHeadPadding` | - |
+| `@card-head-color` | `colorTextHeading` | 全局 Token |
+| `@card-head-background` | `headerBg` | - |
+| `@card-head-font-size` | `headerFontSize` | - |
+| `@card-head-font-size-sm` | `headerFontSizeSM` | - |
+| `@card-head-padding` | - | 已废弃 |
+| `@card-head-padding-sm` | - | 已废弃 |
+| `@card-head-height` | `headerHeight` | - |
+| `@card-head-height-sm` | `headerHeightSM` | - |
+| `@card-inner-head-padding` | - | 已废弃 |
 | `@card-padding-base` | `cardPaddingBase` | - |
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
 | `@card-actions-background` | `actionsBackground` | - |
 | `@card-actions-li-margin` | `actionsLiMargin` | - |
-| `@card-skeleton-bg` | - | 由于样式变化已废弃 |
-| `@card-background` | `cardBackground` | - |
-| `@card-shadow` | `cardShadow` | - |
-| `@card-radius` | `cardRadius` | - |
+| `@card-skeleton-bg` | - | 已废弃，已改为内置 Skeleton 组件 |
+| `@card-background` | `colorBgContainer` | 全局 Token |
+| `@card-shadow` | - | 可由 `className` 或者 `style` 直接修改 |
+| `@card-radius` | `borderRadiusLG` | 全局 Token |
 | `@card-head-tabs-margin-bottom` | `tabsMarginBottom` | - |
-| `@card-head-extra-color` | `headExtraColor` | - |
+| `@card-head-extra-color` | `extraColor` | - |
 
 ### Carousel 走马灯
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -91,7 +91,7 @@ title: Less 变量迁移 Design Token
 | `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
 | `@card-actions-background` | `cardActionsBackground` | - |
 | `@card-actions-li-margin` | `cardActionsLiMargin` | - |
-| `@card-skeleton-bg` | `cardSkeletonBg` | - |
+| `@card-skeleton-bg` | - | 由于样式变化已废弃 |
 | `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
 | `@card-radius` | `cardRadius` | - |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -73,9 +73,32 @@ title: Less 变量迁移 Design Token
 | `@calendar-full-bg` | `fullBg` | - |
 | `@calendar-full-panel-bg` | `fullPanelBg` | - |
 
-<!-- ### Card 卡片 -->
+### Card 卡片
 
-## Carousel 走马灯
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@card-head-color` | - | Deprecated for style change |
+| `@card-head-background` | - | Deprecated for style change |
+| `@card-head-font-size` | - | Deprecated for style change |
+| `@card-head-font-size-sm` | - | Deprecated for style change |
+| `@card-head-padding` | - | Deprecated for style change |
+| `@card-head-padding-sm` | - | Deprecated for style change |
+| `@card-head-height` | - | Deprecated for style change |
+| `@card-head-height-sm` | - | Deprecated for style change |
+| `@card-inner-head-padding` | - | Deprecated for style change |
+| `@card-padding-base` | - | Deprecated for style change |
+| `@card-padding-base-sm` | - | Deprecated for style change |
+| `@card-actions-background` | - | Deprecated for style change |
+| `@card-actions-li-margin` | - | Deprecated for style change |
+| `@card-skeleton-bg` | - | Deprecated for style change |
+| `@card-background` | - | Deprecated for style change |
+| `@card-shadow` | - | Deprecated for style change |
+| `@card-radius` | - | Deprecated for style change |
+| `@card-head-tabs-margin-bottom` | - | Deprecated for style change |
+| `@card-head-extra-color` | - | Deprecated for style change |
+
+### Carousel 走马灯
 
 <!-- prettier-ignore -->
 | Less 变量 | Component Token | 备注 |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -78,25 +78,25 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
 | --- | --- | --- |
-| `@card-head-color` | - | 由于样式变化已废弃 |
-| `@card-head-background` | - | 由于样式变化已废弃 |
-| `@card-head-font-size` | - | 由于样式变化已废弃 |
-| `@card-head-font-size-sm` | - | 由于样式变化已废弃 |
+| `@card-head-color` | `cardHeadColor` | - |
+| `@card-head-background` | `cardHeadBackground` | - |
+| `@card-head-font-size` | `cardHeadFontSize` | - |
+| `@card-head-font-size-sm` | `cardHeadFontSizeSm` | - |
 | `@card-head-padding` | `cardHeadPadding` | - |
 | `@card-head-padding-sm` | `cardPaddingSM` | - |
 | `@card-head-height` | `cardHeadHeight` | - |
 | `@card-head-height-sm` | `cardHeadHeightSM` | - |
-| `@card-inner-head-padding` | - | 由于样式变化已废弃 |
+| `@card-inner-head-padding` | `cardInnerHeadPadding` | - |
 | `@card-padding-base` | `cardPaddingBase` | - |
-| `@card-padding-base-sm` | - | 由于样式变化已废弃 |
-| `@card-actions-background` | - | 由于样式变化已废弃 |
+| `@card-padding-base-sm` | `cardPaddingBaseSm` | - |
+| `@card-actions-background` | `cardActionsBackground` | - |
 | `@card-actions-li-margin` | `cardActionsLiMargin` | - |
-| `@card-skeleton-bg` | - | 由于样式变化已废弃 |
-| `@card-background` | - | 由于样式变化已废弃 |
+| `@card-skeleton-bg` | `cardSkeletonBg` | - |
+| `@card-background` | `cardBackground` | - |
 | `@card-shadow` | `cardShadow` | - |
-| `@card-radius` | - | 由于样式变化已废弃 |
-| `@card-head-tabs-margin-bottom` | - | 由于样式变化已废弃 |
-| `@card-head-extra-color` | - | 由于样式变化已废弃 |
+| `@card-radius` | `cardRadius` | - |
+| `@card-head-tabs-margin-bottom` | `cardHeadTabsMarginBottom` | - |
+| `@card-head-extra-color` | `cardHeadExtraColor` | - |
 
 ### Carousel 走马灯
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
https://github.com/ant-design/ant-design/issues/41884
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Card Component Token      |
| 🇨🇳 Chinese |    迁移v4 less        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a1f7f5</samp>

This pull request refactors the card component style and updates the documentation for migrating less variables to component tokens. It simplifies the `ComponentToken` interface and the `genComponentStyleHook` function in `components/card/style/index.ts`. It also fixes and adds sections for `Modal` and `Card` in both English and Chinese versions of `docs/react/migrate-less-variables.md`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a1f7f5</samp>

*  Refactor card component to use component tokens and simplify style hook ([link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L3-R19),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L105-R104),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L125-R123),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L148-R147),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L368-R389))
* Add documentation for card component tokens and mapping with less variables ([link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL10-R10),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R63),[link](https://github.com/ant-design/ant-design/pull/42061/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R63))
