### PR TITLE
✨ feat: migrate less to token for Avatar

### DIFF
--- a/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -342,6 +342,160 @@ exports[`renders components/avatar/demo/basic.tsx extend context correctly 1`] =
 </div>
 `;
 
+exports[`renders components/avatar/demo/component-token.tsx extend context correctly 1`] = `
+Array [
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right: 8px;"
+    >
+      <span
+        class="ant-avatar ant-avatar-circle ant-avatar-image"
+      >
+        <img
+          src="http://abc.com/not-exist.jpg"
+        />
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <span
+        class="ant-avatar ant-avatar-circle ant-avatar-image"
+      >
+        <img
+          src="http://abc.com/not-exist.jpg"
+        />
+      </span>
+    </div>
+  </div>,
+  <div
+    class="ant-avatar-group"
+  >
+    <span
+      class="ant-avatar ant-avatar-circle ant-avatar-image"
+    >
+      <img
+        src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
+      />
+    </span>
+    <span
+      class="ant-avatar ant-avatar-circle"
+      style="background-color: rgb(245, 106, 0);"
+    >
+      <span
+        class="ant-avatar-string"
+        style="transform: scale(1) translateX(-50%);"
+      >
+        K
+      </span>
+    </span>
+    <span
+      class="ant-avatar ant-avatar-circle"
+      style="color: rgb(245, 106, 0); background-color: rgb(253, 227, 207);"
+    >
+      <span
+        class="ant-avatar-string"
+        style="transform: scale(1) translateX(-50%);"
+      >
+        +2
+      </span>
+    </span>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-avatar-group-popover ant-popover-placement-top"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute; bottom: 0px; left: 0px;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <span
+              class="ant-avatar ant-avatar-circle ant-avatar-icon"
+              style="background-color: rgb(135, 208, 104);"
+            >
+              <span
+                aria-label="user"
+                class="anticon anticon-user"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="user"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; bottom: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                >
+                  Ant User
+                </div>
+              </div>
+            </div>
+            <span
+              class="ant-avatar ant-avatar-circle ant-avatar-icon"
+              style="background-color: rgb(24, 144, 255);"
+            >
+              <span
+                aria-label="ant-design"
+                class="anticon anticon-ant-design"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="ant-design"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/avatar/demo/dynamic.tsx extend context correctly 1`] = `
 Array [
   <span

--- a/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -349,18 +349,6 @@ Array [
   >
     <div
       class="ant-space-item"
-      style="margin-right: 8px;"
-    >
-      <span
-        class="ant-avatar ant-avatar-circle ant-avatar-image"
-      >
-        <img
-          src="http://abc.com/not-exist.jpg"
-        />
-      </span>
-    </div>
-    <div
-      class="ant-space-item"
     >
       <span
         class="ant-avatar ant-avatar-circle ant-avatar-image"
@@ -372,125 +360,220 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-avatar-group"
+    class="ant-space ant-space-horizontal ant-space-align-center"
   >
-    <span
-      class="ant-avatar ant-avatar-circle ant-avatar-image"
-    >
-      <img
-        src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
-      />
-    </span>
-    <span
-      class="ant-avatar ant-avatar-circle"
-      style="background-color: rgb(245, 106, 0);"
-    >
-      <span
-        class="ant-avatar-string"
-        style="transform: scale(1) translateX(-50%);"
-      >
-        K
-      </span>
-    </span>
-    <span
-      class="ant-avatar ant-avatar-circle"
-      style="color: rgb(245, 106, 0); background-color: rgb(253, 227, 207);"
-    >
-      <span
-        class="ant-avatar-string"
-        style="transform: scale(1) translateX(-50%);"
-      >
-        +2
-      </span>
-    </span>
     <div
-      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-avatar-group-popover ant-popover-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      class="ant-space-item"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-popover-content"
+        class="ant-avatar-group"
       >
+        <span
+          class="ant-avatar ant-avatar-circle ant-avatar-image"
+        >
+          <img
+            src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
+          />
+        </span>
+        <span
+          class="ant-avatar ant-avatar-circle"
+          style="background-color: rgb(245, 106, 0);"
+        >
+          <span
+            class="ant-avatar-string"
+            style="transform: scale(1) translateX(-50%);"
+          >
+            K
+          </span>
+        </span>
+        <span
+          class="ant-avatar ant-avatar-circle"
+          style="color: rgb(245, 106, 0); background-color: rgb(253, 227, 207);"
+        >
+          <span
+            class="ant-avatar-string"
+            style="transform: scale(1) translateX(-50%);"
+          >
+            +2
+          </span>
+        </span>
         <div
-          class="ant-popover-inner"
-          role="tooltip"
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-avatar-group-popover ant-popover-placement-top"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-inner-content"
+            class="ant-popover-arrow"
+            style="position: absolute; bottom: 0px; left: 0px;"
+          />
+          <div
+            class="ant-popover-content"
           >
-            <span
-              class="ant-avatar ant-avatar-circle ant-avatar-icon"
-              style="background-color: rgb(135, 208, 104);"
-            >
-              <span
-                aria-label="user"
-                class="anticon anticon-user"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="user"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
-                  />
-                </svg>
-              </span>
-            </span>
             <div
-              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
-              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+              class="ant-popover-inner"
+              role="tooltip"
             >
               <div
-                class="ant-tooltip-arrow"
-                style="position: absolute; bottom: 0px; left: 0px;"
-              />
-              <div
-                class="ant-tooltip-content"
+                class="ant-popover-inner-content"
               >
-                <div
-                  class="ant-tooltip-inner"
-                  role="tooltip"
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-icon"
+                  style="background-color: rgb(135, 208, 104);"
                 >
-                  Ant User
+                  <span
+                    aria-label="user"
+                    class="anticon anticon-user"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="user"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <div
+                  class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
+                  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+                >
+                  <div
+                    class="ant-tooltip-arrow"
+                    style="position: absolute; bottom: 0px; left: 0px;"
+                  />
+                  <div
+                    class="ant-tooltip-content"
+                  >
+                    <div
+                      class="ant-tooltip-inner"
+                      role="tooltip"
+                    >
+                      Ant User
+                    </div>
+                  </div>
                 </div>
+                <span
+                  class="ant-avatar ant-avatar-circle ant-avatar-icon"
+                  style="background-color: rgb(24, 144, 255);"
+                >
+                  <span
+                    aria-label="ant-design"
+                    class="anticon anticon-ant-design"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="ant-design"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
+                      />
+                    </svg>
+                  </span>
+                </span>
               </div>
             </div>
-            <span
-              class="ant-avatar ant-avatar-circle ant-avatar-icon"
-              style="background-color: rgb(24, 144, 255);"
-            >
-              <span
-                aria-label="ant-design"
-                class="anticon anticon-ant-design"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="ant-design"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M716.3 313.8c19-18.9 19-49.7 0-68.6l-69.9-69.9.1.1c-18.5-18.5-50.3-50.3-95.3-95.2-21.2-20.7-55.5-20.5-76.5.5L80.9 474.2a53.84 53.84 0 000 76.4L474.6 944a54.14 54.14 0 0076.5 0l165.1-165c19-18.9 19-49.7 0-68.6a48.7 48.7 0 00-68.7 0l-125 125.2c-5.2 5.2-13.3 5.2-18.5 0L189.5 521.4c-5.2-5.2-5.2-13.3 0-18.5l314.4-314.2c.4-.4.9-.7 1.3-1.1 5.2-4.1 12.4-3.7 17.2 1.1l125.2 125.1c19 19 49.8 19 68.7 0zM408.6 514.4a106.3 106.2 0 10212.6 0 106.3 106.2 0 10-212.6 0zm536.2-38.6L821.9 353.5c-19-18.9-49.8-18.9-68.7.1a48.4 48.4 0 000 68.6l83 82.9c5.2 5.2 5.2 13.3 0 18.5l-81.8 81.7a48.4 48.4 0 000 68.6 48.7 48.7 0 0068.7 0l121.8-121.7a53.93 53.93 0 00-.1-76.4z"
-                  />
-                </svg>
-              </span>
-            </span>
           </div>
         </div>
       </div>
+    </div>
+  </div>,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right: 8px;"
+    >
+      <span
+        class="ant-badge"
+      >
+        <span
+          class="ant-avatar ant-avatar-square ant-avatar-icon"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </span>
+        <sup
+          class="ant-scroll-number ant-badge-count"
+          data-show="true"
+          title="1"
+        >
+          <span
+            class="ant-scroll-number-only"
+            style="transition: none;"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </sup>
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <span
+        class="ant-badge"
+      >
+        <span
+          class="ant-avatar ant-avatar-square ant-avatar-icon"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </span>
+        <sup
+          class="ant-scroll-number ant-badge-dot"
+          data-show="true"
+        />
+      </span>
     </div>
   </div>,
 ]

--- a/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
@@ -349,18 +349,6 @@ Array [
   >
     <div
       class="ant-space-item"
-      style="margin-right:8px"
-    >
-      <span
-        class="ant-avatar ant-avatar-circle ant-avatar-image"
-      >
-        <img
-          src="http://abc.com/not-exist.jpg"
-        />
-      </span>
-    </div>
-    <div
-      class="ant-space-item"
     >
       <span
         class="ant-avatar ant-avatar-circle ant-avatar-image"
@@ -372,37 +360,132 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-avatar-group"
+    class="ant-space ant-space-horizontal ant-space-align-center"
   >
-    <span
-      class="ant-avatar ant-avatar-circle ant-avatar-image"
+    <div
+      class="ant-space-item"
     >
-      <img
-        src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
-      />
-    </span>
-    <span
-      class="ant-avatar ant-avatar-circle"
-      style="background-color:#f56a00"
+      <div
+        class="ant-avatar-group"
+      >
+        <span
+          class="ant-avatar ant-avatar-circle ant-avatar-image"
+        >
+          <img
+            src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
+          />
+        </span>
+        <span
+          class="ant-avatar ant-avatar-circle"
+          style="background-color:#f56a00"
+        >
+          <span
+            class="ant-avatar-string"
+            style="opacity:0"
+          >
+            K
+          </span>
+        </span>
+        <span
+          class="ant-avatar ant-avatar-circle"
+          style="color:#f56a00;background-color:#fde3cf"
+        >
+          <span
+            class="ant-avatar-string"
+            style="opacity:0"
+          >
+            +2
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
     >
       <span
-        class="ant-avatar-string"
-        style="opacity:0"
+        class="ant-badge"
       >
-        K
+        <span
+          class="ant-avatar ant-avatar-square ant-avatar-icon"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </span>
+        <sup
+          class="ant-scroll-number ant-badge-count"
+          data-show="true"
+          title="1"
+        >
+          <span
+            class="ant-scroll-number-only"
+            style="transition:none"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </sup>
       </span>
-    </span>
-    <span
-      class="ant-avatar ant-avatar-circle"
-      style="color:#f56a00;background-color:#fde3cf"
+    </div>
+    <div
+      class="ant-space-item"
     >
       <span
-        class="ant-avatar-string"
-        style="opacity:0"
+        class="ant-badge"
       >
-        +2
+        <span
+          class="ant-avatar ant-avatar-square ant-avatar-icon"
+        >
+          <span
+            aria-label="user"
+            class="anticon anticon-user"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="user"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M858.5 763.6a374 374 0 00-80.6-119.5 375.63 375.63 0 00-119.5-80.6c-.4-.2-.8-.3-1.2-.5C719.5 518 760 444.7 760 362c0-137-111-248-248-248S264 225 264 362c0 82.7 40.5 156 102.8 201.1-.4.2-.8.3-1.2.5-44.8 18.9-85 46-119.5 80.6a375.63 375.63 0 00-80.6 119.5A371.7 371.7 0 00136 901.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8 2-77.2 33-149.5 87.8-204.3 56.7-56.7 132-87.9 212.2-87.9s155.5 31.2 212.2 87.9C779 752.7 810 825 812 902.2c.1 4.4 3.6 7.8 8 7.8h60a8 8 0 008-8.2c-1-47.8-10.9-94.3-29.5-138.2zM512 534c-45.9 0-89.1-17.9-121.6-50.4S340 407.9 340 362c0-45.9 17.9-89.1 50.4-121.6S466.1 190 512 190s89.1 17.9 121.6 50.4S684 316.1 684 362c0 45.9-17.9 89.1-50.4 121.6S557.9 534 512 534z"
+              />
+            </svg>
+          </span>
+        </span>
+        <sup
+          class="ant-scroll-number ant-badge-dot"
+          data-show="true"
+        />
       </span>
-    </span>
+    </div>
   </div>,
 ]
 `;

--- a/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
@@ -342,6 +342,71 @@ exports[`renders components/avatar/demo/basic.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/avatar/demo/component-token.tsx correctly 1`] = `
+Array [
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
+    >
+      <span
+        class="ant-avatar ant-avatar-circle ant-avatar-image"
+      >
+        <img
+          src="http://abc.com/not-exist.jpg"
+        />
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <span
+        class="ant-avatar ant-avatar-circle ant-avatar-image"
+      >
+        <img
+          src="http://abc.com/not-exist.jpg"
+        />
+      </span>
+    </div>
+  </div>,
+  <div
+    class="ant-avatar-group"
+  >
+    <span
+      class="ant-avatar ant-avatar-circle ant-avatar-image"
+    >
+      <img
+        src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2"
+      />
+    </span>
+    <span
+      class="ant-avatar ant-avatar-circle"
+      style="background-color:#f56a00"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        K
+      </span>
+    </span>
+    <span
+      class="ant-avatar ant-avatar-circle"
+      style="color:#f56a00;background-color:#fde3cf"
+    >
+      <span
+        class="ant-avatar-string"
+        style="opacity:0"
+      >
+        +2
+      </span>
+    </span>
+  </div>,
+]
+`;
+
 exports[`renders components/avatar/demo/dynamic.tsx correctly 1`] = `
 Array [
   <span

--- a/components/avatar/demo/comonent-token.md
+++ b/components/avatar/demo/comonent-token.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Component Token Debug.
+
+## en-US
+
+Component Token Debug

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -7,9 +7,9 @@ const App: React.FC = () => (
     theme={{
       components: {
         Avatar: {
-          size: 60,
-          sizeLG: 30,
-          sizeSM: 16,
+          containerSize: 60,
+          containerSizeLG: 30,
+          containerSizeSM: 16,
 
           textFontSize: 18,
           textFontSizeLG: 28,

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -16,8 +16,6 @@ const App: React.FC = () => (
           fontSizeSM: 12,
 
           borderRadius: 10,
-          avatarBg: '#fde3cf',
-          avatarColor: '#a3323d',
           groupOverlapping: -10,
           groupBorderColor: '#eee',
         },

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -11,9 +11,9 @@ const App: React.FC = () => (
           sizeLG: 30,
           sizeSM: 16,
 
-          fontSize: 18,
-          fontSizeLG: 28,
-          fontSizeSM: 12,
+          textFontSize: 18,
+          textFontSizeLG: 28,
+          textFontSizeSM: 12,
 
           borderRadius: 10,
           groupOverlapping: -10,

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -7,7 +7,7 @@ const App: React.FC = () => (
     theme={{
       components: {
         Avatar: {
-          avatarSizeBase: 60,
+          size: 60,
           avatarSizeLG: 30,
           avatarSizeSM: 16,
 

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -1,5 +1,5 @@
 import { AntDesignOutlined, UserOutlined } from '@ant-design/icons';
-import { Avatar, ConfigProvider, Space, Tooltip } from 'antd';
+import { Avatar, Badge, ConfigProvider, Space, Tooltip } from 'antd';
 import React from 'react';
 
 const App: React.FC = () => (
@@ -8,17 +8,17 @@ const App: React.FC = () => (
       components: {
         Avatar: {
           size: 60,
-          avatarSizeLG: 30,
-          avatarSizeSM: 16,
+          sizeLG: 30,
+          sizeSM: 16,
 
-          avatarFontSizeBase: 18,
-          avatarFontSizeLG: 28,
-          avatarFontSizeSM: 12,
+          fontSize: 18,
+          fontSizeLG: 28,
+          fontSizeSM: 12,
 
-          avatarBorderRadius: 10,
+          borderRadius: 10,
           avatarBg: '#fde3cf',
           avatarColor: '#a3323d',
-          groupSpace: -10,
+          groupOverlapping: -10,
           groupBorderColor: '#eee',
         },
       },
@@ -28,18 +28,25 @@ const App: React.FC = () => (
       <Avatar shape="circle" src="http://abc.com/not-exist.jpg">
         A
       </Avatar>
-      <Avatar shape="circle" src="http://abc.com/not-exist.jpg">
-        ABC
-      </Avatar>
     </Space>
-    <Avatar.Group maxCount={2} maxStyle={{ color: '#f56a00', backgroundColor: '#fde3cf' }}>
-      <Avatar src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2" />
-      <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
-      <Tooltip title="Ant User" placement="top">
-        <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
-      </Tooltip>
-      <Avatar style={{ backgroundColor: '#1890ff' }} icon={<AntDesignOutlined />} />
-    </Avatar.Group>
+    <Space>
+      <Avatar.Group maxCount={2} maxStyle={{ color: '#f56a00', backgroundColor: '#fde3cf' }}>
+        <Avatar src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2" />
+        <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
+        <Tooltip title="Ant User" placement="top">
+          <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
+        </Tooltip>
+        <Avatar style={{ backgroundColor: '#1890ff' }} icon={<AntDesignOutlined />} />
+      </Avatar.Group>
+    </Space>
+    <Space>
+      <Badge count={1}>
+        <Avatar shape="square" icon={<UserOutlined />} />
+      </Badge>
+      <Badge dot>
+        <Avatar shape="square" icon={<UserOutlined />} />
+      </Badge>
+    </Space>
   </ConfigProvider>
 );
 

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -1,0 +1,46 @@
+import { AntDesignOutlined, UserOutlined } from '@ant-design/icons';
+import { Avatar, ConfigProvider, Space, Tooltip } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => (
+  <ConfigProvider
+    theme={{
+      components: {
+        Avatar: {
+          avatarSizeBase: 60,
+          avatarSizeLG: 30,
+          avatarSizeSM: 16,
+
+          avatarFontSizeBase: 18,
+          avatarFontSizeLG: 28,
+          avatarFontSizeSM: 12,
+
+          avatarBorderRadius: 10,
+          avatarBg: '#fde3cf',
+          avatarColor: '#a3323d',
+          groupSpace: -10,
+          groupBorderColor: '#eee',
+        },
+      },
+    }}
+  >
+    <Space>
+      <Avatar shape="circle" src="http://abc.com/not-exist.jpg">
+        A
+      </Avatar>
+      <Avatar shape="circle" src="http://abc.com/not-exist.jpg">
+        ABC
+      </Avatar>
+    </Space>
+    <Avatar.Group maxCount={2} maxStyle={{ color: '#f56a00', backgroundColor: '#fde3cf' }}>
+      <Avatar src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=2" />
+      <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
+      <Tooltip title="Ant User" placement="top">
+        <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
+      </Tooltip>
+      <Avatar style={{ backgroundColor: '#1890ff' }} icon={<AntDesignOutlined />} />
+    </Avatar.Group>
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -23,6 +23,7 @@ Avatars can be used to represent people or objects. It supports images, `Icon`s,
 <code src="./demo/toggle-debug.tsx" debug>Calculate text style when hiding</code>
 <code src="./demo/responsive.tsx">Responsive Size</code>
 <code src="./demo/fallback.tsx" debug>Fallback</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API
 

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -28,6 +28,7 @@ group:
 <code src="./demo/toggle-debug.tsx" debug>隐藏情况下计算字符对齐</code>
 <code src="./demo/responsive.tsx">响应式尺寸</code>
 <code src="./demo/fallback.tsx" debug>图片不存在时</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -30,7 +30,6 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     avatarColor,
     sizeLG,
     sizeSM,
-    fontSize,
     fontSizeLG,
     fontSizeSM,
     borderRadius,
@@ -89,7 +88,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
         display: 'block',
       },
 
-      ...avatarSizeStyle(token.size, fontSize, borderRadius),
+      ...avatarSizeStyle(token.size, token.fontSize, borderRadius),
 
       [`&-lg`]: {
         ...avatarSizeStyle(sizeLG, fontSizeLG, borderRadiusLG),

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -12,6 +12,7 @@ export interface ComponentToken {
   fontSize: number;
   fontSizeLG: number;
   fontSizeSM: number;
+  groupSpace: number;
   groupOverlapping: number;
   groupBorderColor: string;
 }
@@ -109,7 +110,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
 };
 
 const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
-  const { componentCls, groupBorderColor, groupOverlapping } = token;
+  const { componentCls, groupBorderColor, groupOverlapping, groupSpace } = token;
 
   return {
     [`${componentCls}-group`]: {
@@ -123,6 +124,11 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
         marginInlineStart: groupOverlapping,
       },
     },
+    [`${componentCls}-group-popover`]: {
+      [`${componentCls} + ${componentCls}`]: {
+        marginInlineStart: groupSpace,
+      },
+    },
   };
 };
 
@@ -130,6 +136,7 @@ export default genComponentStyleHook(
   'Avatar',
   (token) => {
     const avatarToken = mergeToken<AvatarToken>(token, {});
+    console.log([genBaseStyle(avatarToken), genGroupStyle(avatarToken)]);
     return [genBaseStyle(avatarToken), genGroupStyle(avatarToken)];
   },
   (token) => {
@@ -146,6 +153,7 @@ export default genComponentStyleHook(
       fontSizeHeading3,
 
       marginXS,
+      marginXXS,
       colorBorderBg,
       colorTextPlaceholder,
     } = token;
@@ -160,6 +168,7 @@ export default genComponentStyleHook(
 
       avatarBg: colorTextPlaceholder,
       avatarColor: colorTextLightSolid,
+      groupSpace: marginXXS,
       groupOverlapping: -marginXS,
       groupBorderColor: colorBorderBg,
     };

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -18,7 +18,6 @@ export interface ComponentToken {
 }
 
 type AvatarToken = FullToken<'Avatar'> & {
-  avatarGroupOverlapping: number;
   avatarBgColor: string;
 };
 

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -6,15 +6,14 @@ import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 export interface ComponentToken {
   avatarBg: string;
   avatarColor: string;
-  avatarSizeBase: number;
-  avatarSizeLG: number;
-  avatarSizeSM: number;
-  avatarFontSizeBase: number;
-  avatarFontSizeLG: number;
-  avatarFontSizeSM: number;
-  groupSpace: number;
+  size: number;
+  sizeLG: number;
+  sizeSM: number;
+  fontSize: number;
+  fontSizeLG: number;
+  fontSizeSM: number;
+  groupOverlapping: number;
   groupBorderColor: string;
-  avatarBorderRadius: number;
 }
 
 type AvatarToken = FullToken<'Avatar'> & {
@@ -29,12 +28,11 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     iconCls,
     avatarBg,
     avatarColor,
-    avatarSizeBase,
-    avatarSizeLG,
-    avatarSizeSM,
-    avatarFontSizeBase,
-    avatarFontSizeLG,
-    avatarFontSizeSM,
+    sizeLG,
+    sizeSM,
+    fontSize,
+    fontSizeLG,
+    fontSizeSM,
     borderRadius,
     borderRadiusLG,
     borderRadiusSM,
@@ -91,14 +89,14 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
         display: 'block',
       },
 
-      ...avatarSizeStyle(avatarSizeBase, avatarFontSizeBase, borderRadius),
+      ...avatarSizeStyle(token.size, fontSize, borderRadius),
 
       [`&-lg`]: {
-        ...avatarSizeStyle(avatarSizeLG, avatarFontSizeLG, borderRadiusLG),
+        ...avatarSizeStyle(sizeLG, fontSizeLG, borderRadiusLG),
       },
 
       [`&-sm`]: {
-        ...avatarSizeStyle(avatarSizeSM, avatarFontSizeSM, borderRadiusSM),
+        ...avatarSizeStyle(sizeSM, fontSizeSM, borderRadiusSM),
       },
 
       '> img': {
@@ -112,7 +110,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
 };
 
 const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
-  const { componentCls, groupBorderColor, groupSpace } = token;
+  const { componentCls, groupBorderColor, groupOverlapping } = token;
 
   return {
     [`${componentCls}-group`]: {
@@ -123,7 +121,7 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
       },
 
       [`> *:not(:first-child)`]: {
-        marginInlineStart: groupSpace,
+        marginInlineStart: groupOverlapping,
       },
     },
   };
@@ -153,18 +151,17 @@ export default genComponentStyleHook(
       colorTextPlaceholder,
     } = token;
     return {
-      avatarSizeBase: controlHeight,
-      avatarSizeLG: controlHeightLG,
-      avatarSizeSM: controlHeightSM,
+      size: controlHeight,
+      sizeLG: controlHeightLG,
+      sizeSM: controlHeightSM,
 
-      avatarFontSizeBase: Math.round((fontSizeLG + fontSizeXL) / 2),
-      avatarFontSizeLG: fontSizeHeading3,
-      avatarFontSizeSM: fontSize,
+      fontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
+      fontSizeLG: fontSizeHeading3,
+      fontSizeSM: fontSize,
 
-      avatarBorderRadius: token.borderRadius,
       avatarBg: colorTextPlaceholder,
       avatarColor: colorTextLightSolid,
-      groupSpace: -marginXS,
+      groupOverlapping: -marginXS,
       groupBorderColor: colorBorderBg,
     };
   },

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -29,6 +29,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     iconCls,
     avatarBg,
     avatarColor,
+    containerSize,
     containerSizeLG,
     containerSizeSM,
     fontSizeLG,
@@ -41,10 +42,10 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
   } = token;
 
   // Avatar size style
-  const avatarSizeStyle = (containerSize: number, fontSize: number, radius: number): CSSObject => ({
-    width: containerSize,
-    height: containerSize,
-    lineHeight: `${containerSize - lineWidth * 2}px`,
+  const avatarSizeStyle = (size: number, fontSize: number, radius: number): CSSObject => ({
+    width: size,
+    height: size,
+    lineHeight: `${size - lineWidth * 2}px`,
     borderRadius: '50%',
 
     [`&${componentCls}-square`]: {
@@ -89,7 +90,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
         display: 'block',
       },
 
-      ...avatarSizeStyle(token.size, token.fontSize, borderRadius),
+      ...avatarSizeStyle(containerSize, token.fontSize, borderRadius),
 
       [`&-lg`]: {
         ...avatarSizeStyle(containerSizeLG, fontSizeLG, borderRadiusLG),

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -6,9 +6,9 @@ import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 export interface ComponentToken {
   avatarBg: string;
   avatarColor: string;
-  size: number;
-  sizeLG: number;
-  sizeSM: number;
+  containerSize: number;
+  containerSizeLG: number;
+  containerSizeSM: number;
   fontSize: number;
   fontSizeLG: number;
   fontSizeSM: number;
@@ -29,8 +29,8 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     iconCls,
     avatarBg,
     avatarColor,
-    sizeLG,
-    sizeSM,
+    containerSizeLG,
+    containerSizeSM,
     fontSizeLG,
     fontSizeSM,
     borderRadius,
@@ -41,10 +41,10 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
   } = token;
 
   // Avatar size style
-  const avatarSizeStyle = (size: number, fontSize: number, radius: number): CSSObject => ({
-    width: size,
-    height: size,
-    lineHeight: `${size - lineWidth * 2}px`,
+  const avatarSizeStyle = (containerSize: number, fontSize: number, radius: number): CSSObject => ({
+    width: containerSize,
+    height: containerSize,
+    lineHeight: `${containerSize - lineWidth * 2}px`,
     borderRadius: '50%',
 
     [`&${componentCls}-square`]: {
@@ -92,11 +92,11 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
       ...avatarSizeStyle(token.size, token.fontSize, borderRadius),
 
       [`&-lg`]: {
-        ...avatarSizeStyle(sizeLG, fontSizeLG, borderRadiusLG),
+        ...avatarSizeStyle(containerSizeLG, fontSizeLG, borderRadiusLG),
       },
 
       [`&-sm`]: {
-        ...avatarSizeStyle(sizeSM, fontSizeSM, borderRadiusSM),
+        ...avatarSizeStyle(containerSizeSM, fontSizeSM, borderRadiusSM),
       },
 
       '> img': {
@@ -158,9 +158,9 @@ export default genComponentStyleHook(
       colorTextPlaceholder,
     } = token;
     return {
-      size: controlHeight,
-      sizeLG: controlHeightLG,
-      sizeSM: controlHeightSM,
+      containerSize: controlHeight,
+      containerSizeLG: controlHeightLG,
+      containerSizeSM: controlHeightSM,
 
       fontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
       fontSizeLG: fontSizeHeading3,

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -14,9 +14,13 @@ export interface ComponentToken {
   avatarFontSizeSM: number;
   avatarGroupSpace: number;
   avatarGroupBorderColor: string;
+  avatarBorderRadius: number;
 }
 
-type AvatarToken = FullToken<'Avatar'> & {};
+type AvatarToken = FullToken<'Avatar'> & {
+  avatarGroupOverlapping: number;
+  avatarBgColor: string;
+};
 
 const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
   const {
@@ -157,6 +161,7 @@ export default genComponentStyleHook(
       avatarFontSizeLG: fontSizeHeading3,
       avatarFontSizeSM: fontSize,
 
+      avatarBorderRadius: token.borderRadius,
       avatarBg: colorTextPlaceholder,
       avatarColor: colorTextLightSolid,
       avatarGroupSpace: -marginXS,

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -4,8 +4,6 @@ import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
-  avatarBg: string;
-  avatarColor: string;
   containerSize: number;
   containerSizeLG: number;
   containerSizeSM: number;
@@ -19,6 +17,8 @@ export interface ComponentToken {
 
 type AvatarToken = FullToken<'Avatar'> & {
   avatarBgColor: string;
+  avatarBg: string;
+  avatarColor: string;
 };
 
 const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
@@ -135,14 +135,15 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
 export default genComponentStyleHook(
   'Avatar',
   (token) => {
-    const avatarToken = mergeToken<AvatarToken>(token, {});
-    console.log([genBaseStyle(avatarToken), genGroupStyle(avatarToken)]);
+    const { colorTextLightSolid, colorTextPlaceholder } = token;
+    const avatarToken = mergeToken<AvatarToken>(token, {
+      avatarBg: colorTextPlaceholder,
+      avatarColor: colorTextLightSolid,
+    });
     return [genBaseStyle(avatarToken), genGroupStyle(avatarToken)];
   },
   (token) => {
     const {
-      colorTextLightSolid,
-
       controlHeight,
       controlHeightLG,
       controlHeightSM,
@@ -155,7 +156,6 @@ export default genComponentStyleHook(
       marginXS,
       marginXXS,
       colorBorderBg,
-      colorTextPlaceholder,
     } = token;
     return {
       containerSize: controlHeight,
@@ -166,8 +166,6 @@ export default genComponentStyleHook(
       fontSizeLG: fontSizeHeading3,
       fontSizeSM: fontSize,
 
-      avatarBg: colorTextPlaceholder,
-      avatarColor: colorTextLightSolid,
       groupSpace: marginXXS,
       groupOverlapping: -marginXS,
       groupBorderColor: colorBorderBg,

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -12,8 +12,8 @@ export interface ComponentToken {
   avatarFontSizeBase: number;
   avatarFontSizeLG: number;
   avatarFontSizeSM: number;
-  avatarGroupSpace: number;
-  avatarGroupBorderColor: string;
+  groupSpace: number;
+  groupBorderColor: string;
   avatarBorderRadius: number;
 }
 
@@ -112,18 +112,18 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
 };
 
 const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
-  const { componentCls, avatarGroupBorderColor, avatarGroupSpace } = token;
+  const { componentCls, groupBorderColor, groupSpace } = token;
 
   return {
     [`${componentCls}-group`]: {
       display: 'inline-flex',
 
       [`${componentCls}`]: {
-        borderColor: avatarGroupBorderColor,
+        borderColor: groupBorderColor,
       },
 
       [`> *:not(:first-child)`]: {
-        marginInlineStart: avatarGroupSpace,
+        marginInlineStart: groupSpace,
       },
     },
   };
@@ -164,8 +164,8 @@ export default genComponentStyleHook(
       avatarBorderRadius: token.borderRadius,
       avatarBg: colorTextPlaceholder,
       avatarColor: colorTextLightSolid,
-      avatarGroupSpace: -marginXS,
-      avatarGroupBorderColor: colorBorderBg,
+      groupSpace: -marginXS,
+      groupBorderColor: colorBorderBg,
     };
   },
 );

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -7,9 +7,9 @@ export interface ComponentToken {
   containerSize: number;
   containerSizeLG: number;
   containerSizeSM: number;
-  fontSize: number;
-  fontSizeLG: number;
-  fontSizeSM: number;
+  textFontSize: number;
+  textFontSizeLG: number;
+  textFontSizeSM: number;
   groupSpace: number;
   groupOverlapping: number;
   groupBorderColor: string;
@@ -31,8 +31,9 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     containerSize,
     containerSizeLG,
     containerSizeSM,
-    fontSizeLG,
-    fontSizeSM,
+    textFontSize,
+    textFontSizeLG,
+    textFontSizeSM,
     borderRadius,
     borderRadiusLG,
     borderRadiusSM,
@@ -89,14 +90,14 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
         display: 'block',
       },
 
-      ...avatarSizeStyle(containerSize, token.fontSize, borderRadius),
+      ...avatarSizeStyle(containerSize, textFontSize, borderRadius),
 
       [`&-lg`]: {
-        ...avatarSizeStyle(containerSizeLG, fontSizeLG, borderRadiusLG),
+        ...avatarSizeStyle(containerSizeLG, textFontSizeLG, borderRadiusLG),
       },
 
       [`&-sm`]: {
-        ...avatarSizeStyle(containerSizeSM, fontSizeSM, borderRadiusSM),
+        ...avatarSizeStyle(containerSizeSM, textFontSizeSM, borderRadiusSM),
       },
 
       '> img': {
@@ -162,9 +163,9 @@ export default genComponentStyleHook(
       containerSizeLG: controlHeightLG,
       containerSizeSM: controlHeightSM,
 
-      fontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
-      fontSizeLG: fontSizeHeading3,
-      fontSizeSM: fontSize,
+      textFontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
+      textFontSizeLG: fontSizeHeading3,
+      textFontSizeSM: fontSize,
 
       groupSpace: marginXXS,
       groupOverlapping: -marginXS,

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -1,11 +1,9 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { resetComponent } from '../../style';
 
-export interface ComponentToken {}
-
-type AvatarToken = FullToken<'Avatar'> & {
+export interface ComponentToken {
   avatarBg: string;
   avatarColor: string;
   avatarSizeBase: number;
@@ -14,11 +12,11 @@ type AvatarToken = FullToken<'Avatar'> & {
   avatarFontSizeBase: number;
   avatarFontSizeLG: number;
   avatarFontSizeSM: number;
-  avatarGroupOverlapping: number;
   avatarGroupSpace: number;
   avatarGroupBorderColor: string;
-  avatarBgColor: string;
-};
+}
+
+type AvatarToken = FullToken<'Avatar'> & {};
 
 const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
   const {
@@ -127,38 +125,42 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
   };
 };
 
-export default genComponentStyleHook('Avatar', (token) => {
-  const {
-    colorTextLightSolid,
+export default genComponentStyleHook(
+  'Avatar',
+  (token) => {
+    const avatarToken = mergeToken<AvatarToken>(token, {});
+    return [genBaseStyle(avatarToken), genGroupStyle(avatarToken)];
+  },
+  (token) => {
+    const {
+      colorTextLightSolid,
 
-    controlHeight,
-    controlHeightLG,
-    controlHeightSM,
+      controlHeight,
+      controlHeightLG,
+      controlHeightSM,
 
-    fontSize,
-    fontSizeLG,
-    fontSizeXL,
-    fontSizeHeading3,
+      fontSize,
+      fontSizeLG,
+      fontSizeXL,
+      fontSizeHeading3,
 
-    marginXS,
-    colorBorderBg,
-    colorTextPlaceholder,
-  } = token;
+      marginXS,
+      colorBorderBg,
+      colorTextPlaceholder,
+    } = token;
+    return {
+      avatarSizeBase: controlHeight,
+      avatarSizeLG: controlHeightLG,
+      avatarSizeSM: controlHeightSM,
 
-  const avatarToken = mergeToken<AvatarToken>(token, {
-    avatarBg: colorTextPlaceholder,
-    avatarColor: colorTextLightSolid,
+      avatarFontSizeBase: Math.round((fontSizeLG + fontSizeXL) / 2),
+      avatarFontSizeLG: fontSizeHeading3,
+      avatarFontSizeSM: fontSize,
 
-    avatarSizeBase: controlHeight,
-    avatarSizeLG: controlHeightLG,
-    avatarSizeSM: controlHeightSM,
-
-    avatarFontSizeBase: Math.round((fontSizeLG + fontSizeXL) / 2),
-    avatarFontSizeLG: fontSizeHeading3,
-    avatarFontSizeSM: fontSize,
-    avatarGroupSpace: -marginXS,
-    avatarGroupBorderColor: colorBorderBg,
-  });
-
-  return [genBaseStyle(avatarToken), genGroupStyle(avatarToken)];
-});
+      avatarBg: colorTextPlaceholder,
+      avatarColor: colorTextLightSolid,
+      avatarGroupSpace: -marginXS,
+      avatarGroupBorderColor: colorBorderBg,
+    };
+  },
+);

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -26,6 +26,24 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Avatar -->
 
+## Avatar
+
+<!-- prettier-ignore -->
+| less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@avatar-size-base` | `avatarSizeBase` | - |
+| `@avatar-size-lg` | `avatarSizeLG` | - |
+| `@avatar-size-sm` | `avatarSizeSM` | - |
+| `@avatar-font-size-base` | `avatarFontSizeBase` | - |
+| `@avatar-font-size-lg` | `avatarFontSizeLG` | - |
+| `@avatar-font-size-sm` | `avatarFontSizeSM` | - |
+| `@avatar-bg` | `avatarBg` | - |
+| `@avatar-color` | `avatarColor` | - |
+| `@avatar-border-radius` | - | Deprecated for style change |
+| `@avatar-group-overlapping` | - | Deprecated for style change |
+| `@avatar-group-space` | - | Deprecated for style change |
+| `@avatar-group-border-color` | - | Deprecated for style change |
+
 <!-- ### Badge -->
 
 ### BreadCrumb 面包屑

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -29,18 +29,18 @@ This document contains the correspondence between all the less variables related
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
-| `@avatar-size-base` | `avatarSizeBase` | - |
-| `@avatar-size-lg` | `avatarSizeLG` | - |
-| `@avatar-size-sm` | `avatarSizeSM` | - |
-| `@avatar-font-size-base` | `avatarFontSizeBase` | - |
-| `@avatar-font-size-lg` | `avatarFontSizeLG` | - |
-| `@avatar-font-size-sm` | `avatarFontSizeSM` | - |
-| `@avatar-bg` | `avatarBg` | - |
-| `@avatar-color` | `avatarColor` | - |
-| `@avatar-border-radius` | - | Deprecated for style change |
+| `@avatar-size-base` | `size` | - |
+| `@avatar-size-lg` | `sizeLG` | - |
+| `@avatar-size-sm` | `sizeSM` | - |
+| `@avatar-font-size-base` | `textFontSize` | - |
+| `@avatar-font-size-lg` | `textFontSizeLG` | - |
+| `@avatar-font-size-sm` | `textFontSizeSM` | - |
+| `@avatar-bg` | - | Can be directly overridden by `className` or `style` |
+| `@avatar-color` | `colorTextLightSolid` | Global Token |
+| `@avatar-border-radius` | `borderRadius` | Global Token |
 | `@avatar-group-overlapping` | - | Deprecated for style change |
 | `@avatar-group-space` | `groupSpace` | - |
-| `@avatar-group-border-color` | `groupBorderColor` | - |
+| `@avatar-group-border-color` | `colorBorderBg` | Global Token |
 
 <!-- ### Badge -->
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -39,8 +39,8 @@ This document contains the correspondence between all the less variables related
 | `@avatar-color` | `avatarColor` | - |
 | `@avatar-border-radius` | - | Deprecated for style change |
 | `@avatar-group-overlapping` | - | Deprecated for style change |
-| `@avatar-group-space` | `avatarGroupSpace` | - |
-| `@avatar-group-border-color` | `avatarGroupBorderColor` | - |
+| `@avatar-group-space` | `groupSpace` | - |
+| `@avatar-group-border-color` | `groupBorderColor` | - |
 
 <!-- ### Badge -->
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -24,9 +24,7 @@ This document contains the correspondence between all the less variables related
 | `@anchor-link-left` | `linkPaddingInlineStart` | - |
 | `@anchor-link-padding` | - | `${linkPaddingBlock}px ${linkPaddingInlineStart}px` |
 
-<!-- ### Avatar -->
-
-## Avatar
+### Avatar
 
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
@@ -41,8 +39,8 @@ This document contains the correspondence between all the less variables related
 | `@avatar-color` | `avatarColor` | - |
 | `@avatar-border-radius` | - | Deprecated for style change |
 | `@avatar-group-overlapping` | - | Deprecated for style change |
-| `@avatar-group-space` | - | Deprecated for style change |
-| `@avatar-group-border-color` | - | Deprecated for style change |
+| `@avatar-group-space` | `avatarGroupSpace` | - |
+| `@avatar-group-border-color` | `avatarGroupBorderColor` | - |
 
 <!-- ### Badge -->
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -29,9 +29,9 @@ This document contains the correspondence between all the less variables related
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
-| `@avatar-size-base` | `size` | - |
-| `@avatar-size-lg` | `sizeLG` | - |
-| `@avatar-size-sm` | `sizeSM` | - |
+| `@avatar-size-base` | `containerSize` | - |
+| `@avatar-size-lg` | `containerSizeLG` | - |
+| `@avatar-size-sm` | `containerSizeSM` | - |
 | `@avatar-font-size-base` | `textFontSize` | - |
 | `@avatar-font-size-lg` | `textFontSizeLG` | - |
 | `@avatar-font-size-sm` | `textFontSizeSM` | - |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -39,7 +39,7 @@ title: Less 变量迁移 Design Token
 | `@avatar-color` | `colorTextLightSolid` | 全局 Token |
 | `@avatar-border-radius` | `borderRadius` | 全局 Token |
 | `@avatar-group-overlapping` | `groupOverlapping` | - |
-| `@avatar-group-space` | `groupSpace` | Deprecated for style change |
+| `@avatar-group-space` | `groupSpace` | - |
 | `@avatar-group-border-color` | `colorBorderBg` | 全局 Token |
 
 <!-- ### Badge 徽标数 -->

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -29,18 +29,18 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
-| `@avatar-size-base` | `avatarSizeBase` | - |
-| `@avatar-size-lg` | `avatarSizeLG` | - |
-| `@avatar-size-sm` | `avatarSizeSM` | - |
-| `@avatar-font-size-base` | `avatarFontSizeBase` | - |
-| `@avatar-font-size-lg` | `avatarFontSizeLG` | - |
-| `@avatar-font-size-sm` | `avatarFontSizeSM` | - |
-| `@avatar-bg` | `avatarBg` | - |
-| `@avatar-color` | `avatarColor` | - |
-| `@avatar-border-radius` | - | 由于样式变化已废弃 |
-| `@avatar-group-overlapping` | - | 由于样式变化已废弃 |
-| `@avatar-group-space` | `groupSpace` | - |
-| `@avatar-group-border-color` | `groupBorderColor` | - |
+| `@avatar-size-base` | `size` | - |
+| `@avatar-size-lg` | `sizeLG` | - |
+| `@avatar-size-sm` | `sizeSM` | - |
+| `@avatar-font-size-base` | `textFontSize` | - |
+| `@avatar-font-size-lg` | `textFontSizeLG` | - |
+| `@avatar-font-size-sm` | `textFontSizeSM` | - |
+| `@avatar-bg` | - | 可由 `className` 或 `style` 直接覆盖 |
+| `@avatar-color` | `colorTextLightSolid` | 全局 Token |
+| `@avatar-border-radius` | `borderRadius` | 全局 Token |
+| `@avatar-group-overlapping` | `groupOverlapping` | - |
+| `@avatar-group-space` | `groupSpace` | Deprecated for style change |
+| `@avatar-group-border-color` | `colorBorderBg` | 全局 Token |
 
 <!-- ### Badge 徽标数 -->
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -29,9 +29,9 @@ title: Less 变量迁移 Design Token
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
-| `@avatar-size-base` | `size` | - |
-| `@avatar-size-lg` | `sizeLG` | - |
-| `@avatar-size-sm` | `sizeSM` | - |
+| `@avatar-size-base` | `containerSize` | - |
+| `@avatar-size-lg` | `containerSizeLG` | - |
+| `@avatar-size-sm` | `containerSizeSM` | - |
 | `@avatar-font-size-base` | `textFontSize` | - |
 | `@avatar-font-size-lg` | `textFontSizeLG` | - |
 | `@avatar-font-size-sm` | `textFontSizeSM` | - |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -26,6 +26,24 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Avatar 头像 -->
 
+## Avatar 头像
+
+<!-- prettier-ignore -->
+| less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@avatar-size-base` | `avatarSizeBase` | - |
+| `@avatar-size-lg` | `avatarSizeLG` | - |
+| `@avatar-size-sm` | `avatarSizeSM` | - |
+| `@avatar-font-size-base` | `avatarFontSizeBase` | - |
+| `@avatar-font-size-lg` | `avatarFontSizeLG` | - |
+| `@avatar-font-size-sm` | `avatarFontSizeSM` | - |
+| `@avatar-bg` | `avatarBg` | - |
+| `@avatar-color` | `avatarColor` | - |
+| `@avatar-border-radius` | - | 由于样式变化已废弃 |
+| `@avatar-group-overlapping` | - | 由于样式变化已废弃 |
+| `@avatar-group-space` | - | 由于样式变化已废弃 |
+| `@avatar-group-border-color` | - | 由于样式变化已废弃 |
+
 <!-- ### Badge 徽标数 -->
 
 ### BreadCrumb 面包屑

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -24,9 +24,7 @@ title: Less 变量迁移 Design Token
 | `@anchor-link-left` | `linkPaddingInlineStart` | - |
 | `@anchor-link-padding` | - | `${linkPaddingBlock}px ${linkPaddingInlineStart}px` |
 
-<!-- ### Avatar 头像 -->
-
-## Avatar 头像
+### Avatar 头像
 
 <!-- prettier-ignore -->
 | less 变量 | Component Token | 备注 |
@@ -41,8 +39,8 @@ title: Less 变量迁移 Design Token
 | `@avatar-color` | `avatarColor` | - |
 | `@avatar-border-radius` | - | 由于样式变化已废弃 |
 | `@avatar-group-overlapping` | - | 由于样式变化已废弃 |
-| `@avatar-group-space` | - | 由于样式变化已废弃 |
-| `@avatar-group-border-color` | - | 由于样式变化已废弃 |
+| `@avatar-group-space` | `avatarGroupSpace` | - |
+| `@avatar-group-border-color` | `avatarGroupBorderColor` | - |
 
 <!-- ### Badge 徽标数 -->
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -39,8 +39,8 @@ title: Less 变量迁移 Design Token
 | `@avatar-color` | `avatarColor` | - |
 | `@avatar-border-radius` | - | 由于样式变化已废弃 |
 | `@avatar-group-overlapping` | - | 由于样式变化已废弃 |
-| `@avatar-group-space` | `avatarGroupSpace` | - |
-| `@avatar-group-border-color` | `avatarGroupBorderColor` | - |
+| `@avatar-group-space` | `groupSpace` | - |
+| `@avatar-group-border-color` | `groupBorderColor` | - |
 
 <!-- ### Badge 徽标数 -->
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
https://github.com/ant-design/ant-design/issues/41884
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     migrate less to token for Avatar      |
| 🇨🇳 Chinese |     迁移 `Avatar`  组件的 `less token`       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf64ed2</samp>

This pull request refactors the style of the `Avatar` component to use component tokens and updates the documentation for migrating less variables to component tokens in both English and Chinese versions. It also fixes a typo in the document title.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf64ed2</samp>

* Refactor the `genComponentStyleHook` function to accept a third argument that returns the component token properties based on the global token ([link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L130-R166))
* Move the `ComponentToken` interface to the top of the file and add the `avatarBg` and `avatarColor` properties to it ([link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L2-R6))
* Remove the `avatarGroupOverlapping` and `avatarGroupSpace` properties from the `AvatarToken` type as they are deprecated ([link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L17-R20))
* Document the mapping between the less variables and the component token properties for the `Avatar` component and the deprecated variables in `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R56), [link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R56))
* Fix a typo in the title of the `Modal` section in `docs/react/migrate-less-variables.en-US.md` ([link](https://github.com/ant-design/ant-design/pull/42063/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL10-R10))
