### PR TITLE
✨ feat: migrate less to token for Step

### DIFF
--- a/components/steps/style/index.tsx
+++ b/components/steps/style/index.tsx
@@ -1,7 +1,9 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genStepsCustomIconStyle from './custom-icon';
+import genStepsInlineStyle from './inline';
 import genStepsLabelPlacementStyle from './label-placement';
 import genStepsNavStyle from './nav';
 import genStepsProgressStyle from './progress';
@@ -9,15 +11,9 @@ import genStepsProgressDotStyle from './progress-dot';
 import genStepsRTLStyle from './rtl';
 import genStepsSmallStyle from './small';
 import genStepsVerticalStyle from './vertical';
-import genStepsInlineStyle from './inline';
-import { resetComponent } from '../../style';
 
 export interface ComponentToken {
   descriptionWidth: number;
-}
-
-export interface StepsToken extends FullToken<'Steps'> {
-  // Steps variable default.less
   processTailColor: string;
   stepsNavArrowColor: string;
   stepsIconSize: number;
@@ -26,11 +22,16 @@ export interface StepsToken extends FullToken<'Steps'> {
   stepsIconCustomFontSize: number;
   stepsIconTop: number;
   stepsIconFontSize: number;
-  stepsTitleLineHeight: number;
-  stepsSmallIconSize: number;
   stepsDotSize: number;
   stepsCurrentDotSize: number;
   stepsNavContentMaxWidth: string;
+  stepsSmallIconSize: number;
+}
+
+export interface StepsToken extends FullToken<'Steps'> {
+  // Steps variable default.less
+  processTailColor: string;
+  stepsTitleLineHeight: number;
   // Steps component less variable
   processIconColor: string;
   processTitleColor: string;
@@ -329,10 +330,6 @@ export default genComponentStyleHook(
     const {
       wireframe,
       colorTextDisabled,
-      fontSizeHeading3,
-      fontSize,
-      controlHeight,
-      controlHeightSM,
       controlHeightLG,
       colorTextLightSolid,
       colorText,
@@ -345,26 +342,10 @@ export default genComponentStyleHook(
       colorError,
       colorBgContainer,
       colorBorderSecondary,
+      colorSplit,
     } = token;
 
-    const stepsIconSize = token.controlHeight;
-    const processTailColor = token.colorSplit;
-
     const stepsToken = mergeToken<StepsToken>(token, {
-      // Steps variable default.less
-      processTailColor,
-      stepsNavArrowColor: colorTextDisabled,
-      stepsIconSize,
-      stepsIconCustomSize: stepsIconSize,
-      stepsIconCustomTop: 0,
-      stepsIconCustomFontSize: controlHeightSM,
-      stepsIconTop: -0.5, // magic for ui experience
-      stepsIconFontSize: fontSize,
-      stepsTitleLineHeight: controlHeight,
-      stepsSmallIconSize: fontSizeHeading3,
-      stepsDotSize: controlHeight / 4,
-      stepsCurrentDotSize: controlHeightLG / 4,
-      stepsNavContentMaxWidth: 'auto',
       // Steps component less variable
       processIconColor: colorTextLightSolid,
       processTitleColor: colorText,
@@ -375,7 +356,7 @@ export default genComponentStyleHook(
       waitIconColor: wireframe ? colorTextDisabled : colorTextLabel,
       waitTitleColor: colorTextDescription,
       waitDescriptionColor: colorTextDescription,
-      waitTailColor: processTailColor,
+      waitTailColor: colorSplit,
       waitIconBgColor: wireframe ? colorBgContainer : colorFillContent,
       waitIconBorderColor: wireframe ? colorTextDisabled : 'transparent',
       waitDotColor: colorTextDisabled,
@@ -389,7 +370,7 @@ export default genComponentStyleHook(
       errorIconColor: colorTextLightSolid,
       errorTitleColor: colorError,
       errorDescriptionColor: colorError,
-      errorTailColor: processTailColor,
+      errorTailColor: colorSplit,
       errorIconBgColor: colorError,
       errorIconBorderColor: colorError,
       errorDotColor: colorError,
@@ -403,7 +384,31 @@ export default genComponentStyleHook(
 
     return [genStepsStyle(stepsToken)];
   },
-  {
-    descriptionWidth: 140,
+  (token) => {
+    const {
+      colorTextDisabled,
+      fontSize,
+      controlHeightSM,
+      controlHeight,
+      controlHeightLG,
+      fontSizeHeading3,
+      colorSplit,
+    } = token;
+    return {
+      processTailColor: colorSplit,
+      stepsNavArrowColor: colorTextDisabled,
+      stepsIconSize: controlHeight,
+      stepsTitleLineHeight: controlHeight,
+      stepsIconCustomSize: controlHeight,
+      stepsIconCustomTop: 0,
+      stepsIconCustomFontSize: controlHeightSM,
+      stepsIconTop: -0.5, // magic for ui experience
+      stepsIconFontSize: fontSize,
+      stepsDotSize: controlHeight / 4,
+      descriptionWidth: 140,
+      stepsCurrentDotSize: controlHeightLG / 4,
+      stepsNavContentMaxWidth: 'auto',
+      stepsSmallIconSize: fontSizeHeading3,
+    };
   },
 );

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -36,3 +36,30 @@ This document contains the correspondence between all the less variables related
 | `@modal-confirm-body-padding` | - | Deprecated for style change |
 | `@modal-confirm-title-font-size` | `modalHeaderTitleFontSize` | - |
 | `@modal-border-radius` | `borderRadiusLG` | - |
+
+## Step
+
+<!-- prettier-ignore -->
+| less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@process-tail-color` | `processTailColor` | - |
+| `@steps-nav-arrow-color` | `stepsNavArrowColor` | - |
+| `@steps-background` | - | Deprecated for style change |
+| `@steps-icon-size` | `stepsIconSize` | - |
+| `@steps-icon-custom-size` | `stepsIconCustomSize` | - |
+| `@steps-icon-custom-top` | `stepsIconCustomTop` | - |
+| `@steps-icon-custom-font-size` | `stepsIconCustomFontSize` | - |
+| `@steps-icon-top` | `stepsIconTop` | - |
+| `@steps-icon-font-size` | `stepsIconFontSize` | - |
+| `@steps-icon-margin` | - | Deprecated for style change |
+| `@steps-title-line-height` | `stepsTitleLineHeight` | - |
+| `@steps-small-icon-size` | `stepsSmallIconSize` | - |
+| `@steps-small-icon-margin` | - | Deprecated for style change |
+| `@steps-dot-size` | `stepsDotSize` | - |
+| `@steps-dot-top` | - | Deprecated for style change |
+| `@steps-current-dot-size` | `stepsCurrentDotSize` | - |
+| `@steps-description-max-width` | `stepsNavContentMaxWidth` | - |
+| `@steps-nav-content-max-width` | - | Deprecated for style change |
+| `@steps-vertical-icon-width` | - | Deprecated for style change |
+| `@steps-vertical-tail-width` | - | Deprecated for style change |
+| `@steps-vertical-tail-width-sm` | - | Deprecated for style change |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -36,3 +36,30 @@ title: less 变量迁移 Component Token
 | `@modal-confirm-body-padding` | - | 由于样式变化已废弃 |
 | `@modal-confirm-title-font-size` | `modalHeaderTitleFontSize` | - |
 | `@modal-border-radius` | `borderRadiusLG` | - |
+
+## Step 步骤条
+
+<!-- prettier-ignore -->
+| less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@process-tail-color` | `processTailColor` | - |
+| `@steps-nav-arrow-color` | `stepsNavArrowColor` | - |
+| `@steps-background` | - | 由于样式变化已废弃 |
+| `@steps-icon-size` | `stepsIconSize` | - |
+| `@steps-icon-custom-size` | `stepsIconCustomSize` | - |
+| `@steps-icon-custom-top` | `stepsIconCustomTop` | - |
+| `@steps-icon-custom-font-size` | `stepsIconCustomFontSize` | - |
+| `@steps-icon-top` | `stepsIconTop` | - |
+| `@steps-icon-font-size` | `stepsIconFontSize` | - |
+| `@steps-icon-margin` | - | 由于样式变化已废弃 |
+| `@steps-title-line-height` | `stepsTitleLineHeight` | - |
+| `@steps-small-icon-size` | `stepsSmallIconSize` | - |
+| `@steps-small-icon-margin` | - | 由于样式变化已废弃 |
+| `@steps-dot-size` | `stepsDotSize` | - |
+| `@steps-dot-top` | - | 由于样式变化已废弃 |
+| `@steps-current-dot-size` | `stepsCurrentDotSize` | - |
+| `@steps-description-max-width` | `stepsNavContentMaxWidth` | - |
+| `@steps-nav-content-max-width` | - | 由于样式变化已废弃 |
+| `@steps-vertical-icon-width` | - | 由于样式变化已废弃 |
+| `@steps-vertical-tail-width` | - | 由于样式变化已废弃 |
+| `@steps-vertical-tail-width-sm` | - | 由于样式变化已废弃 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/issues/41884
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   migrate less to token for Step      |
| 🇨🇳 Chinese |   迁移 Step   组件  less token        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5d5007</samp>

This pull request refactors the style hook and the less variables for the `Steps` component, and updates the documentation accordingly. It aims to improve the component's customizability, maintainability, and readability. It also adds support for Chinese documentation.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5d5007</samp>

*  Add `resetComponent` import to use the utility function for resetting the component style ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L2-R6))
*  Remove unused `genStepsInlineStyle` import and move `ComponentToken` interface before `StepsToken` interface ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L12-R16))
*  Reorganize and update `StepsToken` interface to group variables by source and support custom icon style ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L29-R34))
*  Simplify `useStepsStyle` function to remove unused variables and merge token with component-specific variables ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L332-L335), [link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L348-R348))
*  Replace `processTailColor` with `colorSplit` to align with less variable name and avoid confusion ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L378-R359), [link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L392-R373))
*  Change second argument of `genComponentStyleHook` function to a function that returns an object based on the token ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L406-R412))
*  Update documentation for `Step` component in `migrate-less-variables.en-US.md` and `migrate-less-variables.zh-CN.md` to reflect the changes in less variables and component token ([link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R65), [link](https://github.com/ant-design/ant-design/pull/42065/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R65))
