### PR TITLE
✨ feat: add selectable types to Calendar `onSelect`

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -5,7 +5,7 @@ import { useContext, useMemo } from 'react';
 import { FormItemInputContext } from '../form/context';
 import { Button, Group } from '../radio';
 import Select from '../select';
-import type { CalendarMode } from './generateCalendar';
+import type { CalendarMode, CalendarSelectable } from './generateCalendar';
 
 const YearSelectOffset = 10;
 const YearSelectTotal = 20;
@@ -18,7 +18,7 @@ interface SharedProps<DateType> {
   locale: Locale;
   fullscreen: boolean;
   divRef: React.RefObject<HTMLDivElement>;
-  onChange: (year: DateType) => void;
+  onChange: (year: DateType, selectType: CalendarSelectable) => void;
 }
 
 function YearSelect<DateType>(props: SharedProps<DateType>) {
@@ -68,7 +68,7 @@ function YearSelect<DateType>(props: SharedProps<DateType>) {
           }
         }
 
-        onChange(newDate);
+        onChange(newDate, 'year');
       }}
       getPopupContainer={() => divRef!.current!}
     />
@@ -110,7 +110,7 @@ function MonthSelect<DateType>(props: SharedProps<DateType>) {
       value={month}
       options={options}
       onChange={(newMonth) => {
-        onChange(generateConfig.setMonth(value, newMonth));
+        onChange(generateConfig.setMonth(value, newMonth), 'month');
       }}
       getPopupContainer={() => divRef!.current!}
     />
@@ -147,7 +147,7 @@ export interface CalendarHeaderProps<DateType> {
   locale: Locale;
   mode: CalendarMode;
   fullscreen: boolean;
-  onChange: (date: DateType) => void;
+  onChange: (date: DateType, selectType: CalendarSelectable) => void;
   onModeChange: (mode: CalendarMode) => void;
 }
 function CalendarHeader<DateType>(props: CalendarHeaderProps<DateType>) {

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -86,6 +86,266 @@ describe('Calendar', () => {
     MockDate.reset();
   });
 
+  it('only month change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['month']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['month']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['month']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
+  it('only year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['year']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only date select should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar onSelect={onSelect} defaultValue={Dayjs('2018-02-02')} selectable={['date']} />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only date select and month change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['date', 'month']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date', 'month']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date', 'month']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
+  it('only date select and year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['date', 'year']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['date', 'year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['date', 'year']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(0);
+  });
+
+  it('only month chnage and year change should trigger onSelect callback', () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        selectable={['month', 'year']}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[title="2018-02-05"]')!);
+    fireEvent.click(container.querySelector('[title="2018-02-07"]')!);
+    expect(onSelect.mock.calls.length).toBe(0);
+
+    onSelect.mockReset();
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(2)!);
+    fireEvent.click(Array.from(container.querySelectorAll('.ant-select-item-option')).at(4)!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    const wrapper = render(
+      <Calendar
+        onSelect={onSelect}
+        defaultValue={Dayjs('2018-02-02')}
+        mode="year"
+        selectable={['month', 'year']}
+      />,
+    );
+
+    fireEvent.click(wrapper.container.querySelector('[title="2018-01"]')!);
+    fireEvent.click(wrapper.container.querySelector('[title="2018-03"]')!);
+    expect(onSelect.mock.calls.length).toBe(2);
+
+    onSelect.mockReset();
+
+    wrapper.rerender(<Calendar onSelect={onSelect} mode='month' selectable={['month', 'year']} />);
+
+    openSelect(wrapper.container, '.ant-picker-calendar-month-select');
+    fireEvent.click(
+      Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(5)!,
+    );
+    expect(onSelect.mock.calls.length).toBe(1);
+  });
+
   it('only Valid range should be selectable', () => {
     const onSelect = jest.fn();
     const validRange: [Dayjs.Dayjs, Dayjs.Dayjs] = [Dayjs('2018-02-02'), Dayjs('2018-02-18')];
@@ -537,15 +797,5 @@ describe('Calendar', () => {
     fireEvent.click(Array.from(container.querySelectorAll(`.ant-radio-button-input`)).at(1)!);
     expect(container.querySelector('.bar')).toBeTruthy();
     errSpy.mockRestore();
-  });
-
-  it('support Calendar.generateCalendar', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2000-01-01'));
-
-    const MyCalendar = Calendar.generateCalendar(dayjsGenerateConfig);
-    const { container } = render(<MyCalendar />);
-    expect(container.firstChild).toMatchSnapshot();
-
-    jest.useRealTimers();
   });
 });

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -319,7 +319,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
           headerRender({
             value: mergedValue,
             type: mergedMode,
-            onChange: triggerChange,
+            onChange: onInternalSelect,
             onTypeChange: triggerModeChange,
           })
         ) : (
@@ -331,7 +331,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
             fullscreen={fullscreen}
             locale={contextLocale?.lang}
             validRange={validRange}
-            onChange={triggerChange}
+            onChange={onInternalSelect}
             onModeChange={triggerModeChange}
           />
         )}

--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -55,7 +55,8 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 | value | The current selected date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback for when date changes | function(date: Dayjs) | - |  |
 | onPanelChange | Callback for when panel changes | function(date: Dayjs, mode: string) | - |  |
-| onSelect | Callback for when a date is selected | function(date: Dayjs） | - |  |
+| onSelect | Callback for when a date is selected | function(date: Dayjs, selectType?: `date` \| `year` \| `month`） | - |  |
+| selectable | Make calendar selectable by `date`, `month` and `year` | (`date` \| `year` \| `month`)[] | - |  |
 
 ## Design Token
 

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -60,7 +60,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-p-wQLik200AAA
 | value | 展示日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 日期变化回调 | function(date: Dayjs) | - |  |
 | onPanelChange | 日期面板变化回调 | function(date: Dayjs, mode: string) | - |  |
-| onSelect | 点击选择日期回调 | function(date: Dayjs） | - |  |
+| onSelect | 点击选择日期回调 | function(date: Dayjs, selectType?: `date` \| `year` \| `month` ） | - |  |
+| selectable | 使日历可以按`date`、`month`和`year`进行选择 | (`date` \| `year` \| `month`)[] | - |  |
 
 ## Design Token
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/40407

### 💡 Background and solution

This is an update to PR https://github.com/ant-design/ant-design/pull/40581, updating the docs and being on the latest master branch version

When I need to go to a specific date in a year and month different from the current selected date, it will require me to select the date 3 times just to get there. First I have to select the year, then select the month and only then select the day which is exhaustive and unnecessary IMO as it gives a really bad UX.
The issue is that the onSelect callback is called whenever we change the month or year. I propose an api that let you choose when you want the onSelect callback to be called, if it is when we change we change the year, when we change the month or only when change click on a day.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Make calendar selectable by `date`, `month` and `year `      |
| 🇨🇳 Chinese |    使日历可以按`date`、`month`和`year`进行选择       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbbb21c</samp>

Added a new feature to the `Calendar` component to allow users to select different types of calendar units (`date`, `year`, or `month`) and trigger the `onSelect` callback accordingly. Updated the `CalendarProps` interface, the `Header` component, and the documentation files (`index.en-US.md` and `index.zh-CN.md`) to support this feature. Added and refactored some tests in `index.test.tsx` to cover the new functionality.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bbbb21c</samp>

*  Export `CalendarSelectable` type and add `selectable` prop to `CalendarProps` interface in `generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L39-R43),[link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L71-R73))
*  Pass `selectable` prop to `Header` component in `generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2R115))
*  Modify `onInternalSelect` function to accept and check `selectType` parameter before calling `onSelect` callback in `generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L201-R213))
*  Pass `triggerChange` function instead of `onInternalSelect` function to `onChange` prop of `Header` and `FullHeader` components in `generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L313-R322),[link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L325-R334))
*  Pass `selectType` as `'date'` or `'month'` to `onSelect` prop of `DatePanel` component in `generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L335-R344))
*  Modify `onChange` prop of `SharedProps` and `CalendarHeaderProps` interfaces to accept `selectType` parameter in `Header.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L21-R21),[link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L150-R150))
*  Pass `selectType` as `'year'` or `'month'` to `onChange` prop of `YearSelect` and `MonthSelect` components in `Header.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L71-R71),[link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L113-R113))
*  Add test cases for `onSelect` callback with different `selectable` prop values in `index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aR89-R348))
*  Remove redundant test case for `Calendar.generateCalendar` in `index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL541-L550))
*  Document `selectType` parameter of `onSelect` prop and `selectable` prop in `index.en-US.md` and `index.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-8fab8ed47a3daf0635a3eb887b1fd4fdb984ec4daba5af51505fea4a5d87051bL58-R59),[link](https://github.com/ant-design/ant-design/pull/42076/files?diff=unified&w=0#diff-58e290dfe67aeb90a9d97d4e3e8a790c9aa964113593229b7f2637b66f0c8a50L63-R64))
