### PR TITLE
feat: migrate less to token for Result

### DIFF
--- a/components/result/style/index.tsx
+++ b/components/result/style/index.tsx
@@ -5,9 +5,7 @@ import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 export interface ComponentToken {
   imageWidth: number;
   imageHeight: number;
-}
 
-interface ResultToken extends FullToken<'Result'> {
   resultTitleFontSize: number;
   resultSubtitleFontSize: number;
   resultIconFontSize: number;
@@ -19,6 +17,8 @@ interface ResultToken extends FullToken<'Result'> {
   resultWarningIconColor: string;
   resultErrorIconColor: string;
 }
+
+interface ResultToken extends FullToken<'Result'> {}
 
 // ============================== Styles ==============================
 const genBaseStyle: GenerateStyle<ResultToken> = (token): CSSObject => {
@@ -127,6 +127,11 @@ const getStyle: GenerateStyle<ResultToken> = (token) => genResultStyle(token);
 export default genComponentStyleHook(
   'Result',
   (token) => {
+    const resultToken = mergeToken<ResultToken>(token, {});
+
+    return [getStyle(resultToken)];
+  },
+  (token) => {
     const { paddingLG, fontSizeHeading3 } = token;
 
     const resultSubtitleFontSize = token.fontSize;
@@ -136,8 +141,10 @@ export default genComponentStyleHook(
     const resultErrorIconColor = token.colorError;
     const resultSuccessIconColor = token.colorSuccess;
     const resultWarningIconColor = token.colorWarning;
+    return {
+      imageWidth: 250,
+      imageHeight: 295,
 
-    const resultToken = mergeToken<ResultToken>(token, {
       resultTitleFontSize: fontSizeHeading3,
       resultSubtitleFontSize,
       resultIconFontSize: fontSizeHeading3 * 3,
@@ -146,12 +153,6 @@ export default genComponentStyleHook(
       resultErrorIconColor,
       resultSuccessIconColor,
       resultWarningIconColor,
-    });
-
-    return [getStyle(resultToken)];
-  },
-  {
-    imageWidth: 250,
-    imageHeight: 295,
+    };
   },
 );

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -103,7 +103,17 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Rate -->
 
-<!-- ### Result -->
+
+## Result
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@result-icon-font-size` | `resultIconFontSize` | - |
+| `@result-title-font-size` | `resultTitleFontSize` | - |
+| `@result-subtitle-font-size` | `resultSubtitleFontSize` | - |
+| `@result-extra-margin` | `resultExtraMargin` | - |
+
 
 <!-- ### Segment -->
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -103,7 +103,17 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Rate 评分 -->
 
-<!-- ### Result 结果 -->
+
+## Result 结果
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@result-icon-font-size` | `resultIconFontSize` | - |
+| `@result-title-font-size` | `resultTitleFontSize` | - |
+| `@result-subtitle-font-size` | `resultSubtitleFontSize` | - |
+| `@result-extra-margin` | `resultExtraMargin` | - |
+
 
 <!-- ### Segment 分段器 -->
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/41884

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | migrate less to token for Result  |
| 🇨🇳 Chinese | 迁移 `Result` 组件的 `less token`  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de0919b</samp>

Refactored and documented the result component style tokens. The `components/result/style/index.tsx` file was updated to use a more consistent and extensible token interface, and the `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` files were updated to reflect the new tokens and their less variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de0919b</samp>

* Move result title and subtitle font size properties from `ResultToken` to `ResultImageToken` interface, since they only apply to image variant ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375L8-R8))
* Add empty `ResultToken` interface as extension of `FullToken<'Result'>` interface, to allow future customization of result component tokens ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375R21-R22))
* Create `resultToken` constant to merge `token` argument with empty object, to avoid mutating original token object and prepare for possible additional properties in `ResultToken` interface ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375R130-R134))
* Move image width and height properties from default values argument of `useResult` hook to `resultToken` object, to make them consistent with other properties and avoid overriding them by `token` argument ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375L139-R147), [link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375L149-R157))
* Remove default values argument of `useResult` hook, since it is no longer needed after moving image width and height properties to `resultToken` object ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-da14e63afcbdbac40d9d176178e16881175c10997b9bb644b9ee8662cfa63375L149-R157))
* Add documentation for result component tokens and their corresponding less variables to English and Chinese versions of migrate less variables guide, to inform users about new tokens (`docs/react/migrate-less-variables.en-US.md`, `docs/react/migrate-less-variables.zh-CN.md`) ([link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R55), [link](https://github.com/ant-design/ant-design/pull/42081/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R55))
