### PR TITLE
revert: revert #42060

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "pub": "npm run version && npm run collect-token-statistic && npm run token-meta && antd-tools run pub",
     "rome:format": "rome format --write .",
     "prepublishOnly": "antd-tools run guard",
-    "postpublish": "ts-node --esm --project tsconfig.node.json scripts/post-script.ts",
+    "postpublish": "node ./scripts/post-script.js",
     "site": "dumi build && cp .surgeignore _site",
     "sort": "npx sort-package-json",
     "sort-api": "antd-tools run sort-api-table",

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
-import chalk from 'chalk';
-import { spawnSync } from 'child_process';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import fetch from 'isomorphic-fetch';
-import semver from 'semver';
+const fetch = require('isomorphic-fetch');
+const semver = require('semver');
+const dayjs = require('dayjs');
+const chalk = require('chalk');
+const { spawnSync } = require('child_process');
+const relativeTime = require('dayjs/plugin/relativeTime');
 
 dayjs.extend(relativeTime);
 
@@ -39,12 +39,12 @@ const DEPRECIATED_VERSION = {
   ],
 };
 
-function matchDeprecated(version: string) {
+function matchDeprecated(version) {
   const match = Object.keys(DEPRECIATED_VERSION).find((depreciated) =>
     semver.satisfies(version, depreciated),
   );
 
-  const reason = DEPRECIATED_VERSION[match as keyof typeof DEPRECIATED_VERSION] || [];
+  const reason = DEPRECIATED_VERSION[match] || [];
 
   return {
     match,
@@ -98,13 +98,12 @@ const SAFE_DAYS_DIFF = 1000 * 60 * 60 * 24 * 3; // 3 days not update seems to be
   const startDefaultVersionIndex = filteredLatestVersions.findIndex(
     ({ timeDiff }) => timeDiff >= SAFE_DAYS_START,
   );
-
   const defaultVersionList = filteredLatestVersions
     .slice(0, startDefaultVersionIndex + 1)
     .reverse();
 
   // Find safe version
-  let defaultVersionObj: any;
+  let defaultVersionObj;
   for (let i = 0; i < defaultVersionList.length - 1; i += 1) {
     defaultVersionObj = defaultVersionList[i];
     const nextVersionObj = defaultVersionList[i + 1];
@@ -126,7 +125,6 @@ const SAFE_DAYS_DIFF = 1000 * 60 * 60 * 24 * 3; // 3 days not update seems to be
   }
 
   const { default: inquirer } = await import('inquirer');
-
   // Selection
   let { conchVersion } = await inquirer.prompt([
     {
@@ -137,6 +135,8 @@ const SAFE_DAYS_DIFF = 1000 * 60 * 60 * 24 * 3; // 3 days not update seems to be
       choices: latestVersions.map((info) => {
         const { value, publishTime, depreciated } = info;
         const desc = dayjs(publishTime).fromNow();
+
+        //
 
         return {
           ...info,
@@ -188,6 +188,9 @@ const SAFE_DAYS_DIFF = 1000 * 60 * 60 * 24 * 3; // 3 days not update seems to be
     console.log(`🎃 Conch Version not change. Safe to ${chalk.green('ignore')}.`);
   } else {
     console.log('💾 Tagging Conch Version:', chalk.green(conchVersion));
-    spawnSync('npm', ['dist-tag', 'add', `antd@${conchVersion}`, CONCH_TAG], { stdio: 'inherit' });
+    spawnSync('npm', ['dist-tag', 'add', `antd@${conchVersion}`, CONCH_TAG], {
+      stdio: 'inherit',
+      stdin: 'inherit',
+    });
   }
 })();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | revert: revert #42060 |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01377ba</samp>

Refactored and fixed `post-script.js` to run without TypeScript and avoid hanging on npm publish.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01377ba</samp>

* Rename the file `post-script.ts` to `post-script.js` and change the import syntax to require syntax to make it compatible with Node.js without TypeScript ([link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL2-R7))
* Remove the type annotations for the `version` parameter of the `matchDeprecated` function and the `defaultVersionObj` variable as they are not needed in JavaScript ([link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL42-R47), [link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL107-R106))
* Add an empty comment line before the `matchDeprecated` function for code readability ([link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dR139-R140))
* Add the `stdin` option to the `spawnSync` call to inherit the standard input from the parent process and fix a bug where the script would hang when prompting for the npm login credentials ([link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL191-R194))
* Remove some empty lines for code style consistency ([link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL101), [link](https://github.com/ant-design/ant-design/pull/42082/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dL129))
