### PR TITLE
feat: migrate less to token for Statistic

### DIFF
--- a/components/statistic/style/index.tsx
+++ b/components/statistic/style/index.tsx
@@ -1,13 +1,15 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { resetComponent } from '../../style';
 
-interface StatisticToken extends FullToken<'Statistic'> {
+export interface ComponentToken {
   statisticTitleFontSize: number;
   statisticContentFontSize: number;
   statisticFontFamily: string;
 }
+
+interface StatisticToken extends FullToken<'Statistic'> {}
 
 const genStatisticStyle: GenerateStyle<StatisticToken> = (token: StatisticToken): CSSObject => {
   const {
@@ -57,13 +59,18 @@ const genStatisticStyle: GenerateStyle<StatisticToken> = (token: StatisticToken)
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Statistic', (token) => {
-  const { fontSizeHeading3, fontSize, fontFamily } = token;
-
-  const statisticToken = mergeToken<StatisticToken>(token, {
-    statisticTitleFontSize: fontSize,
-    statisticContentFontSize: fontSizeHeading3,
-    statisticFontFamily: fontFamily,
-  });
-  return [genStatisticStyle(statisticToken)];
-});
+export default genComponentStyleHook(
+  'Statistic',
+  (token) => {
+    const statisticToken = mergeToken<StatisticToken>(token, {});
+    return [genStatisticStyle(statisticToken)];
+  },
+  (token) => {
+    const { fontSizeHeading3, fontSize, fontFamily } = token;
+    return {
+      statisticTitleFontSize: fontSize,
+      statisticContentFontSize: fontSizeHeading3,
+      statisticFontFamily: fontFamily,
+    };
+  },
+);

--- a/components/theme/interface/components.ts
+++ b/components/theme/interface/components.ts
@@ -48,6 +48,7 @@ import type { ComponentToken as UploadComponentToken } from '../../upload/style'
 import type { ComponentToken as TourComponentToken } from '../../tour/style';
 import type { ComponentToken as QRCodeComponentToken } from '../../qrcode/style';
 import type { ComponentToken as AppComponentToken } from '../../app/style';
+import type { ComponentToken as StatisticComponentToken } from '../../statistic/style';
 import type { ComponentToken as WaveToken } from '../../_util/wave/style';
 
 export interface ComponentTokenMap {
@@ -91,7 +92,7 @@ export interface ComponentTokenMap {
   Skeleton?: SkeletonComponentToken;
   Slider?: SliderComponentToken;
   Spin?: SpinComponentToken;
-  Statistic?: {};
+  Statistic?: StatisticComponentToken;
   Switch?: {};
   Tag?: TagComponentToken;
   Tree?: {};

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -113,7 +113,16 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Slider -->
 
-<!-- ### Statistic -->
+
+## Statistic
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@statistic-title-font-size` | `statisticTitleFontSize` | - |
+| `@statistic-content-font-size` | `statisticContentFontSize` | - |
+| `@statistic-font-family` | `statisticFontFamily` | - |
+
 
 ## Step
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -113,7 +113,16 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Slider 滑动输入条 -->
 
-<!-- ### Statistic 统计数值 -->
+
+## Statistic 统计数值
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@statistic-title-font-size` | `statisticTitleFontSize` | - |
+| `@statistic-content-font-size` | `statisticContentFontSize` | - |
+| `@statistic-font-family` | `statisticFontFamily` | - |
+
 
 ### Step 步骤条
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/41884

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | migrate less to token for Statistic  |
| 🇨🇳 Chinese | 迁移 `Statistic` 组件的 `less token`  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21df437</samp>

Refactored the `Statistic` component style to use component tokens instead of less variables, and updated the documentation and the component token type accordingly. This improves the style customization, performance, and type safety of the component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21df437</samp>

*  Refactor `Statistic` component token to use `FullToken` and `genComponentStyleHook` ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382L2-R6), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382R12-R13), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382L60-R76), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bR51), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bL94-R95))
  - Move and rename `StatisticToken` interface to `ComponentToken` at the end of `components/statistic/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382L2-R6))
  - Extend `ComponentToken` from `FullToken<'Statistic'>` to allow custom properties ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382R12-R13))
  - Add a third argument to `genComponentStyleHook` that returns the default values for the component token based on the global token ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-97e99b19a11b4523a27484f1e3289b0b8cc63589d1a9c0bdf9c65a0648b14382L60-R76))
  - Import `StatisticComponentToken` type from `components/statistic/style` and use it for the `Statistic` property of the `ComponentTokenMap` interface in `components/theme/interface/components.ts` ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bR51), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bL94-R95))
* Update documentation for migrating from less variables to component tokens for `Statistic` ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R51), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R51))
  - Add a new section for `Statistic` in both English and Chinese versions of `docs/react/migrate-less-variables.md` ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R51), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R51))
  - Show the mapping between the less variables and the component token properties in a table, and explain any differences or caveats in the notes column ([link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R51), [link](https://github.com/ant-design/ant-design/pull/42083/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R51))
