### PR TITLE
feat: migrate less to token for Drawer

### DIFF
--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -4,12 +4,11 @@ import genMotionStyle from './motion';
 
 export interface ComponentToken {
   zIndexPopup: number;
-}
-
-export interface DrawerToken extends FullToken<'Drawer'> {
   drawerFooterPaddingVertical: number;
   drawerFooterPaddingHorizontal: number;
 }
+
+export interface DrawerToken extends FullToken<'Drawer'> {}
 
 // =============================== Base ===============================
 const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
@@ -217,14 +216,13 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
 export default genComponentStyleHook(
   'Drawer',
   (token) => {
-    const drawerToken = mergeToken<DrawerToken>(token, {
-      drawerFooterPaddingVertical: token.paddingXS,
-      drawerFooterPaddingHorizontal: token.padding,
-    });
+    const drawerToken = mergeToken<DrawerToken>(token, {});
 
     return [genDrawerStyle(drawerToken), genMotionStyle(drawerToken)];
   },
   (token) => ({
     zIndexPopup: token.zIndexPopupBase,
+    drawerFooterPaddingVertical: token.paddingXS,
+    drawerFooterPaddingHorizontal: token.padding,
   }),
 );

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -39,7 +39,20 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Divider -->
 
-<!-- ### Drawer -->
+
+## Drawer
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@drawer-bg` | `colorBgElevated` | - |
+| `@drawer-header-padding` | `padding`、`paddingLG` | `${padding}px ${paddingLG}px` |
+| `@drawer-title-font-size` | `fontSizeLG` | - |
+| `@drawer-title-line-height` | `lineHeightLG` | - |
+| `@drawer-body-padding` | `paddingLG` | - |
+| `@drawer-footer-padding-vertical` | `drawerFooterPaddingVertical` | `drawerFooterPaddingVertical`  is a number without units, `@drawer-footer-padding-vertical` with units |
+| `@drawer-footer-padding-horizontal` | `drawerFooterPaddingHorizontal` | `drawerFooterPaddingHorizontal`  is a number without units, `@drawer-footer-padding-horizontal` with units |
+
 
 <!-- ### Dropdown -->
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -39,7 +39,20 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Divider 分割线 -->
 
-<!-- ### Drawer 抽屉 -->
+
+## Drawer 抽屉
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@drawer-bg` | `colorBgElevated` | - |
+| `@drawer-header-padding` | `padding`、`paddingLG` | `${padding}px ${paddingLG}px` |
+| `@drawer-title-font-size` | `fontSizeLG` | - |
+| `@drawer-title-line-height` | `lineHeightLG` | - |
+| `@drawer-body-padding` | `paddingLG` | - |
+| `@drawer-footer-padding-vertical` | `drawerFooterPaddingVertical` | `drawerFooterPaddingVertical` 为数字，不带单位，`@drawer-footer-padding-vertical` 带单位 |
+| `@drawer-footer-padding-horizontal` | `drawerFooterPaddingHorizontal` | `drawerFooterPaddingHorizontal` 为数字，不带单位，`@drawer-footer-padding-horizontal` 带单位 |
+
 
 <!-- ### Dropdown 下拉菜单 -->
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/41884

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | migrate less to token for Drawer  |
| 🇨🇳 Chinese | 迁移 `Drawer` 组件的 `less token`  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59383eb</samp>

Refactored the `Drawer` component's padding properties and updated the documentation for the less variables migration. The changes improve the code quality and the user experience for the `Drawer` component and its customization.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59383eb</samp>

*  Move `drawerFooterPaddingVertical` and `drawerFooterPaddingHorizontal` properties from `DrawerToken` to `ComponentToken` interface to make them more generic and reusable ([link](https://github.com/ant-design/ant-design/pull/42084/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L7-R12))
*  Remove `drawerFooterPaddingVertical` and `drawerPaddingHorizontal` properties from `mergeToken` function call in `components/drawer/style/index.ts` since they are inherited from `ComponentToken` ([link](https://github.com/ant-design/ant-design/pull/42084/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L220-R219))
*  Add `drawerFooterPaddingVertical` and `drawerPaddingHorizontal` properties to `genDrawerStyle` function call in `components/drawer/style/index.ts` to pass them as parameters to `getDrawerFooterStyle` function that generates the CSS for the drawer footer element ([link](https://github.com/ant-design/ant-design/pull/42084/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3R225-R226))
*  Update documentation for `Drawer` component in `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` to reflect the changes in the less variables and the component tokens, and add a table to show the mapping between them ([link](https://github.com/ant-design/ant-design/pull/42084/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR39-R66), [link](https://github.com/ant-design/ant-design/pull/42084/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R39-R66))
