### PR TITLE
fix: resolve table filter panel locale display unexpected issue

### DIFF
--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -14,6 +14,74 @@ import type { UploadLocale } from '../upload/interface';
 import type { LocaleContextProps } from './context';
 import LocaleContext from './context';
 
+import arEG from '../locale/ar_EG';
+import azAZ from '../locale/az_AZ';
+import bgBG from '../locale/bg_BG';
+import bnBD from '../locale/bn_BD';
+import byBY from '../locale/by_BY';
+import caES from '../locale/ca_ES';
+import csCZ from '../locale/cs_CZ';
+import daDK from '../locale/da_DK';
+import deDE from '../locale/de_DE';
+import elGR from '../locale/el_GR';
+import enGB from '../locale/en_GB';
+import enUS from '../locale/en_US';
+import esES from '../locale/es_ES';
+import etEE from '../locale/et_EE';
+import euES from '../locale/eu_ES';
+import faIR from '../locale/fa_IR';
+import fiFI from '../locale/fi_FI';
+import frBE from '../locale/fr_BE';
+import gaIE from '../locale/ga_IE';
+import glES from '../locale/gl_ES';
+import heIL from '../locale/he_IL';
+import hiIN from '../locale/hi_IN';
+import hrHR from '../locale/hr_HR';
+import huHU from '../locale/hu_HU';
+import hyAM from '../locale/hy_AM';
+import idID from '../locale/id_ID';
+import isIS from '../locale/is_IS';
+import itIT from '../locale/it_IT';
+import jaJP from '../locale/ja_JP';
+import kaGE from '../locale/ka_GE';
+import kkKZ from '../locale/kk_KZ';
+import kmrIQ from '../locale/kmr_IQ';
+import kmKH from '../locale/km_KH';
+import knIN from '../locale/kn_IN';
+import koKR from '../locale/ko_KR';
+import kuIQ from '../locale/ku_IQ';
+import ltLT from '../locale/lt_LT';
+import lvLV from '../locale/lv_LV';
+import mkMK from '../locale/mk_MK';
+import mlIN from '../locale/ml_IN';
+import mnMN from '../locale/mn_MN';
+import msMY from '../locale/ms_MY';
+import nbNO from '../locale/nb_NO';
+import neNP from '../locale/ne_NP';
+import nlBE from '../locale/nl_BE';
+import nlNL from '../locale/nl_NL';
+import plPL from '../locale/pl_PL';
+import ptBR from '../locale/pt_BR';
+import ptPT from '../locale/pt_PT';
+import roRO from '../locale/ro_RO';
+import ruRU from '../locale/ru_RU';
+import siLK from '../locale/si_LK';
+import skSK from '../locale/sk_SK';
+import slSI from '../locale/sl_SI';
+import srRS from '../locale/sr_RS';
+import svSE from '../locale/sv_SE';
+import taIN from '../locale/ta_IN';
+import thTH from '../locale/th_TH';
+import tkTK from '../locale/tk_TK';
+import trTR from '../locale/tr_TR';
+import ukUA from '../locale/uk_UA';
+import urPK from '../locale/ur_PK';
+import viVN from '../locale/vi_VN';
+import zhCN from '../locale/zh_CN';
+import zhHK from '../locale/zh_HK';
+import zhTW from '../locale/zh_TW';
+import myMM from '../locale/my_MM';
+
 export { default as useLocale } from './useLocale';
 
 export const ANT_MARK = 'internalMark';
@@ -92,5 +160,75 @@ const LocaleProvider: React.FC<LocaleProviderProps> = (props) => {
 if (process.env.NODE_ENV !== 'production') {
   LocaleProvider.displayName = 'LocaleProvider';
 }
+
+export const localeInfo: Record<string, Locale> = {
+  ar: arEG,
+  az: azAZ,
+  bg: bgBG,
+  'bn-bd': bnBD,
+  by: byBY,
+  ca: caES,
+  cs: csCZ,
+  da: daDK,
+  de: deDE,
+  el: elGR,
+  'en-gb': enGB,
+  en: enUS,
+  es: esES,
+  et: etEE,
+  eu: euES,
+  fa: faIR,
+  fi: fiFI,
+  fr: frBE,
+  ga: gaIE,
+  gl: glES,
+  he: heIL,
+  hi: hiIN,
+  hr: hrHR,
+  hu: huHU,
+  'hy-am': hyAM,
+  id: idID,
+  is: isIS,
+  it: itIT,
+  ja: jaJP,
+  ka: kaGE,
+  kk: kkKZ,
+  ku: kmrIQ,
+  km: kmKH,
+  kn: knIN,
+  ko: koKR,
+  'ku-iq': kuIQ,
+  lt: ltLT,
+  lv: lvLV,
+  mk: mkMK,
+  ml: mlIN,
+  'mn-mn': mnMN,
+  'ms-my': msMY,
+  nb: nbNO,
+  'ne-np': neNP,
+  'nl-be': nlBE,
+  nl: nlNL,
+  pl: plPL,
+  'pt-br': ptBR,
+  pt: ptPT,
+  ro: roRO,
+  ru: ruRU,
+  si: siLK,
+  sk: skSK,
+  sl: slSI,
+  sr: srRS,
+  sv: svSE,
+  ta: taIN,
+  th: thTH,
+  tk: tkTK,
+  tr: trTR,
+  uk: ukUA,
+  ur: urPK,
+  vi: viVN,
+  'zh-cn': zhCN,
+  'zh-hk': zhHK,
+  'zh-tw': zhTW,
+  my: myMM,
+};
 
 export default LocaleProvider;

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -13,6 +13,7 @@ import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
+import { localeInfo } from '../locale';
 import defaultLocale from '../locale/en_US';
 import Pagination from '../pagination';
 import type { SpinProps } from '../spin';
@@ -183,8 +184,17 @@ const InternalTable = <RecordType extends AnyObject = any>(
     getPopupContainer: getContextPopupContainer,
   } = React.useContext<ConfigConsumerProps>(ConfigContext);
 
+  const mergedDefaultLocale = React.useMemo(
+    () => (contextLocale.locale ? localeInfo[contextLocale.locale] : defaultLocale),
+    [contextLocale.locale],
+  );
+
   const mergedSize = customizeSize || size;
-  const tableLocale: TableLocale = { ...contextLocale.Table, ...locale };
+  const tableLocale: TableLocale = {
+    ...mergedDefaultLocale.Table,
+    ...contextLocale.Table,
+    ...locale,
+  };
   const rawData: readonly RecordType[] = dataSource || EMPTY_LIST;
 
   const prefixCls = getPrefixCls('table', customizePrefixCls);

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -4,14 +4,15 @@ import React, { useEffect, useState } from 'react';
 import type { ColumnGroupType, ColumnType, TableProps } from '..';
 import Table from '..';
 import { act, fireEvent, render, waitFor } from '../../../tests/utils';
+import { resetWarned } from '../../_util/warning';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
 import Input from '../../input';
+import { localeInfo } from '../../locale';
 import Menu from '../../menu';
 import type { SelectProps } from '../../select';
 import Select from '../../select';
 import Tooltip from '../../tooltip';
-import { resetWarned } from '../../_util/warning';
 import type { TreeColumnFilterItem } from '../hooks/useFilter/FilterDropdown';
 import type {
   ColumnFilterItem,
@@ -2819,5 +2820,106 @@ describe('Table.filter', () => {
     expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
       true,
     );
+  });
+
+  const locales: string[] = [
+    'ar',
+    'az',
+    'bg',
+    'bn-bd',
+    'by',
+    'ca',
+    'cs',
+    'da',
+    'de',
+    'el',
+    'en-gb',
+    'en',
+    'es',
+    'et',
+    'eu',
+    'fa',
+    'fi',
+    'fr',
+    'ga',
+    'gl',
+    'he',
+    'hi',
+    'hr',
+    'hu',
+    'hy-am',
+    'id',
+    'is',
+    'it',
+    'ja',
+    'ka',
+    'kk',
+    'ku',
+    'km',
+    'kn',
+    'ko',
+    'ku-iq',
+    'lt',
+    'lv',
+    'mk',
+    'ml',
+    'mn-mn',
+    'ms-my',
+    'nb',
+    'ne-np',
+    'nl-be',
+    'nl',
+    'pl',
+    'pt-br',
+    'pt',
+    'ro',
+    'ru',
+    'si',
+    'sk',
+    'sl',
+    'sr',
+    'sv',
+    'ta',
+    'th',
+    'tk',
+    'tr',
+    'uk',
+    'ur',
+    'vi',
+    'zh-cn',
+    'zh-hk',
+    'zh-tw',
+    'my',
+  ];
+  const App = ({ locale }: { locale: string }) => (
+    <ConfigProvider
+      locale={{
+        locale,
+      }}
+    >
+      {createTable({
+        columns: [
+          {
+            ...column,
+            filterDropdownOpen: true,
+          },
+        ],
+      })}
+    </ConfigProvider>
+  );
+  locales.forEach((locale) => {
+    it(`display ${locale} when pass locale into ConfigProvider`, () => {
+      const { baseElement } = render(<App locale={locale} />);
+      let confirmText = baseElement.querySelector(
+        '.ant-table-filter-dropdown-btns .ant-btn-primary',
+      )?.textContent;
+      if (['zh-cn', 'zh-hk', 'zh-tw'].includes(locale)) {
+        confirmText = confirmText?.replace(' ', '');
+      }
+      expect(confirmText).toBe(localeInfo[locale].Table!.filterConfirm);
+      expect(
+        baseElement.querySelector('.ant-table-filter-dropdown-btns .ant-btn-link')?.textContent,
+      ).toBe(localeInfo[locale].Table!.filterReset);
+    });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/42069

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Use mergedDefaultLocale to display table filter panel text when use ConfigProvider like this:

```tsx
// will use zh-cn as default locale
<ConfigProvider
      locale={{
        locale: 'zh-cn',
      }}
    >
  <Table columns={columns} dataSource={data} onChange={onChange} />
</ConfigProvider>
```

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Missing ConfigProvider locale for table onFilterDropdown buttons ("RESET", "OK") issue  |
| 🇨🇳 Chinese | 修复表格筛选面板按钮文案丢失国际化文案问题  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c28cd8b</samp>

This pull request adds multilingual support to the `ConfigProvider` and `Table` components. It introduces locale files and a `localeInfo` object to store the translations for different languages. It also updates the `Table` component to use the appropriate locale based on props, context, or default values. Additionally, it improves the test coverage and code style of the `Table.filter.test.tsx` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c28cd8b</samp>

*  Import and define `localeInfo` object to map locale codes to locale objects ([link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-3534e5ff6dff91b165dbf0fe6e1a6ce5dc623601cf689e56d7075a75de9ddaebR17-R84), [link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-3534e5ff6dff91b165dbf0fe6e1a6ce5dc623601cf689e56d7075a75de9ddaebR164-R233), [link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R16), [link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-d86c8b951332164873bf880555e68c0e38dfd36612b14396f4c001b7f2d1187fL7-R15))
*  Compute and merge `mergedDefaultLocale` based on `contextLocale.locale` prop in `InternalTable.tsx` ([link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616L186-R197))
*  Add test case for `Table` component's locale in different languages in `Table.filter.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42085/files?diff=unified&w=0#diff-d86c8b951332164873bf880555e68c0e38dfd36612b14396f4c001b7f2d1187fR2824-R2924))
