### PR TITLE
fix: Upload disable state logic

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -9,8 +9,13 @@ import DisabledContext from '../config-provider/DisabledContext';
 import defaultLocale from '../locale/en_US';
 import { useLocale } from '../locale';
 import warning from '../_util/warning';
-import type { RcFile, ShowUploadListInterface, UploadChangeParam, UploadFile } from './interface';
-import { UploadProps } from './interface';
+import type {
+  RcFile,
+  ShowUploadListInterface,
+  UploadChangeParam,
+  UploadFile,
+  UploadProps,
+} from './interface';
 import UploadList from './UploadList';
 import { file2Obj, getFileItem, removeFileItem, updateFileList } from './utils';
 
@@ -18,7 +23,7 @@ import useStyle from './style';
 
 export const LIST_IGNORE = `__LIST_IGNORE_${Date.now()}__`;
 
-export { UploadProps };
+export type { UploadProps };
 
 const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (props, ref) => {
   const {

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -383,6 +383,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
         appendAction={button}
         appendActionVisible={buttonVisible}
         itemRender={itemRender}
+        disabled={mergedDisabled}
       />
     );
   };

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -41,6 +41,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
     appendAction,
     appendActionVisible = true,
     itemRender,
+    disabled,
   } = props;
   const forceUpdate = useForceUpdate();
   const [motionAppear, setMotionAppear] = React.useState(false);
@@ -129,6 +130,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
         }
       },
       className: `${prefixCls}-list-item-action`,
+      disabled,
     };
     if (isValidElement(customIcon)) {
       const btnIcon = cloneElement(customIcon, {

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import type { CSSMotionListProps } from 'rc-motion';
 import CSSMotion, { CSSMotionList } from 'rc-motion';
 import * as React from 'react';
-import { useMemo } from 'react';
 import type { ButtonProps } from '../../button';
 import Button from '../../button';
 import { ConfigContext } from '../../config-provider';
@@ -183,7 +182,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
     motionAppear,
   };
 
-  const listItemMotion: Partial<CSSMotionListProps> = useMemo(() => {
+  const listItemMotion: Partial<CSSMotionListProps> = React.useMemo(() => {
     const motion = {
       ...initCollapseMotion(rootPrefixCls),
     };

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import type { UploadFile, UploadProps } from '..';
 import Upload from '..';
 import { act, fireEvent, render, waitFakeTimer, waitFor } from '../../../tests/utils';
+import Button from '../../button';
+import type { FormInstance } from '../../form';
 import Form from '../../form';
 import UploadList from '../UploadList';
+import type { UploadListProps, UploadLocale } from '../interface';
 import { previewImage } from '../utils';
 import { setup, teardown } from './mock';
 import { errorRequest, successRequest } from './requests';
-import type { FormInstance } from '../../form';
-import type { UploadFile, UploadProps } from '..';
-import type { UploadListProps, UploadLocale } from '../interface';
 
 const fileList: UploadProps['fileList'] = [
   {
@@ -1540,5 +1541,47 @@ describe('Upload List', () => {
     );
 
     expect(container.querySelector('.ant-upload-list-item-error')).toBeTruthy();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/42056
+  describe('when form is disabled but upload is not', () => {
+    it('should not disable remove button', () => {
+      const { container } = render(
+        <Form name="base" disabled>
+          <Form.Item name="upload">
+            <Upload
+              disabled={false}
+              defaultFileList={[
+                {
+                  uid: '1',
+                  name: 'zzz.png',
+                  status: 'error',
+                  url: 'http://www.baidu.com/zzz.png',
+                },
+              ]}
+            />
+          </Form.Item>
+        </Form>,
+      );
+
+      const removeButton = container.querySelector('.ant-upload-list-item-actions > button');
+      expect(removeButton).toBeTruthy();
+      expect(removeButton).not.toBeDisabled();
+    });
+
+    // TODO: https://github.com/ant-design/ant-design/issues/42056#issuecomment-1529912365
+    it.skip('should not disable upload button', () => {
+      const { getByText } = render(
+        <Form name="base" disabled>
+          <Form.Item name="upload">
+            <Upload disabled={false}>
+              <Button>Click me</Button>
+            </Upload>
+          </Form.Item>
+        </Form>,
+      );
+
+      expect(getByText(/click me/i).closest('button')).not.toBeDisabled();
+    });
   });
 });

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { UploadFile, UploadProps } from '..';
 import Upload from '..';
 import { act, fireEvent, render, waitFakeTimer, waitFor } from '../../../tests/utils';
-import Button from '../../button';
 import type { FormInstance } from '../../form';
 import Form from '../../form';
 import UploadList from '../UploadList';

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1568,20 +1568,5 @@ describe('Upload List', () => {
       expect(removeButton).toBeTruthy();
       expect(removeButton).not.toBeDisabled();
     });
-
-    // TODO: https://github.com/ant-design/ant-design/issues/42056#issuecomment-1529912365
-    it.skip('should not disable upload button', () => {
-      const { getByText } = render(
-        <Form name="base" disabled>
-          <Form.Item name="upload">
-            <Upload disabled={false}>
-              <Button>Click me</Button>
-            </Upload>
-          </Form.Item>
-        </Form>,
-      );
-
-      expect(getByText(/click me/i).closest('button')).not.toBeDisabled();
-    });
   });
 });

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -160,4 +160,8 @@ export interface UploadListProps<T = any> {
   appendAction?: React.ReactNode;
   appendActionVisible?: boolean;
   itemRender?: ItemRender<T>;
+  /**
+   * @internal Only the internal remove button is provided for use
+   */
+  disabled?: boolean;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix: #42056 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Upload disable state logic      |
| 🇨🇳 Chinese |     修复 Upload 禁用状态逻辑

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cd6a66</samp>

Added a `disabled` prop to the `Upload` component and its subcomponents to allow disabling the upload feature when the form is disabled. Added tests and improved code style for the upload component and its related files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cd6a66</samp>

*  Add `disabled` prop to `Upload` and `UploadList` components to allow disabling the upload component when the form is disabled, but also allow overriding the disabled state for individual upload components ([link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dR386), [link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dR44), [link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dR133), [link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-160ee6918ffebe6609f946497b4f3cb4dac8d6676f9c1eea3ba82e5ddc42aea8R163-R166), [link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390R1545-R1586))
*  Change `import` to `import type` for `UploadProps` to indicate that it is only used for type checking and not for runtime values ([link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL12-R18), [link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL21-R26))
*  Reorder and group import statements in `uploadlist.test.tsx` by type and source for readability and consistency ([link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L2-R12))
*  Remove unused `useMemo` import from `UploadList` ([link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dL9))
*  Change `useMemo` hook from `import { useMemo } from 'react'` to `React.useMemo` in `UploadList` for code style consistency ([link](https://github.com/ant-design/ant-design/pull/42102/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dL186-R187))
