### PR TITLE
fix(popup): add stopPropagation to prevent popup from closing

### DIFF
--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import type { AbstractTooltipProps } from '../tooltip';
-import Tooltip from '../tooltip';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
+import { ConfigContext } from '../config-provider';
+import type { AbstractTooltipProps } from '../tooltip';
+import Tooltip from '../tooltip';
 import PurePanel from './PurePanel';
 // CSSINJS
 import useStyle from './style';
@@ -28,7 +28,12 @@ const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => {
   return (
     <>
       {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
-      <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
+      <div
+        onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation()}
+        className={`${prefixCls}-inner-content`}
+      >
+        {getRenderPropValue(content)}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
issue
#42114

### 💡 Background and solution
## Issue:
When the popup is open and you click on an icon inside the content the popup close.

https://user-images.githubusercontent.com/96415864/235683679-cf4bcf73-dc35-48d3-8b09-a990e9cb2f3c.mov


## Solution
By adding stopPropagation to the inner div the popup now functions as it should.

https://user-images.githubusercontent.com/96415864/235683720-4910920c-e330-4a96-a142-ab1b5e2f0e4f.mov


### 📝 Changelog

bugfix: 
when clicking on inner content of the popup the popup was closing
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      `Popup` add stopPropagation to prevent it from closing when clicking inside    |
| 🇨🇳 Chinese |     `Popup` add stopPropagation to prevent it from closing when clicking inside       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5957c0</samp>

Fix a bug in the `Popover` component and improve code readability. The bug caused the `Popover` to close unexpectedly when the user interacted with its content, and the code was refactored to sort the imports in `components/popover/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5957c0</samp>

*  Add a click handler to the popover content div to prevent the popover from closing when clicking inside it ([link](https://github.com/ant-design/ant-design/pull/42107/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L31-R36)). This fixes a bug reported in issue #32851.
