### PR TITLE
fix: Upload disabled state logic

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -373,6 +373,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
               appendAction={button}
               appendActionVisible={buttonVisible}
               itemRender={itemRender}
+              disabled={mergedDisabled}
             />
           );
         }}

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -60,7 +60,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
   const [mergedFileList, setMergedFileList] = useMergedState(defaultFileList || [], {
     value: fileList,
-    postState: (list) => list ?? [],
+    postState: list => list ?? [],
   });
 
   const [dragState, setDragState] = React.useState<string>('drop');
@@ -155,23 +155,21 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     return parsedFile as RcFile;
   };
 
-  const onBatchStart: RcUploadProps['onBatchStart'] = (batchFileInfoList) => {
+  const onBatchStart: RcUploadProps['onBatchStart'] = batchFileInfoList => {
     // Skip file which marked as `LIST_IGNORE`, these file will not add to file list
-    const filteredFileInfoList = batchFileInfoList.filter(
-      (info) => !(info.file as any)[LIST_IGNORE],
-    );
+    const filteredFileInfoList = batchFileInfoList.filter(info => !(info.file as any)[LIST_IGNORE]);
 
     // Nothing to do since no file need upload
     if (!filteredFileInfoList.length) {
       return;
     }
 
-    const objectFileList = filteredFileInfoList.map((info) => file2Obj(info.file as RcFile));
+    const objectFileList = filteredFileInfoList.map(info => file2Obj(info.file as RcFile));
 
     // Concat new files with prev files
     let newFileList = [...mergedFileList];
 
-    objectFileList.forEach((fileObj) => {
+    objectFileList.forEach(fileObj => {
       // Replace file if exist
       newFileList = updateFileList(fileObj, newFileList);
     });
@@ -267,7 +265,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
   const handleRemove = (file: UploadFile) => {
     let currentFile: UploadFile;
-    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then((ret) => {
+    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then(ret => {
       // Prevent removing file
       if (ret === false) {
         return;
@@ -277,7 +275,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
       if (removedFileList) {
         currentFile = { ...file, status: 'removed' };
-        mergedFileList?.forEach((item) => {
+        mergedFileList?.forEach(item => {
           const matchKey = currentFile.uid !== undefined ? 'uid' : 'name';
           if (item[matchKey] === currentFile[matchKey] && !Object.isFrozen(item)) {
             item.status = 'removed';
@@ -343,7 +341,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
   const renderUploadList = (button?: React.ReactNode, buttonVisible?: boolean) =>
     showUploadList ? (
       <LocaleReceiver componentName="Upload" defaultLocale={defaultLocale.Upload}>
-        {(contextLocale) => {
+        {contextLocale => {
           const {
             showRemoveIcon,
             showPreviewIcon,
@@ -388,7 +386,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       prefixCls,
       {
         [`${prefixCls}-drag`]: true,
-        [`${prefixCls}-drag-uploading`]: mergedFileList.some((file) => file.status === 'uploading'),
+        [`${prefixCls}-drag-uploading`]: mergedFileList.some(file => file.status === 'uploading'),
         [`${prefixCls}-drag-hover`]: dragState === 'dragover',
         [`${prefixCls}-disabled`]: mergedDisabled,
         [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -9,14 +9,19 @@ import DisabledContext from '../config-provider/DisabledContext';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import defaultLocale from '../locale/default';
 import warning from '../_util/warning';
-import type { RcFile, ShowUploadListInterface, UploadChangeParam, UploadFile } from './interface';
-import { UploadProps } from './interface';
+import type {
+  RcFile,
+  ShowUploadListInterface,
+  UploadChangeParam,
+  UploadFile,
+  UploadProps,
+} from './interface';
 import UploadList from './UploadList';
 import { file2Obj, getFileItem, removeFileItem, updateFileList } from './utils';
 
 export const LIST_IGNORE = `__LIST_IGNORE_${Date.now()}__`;
 
-export { UploadProps };
+export type { UploadProps };
 
 const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (props, ref) => {
   const {
@@ -55,7 +60,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
   const [mergedFileList, setMergedFileList] = useMergedState(defaultFileList || [], {
     value: fileList,
-    postState: list => list ?? [],
+    postState: (list) => list ?? [],
   });
 
   const [dragState, setDragState] = React.useState<string>('drop');
@@ -150,21 +155,23 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
     return parsedFile as RcFile;
   };
 
-  const onBatchStart: RcUploadProps['onBatchStart'] = batchFileInfoList => {
+  const onBatchStart: RcUploadProps['onBatchStart'] = (batchFileInfoList) => {
     // Skip file which marked as `LIST_IGNORE`, these file will not add to file list
-    const filteredFileInfoList = batchFileInfoList.filter(info => !(info.file as any)[LIST_IGNORE]);
+    const filteredFileInfoList = batchFileInfoList.filter(
+      (info) => !(info.file as any)[LIST_IGNORE],
+    );
 
     // Nothing to do since no file need upload
     if (!filteredFileInfoList.length) {
       return;
     }
 
-    const objectFileList = filteredFileInfoList.map(info => file2Obj(info.file as RcFile));
+    const objectFileList = filteredFileInfoList.map((info) => file2Obj(info.file as RcFile));
 
     // Concat new files with prev files
     let newFileList = [...mergedFileList];
 
-    objectFileList.forEach(fileObj => {
+    objectFileList.forEach((fileObj) => {
       // Replace file if exist
       newFileList = updateFileList(fileObj, newFileList);
     });
@@ -260,7 +267,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
   const handleRemove = (file: UploadFile) => {
     let currentFile: UploadFile;
-    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then(ret => {
+    Promise.resolve(typeof onRemove === 'function' ? onRemove(file) : onRemove).then((ret) => {
       // Prevent removing file
       if (ret === false) {
         return;
@@ -270,7 +277,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
 
       if (removedFileList) {
         currentFile = { ...file, status: 'removed' };
-        mergedFileList?.forEach(item => {
+        mergedFileList?.forEach((item) => {
           const matchKey = currentFile.uid !== undefined ? 'uid' : 'name';
           if (item[matchKey] === currentFile[matchKey] && !Object.isFrozen(item)) {
             item.status = 'removed';
@@ -336,7 +343,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
   const renderUploadList = (button?: React.ReactNode, buttonVisible?: boolean) =>
     showUploadList ? (
       <LocaleReceiver componentName="Upload" defaultLocale={defaultLocale.Upload}>
-        {contextLocale => {
+        {(contextLocale) => {
           const {
             showRemoveIcon,
             showPreviewIcon,
@@ -381,7 +388,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (pr
       prefixCls,
       {
         [`${prefixCls}-drag`]: true,
-        [`${prefixCls}-drag-uploading`]: mergedFileList.some(file => file.status === 'uploading'),
+        [`${prefixCls}-drag-uploading`]: mergedFileList.some((file) => file.status === 'uploading'),
         [`${prefixCls}-drag-hover`]: dragState === 'dragover',
         [`${prefixCls}-disabled`]: mergedDisabled,
         [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -174,7 +174,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
 
   // >>> Motion config
   const motionKeyList = [
-    ...items.map((file) => ({
+    ...items.map(file => ({
       key: file.uid,
       file,
     })),
@@ -232,7 +232,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
       {appendAction && (
         <CSSMotion {...motionConfig} visible={appendActionVisible} forceRender>
           {({ className: motionClassName, style: motionStyle }) =>
-            cloneElement(appendAction, (oriProps) => ({
+            cloneElement(appendAction, oriProps => ({
               className: classNames(oriProps.className, motionClassName),
               style: {
                 ...motionStyle,

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -131,6 +131,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
       type: 'text',
       size: 'small',
       title,
+      disabled,
       onClick: (e: React.MouseEvent<HTMLElement>) => {
         callback();
         if (isValidElement(customIcon) && customIcon.props.onClick) {

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -49,6 +49,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
     appendAction,
     appendActionVisible = true,
     itemRender,
+    disabled,
   } = props;
   const forceUpdate = useForceUpdate();
   const [motionAppear, setMotionAppear] = React.useState(false);
@@ -173,7 +174,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
 
   // >>> Motion config
   const motionKeyList = [
-    ...items.map(file => ({
+    ...items.map((file) => ({
       key: file.uid,
       file,
     })),
@@ -231,7 +232,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<unknown, UploadListProp
       {appendAction && (
         <CSSMotion {...motionConfig} visible={appendActionVisible} forceRender>
           {({ className: motionClassName, style: motionStyle }) =>
-            cloneElement(appendAction, oriProps => ({
+            cloneElement(appendAction, (oriProps) => ({
               className: classNames(oriProps.className, motionClassName),
               style: {
                 ...motionStyle,

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -29,8 +29,8 @@ const fileList: UploadProps['fileList'] = [
 
 describe('Upload List', () => {
   // Mock for rc-util raf
-  window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16);
-  window.cancelAnimationFrame = (id) => window.clearTimeout(id);
+  window.requestAnimationFrame = callback => window.setTimeout(callback, 16);
+  window.cancelAnimationFrame = id => window.clearTimeout(id);
 
   // jsdom not support `createObjectURL` yet. Let's handle this.
   const originCreateObjectURL = window.URL.createObjectURL;
@@ -678,7 +678,7 @@ describe('Upload List', () => {
           <Form.Item
             name="file"
             valuePropName="fileList"
-            getValueFromEvent={(e) => e.fileList}
+            getValueFromEvent={e => e.fileList}
             rules={[
               {
                 required: true,
@@ -801,12 +801,12 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('extname should work correctly when url exists', (done) => {
+  it('extname should work correctly when url exists', done => {
     const items = [{ status: 'done', uid: 'upload-list-item', url: '/example' }];
     const { container: wrapper, unmount } = render(
       <UploadList
         listType="picture"
-        onDownload={(file) => {
+        onDownload={file => {
           expect(file.url).toBe('/example');
           unmount();
           done();
@@ -886,7 +886,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then((dataUrl) => {
+    await previewFunc(mockFile).then(dataUrl => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -915,7 +915,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then((dataUrl) => {
+    await previewFunc(mockFile).then(dataUrl => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -939,7 +939,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then((dataUrl) => {
+    await previewFunc(mockFile).then(dataUrl => {
       expect(dataUrl).toBe('');
     });
 
@@ -1045,7 +1045,7 @@ describe('Upload List', () => {
       let wrapper: ReturnType<typeof render>;
       const onChange = jest.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
         ({ fileList: files }) => {
-          const newFileList = files?.map<UploadFile<any>>((item) => ({ ...item, thumbUrl }));
+          const newFileList = files?.map<UploadFile<any>>(item => ({ ...item, thumbUrl }));
 
           wrapper.rerender(
             <Upload
@@ -1139,7 +1139,7 @@ describe('Upload List', () => {
     });
   });
 
-  it('[deprecated] should support transformFile', (done) => {
+  it('[deprecated] should support transformFile', done => {
     jest.useRealTimers();
     let wrapper: ReturnType<typeof render>;
     let lastFile: UploadFile;
@@ -1228,7 +1228,7 @@ describe('Upload List', () => {
           fileList={testFileList}
           action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
           multiple
-          onChange={(info) => {
+          onChange={info => {
             setTestFileList([...info.fileList]);
           }}
         >
@@ -1244,7 +1244,7 @@ describe('Upload List', () => {
 
     await act(() => {
       uploadRef.current.onBatchStart(
-        fileNames.map((fileName) => {
+        fileNames.map(fileName => {
           const file = new File([], fileName);
           (file as any).uid = fileName;
           return { file, parsedFile: file };

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -29,8 +29,8 @@ const fileList: UploadProps['fileList'] = [
 
 describe('Upload List', () => {
   // Mock for rc-util raf
-  window.requestAnimationFrame = callback => window.setTimeout(callback, 16);
-  window.cancelAnimationFrame = id => window.clearTimeout(id);
+  window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16);
+  window.cancelAnimationFrame = (id) => window.clearTimeout(id);
 
   // jsdom not support `createObjectURL` yet. Let's handle this.
   const originCreateObjectURL = window.URL.createObjectURL;
@@ -678,7 +678,7 @@ describe('Upload List', () => {
           <Form.Item
             name="file"
             valuePropName="fileList"
-            getValueFromEvent={e => e.fileList}
+            getValueFromEvent={(e) => e.fileList}
             rules={[
               {
                 required: true,
@@ -801,12 +801,12 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('extname should work correctly when url exists', done => {
+  it('extname should work correctly when url exists', (done) => {
     const items = [{ status: 'done', uid: 'upload-list-item', url: '/example' }];
     const { container: wrapper, unmount } = render(
       <UploadList
         listType="picture"
-        onDownload={file => {
+        onDownload={(file) => {
           expect(file.url).toBe('/example');
           unmount();
           done();
@@ -886,7 +886,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -915,7 +915,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -939,7 +939,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toBe('');
     });
 
@@ -1045,7 +1045,7 @@ describe('Upload List', () => {
       let wrapper: ReturnType<typeof render>;
       const onChange = jest.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
         ({ fileList: files }) => {
-          const newFileList = files?.map<UploadFile<any>>(item => ({ ...item, thumbUrl }));
+          const newFileList = files?.map<UploadFile<any>>((item) => ({ ...item, thumbUrl }));
 
           wrapper.rerender(
             <Upload
@@ -1139,7 +1139,7 @@ describe('Upload List', () => {
     });
   });
 
-  it('[deprecated] should support transformFile', done => {
+  it('[deprecated] should support transformFile', (done) => {
     jest.useRealTimers();
     let wrapper: ReturnType<typeof render>;
     let lastFile: UploadFile;
@@ -1228,7 +1228,7 @@ describe('Upload List', () => {
           fileList={testFileList}
           action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
           multiple
-          onChange={info => {
+          onChange={(info) => {
             setTestFileList([...info.fileList]);
           }}
         >
@@ -1244,7 +1244,7 @@ describe('Upload List', () => {
 
     await act(() => {
       uploadRef.current.onBatchStart(
-        fileNames.map(fileName => {
+        fileNames.map((fileName) => {
           const file = new File([], fileName);
           (file as any).uid = fileName;
           return { file, parsedFile: file };
@@ -1540,5 +1540,32 @@ describe('Upload List', () => {
     );
 
     expect(container.querySelector('.ant-upload-list-item-error')).toBeTruthy();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/42056
+  describe('when form is disabled but upload is not', () => {
+    it('should not disable remove button', () => {
+      const { container } = render(
+        <Form name="base" disabled>
+          <Form.Item name="upload">
+            <Upload
+              disabled={false}
+              defaultFileList={[
+                {
+                  uid: '1',
+                  name: 'zzz.png',
+                  status: 'error',
+                  url: 'http://www.baidu.com/zzz.png',
+                },
+              ]}
+            />
+          </Form.Item>
+        </Form>,
+      );
+
+      const removeButton = container.querySelector('.ant-upload-list-item-actions > button');
+      expect(removeButton).toBeTruthy();
+      expect(removeButton).not.toBeDisabled();
+    });
   });
 });

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -29,8 +29,8 @@ const fileList: UploadProps['fileList'] = [
 
 describe('Upload List', () => {
   // Mock for rc-util raf
-  window.requestAnimationFrame = callback => window.setTimeout(callback, 16);
-  window.cancelAnimationFrame = id => window.clearTimeout(id);
+  window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16);
+  window.cancelAnimationFrame = (id) => window.clearTimeout(id);
 
   // jsdom not support `createObjectURL` yet. Let's handle this.
   const originCreateObjectURL = window.URL.createObjectURL;
@@ -678,7 +678,7 @@ describe('Upload List', () => {
           <Form.Item
             name="file"
             valuePropName="fileList"
-            getValueFromEvent={e => e.fileList}
+            getValueFromEvent={(e) => e.fileList}
             rules={[
               {
                 required: true,
@@ -801,12 +801,12 @@ describe('Upload List', () => {
     unmount();
   });
 
-  it('extname should work correctly when url exists', done => {
+  it('extname should work correctly when url exists', (done) => {
     const items = [{ status: 'done', uid: 'upload-list-item', url: '/example' }];
     const { container: wrapper, unmount } = render(
       <UploadList
         listType="picture"
-        onDownload={file => {
+        onDownload={(file) => {
           expect(file.url).toBe('/example');
           unmount();
           done();
@@ -886,7 +886,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -915,7 +915,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toEqual('data:image/png;base64,');
     });
     unmount();
@@ -939,7 +939,7 @@ describe('Upload List', () => {
     await waitFor(() => {
       expect(previewFunc).toHaveBeenCalled();
     });
-    await previewFunc(mockFile).then(dataUrl => {
+    await previewFunc(mockFile).then((dataUrl) => {
       expect(dataUrl).toBe('');
     });
 
@@ -1045,7 +1045,7 @@ describe('Upload List', () => {
       let wrapper: ReturnType<typeof render>;
       const onChange = jest.fn<void, Record<'fileList', UploadProps['fileList']>[]>(
         ({ fileList: files }) => {
-          const newFileList = files?.map<UploadFile<any>>(item => ({ ...item, thumbUrl }));
+          const newFileList = files?.map<UploadFile<any>>((item) => ({ ...item, thumbUrl }));
 
           wrapper.rerender(
             <Upload
@@ -1139,7 +1139,7 @@ describe('Upload List', () => {
     });
   });
 
-  it('[deprecated] should support transformFile', done => {
+  it('[deprecated] should support transformFile', (done) => {
     jest.useRealTimers();
     let wrapper: ReturnType<typeof render>;
     let lastFile: UploadFile;
@@ -1228,7 +1228,7 @@ describe('Upload List', () => {
           fileList={testFileList}
           action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
           multiple
-          onChange={info => {
+          onChange={(info) => {
             setTestFileList([...info.fileList]);
           }}
         >
@@ -1244,7 +1244,7 @@ describe('Upload List', () => {
 
     await act(() => {
       uploadRef.current.onBatchStart(
-        fileNames.map(fileName => {
+        fileNames.map((fileName) => {
           const file = new File([], fileName);
           (file as any).uid = fileName;
           return { file, parsedFile: file };
@@ -1563,7 +1563,7 @@ describe('Upload List', () => {
         </Form>,
       );
 
-      const removeButton = container.querySelector('.ant-upload-list-item-actions > button');
+      const removeButton = container.querySelector('.ant-upload-list-item-card-actions > button');
       expect(removeButton).toBeTruthy();
       expect(removeButton).not.toBeDisabled();
     });

--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -159,4 +159,8 @@ export interface UploadListProps<T = any> {
   appendAction?: React.ReactNode;
   appendActionVisible?: boolean;
   itemRender?: ItemRender<T>;
+  /**
+   * @internal Only the internal remove button is provided for use
+   */
+  disabled?: boolean;
 }


### PR DESCRIPTION
* chore(typo): update

* test(upload): add case

* fix: Upload disable state logic

* test: remove case

* chore: remove unused

(cherry picked from commit 6d0acb0518bc285e7a7717ae52fba0765d25e141)

# Conflicts:
#	components/upload/Upload.tsx
#	components/upload/UploadList/index.tsx

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/42056#issuecomment-1534369557

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Upload disable state logic      |
| 🇨🇳 Chinese |      修复 Upload 禁用状态逻辑     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e75f0f</samp>

The pull request adds a new feature to the `UploadList` component that allows disabling the remove button when the form is disabled but the upload is not. It also improves the code quality of the `Upload` and `UploadList` components and their tests by following TypeScript and ESLint conventions. The changes affect the files `Upload.tsx`, `UploadList/index.tsx`, `interface.tsx`, and `uploadlist.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e75f0f</samp>

*  Add `disabled` prop to `UploadListProps` interface to allow disabling remove button when form is disabled but upload is not ([link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dR52), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-15f89439652a2abdff4246641259805043f69e3312189bc6fd87a1a9cb3851fcR162-R165))
*  Use `import type` and `export type` syntax for `UploadProps` to indicate type-only usage and avoid duplicate exports ([link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL12-R18), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL19-R24))
*  Wrap single-argument arrow function parameters with parentheses to follow ESLint rule `arrow-parens` ([link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL58-R63), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL153-R162), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL162-R174), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL263-R270), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL273-R280), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL339-R346), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL384-R391), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dL176-R177), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-facbb1dee1bb7771145b37f482a70fb1fe9e43942520be5a31e6a36aab1f059dL234-R235), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L32-R33), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L681-R681), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L804-R809), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L889-R889), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L918-R918), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L942-R942), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L1048-R1048), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L1142-R1142), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L1231-R1231), [link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L1247-R1247))
*  Reorder import statements in `uploadlist.test.tsx` to follow convention of importing types, components, utils, mocks, and requests ([link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390L2-R11))
*  Add test case in `uploadlist.test.tsx` to check that remove button is not disabled when form is disabled but upload is not ([link](https://github.com/ant-design/ant-design/pull/42143/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390R1544-R1570))
