### PR TITLE
fix: margin between menu item and submenu title

### DIFF
--- a/components/menu/style/vertical.tsx
+++ b/components/menu/style/vertical.tsx
@@ -19,6 +19,11 @@ const getVerticalInlineStyle: GenerateStyle<MenuToken, CSSObject> = (token) => {
   return {
     [`${componentCls}-item`]: {
       position: 'relative',
+
+      // https://github.com/ant-design/ant-design/blob/5e52057671f9781ad2b957b0ff9adfcd1eb1eb88/components/menu/style/index.less#L487-L489
+      [`&:not(:last-child)`]: {
+        marginBottom: marginXS,
+      },
     },
 
     [`${componentCls}-item, ${componentCls}-submenu-title`]: {


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/42159

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->



修改前后效果对比在这里 https://app.argos-ci.com/ant-design/ant-design/builds/7920/46194312


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Menu different margin between Menu.Item and Menu.Submenu in vertical and inline mode.        |
| 🇨🇳 Chinese |   修复 Menu.Item 与 Submenu 之间间距不统一的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1498169</samp>

Add bottom margin to vertical menu items in `components/menu/style/vertical.tsx`. This improves the style consistency of the ant-design library with styled-components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1498169</samp>

* Add bottom margin to vertical menu items, except for the last one, to match ant-design style ([link](https://github.com/ant-design/ant-design/pull/42160/files?diff=unified&w=0#diff-b7b7775fd3e73c4510f6e127d709629338c94f257ad4cde92ffa63c62f11e25bR22-R26))
