### PR TITLE
chore: fix genCssinjs with async-await

### DIFF
--- a/scripts/check-cssinjs.ts
+++ b/scripts/check-cssinjs.ts
@@ -23,22 +23,24 @@ console.error = (msg: any) => {
   }
 };
 
-generateCssinjs({
-  key: 'check',
-  render(Component: any) {
-    ReactDOMServer.renderToString(
-      React.createElement(
-        StyleProvider,
-        { linters: [logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter] },
-        React.createElement(Component),
-      ),
-    );
-  },
-});
+(async () => {
+  await generateCssinjs({
+    key: 'check',
+    render(Component: any) {
+      ReactDOMServer.renderToString(
+        React.createElement(
+          StyleProvider,
+          { linters: [logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter] },
+          React.createElement(Component),
+        ),
+      );
+    },
+  });
 
-if (errorCount > 0) {
-  console.log(chalk.red(`❌  CSS-in-JS check failed with ${errorCount} errors.`));
-  process.exit(1);
-} else {
-  console.log(chalk.green(`✅  CSS-in-JS check passed.`));
-}
+  if (errorCount > 0) {
+    console.log(chalk.red(`❌  CSS-in-JS check failed with ${errorCount} errors.`));
+    process.exit(1);
+  } else {
+    console.log(chalk.green(`✅  CSS-in-JS check passed.`));
+  }
+})();

--- a/scripts/collect-token-statistic.ts
+++ b/scripts/collect-token-statistic.ts
@@ -17,25 +17,25 @@ const bar = new ProgressBar('🚀 Collecting by component: [:bar] :component (:c
   total: styleFiles.length,
 });
 
-generateCssinjs({
-  key: 'file',
-  beforeRender(componentName: string) {
-    bar.tick(1, { component: componentName });
-  },
-  render(Component: any) {
-    ReactDOMServer.renderToString(React.createElement(Component));
-    // Render wireframe
-    ReactDOMServer.renderToString(
-      React.createElement(
-        DesignTokenContext.Provider,
-        { value: { token: { ...seedToken, wireframe: true } } },
-        React.createElement(Component),
-      ),
-    );
-  },
-});
+(async () => {
+  await generateCssinjs({
+    key: 'file',
+    beforeRender(componentName: string) {
+      bar.tick(1, { component: componentName });
+    },
+    render(Component: any) {
+      ReactDOMServer.renderToString(React.createElement(Component));
+      // Render wireframe
+      ReactDOMServer.renderToString(
+        React.createElement(
+          DesignTokenContext.Provider,
+          { value: { token: { ...seedToken, wireframe: true } } },
+          React.createElement(Component),
+        ),
+      );
+    },
+  });
 
-(() => {
   const tokenPath = `${process.cwd()}/components/version/token.json`;
   fs.writeJsonSync(tokenPath, statistic, 'utf8');
   console.log(chalk.green(`✅  Collected token statistics successfully, check it in`), tokenPath);

--- a/scripts/generate-cssinjs.ts
+++ b/scripts/generate-cssinjs.ts
@@ -1,8 +1,15 @@
 import { globSync } from 'glob';
 import path from 'path';
+import type { FC } from 'react';
 import React from 'react';
 
 type StyleFn = (prefix?: string) => void;
+
+type GenCssinjs = (options: {
+  key: string;
+  render: (component: FC) => void;
+  beforeRender?: (componentName: string) => void;
+}) => Promise<void>;
 
 export const styleFiles = globSync(
   path.join(
@@ -11,26 +18,29 @@ export const styleFiles = globSync(
   ),
 );
 
-export const generateCssinjs = ({ key, beforeRender, render }: any) => {
-  styleFiles.forEach(async (file) => {
+export const generateCssinjs: GenCssinjs = async ({ key, beforeRender, render }) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const file of styleFiles) {
     const pathArr = file.split('/');
     const styleIndex = pathArr.lastIndexOf('style');
     const componentName = pathArr[styleIndex - 1];
     let useStyle: StyleFn = () => {};
     if (file.includes('grid')) {
+      // eslint-disable-next-line no-await-in-loop
       const { useColStyle, useRowStyle } = await import(file);
       useStyle = (prefixCls: string) => {
         useRowStyle(prefixCls);
         useColStyle(prefixCls);
       };
     } else {
+      // eslint-disable-next-line no-await-in-loop
       useStyle = (await import(file)).default;
     }
-    const Component: React.FC = () => {
+    const Demo: FC = () => {
       useStyle(`${key}-${componentName}`);
       return React.createElement('div');
     };
     beforeRender?.(componentName);
-    render?.(Component);
-  });
+    render?.(Demo);
+  }
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
https://unpkg.com/browse/antd@5.4.7/es/version/token.json
产物空了，原因是 async import 上层没有 await，整个方法异步执行了。
其实改成 Promise.all 还能优化一下执行速度，但是在 swc 下已经很快了：
![GIF](https://user-images.githubusercontent.com/27722486/236757851-89729def-4b95-4fcc-a2a7-4609112fc772.gif)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ea6c60</samp>

Improved the `generateCssinjs` function and its usage in three scripts: `generate-cssinjs.ts`, `check-cssinjs.ts`, and `collect-token-statistic.ts`. The main goals were to enhance the type safety, readability, and correctness of the function, and to fix a bug that caused the CSS-in-JS check script to exit prematurely. These changes aimed to improve the quality and consistency of the style and design token processing in the ant-design project.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ea6c60</samp>

*  Wrap `generateCssinjs` function in async IIFE to fix CSS-in-JS check script bug ([link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-033fabf4de4c9af9c5add02d7253892b5de7bbf8bbffe720b022fc7e9177fd20L26-R46), [link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-7cb0a86c66771adbfc0d32cfa95c05e937d41e66ab268c74494cae8d7c4a7f6dL20-R38))
*  Change `React` import to import only `FC` type and add type annotation to `generateCssinjs` function to improve type safety and readability ([link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-f767f34c2dcf1e08fb6be20f2ed33bb0aaa2aad39c7c97c07c71ab7c7193033cL3-R13))
*  Change `styleFiles.forEach` loop to `for...of` loop with `await` keyword to avoid race conditions or errors when importing style files dynamically ([link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-f767f34c2dcf1e08fb6be20f2ed33bb0aaa2aad39c7c97c07c71ab7c7193033cL14-R23))
*  Add ESLint comment to disable `no-await-in-loop` rule for `import` statement ([link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-f767f34c2dcf1e08fb6be20f2ed33bb0aaa2aad39c7c97c07c71ab7c7193033cR29))
*  Rename `Component` variable to `Demo` to avoid confusion with `Component` type ([link](https://github.com/ant-design/ant-design/pull/42212/files?diff=unified&w=0#diff-f767f34c2dcf1e08fb6be20f2ed33bb0aaa2aad39c7c97c07c71ab7c7193033cL27-R45))
