### PR TITLE
fix: Popover display empty div when title and content is null

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -49,8 +49,8 @@ describe('Popover', () => {
     );
     fireEvent.click(container.querySelector('span')!);
 
-    expect(container.querySelector('.ant-popover-title')?.textContent).toBeFalsy();
-    expect(container.querySelector('.ant-popover-inner-content')?.textContent).toBeFalsy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup).toBe(null);
   });
 
   it('should not render popover when the title & content props is empty', () => {
@@ -61,8 +61,8 @@ describe('Popover', () => {
     );
     fireEvent.click(container.querySelector('span')!);
 
-    expect(container.querySelector('.ant-popover-title')?.textContent).toBeFalsy();
-    expect(container.querySelector('.ant-popover-inner-content')?.textContent).toBeFalsy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup).toBe(null);
   });
 
   it('props#overlay do not warn anymore', () => {

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -21,14 +21,12 @@ interface OverlayProps {
   content?: PopoverProps['content'];
 }
 
-const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => {
-  return (
-    <>
-      {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
-      <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
-    </>
-  );
-};
+const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => (
+  <>
+    {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
+    <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
+  </>
+);
 
 const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
   const {

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -22,9 +22,6 @@ interface OverlayProps {
 }
 
 const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => {
-  if (!title && !content) {
-    return null;
-  }
   return (
     <>
       {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
@@ -65,7 +62,9 @@ const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
       prefixCls={prefixCls}
       overlayClassName={overlayCls}
       ref={ref}
-      overlay={<Overlay prefixCls={prefixCls} title={title} content={content} />}
+      overlay={
+        (title || content) && <Overlay prefixCls={prefixCls} title={title} content={content} />
+      }
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}
       data-popover-inject
     />,

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import type { AbstractTooltipProps } from '../tooltip';
-import Tooltip from '../tooltip';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
+import { ConfigContext } from '../config-provider';
+import type { AbstractTooltipProps } from '../tooltip';
+import Tooltip from '../tooltip';
 import PurePanel from './PurePanel';
 // CSSINJS
 import useStyle from './style';
@@ -63,7 +63,7 @@ const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
       overlayClassName={overlayCls}
       ref={ref}
       overlay={
-        (title || content) && <Overlay prefixCls={prefixCls} title={title} content={content} />
+        title || content ? <Overlay prefixCls={prefixCls} title={title} content={content} /> : null
       }
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}
       data-popover-inject


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix #42216 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Popover display empty div when title and content is null      |
| 🇨🇳 Chinese |    修复: 当title和content属性均为空值时，Popover组件展示空白气泡      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eab7c90</samp>

Simplify `Popover` component logic and rendering. Remove redundant `title` and `content` props from `OverlayProps` and render `Overlay` only when it has content.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eab7c90</samp>

* Remove unnecessary check for `title` and `content` in `OverlayProps` interface ([link](https://github.com/ant-design/ant-design/pull/42217/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L25-L27))
* Conditionally render `Overlay` component in `Popover` component based on `title` or `content` ([link](https://github.com/ant-design/ant-design/pull/42217/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L68-R67))
