### PR TITLE
fix: add props to notification open api

### DIFF
--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -301,4 +301,37 @@ describe('notification', () => {
 
     expect(document.querySelectorAll("[data-testid='test-notification']").length).toBe(1);
   });
+
+  it('support top', async () => {
+    notification.config({
+      top: 300,
+    });
+
+    notification.open({
+      message: 'Notification Title',
+      top: 100,
+    });
+    await awaitPromise();
+
+    expect((document.querySelector('.ant-notification') as HTMLElement)?.style?.top).toEqual(
+      '100px',
+    );
+  });
+
+  it('support bottom', async () => {
+    notification.config({
+      bottom: 300,
+      placement:'bottomRight',
+    });
+
+    notification.open({
+      message: 'Notification Title',
+      bottom: 100,
+    });
+    await awaitPromise();
+
+    expect((document.querySelector('.ant-notification') as HTMLElement)?.style?.bottom).toEqual(
+      '100px',
+    );
+  });
 });

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -15,6 +15,9 @@ export type NotificationPlacement =
 export type IconType = 'success' | 'info' | 'error' | 'warning';
 
 export interface ArgsProps {
+  top?: number;
+  bottom?: number;
+  getContainer?: () => HTMLElement;
   message: React.ReactNode;
   description?: React.ReactNode;
   btn?: React.ReactNode;

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -86,7 +86,10 @@ export function useInternalNotification(
   notificationConfig?: HolderProps,
 ): readonly [NotificationInstance, React.ReactElement] {
   const holderRef = React.useRef<HolderRef>(null);
-
+  const [positionConfig, setPositionConfig] = React.useState<Pick<
+    HolderProps,
+    'top' | 'bottom' | 'getContainer'
+  > | null>(null);
   // ================================ API ================================
   const wrapAPI = React.useMemo<NotificationInstance>(() => {
     // Wrap with notification content
@@ -105,7 +108,24 @@ export function useInternalNotification(
       const { open: originOpen, prefixCls, hashId } = holderRef.current;
       const noticePrefixCls = `${prefixCls}-notice`;
 
-      const { message, description, icon, type, btn, className, ...restConfig } = config;
+      const {
+        message,
+        description,
+        icon,
+        type,
+        btn,
+        className,
+        top,
+        bottom,
+        getContainer,
+        ...restConfig
+      } = config;
+
+      setPositionConfig({
+        top: top ?? notificationConfig?.top,
+        bottom: bottom ?? notificationConfig?.bottom,
+        getContainer: getContainer ?? notificationConfig?.getContainer,
+      });
 
       return originOpen({
         placement: 'topRight',
@@ -153,7 +173,12 @@ export function useInternalNotification(
   // ============================== Return ===============================
   return [
     wrapAPI,
-    <Holder key="notification-holder" {...notificationConfig} ref={holderRef} />,
+    <Holder
+      key="notification-holder"
+      {...notificationConfig}
+      {...positionConfig}
+      ref={holderRef}
+    />,
   ] as const;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/41804

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add props to `notification` open api      |
| 🇨🇳 Chinese |     为 `notification` 组件的 `open` api 补充 props       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc9eaad</samp>

Added support for custom positioning of the notification component. The `useInternalNotification` hook and the `IconType` interface were updated to handle `top`, `bottom`, and `getContainer` props. New test cases were added to `components/notification/__tests__/index.test.tsx` to verify the functionality.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc9eaad</samp>

*  Add support for `top`, `bottom`, and `getContainer` props to customize the position and container of the notification element ([link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-c80bd08ac7a1f6a8ae2046fe84cc562807b2d11b1a63316286546b888a86ed08R18-R20), [link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL89-R92), [link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL108-R129), [link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL156-R181))
*  Update the `useInternalNotification` hook to destructure and set the props from the `config` object or the default `notificationConfig` object ([link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL108-R129))
*  Pass the `positionConfig` state to the `Holder` component and apply it to the notification element ([link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL89-R92), [link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL156-R181))
*  Add test cases to `components/notification/__tests__/index.test.tsx` to check the position of the notification element with different props ([link](https://github.com/ant-design/ant-design/pull/42223/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690R304-R336))
