### PR TITLE
fix: Popover display empty div when title and content is null

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -15,8 +15,8 @@ describe('Popover', () => {
     );
     expect(document.querySelector('.ant-popover')).toBe(null);
     fireEvent.click(popover.container.querySelector('span')!);
-    const popup = document.querySelector('.ant-popover')!;
-    expect(popup.querySelector('.ant-popover-inner-content')).toBeTruthy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup?.querySelector?.('.ant-popover-inner-content')).toBeTruthy();
   });
 
   it('shows content for render functions', () => {

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -33,9 +33,9 @@ describe('Popover', () => {
 
     const popup = document.querySelector('.ant-popover');
     expect(popup).not.toBe(null);
-    expect(popup.innerHTML).toContain('some-title');
-    expect(popup.innerHTML).toContain('some-content');
-    expect(popup.innerHTML).toMatchSnapshot();
+    expect(popup?.innerHTML).toContain('some-title');
+    expect(popup?.innerHTML).toContain('some-content');
+    expect(popup?.innerHTML).toMatchSnapshot();
   });
 
   it('handles empty title/content props safely', () => {

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -15,7 +15,7 @@ describe('Popover', () => {
     );
     expect(document.querySelector('.ant-popover')).toBe(null);
     fireEvent.click(popover.container.querySelector('span')!);
-    const popup = document.querySelector('.ant-popover');
+    const popup = document.querySelector('.ant-popover')!;
     expect(popup.querySelector('.ant-popover-inner-content')).toBeTruthy();
   });
 

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -8,34 +8,30 @@ describe('Popover', () => {
   mountTest(Popover);
 
   it('should show overlay when trigger is clicked', () => {
-    const ref = React.createRef<any>();
-
     const popover = render(
-      <Popover ref={ref} content="console.log('hello world')" title="code" trigger="click">
+      <Popover content="console.log('hello world')" title="code" trigger="click">
         <span>show me your code</span>
       </Popover>,
     );
-
-    expect(ref.current.getPopupDomNode()).toBe(null);
-    expect(popover.container.querySelector('.ant-popover-inner-content')).toBeFalsy();
+    expect(document.querySelector('.ant-popover')).toBe(null);
     fireEvent.click(popover.container.querySelector('span')!);
-    expect(popover.container.querySelector('.ant-popover-inner-content')).toBeTruthy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup.querySelector('.ant-popover-inner-content')).toBeTruthy();
   });
 
   it('shows content for render functions', () => {
     const renderTitle = () => 'some-title';
     const renderContent = () => 'some-content';
-    const ref = React.createRef<any>();
 
     const popover = render(
-      <Popover ref={ref} content={renderContent} title={renderTitle} trigger="click">
+      <Popover content={renderContent} title={renderTitle} trigger="click">
         <span>show me your code </span>
       </Popover>,
     );
 
     fireEvent.click(popover.container.querySelector('span')!);
 
-    const popup = ref.current.getPopupDomNode();
+    const popup = document.querySelector('.ant-popover');
     expect(popup).not.toBe(null);
     expect(popup.innerHTML).toContain('some-title');
     expect(popup.innerHTML).toContain('some-content');
@@ -50,8 +46,8 @@ describe('Popover', () => {
     );
     fireEvent.click(container.querySelector('span')!);
 
-    expect(container.querySelector('.ant-popover-title')?.textContent).toBeFalsy();
-    expect(container.querySelector('.ant-popover-inner-content')?.textContent).toBeFalsy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup).toBe(null);
   });
 
   it('should not render popover when the title & content props is empty', () => {
@@ -62,8 +58,8 @@ describe('Popover', () => {
     );
     fireEvent.click(container.querySelector('span')!);
 
-    expect(container.querySelector('.ant-popover-title')?.textContent).toBeFalsy();
-    expect(container.querySelector('.ant-popover-inner-content')?.textContent).toBeFalsy();
+    const popup = document.querySelector('.ant-popover');
+    expect(popup).toBe(null);
   });
 
   it('props#overlay do not warn anymore', () => {

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -44,6 +44,16 @@ const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
   const prefixCls = getPrefixCls('popover', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
 
+  const mergedOverlay = React.useMemo<React.ReactNode>(() => {
+    if (_overlay) {
+      return _overlay;
+    }
+    if (!title && !content) {
+      return null;
+    }
+    return <Overlay prefixCls={prefixCls} title={title} content={content} />;
+  }, [_overlay, title, content, prefixCls]);
+
   return (
     <Tooltip
       placement={placement}
@@ -54,12 +64,7 @@ const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
       {...otherProps}
       prefixCls={prefixCls}
       ref={ref}
-      overlay={
-        _overlay ||
-        (title || content ? (
-          <Overlay prefixCls={prefixCls} title={title} content={content} />
-        ) : null)
-      }
+      overlay={mergedOverlay}
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}
     />
   );

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import type { AbstractTooltipProps } from '../tooltip';
-import Tooltip from '../tooltip';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
+import { ConfigContext } from '../config-provider';
+import type { AbstractTooltipProps } from '../tooltip';
+import Tooltip from '../tooltip';
 
 export interface PopoverProps extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;
@@ -19,17 +19,12 @@ interface OverlayPorps {
   content?: PopoverProps['content'];
 }
 
-const Overlay: React.FC<OverlayPorps> = ({ title, content, prefixCls }) => {
-  if (!title && !content) {
-    return null;
-  }
-  return (
-    <>
-      {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
-      <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
-    </>
-  );
-};
+const Overlay: React.FC<OverlayPorps> = ({ title, content, prefixCls }) => (
+  <>
+    {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
+    <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
+  </>
+);
 
 const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
   const {
@@ -59,7 +54,12 @@ const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
       {...otherProps}
       prefixCls={prefixCls}
       ref={ref}
-      overlay={_overlay || <Overlay prefixCls={prefixCls} title={title} content={content} />}
+      overlay={
+        _overlay ||
+        (title || content ? (
+          <Overlay prefixCls={prefixCls} title={title} content={content} />
+        ) : null)
+      }
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}
     />
   );

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.1.2",
-    "eslint-plugin-unicorn": "^44.0.0",
+    "eslint-plugin-unicorn": "^47.0.0",
     "fast-glob": "^3.2.11",
     "fetch-jsonp": "^1.1.3",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
* fix: Popover display empty div when title and content is null

* test: Popover add test

* lint: remove useless block statement

---------

Co-authored-by: MaHui <mahuiyoung@cmbchina.com>
(cherry picked from commit 4271ff0976099619005509de57d24381f9fa34e5)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
fix #42216
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: Popover display empty div when title and content is null       |
| 🇨🇳 Chinese |      修复: 当title和content属性均为空值时，Popover组件展示空白气泡     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36f2518</samp>

Refactored and tested the Popover component. Improved the test cases by using `document.querySelector` and checking the popup element. Simplified the component rendering and avoided empty overlays.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36f2518</samp>

*  Refactor Overlay component to use a single JSX fragment and render only if title or content props are truthy ([link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L22-R27), [link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L62-R62))
*  Reorder import statements in `index.tsx` to follow convention ([link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L2-R7))
*  Simplify test cases for showing and hiding the overlay in `index.test.tsx` by removing ref prop and using document.querySelector instead of getPopupDomNode ([link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-aba347c569ea59c8e23c5f2dea72628b23a47705e50cd9ea98c578bad2a38184L11-R19), [link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-aba347c569ea59c8e23c5f2dea72628b23a47705e50cd9ea98c578bad2a38184L28-R27), [link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-aba347c569ea59c8e23c5f2dea72628b23a47705e50cd9ea98c578bad2a38184L38-R34), [link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-aba347c569ea59c8e23c5f2dea72628b23a47705e50cd9ea98c578bad2a38184L53-R50), [link](https://github.com/ant-design/ant-design/pull/42229/files?diff=unified&w=0#diff-aba347c569ea59c8e23c5f2dea72628b23a47705e50cd9ea98c578bad2a38184L65-R62))
