### PR TITLE
chore: improved support for generics MenuItemType and MenuItemProps in the Menu component

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -18,7 +18,24 @@ export interface MenuItemProps extends Omit<RcMenuItemProps, 'title'> {
   title?: React.ReactNode;
 }
 
-const MenuItem: React.FC<MenuItemProps> = (props) => {
+type MenuItemComponent = React.FC<MenuItemProps>;
+
+type RestArgs<T> = T extends (arg: any, ...args: infer P) => any ? P : never;
+
+type GenericProps<T = unknown> = T extends infer U extends MenuItemProps
+  ? unknown extends U
+    ? MenuItemProps
+    : U
+  : MenuItemProps;
+
+interface GenericComponent extends Omit<MenuItemComponent, ''> {
+  <T extends MenuItemProps>(
+    props: GenericProps<T>,
+    ...args: RestArgs<MenuItemComponent>
+  ): ReturnType<MenuItemComponent>;
+}
+
+const MenuItem: GenericComponent = (props) => {
   const { className, children, icon, title, danger } = props;
   const {
     prefixCls,

--- a/components/menu/__tests__/type.test.tsx
+++ b/components/menu/__tests__/type.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Menu from '..';
+import Menu, { type MenuItemProps } from '..';
+import type { MenuItemType } from '../hooks/useItems';
 
 describe('Menu.typescript', () => {
   it('Menu.items', () => {
@@ -33,6 +34,73 @@ describe('Menu.typescript', () => {
           null,
         ]}
       />
+    );
+
+    expect(menu).toBeTruthy();
+  });
+
+  it('Menu.items should accept custom item type', () => {
+    interface CustomItemType extends MenuItemType {
+      'data-x': number;
+    }
+
+    const menu = (
+      <Menu<CustomItemType>
+        items={[
+          { key: 'item', title: 'Item', 'data-x': 0 },
+          {
+            key: 'submenu',
+            theme: 'light',
+            children: [
+              { key: 'submenu-item', title: 'SubmenuItem', 'data-x': 0 },
+              { key: 'submenu-submenu', theme: 'light', children: [], 'data-x': 0 },
+              { key: 'submenu-divider', type: 'divider' },
+              { key: 'submenu-group', type: 'group' },
+              null,
+            ],
+          },
+          {
+            key: 'group',
+            type: 'group',
+            children: [
+              { key: 'group-item', label: 'GroupItem', 'data-x': 0 },
+              { key: 'group-submenu', theme: 'light', children: [], 'data-x': 0 },
+              { key: 'group-divider', type: 'divider' },
+              { key: 'group-group', type: 'group' },
+              null,
+            ],
+          },
+          { key: 'divider', type: 'divider' },
+          null,
+        ]}
+      />
+    );
+
+    expect(menu).toBeTruthy();
+  });
+
+  it('MenuItem.props should accept custom props', () => {
+    interface CustomItemProps extends MenuItemProps {
+      'data-x': number;
+    }
+
+    const menu = (
+      <Menu>
+        <Menu.Item<CustomItemProps> key="item" title="Item" data-x={0} />
+        <Menu.SubMenu key="submenu" theme="light">
+          <Menu.Item<CustomItemProps> key="submenu-item" title="SubmenuItem" data-x={0} />
+          <Menu.SubMenu key="submenu-submenu" theme="light" />
+          <Menu.Divider key="submenu-divider" />
+          <Menu.ItemGroup key="submenu-group" />
+        </Menu.SubMenu>
+        <Menu.ItemGroup key="group">
+          <Menu.Item<CustomItemProps> key="group-item" title="GroupItem" data-x={0} />
+          <Menu.SubMenu key="group-submenu" theme="light" />
+          <Menu.Divider key="group-divider" />
+          <Menu.ItemGroup key="group-group" />
+        </Menu.ItemGroup>
+        <Menu.Divider key="divider" />
+      </Menu>
     );
 
     expect(menu).toBeTruthy();

--- a/components/menu/hooks/useItems.tsx
+++ b/components/menu/hooks/useItems.tsx
@@ -32,7 +32,12 @@ export interface MenuDividerType extends RcMenuDividerType {
   key?: React.Key;
 }
 
-export type ItemType = MenuItemType | SubMenuType | MenuItemGroupType | MenuDividerType | null;
+export type ItemType<T extends MenuItemType = MenuItemType> =
+  | T
+  | SubMenuType
+  | MenuItemGroupType
+  | MenuDividerType
+  | null;
 
 function convertItemsToNodes(list: ItemType[]) {
   return (list || [])

--- a/components/menu/hooks/useItems.tsx
+++ b/components/menu/hooks/useItems.tsx
@@ -16,14 +16,16 @@ export interface MenuItemType extends RcMenuItemType {
   title?: string;
 }
 
-export interface SubMenuType extends Omit<RcSubMenuType, 'children'> {
+export interface SubMenuType<T extends MenuItemType = MenuItemType>
+  extends Omit<RcSubMenuType, 'children'> {
   icon?: React.ReactNode;
   theme?: 'dark' | 'light';
-  children: ItemType[];
+  children: ItemType<T>[];
 }
 
-export interface MenuItemGroupType extends Omit<RcMenuItemGroupType, 'children'> {
-  children?: ItemType[];
+export interface MenuItemGroupType<T extends MenuItemType = MenuItemType>
+  extends Omit<RcMenuItemGroupType, 'children'> {
+  children?: ItemType<T>[];
   key?: React.Key;
 }
 
@@ -34,8 +36,8 @@ export interface MenuDividerType extends RcMenuDividerType {
 
 export type ItemType<T extends MenuItemType = MenuItemType> =
   | T
-  | SubMenuType
-  | MenuItemGroupType
+  | SubMenuType<T>
+  | MenuItemGroupType<T>
   | MenuDividerType
   | null;
 

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -116,7 +116,7 @@ Tree selection control.
 
 ### How to get parent node in onChange?
 
-We don't provide this since performance consideration. You can get by this way: <https://codesandbox.io/s/wk080nn81k>
+We don't provide this since performance consideration. You can get by this way: <https://codesandbox.io/s/get-parent-node-in-onchange-eb1608>
 
 ### Why sometime customize Option cause scroll break?
 

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -117,7 +117,7 @@ demo:
 
 ### onChange 时如何获得父节点信息？
 
-从性能角度考虑，我们默认不透出父节点信息。你可以这样获得：<https://codesandbox.io/s/wk080nn81k>
+从性能角度考虑，我们默认不透出父节点信息。你可以这样获得：<https://codesandbox.io/s/get-parent-node-in-onchange-eb1608>
 
 ### 自定义 Option 样式导致滚动异常怎么办？
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Fix: https://github.com/ant-design/ant-design/issues/36065

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | improved support for generics MenuItemType and MenuItemProps in the Menu component |
| 🇨🇳 Chinese | 改进了 Menu 组件对 MenuItemType 和 MenuItemProps 泛型的支持 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83dbe46</samp>

Refactored `Menu` and `MenuItem` components to support custom menu item types and props as generic parameters. This allows users to create and use their own menu item types with additional props and callbacks.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83dbe46</samp>

*  Modify `ItemType` type alias to support custom menu item types using generic parameter and conditional type ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-ee56d19904d4f35bfbaae5f787d9b49849310eb0f0941bc5599c27b64eb636c7L35-R40))
*  Import `ItemType` and `MenuItemType` types from `useItems` hook module to `Menu` component module ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-15ec76133b505a57a668763f4320e20a6f98d006b168097c97b43da4029b30a3R12))
*  Modify `CompoundedComponent` type alias to support custom props for `Menu` component using generic parameter and custom type aliases ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-15ec76133b505a57a668763f4320e20a6f98d006b168097c97b43da4029b30a3L22-R35))
*  Add `GenericComponent` interface to extend `CompoundedComponent` type and override call signature to accept generic props ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-15ec76133b505a57a668763f4320e20a6f98d006b168097c97b43da4029b30a3R42-R45))
*  Cast `Menu` component to `GenericComponent` type instead of `CompoundedComponent` type to export generic call signature and subcomponents ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-15ec76133b505a57a668763f4320e20a6f98d006b168097c97b43da4029b30a3L42-R57))
*  Modify `MenuItem` component to support custom props for different menu items using generic parameter and custom type alias ([link](https://github.com/ant-design/ant-design/pull/42240/files?diff=unified&w=0#diff-871ad818189b22c5d499c18f2e2d8905b9b6ff5e8fb01bc8008d57ffe2aa8509L21-R38))
