### PR TITLE
fix: fix Descriptions size small of CP

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -4,6 +4,7 @@ import Descriptions from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import { resetWarned } from '../../_util/warning';
 import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 describe('Descriptions', () => {
   mountTest(Descriptions);
@@ -266,5 +267,16 @@ describe('Descriptions', () => {
     const container = getByTestId('test-id');
     expect(container).toHaveAttribute('data-id', '12345');
     expect(container).toHaveAttribute('aria-describedby', 'some-label');
+  });
+
+  it('Descriptions should inherit the size from ConfigProvider if the componentSize is set ', () => {
+    const { container } = render(
+      <ConfigProvider componentSize="small">
+        <Descriptions bordered>
+          <Descriptions.Item label="small">small</Descriptions.Item>
+        </Descriptions>
+      </ConfigProvider>,
+    );
+    expect(container.querySelectorAll('.ant-descriptions-small')).toHaveLength(1);
   });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -11,6 +11,7 @@ import DescriptionsItem from './Item';
 import Row from './Row';
 
 import useStyle from './style';
+import SizeContext from '../config-provider/SizeContext';
 
 export interface DescriptionsContextProps {
   labelStyle?: React.CSSProperties;
@@ -127,7 +128,7 @@ function Descriptions({
   className,
   rootClassName,
   style,
-  size,
+  size: customizeSize,
   labelStyle,
   contentStyle,
   ...restProps
@@ -136,6 +137,9 @@ function Descriptions({
   const prefixCls = getPrefixCls('descriptions', customizePrefixCls);
   const [screens, setScreens] = React.useState<ScreenMap>({});
   const mergedColumn = getColumn(column, screens);
+
+  const size = React.useContext(SizeContext);
+  const mergedSize = customizeSize ?? size;
 
   const [wrapSSR, hashId] = useStyle(prefixCls);
   const responsiveObserver = useResponsiveObserver();
@@ -167,7 +171,7 @@ function Descriptions({
         className={classNames(
           prefixCls,
           {
-            [`${prefixCls}-${size}`]: size && size !== 'default',
+            [`${prefixCls}-${mergedSize}`]: mergedSize && mergedSize !== 'default',
             [`${prefixCls}-bordered`]: !!bordered,
             [`${prefixCls}-rtl`]: direction === 'rtl',
           },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ConfigProvider `size` prop not work on Descriptions. |
| 🇨🇳 Chinese | 修复 ConfigProvider `size` 对 Descriptions 无效的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17ad002</samp>

Added support for `componentSize` from `ConfigProvider` to `Descriptions` component. Renamed `size` prop to `customizeSize` and updated tests accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17ad002</samp>

*  Rename `size` prop of `Descriptions` component to `customizeSize` and use `SizeContext` to get `componentSize` value from `ConfigProvider` ([link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR14), [link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL130-R131), [link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR141-R143), [link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL170-R174))
*  Add `ConfigProvider` component to test file and create a new test case to check that `Descriptions` component inherits size from `ConfigProvider` ([link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R7), [link](https://github.com/ant-design/ant-design/pull/42244/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R271-R281))
