### PR TITLE
style: fix InputNumber out of range style error

### DIFF
--- a/components/input-number/__tests__/index.test.tsx
+++ b/components/input-number/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
+import Button from '../../button';
 
 describe('InputNumber', () => {
   focusTest(InputNumber, { refFocus: true });
@@ -67,6 +68,32 @@ describe('InputNumber', () => {
     );
     expect(
       container.querySelector('.anticon-arrow-down')?.className.includes('my-class-name'),
+    ).toBe(true);
+  });
+
+  it('renders correctly when the controlled mode number is out of range', () => {
+    const App: React.FC = () => {
+      const [value, setValue] = React.useState<number | null>(1);
+      return (
+        <>
+          <InputNumber min={1} max={10} value={value} onChange={(v) => setValue(v)} />
+          <Button
+            type="primary"
+            onClick={() => {
+              setValue(99);
+            }}
+          >
+            Reset
+          </Button>
+        </>
+      );
+    };
+    const { container } = render(<App />);
+    fireEvent.click(container.querySelector('button')!);
+    expect(
+      container
+        .querySelector('.ant-input-number')
+        ?.className.includes('ant-input-number-out-of-range'),
     ).toBe(true);
   });
 });

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -108,8 +108,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
 
         // ===================== Out Of Range =====================
         '&-out-of-range': {
-          input: {
-            color: colorError,
+          [`${componentCls}-input-wrap`]: {
+            input: {
+              color: colorError,
+            },
           },
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/42243

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

详情请查看issue

加了个选择器，增加了权重，使样式不会被inputNumber默认样式覆盖

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix inputNumber out of range style does not take effect  |
| 🇨🇳 Chinese |    修复 inputNumber out of range 样式不生效的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a2328c</samp>

Fixed a style bug and added a test case for `InputNumber` component. The bug caused the input element to have the wrong color when the component is disabled and out of range. The test case verified the error class name when the component is controlled and out of range.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a2328c</samp>

* Import `Button` component to use in a new test case for `InputNumber` ([link](https://github.com/ant-design/ant-design/pull/42250/files?diff=unified&w=0#diff-02fe56ddd3a9726e8e8428eea17c24505fb5fbdf02fa1416b2a02ebffcf067f8R8))
* Add a test case to check the rendering of `InputNumber` when the controlled mode number is out of range ([link](https://github.com/ant-design/ant-design/pull/42250/files?diff=unified&w=0#diff-02fe56ddd3a9726e8e8428eea17c24505fb5fbdf02fa1416b2a02ebffcf067f8R73-R98))
* Modify the style rule for the `ant-input-number-out-of-range` class name in `components/input-number/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/42250/files?diff=unified&w=0#diff-63d0bbc4ed8cb1745da77de552d75aa0fd581ef3eb2d25d0108b2d55eb5f1857L111-R114))
