### PR TITLE
Feat: Space support ref

### DIFF
--- a/components/space/__tests__/index.test.tsx
+++ b/components/space/__tests__/index.test.tsx
@@ -210,4 +210,16 @@ describe('Space', () => {
     expect(item).toBeEmptyDOMElement();
     expect(getComputedStyle(item).display).toBe('none');
   });
+
+  it('should ref work', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <Space ref={ref}>
+        <span>Text1</span>
+        <span>Text2</span>
+      </Space>,
+    );
+
+    expect(ref.current).toBe(container.firstChild);
+  });
 });

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import toArray from 'rc-util/lib/Children/toArray';
 import * as React from 'react';
+import useFlexGapSupport from '../_util/hooks/useFlexGapSupport';
 import { ConfigContext } from '../config-provider';
 import type { SizeType } from '../config-provider/SizeContext';
-import useFlexGapSupport from '../_util/hooks/useFlexGapSupport';
 import Compact from './Compact';
 import Item from './Item';
 
@@ -41,7 +41,7 @@ function getNumberSize(size: SpaceSize) {
   return typeof size === 'string' ? spaceSize[size] : size || 0;
 }
 
-const Space: React.FC<SpaceProps> = (props) => {
+const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
   const { getPrefixCls, space, direction: directionConfig } = React.useContext(ConfigContext);
 
   const {
@@ -142,6 +142,7 @@ const Space: React.FC<SpaceProps> = (props) => {
 
   return wrapSSR(
     <div
+      ref={ref}
       className={cn}
       style={{
         ...gapStyle,
@@ -152,13 +153,15 @@ const Space: React.FC<SpaceProps> = (props) => {
       <SpaceContext.Provider value={spaceContext}>{nodes}</SpaceContext.Provider>
     </div>,
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Space.displayName = 'Space';
 }
 
-type CompoundedComponent = React.FC<SpaceProps> & {
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  SpaceProps & React.RefAttributes<HTMLDivElement>
+> & {
   Compact: typeof Compact;
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Make `Space` support ref       |
| 🇨🇳 Chinese |      让 `Space` 组件支持 ref     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b83d36</samp>

This pull request adds ref support to the `Space` component, allowing users to access the underlying DOM element. It also updates the type definition and the test suite for the `Space` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b83d36</samp>

*  Wrap Space component with `React.forwardRef` and pass ref prop to div element ([link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L44-R44), [link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948R145), [link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L155-R156), [link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L161-R164))
* Update type definition of CompoundedComponent to match forward ref component ([link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L161-R164))
* Reorder import statements in `components/space/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L4-R6))
* Add test case for ref prop of Space component in `components/space/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42266/files?diff=unified&w=0#diff-93edd300f3e0d705dfe5647471697e62c1698695f56c65e766221ef0985d859cR213-R224))
