### PR TITLE
feat: add onPopupClick props

### DIFF
--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -2,14 +2,14 @@ import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import classNames from 'classnames';
 import * as React from 'react';
 import type { PopconfirmProps } from '.';
+import ActionButton from '../_util/ActionButton';
+import { getRenderPropValue } from '../_util/getRenderPropValue';
 import Button from '../button';
 import { convertLegacyProps } from '../button/button';
 import { ConfigContext } from '../config-provider';
-import defaultLocale from '../locale/en_US';
 import { useLocale } from '../locale';
+import defaultLocale from '../locale/en_US';
 import PopoverPurePanel from '../popover/PurePanel';
-import ActionButton from '../_util/ActionButton';
-import { getRenderPropValue } from '../_util/getRenderPropValue';
 
 import useStyle from './style';
 
@@ -30,6 +30,7 @@ export interface OverlayProps
     | 'showCancel'
     | 'title'
     | 'description'
+    | 'onPopupClick'
   > {
   prefixCls: string;
   close?: Function;
@@ -52,6 +53,7 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
     close,
     onConfirm,
     onCancel,
+    onPopupClick,
   } = props;
 
   const { getPrefixCls } = React.useContext(ConfigContext);
@@ -59,7 +61,7 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
   const [contextLocale] = useLocale('Popconfirm', defaultLocale.Popconfirm);
 
   return (
-    <div className={`${prefixCls}-inner-content`}>
+    <div className={`${prefixCls}-inner-content`} onClick={onPopupClick}>
       <div className={`${prefixCls}-message`}>
         {icon && <span className={`${prefixCls}-message-icon`}>{icon}</span>}
         <div

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -286,4 +286,19 @@ describe('Popconfirm', () => {
     // expect(container.textContent).toEqual('Unmounted');
     expect(error).not.toHaveBeenCalled();
   });
+
+  it('should trigger onPopupClick', async () => {
+    const onPopupClick = jest.fn();
+
+    const popconfirm = render(
+      <Popconfirm title="pop test" onPopupClick={onPopupClick}>
+        <span>show me your code</span>
+      </Popconfirm>,
+    );
+    const triggerNode = popconfirm.container.querySelector('span')!;
+    fireEvent.click(triggerNode);
+    await waitFakeTimer();
+    fireEvent.click(popconfirm.container.querySelector('.ant-popover-inner-content')!);
+    expect(onPopupClick).toHaveBeenCalled();
+  });
 });

--- a/components/popconfirm/demo/basic.tsx
+++ b/components/popconfirm/demo/basic.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Button, message, Popconfirm } from 'antd';
+import React from 'react';
 
 const confirm = (e: React.MouseEvent<HTMLElement>) => {
   console.log(e);

--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -45,6 +45,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 | description | The description of the confirmation box title | ReactNode \| () => ReactNode | - | 5.1.0 |
 | onCancel | A callback of cancel | function(e) | - |  |
 | onConfirm | A callback of confirmation | function(e) | - |  |
+| onPopupClick | 弹出气泡点击事件 | function(e) | - | 5.5.0 |
 
 Consult [Tooltip's documentation](/components/tooltip/#api) to find more APIs.
 

--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -45,7 +45,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 | description | The description of the confirmation box title | ReactNode \| () => ReactNode | - | 5.1.0 |
 | onCancel | A callback of cancel | function(e) | - |  |
 | onConfirm | A callback of confirmation | function(e) | - |  |
-| onPopupClick | 弹出气泡点击事件 | function(e) | - | 5.5.0 |
+| onPopupClick | A callback of popup click | function(e) | - | 5.5.0 |
 
 Consult [Tooltip's documentation](/components/tooltip/#api) to find more APIs.
 

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -1,15 +1,15 @@
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import classNames from 'classnames';
-import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import KeyCode from 'rc-util/lib/KeyCode';
-import * as React from 'react';
+import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
+import * as React from 'react';
+import type { RenderFunction } from '../_util/getRenderPropValue';
+import { cloneElement } from '../_util/reactNode';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
 import { ConfigContext } from '../config-provider';
 import Popover from '../popover';
 import type { AbstractTooltipProps } from '../tooltip';
-import type { RenderFunction } from '../_util/getRenderPropValue';
-import { cloneElement } from '../_util/reactNode';
 import PurePanel, { Overlay } from './PurePanel';
 import usePopconfirmStyle from './style';
 
@@ -30,6 +30,7 @@ export interface PopconfirmProps extends AbstractTooltipProps {
     open: boolean,
     e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLDivElement>,
   ) => void;
+  onPopupClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 export interface PopconfirmState {

--- a/components/popconfirm/index.zh-CN.md
+++ b/components/popconfirm/index.zh-CN.md
@@ -46,6 +46,7 @@ demo:
 | description | 确认内容的详细描述 | ReactNode \| () => ReactNode | - | 5.1.0 |
 | onCancel | 点击取消的回调 | function(e) | - |  |
 | onConfirm | 点击确认的回调 | function(e) | - |  |
+| onPopupClick | 弹出气泡点击事件 | function(e) | - | 5.5.0 |
 
 更多属性请参考 [Tooltip](/components/tooltip-cn/#api)。
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/42265
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
新增onPopupClick事件，可用于阻止content内部的事件冒泡。
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        add onPopupClick props    |
| 🇨🇳 Chinese |       新增 onPopupClick 属性  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d18055</samp>

Added a new prop `onPopupClick` to `Popconfirm` component to enable custom click handling on the popconfirm content. Updated the API documentation, the demo, and the test cases accordingly. Also sorted and reordered some imports to follow the code style guidelines.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d18055</samp>

*  Add `onPopupClick` prop to `Popconfirm` component to allow customizing the click event on the popconfirm content ([link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285R33), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770R33), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770R56), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L62-R64))
*  Update API documentation for `Popconfirm` component in English and Chinese to include the new `onPopupClick` prop ([link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-b1926d74c842067e60808782af211d78c5b1d4b3506e435a52d922fbf13d5d8fR48), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-a78c867e8ff32690f90fe5ed8f0a120521a9bcfdfb1a94b271e99af5f9c354f1R49))
*  Add a test case for `onPopupClick` prop in `components/popconfirm/__tests__/index.test.tsx` to verify its functionality ([link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362R289-R303))
*  Reorder imports alphabetically in `components/popconfirm/index.tsx`, `components/popconfirm/demo/basic.tsx`, and `components/popconfirm/PurePanel.tsx` to follow the code style guidelines ([link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L3-R12), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-661442229d2d6d561e8842c81f83c4baa43ab7d6071a6d1ddc2f91427a4a8d8bL1-R2), [link](https://github.com/ant-design/ant-design/pull/42272/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L5-R12))
