### PR TITLE
docs: progress

### DIFF
--- a/.dumi/hooks/useProgress.ts
+++ b/.dumi/hooks/useProgress.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const ProgressContext = createContext<(value: boolean) => void>(() => {});
+
+const useProgress = () => useContext(ProgressContext);
+
+export default useProgress;

--- a/.dumi/theme/common/Link.tsx
+++ b/.dumi/theme/common/Link.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from 'react';
 import React, { forwardRef, startTransition } from 'react';
 import { useNavigate } from 'dumi';
+import useProgress from '../../hooks/useProgress';
 
 export type LinkProps = {
   to?: string;
@@ -11,12 +12,15 @@ export type LinkProps = {
 const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const { to, children, ...rest } = props;
   const navigate = useNavigate();
+  const setProgress = useProgress();
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     if (!to.startsWith('http')) {
+      setProgress(true);
       e.preventDefault();
       startTransition(() => {
         navigate(to);
+        setProgress(false);
       });
     }
   };

--- a/.dumi/theme/common/NProgress.tsx
+++ b/.dumi/theme/common/NProgress.tsx
@@ -1,5 +1,6 @@
 import { useNProgress } from '@tanem/react-nprogress';
 import React from 'react';
+import theme from 'antd';
 
 const Container: React.FC<{
   animationDuration: number;
@@ -20,34 +21,38 @@ const Container: React.FC<{
 const Bar: React.FC<{
   animationDuration: number;
   progress: number;
-}> = ({ animationDuration, progress }) => (
-  <div
-    style={{
-      background: '#29d',
-      height: 2,
-      left: 0,
-      marginLeft: `${(-1 + progress) * 100}%`,
-      position: 'fixed',
-      top: 0,
-      transition: `margin-left ${animationDuration}ms linear`,
-      width: '100%',
-      zIndex: 1031,
-    }}
-  >
+}> = ({ animationDuration, progress }) => {
+  const { token } = theme.useToken();
+
+  return (
     <div
       style={{
-        boxShadow: '0 0 10px #29d, 0 0 5px #29d',
-        display: 'block',
-        height: '100%',
-        opacity: 1,
-        position: 'absolute',
-        right: 0,
-        transform: 'rotate(3deg) translate(0px, -4px)',
-        width: 100,
+        background: token.colorPrimary,
+        height: 2,
+        left: 0,
+        marginLeft: `${(-1 + progress) * 100}%`,
+        position: 'fixed',
+        top: 0,
+        transition: `margin-left ${animationDuration}ms linear`,
+        width: '100%',
+        zIndex: 1031,
       }}
-    />
-  </div>
-);
+    >
+      <div
+        style={{
+          boxShadow: `0 0 10px ${token.colorPrimary}, 0 0 5px ${token.colorPrimary}`,
+          display: 'block',
+          height: '100%',
+          opacity: 1,
+          position: 'absolute',
+          right: 0,
+          transform: 'rotate(3deg) translate(0px, -4px)',
+          width: 100,
+        }}
+      />
+    </div>
+  );
+};
 
 const NProgress = ({ isAnimating }) => {
   const { animationDuration, isFinished, progress } = useNProgress({

--- a/.dumi/theme/common/NProgress.tsx
+++ b/.dumi/theme/common/NProgress.tsx
@@ -1,6 +1,6 @@
 import { useNProgress } from '@tanem/react-nprogress';
 import React from 'react';
-import theme from 'antd';
+import { theme } from 'antd';
 
 const Container: React.FC<{
   animationDuration: number;

--- a/.dumi/theme/common/NProgress.tsx
+++ b/.dumi/theme/common/NProgress.tsx
@@ -1,0 +1,64 @@
+import { useNProgress } from '@tanem/react-nprogress';
+import React from 'react';
+
+const Container: React.FC<{
+  animationDuration: number;
+  isFinished: boolean;
+  children?: React.ReactNode;
+}> = ({ animationDuration, children, isFinished }) => (
+  <div
+    style={{
+      opacity: isFinished ? 0 : 1,
+      pointerEvents: 'none',
+      transition: `opacity ${animationDuration}ms linear`,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Bar: React.FC<{
+  animationDuration: number;
+  progress: number;
+}> = ({ animationDuration, progress }) => (
+  <div
+    style={{
+      background: '#29d',
+      height: 2,
+      left: 0,
+      marginLeft: `${(-1 + progress) * 100}%`,
+      position: 'fixed',
+      top: 0,
+      transition: `margin-left ${animationDuration}ms linear`,
+      width: '100%',
+      zIndex: 1031,
+    }}
+  >
+    <div
+      style={{
+        boxShadow: '0 0 10px #29d, 0 0 5px #29d',
+        display: 'block',
+        height: '100%',
+        opacity: 1,
+        position: 'absolute',
+        right: 0,
+        transform: 'rotate(3deg) translate(0px, -4px)',
+        width: 100,
+      }}
+    />
+  </div>
+);
+
+const NProgress = ({ isAnimating }) => {
+  const { animationDuration, isFinished, progress } = useNProgress({
+    isAnimating,
+  });
+
+  return (
+    <Container animationDuration={animationDuration} isFinished={isFinished}>
+      <Bar animationDuration={animationDuration} progress={progress} />
+    </Container>
+  );
+};
+
+export default NProgress;

--- a/.dumi/theme/layouts/DocLayout/index.tsx
+++ b/.dumi/theme/layouts/DocLayout/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import { Helmet, useOutlet, useSiteData } from 'dumi';
-import React, { useContext, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useLocale from '../../../hooks/useLocale';
 import useLocation from '../../../hooks/useLocation';
 import GlobalStyles from '../../common/GlobalStyles';
@@ -14,6 +14,8 @@ import SiteContext from '../../slots/SiteContext';
 import '../../static/style';
 import ResourceLayout from '../ResourceLayout';
 import SidebarLayout from '../SidebarLayout';
+import NProgress from '../../common/NProgress';
+import { ProgressContext } from '../../../hooks/useProgress';
 
 const locales = {
   cn: {
@@ -35,6 +37,7 @@ const DocLayout: React.FC = () => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const { direction } = useContext(SiteContext);
   const { loading } = useSiteData();
+  const [progressing, setProgressing] = useState<boolean>(false);
 
   useLayoutEffect(() => {
     if (lang === 'cn') {
@@ -57,7 +60,7 @@ const DocLayout: React.FC = () => {
   useEffect(() => {
     const id = hash.replace('#', '');
 
-    if (id) document.getElementById(decodeURIComponent(id))?.scrollIntoView();
+    if (id && !loading) document.getElementById(decodeURIComponent(id))?.scrollIntoView();
   }, [loading, hash]);
 
   React.useEffect(() => {
@@ -112,9 +115,12 @@ const DocLayout: React.FC = () => {
         />
       </Helmet>
       <ConfigProvider direction={direction} locale={lang === 'cn' ? zhCN : undefined}>
-        <GlobalStyles />
-        <Header />
-        {content}
+        <ProgressContext.Provider value={setProgressing}>
+          <GlobalStyles />
+          <Header />
+          <NProgress isAnimating={loading || progressing} />
+          {content}
+        </ProgressContext.Provider>
       </ConfigProvider>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "@stackblitz/sdk": "^1.3.0",
     "@swc/core": "^1.3.50",
     "@swc/helpers": "^0.5.0",
+    "@tanem/react-nprogress": "^5.0.37",
     "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^14.0.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
给 Menu 切换时加一个全局 Progress。目前的实现比较 hack，等 umi 的优化方案敲定之后还可以改改。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a1258b</samp>

This pull request adds a progress bar component and a custom hook to the documentation theme of the ant-design library. It uses the `NProgress` component, the `useNProgress` hook, and the `useProgress` hook to show the loading and route transition status of the documentation pages. It also fixes a scroll bug in the hash anchor.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a1258b</samp>

*  Add a custom hook `useProgress` and a context `ProgressContext` to manage the state of a progress indicator component ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-8538169bf18dcbab70e357c2358b6526cc61e694e867fe0b045f6d09b2bf8168R1-R7))
*  Import and use the `useProgress` hook in the `Link` component to set the progress state before and after navigating to a target route ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bR4),[link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL14-R23))
*  Add a new component `NProgress` that uses the `useNProgress` hook from the `@tanem/react-nprogress` package to render a progress bar at the top of the page ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-b042594c0bf0be1cfdb5022c1e7e8228e63ed6f84348009b709dfc31e3fcf6d1R1-R64))
*  Add the `@tanem/react-nprogress` package as a dependency in the `package.json` file ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R175))
*  Add a new state variable `progressing` and a setter function `setProgressing` to the `DocLayout` component using the `useState` hook ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bL7-R7),[link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bR40))
*  Wrap the children components of the `DocLayout` component with the `ProgressContext` provider, passing the `setProgressing` function as the value ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bL115-R123))
*  Add the `NProgress` component as a sibling of the `Header` component in the `DocLayout` component, passing the `loading` and `progressing` states as the `isAnimating` prop ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bL115-R123))
*  Fix a bug in the `useEffect` hook of the `DocLayout` component that scrolls to the hash anchor after the page is loaded, by adding a condition to check if the loading state is false before scrolling ([link](https://github.com/ant-design/ant-design/pull/42277/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bL60-R63))
