### PR TITLE
fix: fix Steps size small of CP

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -29809,7 +29809,7 @@ exports[`ConfigProvider components Steps configProvider componentDisabled 1`] = 
 
 exports[`ConfigProvider components Steps configProvider componentSize large 1`] = `
 <div
-  class="config-steps config-steps-vertical"
+  class="config-steps config-steps-vertical config-steps-large"
 >
   <div
     class="config-steps-item config-steps-item-process config-steps-item-active"
@@ -29850,7 +29850,7 @@ exports[`ConfigProvider components Steps configProvider componentSize large 1`] 
 
 exports[`ConfigProvider components Steps configProvider componentSize middle 1`] = `
 <div
-  class="config-steps config-steps-vertical"
+  class="config-steps config-steps-vertical config-steps-middle"
 >
   <div
     class="config-steps-item config-steps-item-process config-steps-item-active"
@@ -29891,7 +29891,7 @@ exports[`ConfigProvider components Steps configProvider componentSize middle 1`]
 
 exports[`ConfigProvider components Steps configProvider componentSize small 1`] = `
 <div
-  class="config-steps config-steps-vertical"
+  class="config-steps config-steps-vertical config-steps-small"
 >
   <div
     class="config-steps-item config-steps-item-process config-steps-item-active"

--- a/components/steps/__tests__/index.test.tsx
+++ b/components/steps/__tests__/index.test.tsx
@@ -4,6 +4,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, screen } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
+import ConfigProvider from '../../config-provider';
 
 describe('Steps', () => {
   mountTest(Steps);
@@ -105,5 +106,14 @@ describe('Steps', () => {
       'Warning: [antd: Steps] Step is deprecated. Please use `items` directly.',
     );
     errorSpy.mockRestore();
+  });
+
+  it('Steps should inherit the size from ConfigProvider if the componentSize is set ', () => {
+    const { container } = render(
+      <ConfigProvider componentSize="small">
+        <Steps items={[{ title: 'In Progress' }, { title: 'Finished' }]} />
+      </ConfigProvider>,
+    );
+    expect(container.querySelectorAll('.ant-steps-small')).toHaveLength(1);
   });
 });

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -14,6 +14,7 @@ import useBreakpoint from '../grid/hooks/useBreakpoint';
 import Progress from '../progress';
 import useLegacyItems from './useLegacyItems';
 import useStyle from './style';
+import useSize from '../_util/hooks/useSize';
 
 export interface StepProps {
   className?: string;
@@ -55,7 +56,7 @@ type CompoundedComponent = React.FC<StepsProps> & {
 const Steps: CompoundedComponent = (props) => {
   const {
     percent,
-    size,
+    size: customizeSize,
     className,
     rootClassName,
     direction,
@@ -72,6 +73,8 @@ const Steps: CompoundedComponent = (props) => {
     () => (responsive && xs ? 'vertical' : direction),
     [xs, direction],
   );
+
+  const size = useSize(customizeSize);
 
   const prefixCls = getPrefixCls('steps', props.prefixCls);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ConfigProvider `size` prop not work on Steps.  |
| 🇨🇳 Chinese | 修复 ConfigProvider `size` 对 Steps 无效的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c2ed5e</samp>

Refactored `Steps` component to use `useSize` hook and added a test case for size inheritance from `ConfigProvider`. Renamed `size` prop to `customizeSize` for clarity.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c2ed5e</samp>

*  Rename `size` prop to `customizeSize` and use `useSize` hook to get the component size from global configuration or prop ([link](https://github.com/ant-design/ant-design/pull/42278/files?diff=unified&w=0#diff-a9a9cfe5e51c2d313f50fd8b15ef2d2723b06b9992d42063cf1ebe97023d1968R17), [link](https://github.com/ant-design/ant-design/pull/42278/files?diff=unified&w=0#diff-a9a9cfe5e51c2d313f50fd8b15ef2d2723b06b9992d42063cf1ebe97023d1968L58-R59), [link](https://github.com/ant-design/ant-design/pull/42278/files?diff=unified&w=0#diff-a9a9cfe5e51c2d313f50fd8b15ef2d2723b06b9992d42063cf1ebe97023d1968R77-R78))
* Add a test case to verify that `Steps` component inherits the size from `ConfigProvider` ([link](https://github.com/ant-design/ant-design/pull/42278/files?diff=unified&w=0#diff-17bea1bad52c2a4a8efbbb48ee1ad5b2a586233986b62ead0ccf67306f886bc3R7), [link](https://github.com/ant-design/ant-design/pull/42278/files?diff=unified&w=0#diff-17bea1bad52c2a4a8efbbb48ee1ad5b2a586233986b62ead0ccf67306f886bc3R110-R118))
