### PR TITLE
docs: improve Layout demo code

### DIFF
--- a/.dumi/global.css
+++ b/.dumi/global.css
@@ -7,7 +7,7 @@
 
 .demo-logo-vertical {
   height: 32px;
+  margin: 16px;
   background: rgba(255, 255, 255, 0.2);
   border-radius: 6px;
-  margin: 16px;
 }

--- a/.dumi/global.css
+++ b/.dumi/global.css
@@ -1,0 +1,13 @@
+.demo-logo {
+  width: 120px;
+  height: 32px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+}
+
+.demo-logo-vertical {
+  height: 32px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  margin: 16px;
+}

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -169,7 +169,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx extend context correc
       class="ant-layout-sider-children"
     >
       <div
-        class="logo"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -432,10 +432,10 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
 >
   <header
     class="ant-layout-header"
-    style="position: sticky; top: 0px; z-index: 1; width: 100%;"
+    style="position: sticky; top: 0px; z-index: 1; width: 100%; display: flex; align-items: center;"
   >
     <div
-      style="float: left; width: 120px; height: 31px; margin: 16px 24px 16px 0px; background: rgba(255, 255, 255, 0.2);"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -712,7 +712,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
       class="ant-layout-sider-children"
     >
       <div
-        style="height: 32px; margin: 16px; background: rgba(255, 255, 255, 0.2);"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -1498,7 +1498,7 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
       class="ant-layout-sider-children"
     >
       <div
-        class="logo"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-vertical ant-menu-dark ant-menu-inline-collapsed"
@@ -1857,7 +1857,7 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       class="ant-layout-sider-children"
     >
       <div
-        style="height: 32px; margin: 16px; background: rgba(255, 255, 255, 0.2);"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -2445,7 +2445,7 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
     </div>
   </aside>
   <section
-    class="ant-layout site-layout"
+    class="ant-layout"
   >
     <header
       class="ant-layout-header"
@@ -2504,9 +2504,10 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
 >
   <header
     class="ant-layout-header"
+    style="display: flex; align-items: center;"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -3329,10 +3330,11 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
   class="ant-layout"
 >
   <header
-    class="ant-layout-header header"
+    class="ant-layout-header"
+    style="display: flex; align-items: center;"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -4492,10 +4494,11 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
   class="ant-layout"
 >
   <header
-    class="ant-layout-header header"
+    class="ant-layout-header"
+    style="display: flex; align-items: center;"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -169,7 +169,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
       class="ant-layout-sider-children"
     >
       <div
-        class="logo"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -326,10 +326,10 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
 >
   <header
     class="ant-layout-header"
-    style="position:sticky;top:0;z-index:1;width:100%"
+    style="position:sticky;top:0;z-index:1;width:100%;display:flex;align-items:center"
   >
     <div
-      style="float:left;width:120px;height:31px;margin:16px 24px 16px 0;background:rgba(255, 255, 255, 0.2)"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -487,7 +487,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
       class="ant-layout-sider-children"
     >
       <div
-        style="height:32px;margin:16px;background:rgba(255, 255, 255, 0.2)"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -992,7 +992,7 @@ exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
       class="ant-layout-sider-children"
     >
       <div
-        class="logo"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -1171,7 +1171,7 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       class="ant-layout-sider-children"
     >
       <div
-        style="height:32px;margin:16px;background:rgba(255, 255, 255, 0.2)"
+        class="demo-logo-vertical"
       />
       <ul
         class="ant-menu ant-menu-root ant-menu-inline ant-menu-dark"
@@ -1386,7 +1386,7 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
     </div>
   </aside>
   <section
-    class="ant-layout site-layout"
+    class="ant-layout"
   >
     <header
       class="ant-layout-header"
@@ -1445,9 +1445,10 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
 >
   <header
     class="ant-layout-header"
+    style="display:flex;align-items:center"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -1743,10 +1744,11 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
   class="ant-layout"
 >
   <header
-    class="ant-layout-header header"
+    class="ant-layout-header"
+    style="display:flex;align-items:center"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"
@@ -2101,10 +2103,11 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
   class="ant-layout"
 >
   <header
-    class="ant-layout-header header"
+    class="ant-layout-header"
+    style="display:flex;align-items:center"
   >
     <div
-      class="logo"
+      class="demo-logo"
     />
     <ul
       class="ant-menu-overflow ant-menu ant-menu-root ant-menu-horizontal ant-menu-dark"

--- a/components/layout/demo/custom-trigger-debug.tsx
+++ b/components/layout/demo/custom-trigger-debug.tsx
@@ -73,7 +73,7 @@ const App: React.FC = () => {
   return (
     <Layout>
       <Sider trigger={null} collapsible collapsed={collapsed}>
-        <div className="logo" />
+        <div className="demo-logo-vertical" />
         <Menu
           theme="dark"
           mode="inline"

--- a/components/layout/demo/custom-trigger.tsx
+++ b/components/layout/demo/custom-trigger.tsx
@@ -19,7 +19,7 @@ const App: React.FC = () => {
   return (
     <Layout>
       <Sider trigger={null} collapsible collapsed={collapsed}>
-        <div className="logo" />
+        <div className="demo-logo-vertical" />
         <Menu
           theme="dark"
           mode="inline"

--- a/components/layout/demo/fixed-sider.tsx
+++ b/components/layout/demo/fixed-sider.tsx
@@ -46,7 +46,7 @@ const App: React.FC = () => {
           bottom: 0,
         }}
       >
-        <div style={{ height: 32, margin: 16, background: 'rgba(255, 255, 255, 0.2)' }} />
+        <div className="demo-logo-vertical" />
         <Menu theme="dark" mode="inline" defaultSelectedKeys={['4']} items={items} />
       </Sider>
       <Layout className="site-layout" style={{ marginLeft: 200 }}>

--- a/components/layout/demo/fixed.tsx
+++ b/components/layout/demo/fixed.tsx
@@ -10,16 +10,17 @@ const App: React.FC = () => {
 
   return (
     <Layout>
-      <Header style={{ position: 'sticky', top: 0, zIndex: 1, width: '100%' }}>
-        <div
-          style={{
-            float: 'left',
-            width: 120,
-            height: 31,
-            margin: '16px 24px 16px 0',
-            background: 'rgba(255, 255, 255, 0.2)',
-          }}
-        />
+      <Header
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 1,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <div className="demo-logo" />
         <Menu
           theme="dark"
           mode="horizontal"

--- a/components/layout/demo/responsive.md
+++ b/components/layout/demo/responsive.md
@@ -9,11 +9,3 @@ Layout.Sider 支持响应式布局。
 Layout.Sider supports responsive layout.
 
 > Note: You can get a responsive layout by setting `breakpoint`, the Sider will collapse to the width of `collapsedWidth` when window width is below the `breakpoint`. And a special trigger will appear if the `collapsedWidth` is set to 0.
-
-```css
-#components-layout-demo-responsive .logo {
-  height: 32px;
-  margin: 16px;
-  background: rgba(255, 255, 255, 0.2);
-}
-```

--- a/components/layout/demo/responsive.tsx
+++ b/components/layout/demo/responsive.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => {
           console.log(collapsed, type);
         }}
       >
-        <div className="logo" />
+        <div className="demo-logo-vertical" />
         <Menu
           theme="dark"
           mode="inline"

--- a/components/layout/demo/side.tsx
+++ b/components/layout/demo/side.tsx
@@ -48,10 +48,10 @@ const App: React.FC = () => {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Sider collapsible collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
-        <div style={{ height: 32, margin: 16, background: 'rgba(255, 255, 255, 0.2)' }} />
+        <div className="demo-logo-vertical" />
         <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" items={items} />
       </Sider>
-      <Layout className="site-layout">
+      <Layout>
         <Header style={{ padding: 0, background: colorBgContainer }} />
         <Content style={{ margin: '0 16px' }}>
           <Breadcrumb style={{ margin: '16px 0' }}>

--- a/components/layout/demo/top-side-2.md
+++ b/components/layout/demo/top-side-2.md
@@ -5,18 +5,3 @@
 ## en-US
 
 Both the top navigation and the sidebar, commonly used in application site.
-
-```css
-#components-layout-demo-top-side-2 .logo {
-  float: left;
-  width: 120px;
-  height: 31px;
-  margin: 16px 24px 16px 0;
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.ant-row-rtl #components-layout-demo-top-side-2 .logo {
-  float: right;
-  margin: 16px 0 16px 24px;
-}
-```

--- a/components/layout/demo/top-side-2.tsx
+++ b/components/layout/demo/top-side-2.tsx
@@ -37,8 +37,8 @@ const App: React.FC = () => {
 
   return (
     <Layout>
-      <Header className="header">
-        <div className="logo" />
+      <Header style={{ display: 'flex', alignItems: 'center' }}>
+        <div className="demo-logo" />
         <Menu theme="dark" mode="horizontal" defaultSelectedKeys={['2']} items={items1} />
       </Header>
       <Layout>

--- a/components/layout/demo/top-side.md
+++ b/components/layout/demo/top-side.md
@@ -5,18 +5,3 @@
 ## en-US
 
 Both the top navigation and the sidebar, commonly used in documentation site.
-
-```css
-#components-layout-demo-top-side .logo {
-  float: left;
-  width: 120px;
-  height: 31px;
-  margin: 16px 24px 16px 0;
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.ant-row-rtl #components-layout-demo-top-side .logo {
-  float: right;
-  margin: 16px 0 16px 24px;
-}
-```

--- a/components/layout/demo/top-side.tsx
+++ b/components/layout/demo/top-side.tsx
@@ -37,8 +37,8 @@ const App: React.FC = () => {
 
   return (
     <Layout>
-      <Header className="header">
-        <div className="logo" />
+      <Header style={{ display: 'flex', alignItems: 'center' }}>
+        <div className="demo-logo" />
         <Menu theme="dark" mode="horizontal" defaultSelectedKeys={['2']} items={items1} />
       </Header>
       <Content style={{ padding: '0 50px' }}>

--- a/components/layout/demo/top.md
+++ b/components/layout/demo/top.md
@@ -11,21 +11,3 @@ The most basic "header-content-footer" layout.
 Generally, the mainnav is placed at the top of the page, and includes the logo, the first level navigation, and the secondary menu (users, settings, notifications) from left to right in it. We always put contents in a fixed size navigation (eg: `1200px`), the layout of the whole page is stable, it's not affected by viewing area.
 
 Top-bottom structure is conform with the top-bottom viewing habit, it's a classical navigation pattern of websites. This pattern demonstrates efficiency in the main workarea, while using some vertical space. And because the horizontal space of the navigation is limited, this pattern is not suitable for cases when the first level navigation contains many elements or links.
-
-```css
-.site-layout-content {
-  min-height: 280px;
-  padding: 24px;
-}
-#components-layout-demo-top .logo {
-  float: left;
-  width: 120px;
-  height: 31px;
-  margin: 16px 24px 16px 0;
-  background: rgba(255, 255, 255, 0.3);
-}
-.ant-row-rtl #components-layout-demo-top .logo {
-  float: right;
-  margin: 16px 0 16px 24px;
-}
-```

--- a/components/layout/demo/top.tsx
+++ b/components/layout/demo/top.tsx
@@ -10,8 +10,8 @@ const App: React.FC = () => {
 
   return (
     <Layout className="layout">
-      <Header>
-        <div className="logo" />
+      <Header style={{ display: 'flex', alignItems: 'center' }}>
+        <div className="demo-logo" />
         <Menu
           theme="dark"
           mode="horizontal"

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -61,8 +61,8 @@ Style of a navigation should conform to its level.
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic Structure</code>
 <code src="./demo/top.tsx" compact background="grey">Header-Content-Footer</code>
-<code src="./demo/top-side-2.tsx" compact background="grey">Header Sider 2</code>
 <code src="./demo/top-side.tsx" compact background="grey">Header-Sider</code>
+<code src="./demo/top-side-2.tsx" compact background="grey">Header Sider 2</code>
 <code src="./demo/side.tsx" iframe="360">Sider</code>
 <code src="./demo/custom-trigger.tsx" compact background="grey">Custom trigger</code>
 <code src="./demo/responsive.tsx" compact background="grey">Responsive</code>

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -62,8 +62,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本结构</code>
 <code src="./demo/top.tsx" compact background="grey">上中下布局</code>
-<code src="./demo/top-side-2.tsx" compact background="grey">顶部-侧边布局-通栏</code>
 <code src="./demo/top-side.tsx" compact background="grey">顶部-侧边布局</code>
+<code src="./demo/top-side-2.tsx" compact background="grey">顶部-侧边布局-通栏</code>
 <code src="./demo/side.tsx" iframe="360">侧边布局</code>
 <code src="./demo/custom-trigger.tsx" compact background="grey">自定义触发器</code>
 <code src="./demo/responsive.tsx" compact background="grey">响应式布局</code>

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -703,7 +703,7 @@ describe('Menu', () => {
             collapsed={collapsed}
             onCollapse={() => setCollapsed(!collapsed)}
           >
-            <div className="logo" />
+            <div className="demo-logo" />
             <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline">
               <SubMenu key="sub1" icon={<UserOutlined />} title="User">
                 <Menu.Item key="3">Tom</Menu.Item>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
简化了一些演示里的自定义样式。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c1fa76</samp>

This pull request refactors the logo style in the layout and menu demos and documents. It adds two global CSS classes for the logo, `demo-logo` and `demo-logo-vertical`, and replaces the inline styles and the old `logo` class with them. It also improves the header layout with flex display and alignment. It also swaps the order of two demos in the layout documents to make them consistent.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c1fa76</samp>

*  Add two new CSS classes for the demo logo, one for horizontal and one for vertical layout, in `.dumi/global.css` to unify the logo style across different layout demos and make it easier to adjust the logo size and position. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-3e8983100b087a6177949ced2d0afce143b206d325eb795c008fba231d14851dR1-R13))
* Replace the `logo` class with the `demo-logo-vertical` class in four layout demos (`custom-trigger-debug.tsx`, `custom-trigger.tsx`, `fixed-sider.tsx`, and `responsive.tsx`) to apply the new logo style and remove the redundant CSS code. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-4fc7e96807a0180c039d04a5b444d17aae7490ce2c9db1a76c07328dc05b4bfeL76-R76), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-6841519a953d2c70f06eb02062e54e2e87103f95e282d59c6db85703a1612f05L22-R22), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-87233f25967c9e016b0d5b69527b8dadadcb2eb412ae81980846cd9ec51172fcL49-R49), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-79c9cb2266f7c6207e16dd935b25e35295c32740fa286ec84df1dce899d0ef3fL24-R24))
* Replace the inline style with the `demo-logo-vertical` class and remove the `site-layout` class from the layout in the `side.tsx` demo to apply the new logo style and simplify the layout class name. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-c191ab4e67d7188e461cdf3617acd0baa1411f15c8f93a0c893b82ed80a1c2aeL51-R54))
* Replace the `logo` class with the `demo-logo` class and add a flex display and alignment to the header in four layout demos (`fixed.tsx`, `top-side-2.tsx`, `top-side.tsx`, and `top.tsx`) to apply the new logo style and improve the header layout. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-c8eaa4810070584591489a727e42daff97661b7b608a601474d2167f9bdaeb7dL13-R23), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-ef956bca85e7bd3ae0bf36b9ff295b2756d517a5254ef230c52d172c278f0f07L40-R41), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-fa09e88c6c73fe2900783fb678c3d89e43ccd28b0d58dd20b0062f961b7b0f09L40-R41), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-d57a481b7905fd5c3078534272b1fb0c7bce3fbab82fff0578ac5d3a210ef628L13-R14))
* Remove the CSS code for the `logo` class in three layout documents (`responsive.md`, `top-side-2.md`, and `top-side.md`) to avoid duplicate and conflicting CSS code with the global CSS file. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-714fd7d6009a8226475ad05097b38ae297b654b7856175be5d3ce5d294d5b969L12-L19), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-8155599572c3f7ae3cd5617c8aa7ffc799bddb62d31de4776df7e8821b50f9f6L8-L22), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-765a48fa489ce394e006b8d2c47087193d7c03f333514f507f69cebdcdbcd673L8-L22))
* Remove the CSS code for the `logo` class and the `site-layout-content` class in the `top.md` document to avoid duplicate and conflicting CSS code with the global CSS file and the antd layout component. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-1623ec31b5e56124f053f577acb9b6d4f0a02f0521f65bb6347e0ab07332ec2bL14-L31))
* Swap the order of the `top-side.tsx` and `top-side-2.tsx` demos in the English and Chinese layout documents (`index.en-US.md` and `index.zh-CN.md`) to make the demo order consistent with the layout menu order. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-cfed203e63a6fda2d4fca4d36368902c262c5045bab99e637d56f3b8ab6e0162L64-R65), [link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-e569cd5cdaf648d1fff09eeab44bd2dedb1793e6f909330016137d3120cea581L65-R66))
* Replace the `logo` class with the `demo-logo` class in the menu test file (`index.test.tsx`) to apply the new logo style and make the test case consistent with the demo code. ([link](https://github.com/ant-design/ant-design/pull/42283/files?diff=unified&w=0#diff-1cad196e610d68ddf06e127c070d41cb9e4bfa00016e77c472841f261f154433L706-R706))
