### PR TITLE
fix: style not applied to overflowed Menu

### DIFF
--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -152,7 +152,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
         <RcMenu
           getPopupContainer={getPopupContainer}
           overflowedIndicator={<EllipsisOutlined />}
-          overflowedIndicatorPopupClassName={`${prefixCls}-${theme}`}
+          overflowedIndicatorPopupClassName={classNames(prefixCls, `${prefixCls}-${theme}`)}
           mode={mergedMode}
           selectable={mergedSelectable}
           onClick={onItemClick}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
I've noticed that links in overflow menu were not working, if you were not clicking on the exact text in the link. This is due to `prefixCls` not being applied to the overflow menu.

| ![Screenshot 2023-05-11 at 14 26 42](https://github.com/ant-design/ant-design/assets/3399445/942ce890-514b-47df-8b2e-b560e066ff01) | ![Screenshot 2023-05-11 at 14 27 13](https://github.com/ant-design/ant-design/assets/3399445/2298d0ed-c27d-490a-bc8b-52016de5ab9e) |
| ---------- | --------- |


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix style not applied to overflowed Menu |
| 🇨🇳 Chinese | 修復樣式不適用於溢出的菜單 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 349eff8</samp>

Fixed a theme bug for the overflowed menu items in `Menu` component. Used `classNames` instead of string interpolation for the `overflowedIndicatorPopupClassName` prop of `rc-menu`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 349eff8</samp>

* Fix popup menu theme bug for overflowed menu items by using `classNames` for `overflowedIndicatorPopupClassName` prop of `rc-menu` component ([link](https://github.com/ant-design/ant-design/pull/42290/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L155-R155))
