### PR TITLE
chore: add warning of tip with spin

### DIFF
--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-import { waitFakeTimer } from '../../../tests/utils';
+import React from 'react';
 import Spin from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import { waitFakeTimer } from '../../../tests/utils';
 
 describe('Spin', () => {
   mountTest(Spin);
@@ -51,5 +51,16 @@ describe('Spin', () => {
   it('should render 0', () => {
     const { container } = render(<Spin>{0}</Spin>);
     expect(container.querySelector('.ant-spin-container')?.textContent).toBe('0');
+  });
+
+  it('warning tip without nest', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { container } = render(<Spin tip="Not Show" />);
+    expect(container.querySelector('.ant-spin-text')).toBeFalsy();
+
+    expect(errSpy).toHaveBeenCalledWith('Warning: [antd: Spin] `tip` only work in nest pattern.');
+
+    errSpy.mockRestore();
   });
 });

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
-import { debounce } from 'throttle-debounce';
 import omit from 'rc-util/lib/omit';
 import * as React from 'react';
+import { debounce } from 'throttle-debounce';
+import { cloneElement, isValidElement } from '../_util/reactNode';
+import warning from '../_util/warning';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import { cloneElement, isValidElement } from '../_util/reactNode';
 import useStyle from './style/index';
 
 const SpinSizes = ['small', 'default', 'large'] as const;
@@ -108,6 +109,10 @@ const Spin: React.FC<SpinClassProps> = (props) => {
 
   const isNestedPattern = React.useMemo<boolean>(() => typeof children !== 'undefined', [children]);
 
+  if (process.env.NODE_ENV !== 'production') {
+    warning(!tip || isNestedPattern, 'Spin', '`tip` only work in nest pattern.');
+  }
+
   const { direction } = React.useContext<ConfigConsumerProps>(ConfigContext);
 
   const spinClassName = classNames(
@@ -140,7 +145,7 @@ const Spin: React.FC<SpinClassProps> = (props) => {
       aria-busy={spinning}
     >
       {renderIndicator(prefixCls, props)}
-      {tip ? <div className={`${prefixCls}-text`}>{tip}</div> : null}
+      {tip && isNestedPattern ? <div className={`${prefixCls}-text`}>{tip}</div> : null}
     </div>
   );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #42291

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Spin add warning if use `tip` when not in nest pattern.     |
| 🇨🇳 Chinese |      Spin 添加在非嵌套下使用 `tip` 的警告提示。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c77da62</samp>

Improved the `tip` prop validation and testing for the `Spin` component. Refactored the imports in `components/spin` files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c77da62</samp>

*  Reorder imports in `components/spin/__tests__/index.test.tsx` and `components/spin/index.tsx` to follow convention and group React imports ([link](https://github.com/ant-design/ant-design/pull/42293/files?diff=unified&w=0#diff-4af758683185a8c27f51dfc385f8f0e38d88963d2faa81ff2db1e99d1b7386dbL1-R6), [link](https://github.com/ant-design/ant-design/pull/42293/files?diff=unified&w=0#diff-5703e1f246d34eb8b38fcf640e6b64b44e3a1131cdbd49306153af3c1bc0618aL2-R8))
* Add warning function to `components/spin/index.tsx` to log a warning when `tip` prop is used without a nested element ([link](https://github.com/ant-design/ant-design/pull/42293/files?diff=unified&w=0#diff-5703e1f246d34eb8b38fcf640e6b64b44e3a1131cdbd49306153af3c1bc0618aR112-R115))
* Add condition to `components/spin/index.tsx` to render `tip` only when `tip` prop is present and component has a nested element ([link](https://github.com/ant-design/ant-design/pull/42293/files?diff=unified&w=0#diff-5703e1f246d34eb8b38fcf640e6b64b44e3a1131cdbd49306153af3c1bc0618aL143-R148))
* Add test case to `components/spin/__tests__/index.test.tsx` to check warning and tip rendering logic ([link](https://github.com/ant-design/ant-design/pull/42293/files?diff=unified&w=0#diff-4af758683185a8c27f51dfc385f8f0e38d88963d2faa81ff2db1e99d1b7386dbR55-R65))
