### PR TITLE
fix: style not applied to overflowed Menu

### DIFF
--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -571,7 +571,7 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
         </div>
         <div>
           <div
-            class="ant-menu-submenu ant-menu-submenu-popup ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+            class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
             style="opacity: 0;"
           >
             <ul
@@ -2990,7 +2990,7 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
         </div>
         <div>
           <div
-            class="ant-menu-submenu ant-menu-submenu-popup ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+            class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
             style="opacity: 0;"
           >
             <ul
@@ -3468,7 +3468,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
         </div>
         <div>
           <div
-            class="ant-menu-submenu ant-menu-submenu-popup ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+            class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
             style="opacity: 0;"
           >
             <ul
@@ -4631,7 +4631,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
         </div>
         <div>
           <div
-            class="ant-menu-submenu ant-menu-submenu-popup ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+            class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
             style="opacity: 0;"
           >
             <ul

--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -222,7 +222,7 @@ Array [
       </div>
       <div>
         <div
-          class="ant-menu-submenu ant-menu-submenu-popup ant-menu-light ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+          class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-light ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
           style="opacity: 0;"
         >
           <ul
@@ -584,7 +584,7 @@ Array [
       </div>
       <div>
         <div
-          class="ant-menu-submenu ant-menu-submenu-popup ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
+          class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-dark ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up"
           style="opacity: 0;"
         >
           <ul

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -152,7 +152,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
         <RcMenu
           getPopupContainer={getPopupContainer}
           overflowedIndicator={<EllipsisOutlined />}
-          overflowedIndicatorPopupClassName={`${prefixCls}-${theme}`}
+          overflowedIndicatorPopupClassName={classNames(prefixCls, `${prefixCls}-${theme}`)}
           mode={mergedMode}
           selectable={mergedSelectable}
           onClick={onItemClick}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
None

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
I've noticed that links in overflow menu were not working, if you were not clicking on the exact text in the link. This is due to `prefixCls` not being applied to the overflow menu.

| ![Screenshot 2023-05-11 at 14 26 42](https://github.com/ant-design/ant-design/assets/3399445/942ce890-514b-47df-8b2e-b560e066ff01) | ![Screenshot 2023-05-11 at 14 27 13](https://github.com/ant-design/ant-design/assets/3399445/2298d0ed-c27d-490a-bc8b-52016de5ab9e) |
| ---------- | --------- |


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix style not applied to overflowed Menu |
| 🇨🇳 Chinese | 修復樣式不適用於溢出的菜單 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5aa9d4f</samp>

Fixed a theme bug for the overflowed menu items in `Menu` component. Used `classNames` to handle the `overflowedIndicatorPopupClassName` prop of `rc-menu`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5aa9d4f</samp>

* Fix popup menu theme bug for overflowed menu items by using `classNames` instead of string concatenation for `overflowedIndicatorPopupClassName` prop of `rc-menu` component ([link](https://github.com/ant-design/ant-design/pull/42294/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L155-R155) in `components/menu/menu.tsx`)
