### PR TITLE
style: optimize ColorPicker code

### DIFF
--- a/components/color-picker/ColorPickerPanel.tsx
+++ b/components/color-picker/ColorPickerPanel.tsx
@@ -37,16 +37,10 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
         prefixCls={prefixCls}
         {...injectProps}
       />
-
       {Array.isArray(presets) && (
         <>
           <Divider className={`${colorPickerPanelPrefixCls}-divider`} />
-          <ColorPresets
-            value={color}
-            presets={presets}
-            onChange={(value) => onChange?.(value)}
-            prefixCls={prefixCls}
-          />
+          <ColorPresets value={color} presets={presets} prefixCls={prefixCls} onChange={onChange} />
         </>
       )}
     </div>
@@ -60,4 +54,9 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
     />
   );
 };
+
+if (process.env.NODE_ENV !== 'production') {
+  ColorPickerPanel.displayName = 'ColorPickerPanel';
+}
+
 export default ColorPickerPanel;

--- a/components/color-picker/ColorPickerPanel.tsx
+++ b/components/color-picker/ColorPickerPanel.tsx
@@ -31,12 +31,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
         />
       )}
       {panel}
-      <ColorInput
-        value={color}
-        onChange={(value) => onChange?.(value)}
-        prefixCls={prefixCls}
-        {...injectProps}
-      />
+      <ColorInput value={color} onChange={onChange} prefixCls={prefixCls} {...injectProps} />
       {Array.isArray(presets) && (
         <>
           <Divider className={`${colorPickerPanelPrefixCls}-divider`} />

--- a/components/color-picker/components/ColorAlphaInput.tsx
+++ b/components/color-picker/components/ColorAlphaInput.tsx
@@ -12,7 +12,7 @@ interface ColorAlphaInputProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
 
 const ColorAlphaInput: FC<ColorAlphaInputProps> = ({ prefixCls, value, onChange }) => {
   const colorAlphaInputPrefixCls = `${prefixCls}-alpha-input`;
-  const [alphaValue, setAlphaValue] = useState(generateColor(value || '#000'));
+  const [alphaValue, setAlphaValue] = useState<Color>(generateColor(value || '#000'));
 
   // Update step value
   useEffect(() => {

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -18,7 +18,7 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange }) => {
       onChange?.(genColor);
     }
   };
-
   return <div className={`${prefixCls}-clear`} onClick={handleClick} />;
 };
+
 export default ColorClear;

--- a/components/color-picker/components/ColorHsbInput.tsx
+++ b/components/color-picker/components/ColorHsbInput.tsx
@@ -14,7 +14,7 @@ interface ColorHsbInputProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
 
 const ColorHsbInput: FC<ColorHsbInputProps> = ({ prefixCls, value, onChange }) => {
   const colorHsbInputPrefixCls = `${prefixCls}-hsb-input`;
-  const [hsbValue, setHsbValue] = useState(generateColor(value || '#000'));
+  const [hsbValue, setHsbValue] = useState<Color>(generateColor(value || '#000'));
 
   // Update step value
   useEffect(() => {

--- a/components/color-picker/components/ColorInput.tsx
+++ b/components/color-picker/components/ColorInput.tsx
@@ -42,7 +42,6 @@ const ColorInput: FC<ColorInputProps> = (props) => {
       case ColorFormat.rgb:
         return <ColorRgbInput {...inputProps} />;
       case ColorFormat.hex:
-        return <ColorHexInput {...inputProps} />;
       default:
         return <ColorHexInput {...inputProps} />;
     }

--- a/components/color-picker/components/ColorInput.tsx
+++ b/components/color-picker/components/ColorInput.tsx
@@ -1,10 +1,10 @@
-import type { FC } from 'react';
-import React from 'react';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
 import Select from '../../select';
+import type { Color } from '../color';
 import type { ColorPickerBaseProps } from '../interface';
 import { ColorFormat } from '../interface';
-import type { Color } from '../color';
 import ColorAlphaInput from './ColorAlphaInput';
 import ColorHexInput from './ColorHexInput';
 import ColorHsbInput from './ColorHsbInput';
@@ -16,8 +16,13 @@ interface ColorInputProps
   onChange?: (value: Color) => void;
 }
 
+const selectOptions = [ColorFormat.hex, ColorFormat.hsb, ColorFormat.rgb].map((format) => ({
+  value: format,
+  label: format.toLocaleUpperCase(),
+}));
+
 const ColorInput: FC<ColorInputProps> = (props) => {
-  const { prefixCls, format, onFormatChange, value, onChange } = props;
+  const { prefixCls, format, value, onFormatChange, onChange } = props;
   const [colorFormat, setColorFormat] = useMergedState('hex', {
     value: format,
     onChange: onFormatChange,
@@ -29,17 +34,19 @@ const ColorInput: FC<ColorInputProps> = (props) => {
     setColorFormat(newFormat);
   };
 
-  const steppersRender = () => {
+  const steppersNode = useMemo<React.ReactNode>(() => {
+    const inputProps = { value, prefixCls, onChange };
     switch (colorFormat) {
       case ColorFormat.hsb:
-        return <ColorHsbInput value={value} onChange={onChange} prefixCls={prefixCls} />;
+        return <ColorHsbInput {...inputProps} />;
       case ColorFormat.rgb:
-        return <ColorRgbInput value={value} onChange={onChange} prefixCls={prefixCls} />;
+        return <ColorRgbInput {...inputProps} />;
       case ColorFormat.hex:
+        return <ColorHexInput {...inputProps} />;
       default:
-        return <ColorHexInput value={value} onChange={onChange} prefixCls={prefixCls} />;
+        return <ColorHexInput {...inputProps} />;
     }
-  };
+  }, [colorFormat, prefixCls, value, onChange]);
 
   return (
     <div className={`${colorInputPrefixCls}-container`}>
@@ -52,24 +59,12 @@ const ColorInput: FC<ColorInputProps> = (props) => {
         onChange={handleFormatChange}
         className={`${prefixCls}-format-select`}
         size="small"
-        options={[
-          {
-            label: ColorFormat.hex.toLocaleUpperCase(),
-            value: ColorFormat.hex,
-          },
-          {
-            label: ColorFormat.hsb.toLocaleUpperCase(),
-            value: ColorFormat.hsb,
-          },
-          {
-            label: ColorFormat.rgb.toLocaleUpperCase(),
-            value: ColorFormat.rgb,
-          },
-        ]}
+        options={selectOptions}
       />
-      <div className={colorInputPrefixCls}>{steppersRender()}</div>
+      <div className={colorInputPrefixCls}>{steppersNode}</div>
       <ColorAlphaInput prefixCls={prefixCls} value={value} onChange={onChange} />
     </div>
   );
 };
+
 export default ColorInput;

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -57,7 +57,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
             key={`panel-${preset?.label}`}
           >
             <div className={`${colorPresetsPrefixCls}-items`}>
-              {Array.isArray(preset?.colors) && preset?.colors.length ? (
+              {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
                 preset.colors.map((presetColor: Color) => (
                   <ColorBlock
                     key={`preset-${presetColor.toHexString()}`}

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -1,8 +1,8 @@
+import { ColorBlock } from '@rc-component/color-picker';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { ColorBlock } from '@rc-component/color-picker';
 import Collapse from '../../collapse';
 import { useLocale } from '../../locale';
 import type { Color } from '../color';
@@ -39,7 +39,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   });
   const colorPresetsPrefixCls = `${prefixCls}-presets`;
 
-  const activeKey = useMemo(
+  const activeKeys = useMemo<string[]>(
     () => presetsValue.map((preset) => `panel-${preset.label}`),
     [presetsValue],
   );
@@ -50,7 +50,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
 
   return (
     <div className={colorPresetsPrefixCls}>
-      <Collapse defaultActiveKey={activeKey} ghost>
+      <Collapse defaultActiveKey={activeKeys} ghost>
         {presetsValue.map((preset) => (
           <Panel
             header={<div className={`${colorPresetsPrefixCls}-label`}>{preset?.label}</div>}
@@ -81,4 +81,5 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
     </div>
   );
 };
+
 export default ColorPresets;

--- a/components/color-picker/components/ColorRgbInput.tsx
+++ b/components/color-picker/components/ColorRgbInput.tsx
@@ -13,7 +13,7 @@ interface ColorRgbInputProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
 
 const ColorRgbInput: FC<ColorRgbInputProps> = ({ prefixCls, value, onChange }) => {
   const colorRgbInputPrefixCls = `${prefixCls}-rgb-input`;
-  const [rgbValue, setRgbValue] = useState(generateColor(value || '#000'));
+  const [rgbValue, setRgbValue] = useState<Color>(generateColor(value || '#000'));
 
   // Update step value
   useEffect(() => {

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -1,7 +1,7 @@
+import { ColorBlock } from '@rc-component/color-picker';
 import classNames from 'classnames';
 import type { CSSProperties, MouseEventHandler } from 'react';
 import React, { forwardRef, useMemo } from 'react';
-import { ColorBlock } from '@rc-component/color-picker';
 import type { ColorPickerBaseProps } from '../interface';
 import ColorClear from './ColorClear';
 
@@ -20,14 +20,14 @@ const ColorTrigger = forwardRef<HTMLDivElement, colorTriggerProps>((props, ref) 
   const { color, prefixCls, open, clearColor, disabled, className, ...rest } = props;
   const colorTriggerPrefixCls = `${prefixCls}-trigger`;
 
-  const containerRender = useMemo(
+  const containerNode = useMemo<React.ReactNode>(
     () =>
       clearColor ? (
         <ColorClear prefixCls={prefixCls} />
       ) : (
-        <ColorBlock color={color.toRgbString()} prefixCls={prefixCls} />
+        <ColorBlock prefixCls={prefixCls} color={color.toRgbString()} />
       ),
-    [color, clearColor],
+    [color, clearColor, prefixCls],
   );
 
   return (
@@ -39,8 +39,9 @@ const ColorTrigger = forwardRef<HTMLDivElement, colorTriggerProps>((props, ref) 
       })}
       {...rest}
     >
-      {containerRender}
+      {containerNode}
     </div>
   );
 });
+
 export default ColorTrigger;

--- a/components/color-picker/hooks/useColorState.ts
+++ b/components/color-picker/hooks/useColorState.ts
@@ -2,19 +2,16 @@ import { useEffect, useState } from 'react';
 import type { Color } from '../color';
 import { generateColor } from '../util';
 
-function hasValue(value: Color | string | undefined) {
+function hasValue(value?: Color | string) {
   return value !== undefined;
 }
 
 const useColorState = (
   defaultStateValue: Color | string,
-  option: {
-    defaultValue?: Color | string;
-    value?: Color | string;
-  },
-): [Color, React.Dispatch<React.SetStateAction<Color>>] => {
+  option: { defaultValue?: Color | string; value?: Color | string },
+): readonly [Color, React.Dispatch<React.SetStateAction<Color>>] => {
   const { defaultValue, value } = option;
-  const [colorValue, setColorValue] = useState(() => {
+  const [colorValue, setColorValue] = useState<Color>(() => {
     let mergeState: string | Color | undefined;
     if (hasValue(value)) {
       mergeState = value;
@@ -32,7 +29,7 @@ const useColorState = (
     }
   }, [value]);
 
-  return [colorValue, setColorValue];
+  return [colorValue, setColorValue] as const;
 };
 
 export default useColorState;

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -8,7 +8,10 @@ export enum ColorFormat {
   hsb = 'hsb',
 }
 
-export type PresetsItem = { label: ReactNode; colors: Array<string | Color> };
+export interface PresetsItem {
+  label: ReactNode;
+  colors: (string | Color)[];
+}
 
 export interface ColorPickerBaseProps {
   color?: Color;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ref: #42326 |
| 🇨🇳 Chinese | 无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e11e07a</samp>

This pull request refactors and improves the code quality, readability, type safety, and debuggability of the color picker component and its subcomponents. It simplifies some syntax, reorders and annotates imports, adds type annotations, extracts constants, and renames some variables and props. It affects the files `components/color-picker/ColorPickerPanel.tsx`, `components/color-picker/components/ColorInput.tsx`, `components/color-picker/components/ColorPresets.tsx`, `components/color-picker/components/ColorTrigger.tsx`, `components/color-picker/hooks/useColorState.ts`, `components/color-picker/components/ColorAlphaInput.tsx`, `components/color-picker/components/ColorClear.tsx`, `components/color-picker/components/ColorHsbInput.tsx`, `components/color-picker/components/ColorRgbInput.tsx`, and `components/color-picker/interface.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e11e07a</samp>

*  Simplify and improve the `ColorPresets` component by using shorthand syntax for `onChange` ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-3abf1a34a643a7087dfbaf3039447778574de2b61e627f4c1218297fb961c70fL40-R43)), removing unnecessary `?.` operator ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L60-R60)), adding type annotation for `activeKeys` ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L42-R42)), renaming `activeKey` prop to `activeKeys` ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L53-R53)), and reordering imports ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L1-R5))
* Add `displayName` property to `ColorPickerPanel` component for better debugging and testing ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-3abf1a34a643a7087dfbaf3039447778574de2b61e627f4c1218297fb961c70fR57-R61))
* Refactor and optimize the `ColorInput` component by defining a constant `selectOptions` for the format select component ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L19-R25), [link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L55-R69)), replacing the `steppersRender` function with a `steppersNode` memoized variable ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L32-R49)), and reordering imports ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L1-R7))
* Refactor and optimize the `ColorTrigger` component by adding a type annotation for the `containerNode` memoized variable ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-a6ee2d10d78910c13966101dad864556005e359953d2cc1059773b0a8e7f57c5L23-R30)), renaming the `containerRender` variable to `containerNode` ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-a6ee2d10d78910c13966101dad864556005e359953d2cc1059773b0a8e7f57c5L42-R46)), and reordering imports ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-a6ee2d10d78910c13966101dad864556005e359953d2cc1059773b0a8e7f57c5L1-R4))
* Improve the `useColorState` hook by adding the `readonly` modifier to the return type ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-9576ead765b69ad9edf8f148171300a9ac514ef80167a23b0ecd7e0704439647L11-R14)), changing the initial state value to be of type `Color` ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-9576ead765b69ad9edf8f148171300a9ac514ef80167a23b0ecd7e0704439647L11-R14)), adding the `as const` assertion to the return value ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-9576ead765b69ad9edf8f148171300a9ac514ef80167a23b0ecd7e0704439647L35-R32)), and simplifying the `hasValue` function parameter ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-9576ead765b69ad9edf8f148171300a9ac514ef80167a23b0ecd7e0704439647L5-R5))
* Change the `PresetsItem` interface to use an array type instead of a generic type for the `colors` property ([link](https://github.com/ant-design/ant-design/pull/42329/files?diff=unified&w=0#diff-83dba3026e7dc41ad64d3a2f4d484eeb085f0c3798dc2316fbb90d23520fca6eL11-R14))