### PR TITLE
feat: migrate less to token for Input

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -5,8 +5,8 @@ import type { GlobalToken } from '../../theme/interface';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
-export type InputToken<T extends GlobalToken = FullToken<'Input'>> = T & {
-  inputAffixPadding: number;
+/** Component only token. Which will handle additional calculation of alias token */
+export interface ComponentToken {
   inputPaddingVertical: number;
   inputPaddingVerticalLG: number;
   inputPaddingVerticalSM: number;
@@ -14,6 +14,10 @@ export type InputToken<T extends GlobalToken = FullToken<'Input'>> = T & {
   inputPaddingHorizontalLG: number;
   inputPaddingHorizontalSM: number;
   inputBorderHoverColor: string;
+}
+
+export type InputToken<T extends GlobalToken = FullToken<'Input'>> = T & {
+  inputAffixPadding: number;
   inputBorderActiveColor: string;
 };
 
@@ -849,23 +853,6 @@ export function initInputToken<T extends GlobalToken = GlobalToken>(token: T): I
   // @ts-ignore
   return mergeToken<InputToken<T>>(token, {
     inputAffixPadding: token.paddingXXS,
-    inputPaddingVertical: Math.max(
-      Math.round(((token.controlHeight - token.fontSize * token.lineHeight) / 2) * 10) / 10 -
-        token.lineWidth,
-      3,
-    ),
-    inputPaddingVerticalLG:
-      Math.ceil(((token.controlHeightLG - token.fontSizeLG * token.lineHeightLG) / 2) * 10) / 10 -
-      token.lineWidth,
-    inputPaddingVerticalSM: Math.max(
-      Math.round(((token.controlHeightSM - token.fontSize * token.lineHeight) / 2) * 10) / 10 -
-        token.lineWidth,
-      0,
-    ),
-    inputPaddingHorizontal: token.paddingSM - token.lineWidth,
-    inputPaddingHorizontalSM: token.paddingXS - token.lineWidth,
-    inputPaddingHorizontalLG: token.controlPaddingHorizontal - token.lineWidth,
-    inputBorderHoverColor: token.colorPrimaryHover,
     inputBorderActiveColor: token.colorPrimaryHover,
   });
 }
@@ -952,18 +939,40 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Input', (token) => {
-  const inputToken = initInputToken<FullToken<'Input'>>(token);
+export default genComponentStyleHook(
+  'Input',
+  (token) => {
+    const inputToken = initInputToken<FullToken<'Input'>>(token);
 
-  return [
-    genInputStyle(inputToken),
-    genTextAreaStyle(inputToken),
-    genAffixStyle(inputToken),
-    genGroupStyle(inputToken),
-    genSearchInputStyle(inputToken),
-    // =====================================================
-    // ==             Space Compact                       ==
-    // =====================================================
-    genCompactItemStyle(inputToken),
-  ];
-});
+    return [
+      genInputStyle(inputToken),
+      genTextAreaStyle(inputToken),
+      genAffixStyle(inputToken),
+      genGroupStyle(inputToken),
+      genSearchInputStyle(inputToken),
+      // =====================================================
+      // ==             Space Compact                       ==
+      // =====================================================
+      genCompactItemStyle(inputToken),
+    ];
+  },
+  (token) => ({
+    inputPaddingVertical: Math.max(
+      Math.round(((token.controlHeight - token.fontSize * token.lineHeight) / 2) * 10) / 10 -
+        token.lineWidth,
+      3,
+    ),
+    inputPaddingVerticalLG:
+      Math.ceil(((token.controlHeightLG - token.fontSizeLG * token.lineHeightLG) / 2) * 10) / 10 -
+      token.lineWidth,
+    inputPaddingVerticalSM: Math.max(
+      Math.round(((token.controlHeightSM - token.fontSize * token.lineHeight) / 2) * 10) / 10 -
+        token.lineWidth,
+      0,
+    ),
+    inputPaddingHorizontal: token.paddingSM - token.lineWidth,
+    inputPaddingHorizontalSM: token.paddingXS - token.lineWidth,
+    inputPaddingHorizontalLG: token.controlPaddingHorizontal - token.lineWidth,
+    inputBorderHoverColor: token.colorPrimaryHover,
+  }),
+);

--- a/components/theme/interface/components.ts
+++ b/components/theme/interface/components.ts
@@ -49,6 +49,7 @@ import type { ComponentToken as TourComponentToken } from '../../tour/style';
 import type { ComponentToken as QRCodeComponentToken } from '../../qrcode/style';
 import type { ComponentToken as AppComponentToken } from '../../app/style';
 import type { ComponentToken as StatisticComponentToken } from '../../statistic/style';
+import type { ComponentToken as InputComponentToken } from '../../input/style';
 import type { ComponentToken as WaveToken } from '../../_util/wave/style';
 
 export interface ComponentTokenMap {
@@ -75,7 +76,7 @@ export interface ComponentTokenMap {
   Form?: {};
   Grid?: {};
   Image?: ImageComponentToken;
-  Input?: {};
+  Input?: InputComponentToken;
   InputNumber?: InputNumberComponentToken;
   Layout?: LayoutComponentToken;
   List?: ListComponentToken;

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -39,7 +39,6 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Divider -->
 
-
 ## Drawer
 
 <!-- prettier-ignore -->
@@ -53,7 +52,6 @@ This document contains the correspondence between all the less variables related
 | `@drawer-footer-padding-vertical` | `drawerFooterPaddingVertical` | `drawerFooterPaddingVertical`  is a number without units, `@drawer-footer-padding-vertical` with units |
 | `@drawer-footer-padding-horizontal` | `drawerFooterPaddingHorizontal` | `drawerFooterPaddingHorizontal`  is a number without units, `@drawer-footer-padding-horizontal` with units |
 
-
 <!-- ### Dropdown -->
 
 <!-- ### Empty -->
@@ -63,6 +61,35 @@ This document contains the correspondence between all the less variables related
 <!-- ### Image -->
 
 <!-- ### Input -->
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@input-height-base` | - | Deprecated for style change |
+| `@input-height-lg` | - | Deprecated for style change |
+| `@input-height-sm` | - | Deprecated for style change |
+| `@input-padding-horizontal` | - | Deprecated for style change |
+| `@input-padding-horizontal-base` | `inputPaddingHorizontal` | - |
+| `@input-padding-horizontal-sm` | `inputPaddingHorizontalSM` | - |
+| `@input-padding-horizontal-lg` | `inputPaddingHorizontalLG` | - |
+| `@input-padding-vertical-base` | `inputPaddingVertical` | - |
+| `@input-padding-vertical-sm` | `inputPaddingVerticalSM` | - |
+| `@input-padding-vertical-lg` | `inputPaddingVerticalLG` | - |
+| `@input-placeholder-color` | - | Deprecated for style change |
+| `@input-color` | - | Deprecated for style change |
+| `@input-icon-color` | - | Deprecated for style change |
+| `@input-border-color` | - | Deprecated for style change |
+| `@input-bg` | - | Deprecated for style change |
+| `@input-number-hover-border-color` | - | Deprecated for style change |
+| `@input-number-handler-active-bg` | - | Deprecated for style change |
+| `@input-number-handler-hover-bg` | - | Deprecated for style change |
+| `@input-number-handler-bg` | - | Deprecated for style change |
+| `@input-number-handler-border-color` | - | Deprecated for style change |
+| `@input-addon-bg` | - | Deprecated for style change |
+| `@input-hover-border-color` | `inputBorderHoverColor` | - |
+| `@input-disabled-bg` | - | Deprecated for style change |
+| `@input-outline-offset` | - | Deprecated for style change |
+| `@input-icon-hover-color` | - | Deprecated for style change |
+| `@input-disabled-color` | - | Deprecated for style change |
 
 <!-- ### Layout -->
 
@@ -134,7 +161,6 @@ This document contains the correspondence between all the less variables related
 
 <!-- ### Rate -->
 
-
 ## Result
 
 <!-- prettier-ignore -->
@@ -145,7 +171,6 @@ This document contains the correspondence between all the less variables related
 | `@result-subtitle-font-size` | `resultSubtitleFontSize` | - |
 | `@result-extra-margin` | `resultExtraMargin` | - |
 
-
 <!-- ### Segment -->
 
 <!-- ### Select -->
@@ -153,7 +178,6 @@ This document contains the correspondence between all the less variables related
 <!-- ### Skeleton -->
 
 <!-- ### Slider -->
-
 
 ## Statistic
 
@@ -163,7 +187,6 @@ This document contains the correspondence between all the less variables related
 | `@statistic-title-font-size` | `statisticTitleFontSize` | - |
 | `@statistic-content-font-size` | `statisticContentFontSize` | - |
 | `@statistic-font-family` | `statisticFontFamily` | - |
-
 
 ## Step
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -39,7 +39,6 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Divider 分割线 -->
 
-
 ## Drawer 抽屉
 
 <!-- prettier-ignore -->
@@ -53,7 +52,6 @@ title: Less 变量迁移 Design Token
 | `@drawer-footer-padding-vertical` | `drawerFooterPaddingVertical` | `drawerFooterPaddingVertical` 为数字，不带单位，`@drawer-footer-padding-vertical` 带单位 |
 | `@drawer-footer-padding-horizontal` | `drawerFooterPaddingHorizontal` | `drawerFooterPaddingHorizontal` 为数字，不带单位，`@drawer-footer-padding-horizontal` 带单位 |
 
-
 <!-- ### Dropdown 下拉菜单 -->
 
 <!-- ### Empty 空状态 -->
@@ -63,6 +61,35 @@ title: Less 变量迁移 Design Token
 <!-- ### Image 图片 -->
 
 <!-- ### Input 输入框 -->
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@input-height-base` | - | 由于样式变化已废弃 |
+| `@input-height-lg` | - | 由于样式变化已废弃 |
+| `@input-height-sm` | - | 由于样式变化已废弃 |
+| `@input-padding-horizontal` | - | 由于样式变化已废弃 |
+| `@input-padding-horizontal-base` | `inputPaddingHorizontal` | - |
+| `@input-padding-horizontal-sm` | `inputPaddingHorizontalSM` | - |
+| `@input-padding-horizontal-lg` | `inputPaddingHorizontalLG` | - |
+| `@input-padding-vertical-base` | `inputPaddingVertical` | - |
+| `@input-padding-vertical-sm` | `inputPaddingVerticalSM` | - |
+| `@input-padding-vertical-lg` | `inputPaddingVerticalLG` | - |
+| `@input-placeholder-color` | - | 由于样式变化已废弃 |
+| `@input-color` | - | 由于样式变化已废弃 |
+| `@input-icon-color` | - | 由于样式变化已废弃 |
+| `@input-border-color` | - | 由于样式变化已废弃 |
+| `@input-bg` | - | 由于样式变化已废弃 |
+| `@input-number-hover-border-color` | - | 由于样式变化已废弃 |
+| `@input-number-handler-active-bg` | - | 由于样式变化已废弃 |
+| `@input-number-handler-hover-bg` | - | 由于样式变化已废弃 |
+| `@input-number-handler-bg` | - | 由于样式变化已废弃 |
+| `@input-number-handler-border-color` | - | 由于样式变化已废弃 |
+| `@input-addon-bg` | - | 由于样式变化已废弃 |
+| `@input-hover-border-color` | `inputBorderHoverColor` | - |
+| `@input-disabled-bg` | - | 由于样式变化已废弃 |
+| `@input-outline-offset` | - | 由于样式变化已废弃 |
+| `@input-icon-hover-color` | - | 由于样式变化已废弃 |
+| `@input-disabled-color` | - | 由于样式变化已废弃 |
 
 <!-- ### Layout 布局 -->
 
@@ -134,7 +161,6 @@ title: Less 变量迁移 Design Token
 
 <!-- ### Rate 评分 -->
 
-
 ## Result 结果
 
 <!-- prettier-ignore -->
@@ -145,7 +171,6 @@ title: Less 变量迁移 Design Token
 | `@result-subtitle-font-size` | `resultSubtitleFontSize` | - |
 | `@result-extra-margin` | `resultExtraMargin` | - |
 
-
 <!-- ### Segment 分段器 -->
 
 <!-- ### Select 选择器 -->
@@ -153,7 +178,6 @@ title: Less 变量迁移 Design Token
 <!-- ### Skeleton 骨架屏 -->
 
 <!-- ### Slider 滑动输入条 -->
-
 
 ## Statistic 统计数值
 
@@ -163,7 +187,6 @@ title: Less 变量迁移 Design Token
 | `@statistic-title-font-size` | `statisticTitleFontSize` | - |
 | `@statistic-content-font-size` | `statisticContentFontSize` | - |
 | `@statistic-font-family` | `statisticFontFamily` | - |
-
 
 ### Step 步骤条
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
#41884 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Migrate Input less variables |
| 🇨🇳 Chinese | 迁移 Input less 变量 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 298bd95</samp>

Refactored and updated the input component style and theme interface, and documented the component tokens for migration from less variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 298bd95</samp>

*  Split `InputToken` type into `ComponentToken` and `InputToken` types to improve readability and maintainability, and avoid repeating calculations ([link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL8-R9), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bR52), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bL78-R79))
* Move `inputAffixPadding` token from `ComponentToken` to `InputToken` type, since it is an alias token that depends on global token `paddingSM` ([link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aR17-R20))
* Remove code that calculates component tokens from `initInputToken` function, and move it to third argument of `genComponentStyleHook` function, to follow same pattern as other components and simplify `initInputToken` function ([link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL852-L868), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL955-R978))
* Remove unnecessary empty lines from `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` files, to make them consistent with rest of document ([link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL42), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL56), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL137), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL148), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL157), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL167), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L42), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L56), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L137), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L148), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L157), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L167))
* Add table that maps less variables to component tokens for input component to `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` files, to document migration from less variables to component tokens, and indicate which less variables are deprecated or valid ([link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR65-R93), [link](https://github.com/ant-design/ant-design/pull/42344/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R65-R93))
