### PR TITLE
#42345 Call onEnd when Typography Editable onBlur

### DIFF
--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -110,6 +110,7 @@ const Editable: React.FC<EditableProps> = ({
 
   const onBlur: React.FocusEventHandler<HTMLTextAreaElement> = () => {
     confirmChange();
+    onEnd?.();
   };
 
   const textClassName = component ? `${prefixCls}-${component}` : '';

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -126,7 +126,7 @@ Basic text writing, including headings, body text, lists, and more.
 | onChange | Called when input at textarea | function(value: string) | - |  |
 | onCancel | Called when type ESC to exit editable state | function | - |  |
 | onStart | Called when enter editable state | function | - |  |
-| onEnd | Called when type ENTER to exit editable state | function | - | 4.14.0 |
+| onEnd | Called when type ENTER or onBlur to exit editable state | function | - | 4.14.0 |
 | triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | enterIcon | Custom "enter" icon in the edit field (passing `null` removes the icon) | ReactNode | `<EnterOutlined />` | 4.17.0 |
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Close #42345

### 💡 Background and solution

Call onEnd when leaving editing with onBlur

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Call onEnd in Typographt when leaving editing with onBlur |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48a23d5</samp>

Improve the behavior and documentation of the `onEnd` prop for the `Typography.Editable` component. Call `onEnd` when the component loses focus, and update the `components/typography/index.en-US.md` file to reflect this change.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 48a23d5</samp>

* Add `onEnd` prop function to `Editable` component and call it on both ENTER and onBlur events ([link](https://github.com/ant-design/ant-design/pull/42346/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7R113), [link](https://github.com/ant-design/ant-design/pull/42346/files?diff=unified&w=0#diff-b1bc5946fa4c3e542e3d90209e9be0a5d0662888eb317ce543a7b67f5ce0bfe4L129-R129))
* Update `Typography` documentation to reflect the new behavior of `onEnd` prop ([link](https://github.com/ant-design/ant-design/pull/42346/files?diff=unified&w=0#diff-b1bc5946fa4c3e542e3d90209e9be0a5d0662888eb317ce543a7b67f5ce0bfe4L129-R129))
