### PR TITLE
fix: Popconfirm onVisibleChange trigger twice

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -158,7 +158,7 @@ describe('Popconfirm', () => {
 
   it('should support onConfirm to return Promise', async () => {
     const confirm = () =>
-      new Promise(res => {
+      new Promise((res) => {
         setTimeout(res, 300);
       });
     const onOpenChange = jest.fn((_, e) => {
@@ -256,7 +256,7 @@ describe('Popconfirm', () => {
           <Popconfirm
             title="will unmount"
             onConfirm={() =>
-              new Promise(resolve => {
+              new Promise((resolve) => {
                 setTimeout(() => {
                   setShow(false);
                   resolve(true);
@@ -285,5 +285,27 @@ describe('Popconfirm', () => {
     await waitFakeTimer(500);
     // expect(container.textContent).toEqual('Unmounted');
     expect(error).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/42314
+  it('legacy onVisibleChange should only trigger once', async () => {
+    const onOpenChange = jest.fn();
+    const onVisibleChange = jest.fn();
+
+    const { container } = render(
+      <Popconfirm
+        title="will unmount"
+        onOpenChange={onOpenChange}
+        onVisibleChange={onVisibleChange}
+      >
+        <span className="target" />
+      </Popconfirm>,
+    );
+
+    fireEvent.click(container.querySelector('.target')!);
+    await waitFakeTimer();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onVisibleChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -42,6 +42,19 @@ export interface PopconfirmState {
 }
 
 const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    placement = 'top',
+    trigger = 'click',
+    okType = 'primary',
+    icon = <ExclamationCircleFilled />,
+    children,
+    overlayClassName,
+    onOpenChange,
+    onVisibleChange,
+    ...restProps
+  } = props;
+
   const { getPrefixCls } = React.useContext(ConfigContext);
   const [open, setOpen] = useMergedState(false, {
     value: props.open !== undefined ? props.open : props.visible,
@@ -55,8 +68,8 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     e?: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLDivElement>,
   ) => {
     setOpen(value, true);
-    props.onVisibleChange?.(value, e);
-    props.onOpenChange?.(value, e);
+    onVisibleChange?.(value, e);
+    onOpenChange?.(value, e);
   };
 
   const close = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -76,7 +89,7 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     }
   };
 
-  const onOpenChange = (value: boolean) => {
+  const onInternalOpenChange = (value: boolean) => {
     const { disabled = false } = props;
     if (disabled) {
       return;
@@ -84,16 +97,6 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     settingOpen(value);
   };
 
-  const {
-    prefixCls: customizePrefixCls,
-    placement = 'top',
-    trigger = 'click',
-    okType = 'primary',
-    icon = <ExclamationCircleFilled />,
-    children,
-    overlayClassName,
-    ...restProps
-  } = props;
   const prefixCls = getPrefixCls('popover', customizePrefixCls);
   const prefixClsConfirm = getPrefixCls('popconfirm', customizePrefixCls);
   const overlayClassNames = classNames(prefixClsConfirm, overlayClassName);
@@ -104,7 +107,7 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
       trigger={trigger}
       prefixCls={prefixCls}
       placement={placement}
-      onOpenChange={onOpenChange}
+      onOpenChange={onInternalOpenChange}
       open={open}
       ref={ref}
       overlayClassName={overlayClassNames}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Popconfirm trigger `onVisibleChange` twice.         |
| 🇨🇳 Chinese |      修复 Popconfirm 的 `onVisibleChange` 会重复触发的问题。     |     

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29276c5</samp>

This pull request improves the code quality and test coverage of the `Popconfirm` component. It fixes a lint issue, adds a test for the `onVisibleChange` prop, and simplifies the props handling logic.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 29276c5</samp>

* Destructure props and assign default values to simplify `Popconfirm` component code ([link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285R45-R57))
* Replace `props.onVisibleChange` and `props.onOpenChange` with destructured variables ([link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L58-R72))
* Rename `onOpenChange` function to `onInternalOpenChange` to avoid confusion and indicate internal usage ([link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L79-R92), [link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L107-R110))
* Remove unused props from `Popconfirm` component and pass them down to `Tooltip` component ([link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L87-L96))
* Add parentheses around arrow function parameters to follow code style and lint rules ([link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L161-R161), [link](https://github.com/ant-design/ant-design/pull/42351/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L259-R259))
