### PR TITLE
fix: color-picker review issues

### DIFF
--- a/components/color-picker/demo/format.tsx
+++ b/components/color-picker/demo/format.tsx
@@ -26,8 +26,8 @@ export default () => {
   );
 
   return (
-    <Space direction='vertical' size='middle' style={{ display: 'flex' }}>
-      <Row align='middle'>
+    <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
+      <Row align="middle">
         <Space>
           <Col>
             <ColorPicker
@@ -42,7 +42,7 @@ export default () => {
           </Col>
         </Space>
       </Row>
-      <Row align='middle'>
+      <Row align="middle">
         <Space>
           <Col>
             <ColorPicker
@@ -57,7 +57,7 @@ export default () => {
           </Col>
         </Space>
       </Row>
-      <Row align='middle'>
+      <Row align="middle">
         <Space>
           <Col>
             <ColorPicker

--- a/components/color-picker/demo/format.tsx
+++ b/components/color-picker/demo/format.tsx
@@ -1,11 +1,14 @@
 import { Col, ColorPicker, Row, Space } from 'antd';
-import type { Color } from 'antd/es/color-picker';
+import type { Color, ColorPickerProps } from 'antd/es/color-picker';
 import React, { useMemo, useState } from 'react';
 
 export default () => {
   const [colorHex, setColorHex] = useState<Color | string>('#1677ff');
   const [colorHsb, setColorHsb] = useState<Color | string>('hsb(215, 91%, 100%)');
   const [colorRgb, setColorRgb] = useState<Color | string>('rgb(22, 119, 255)');
+  const [formatHex, setFormatHex] = useState<ColorPickerProps['format']>('hex');
+  const [formatHsb, setFormatHsb] = useState<ColorPickerProps['format']>('hsb');
+  const [formatRgb, setFormatRgb] = useState<ColorPickerProps['format']>('rgb');
 
   const hexString = useMemo(
     () => (typeof colorHex === 'string' ? colorHex : colorHex.toHexString()),
@@ -23,31 +26,46 @@ export default () => {
   );
 
   return (
-    <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
-      <Row align="middle">
+    <Space direction='vertical' size='middle' style={{ display: 'flex' }}>
+      <Row align='middle'>
         <Space>
           <Col>
-            <ColorPicker format="hex" value={colorHex} onChange={setColorHex} />
+            <ColorPicker
+              format={formatHex}
+              value={colorHex}
+              onChange={setColorHex}
+              onFormatChange={setFormatHex}
+            />
           </Col>
           <Col>
             HEX: <span>{hexString}</span>
           </Col>
         </Space>
       </Row>
-      <Row align="middle">
+      <Row align='middle'>
         <Space>
           <Col>
-            <ColorPicker format="hsb" value={colorHsb} onChange={setColorHsb} />
+            <ColorPicker
+              format={formatHsb}
+              value={colorHsb}
+              onChange={setColorHsb}
+              onFormatChange={setFormatHsb}
+            />
           </Col>
           <Col>
             HSB: <span>{hsbString}</span>
           </Col>
         </Space>
       </Row>
-      <Row align="middle">
+      <Row align='middle'>
         <Space>
           <Col>
-            <ColorPicker format="rgb" value={colorRgb} onChange={setColorRgb} />
+            <ColorPicker
+              format={formatRgb}
+              value={colorRgb}
+              onChange={setColorRgb}
+              onFormatChange={setFormatRgb}
+            />
           </Col>
           <Col>
             RGB: <span>{rgbString}</span>

--- a/components/color-picker/style/input.ts
+++ b/components/color-picker/style/input.ts
@@ -42,6 +42,7 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
 
       [`${componentCls}-format-select${antCls}-select`]: {
         marginInlineEnd: marginXS,
+        width: 'auto',
         '&-single': {
           [`${antCls}-select-selector`]: {
             padding: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/42333#issuecomment-1546687704
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Optimize format demo, and fix style issues        |
| 🇨🇳 Chinese |    优化 format demo，并且修复样式问题         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a56d483</samp>

Added a new feature to the `ColorPicker` component that allows users to choose and display different color formats. Adjusted the input box style to fit the color value length.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a56d483</samp>

*  Import `ColorPickerProps` type from `antd/es/color-picker` to use `format` and `onFormatChange` props in `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-7be4f6ff081124d854515c9e6f08a451f4073636c9526bd71c1cb3408f0c6802L2-R2))
* Add state variables for `format` prop of each `ColorPicker` component, which can be `hex`, `hsb`, or `rgb` ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-7be4f6ff081124d854515c9e6f08a451f4073636c9526bd71c1cb3408f0c6802R9-R11))
* Add `format` and `onFormatChange` props to first `ColorPicker` component, which uses `formatHex` and `setFormatHex` state variables ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-7be4f6ff081124d854515c9e6f08a451f4073636c9526bd71c1cb3408f0c6802L26-R38))
* Add same props to second `ColorPicker` component, which uses `formatHsb` and `setFormatHsb` state variables ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-7be4f6ff081124d854515c9e6f08a451f4073636c9526bd71c1cb3408f0c6802L37-R53))
* Add same props to third `ColorPicker` component, which uses `formatRgb` and `setFormatRgb` state variables ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-7be4f6ff081124d854515c9e6f08a451f4073636c9526bd71c1cb3408f0c6802L47-R68))
* Set `width` style to `auto` for input box of `ColorPicker` component, to make it adjust to length of color value ([link](https://github.com/ant-design/ant-design/pull/42356/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7R45))
