### PR TITLE
fix: Preset color block style

### DIFF
--- a/components/color-picker/style/color-block.ts
+++ b/components/color-picker/style/color-block.ts
@@ -6,9 +6,9 @@ const TRANSPARENT_DOT_COLOR = '#EEE';
 /**
  * @private Internal usage only
  */
-export const getTransBg = (size: number): CSSObject => ({
+export const getTransBg = (size: string): CSSObject => ({
   backgroundImage: `conic-gradient(${TRANSPARENT_DOT_COLOR} 0 25%, transparent 0 50%, ${TRANSPARENT_DOT_COLOR} 0 75%, transparent 0)`,
-  backgroundSize: `${size}px ${size}px`,
+  backgroundSize: `${size} ${size}`,
 });
 
 const genColorBlockStyle = (token: ColorPickerToken, size: number): CSSObject => {
@@ -21,7 +21,7 @@ const genColorBlockStyle = (token: ColorPickerToken, size: number): CSSObject =>
       width: size,
       height: size,
       boxShadow: colorPickerInsetShadow,
-      ...getTransBg(size / 2),
+      ...getTransBg('50%'),
       [`${componentCls}-color-block-inner`]: {
         width: '100%',
         height: '100%',

--- a/components/color-picker/style/picker.ts
+++ b/components/color-picker/style/picker.ts
@@ -58,7 +58,7 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         borderRadius: colorPickerSliderHeight / 2,
         boxShadow: colorPickerInsetShadow,
       },
-      '&-alpha': getTransBg(8),
+      '&-alpha': getTransBg(`8px`),
       marginBottom: marginSM,
     },
 

--- a/components/color-picker/style/picker.ts
+++ b/components/color-picker/style/picker.ts
@@ -58,7 +58,7 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         borderRadius: colorPickerSliderHeight / 2,
         boxShadow: colorPickerInsetShadow,
       },
-      '&-alpha': getTransBg(`8px`),
+      '&-alpha': getTransBg(`${colorPickerSliderHeight}px`),
       marginBottom: marginSM,
     },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<img width="773" alt="image" src="https://github.com/ant-design/ant-design/assets/5378891/bd9a3e1f-b42f-4674-a791-01ffd30b02ec">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     新加组件，无需changelog      |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6defe9</samp>

Fixed a bug in the `color-picker` component and improved its responsiveness. Updated the `genPickerStyle` function to use the new `getTransBg` function with a pixel value.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e6defe9</samp>

* Fix a bug where the transparent background of the color block component was not rendered correctly in some browsers by modifying the `getTransBg` function to accept a string parameter instead of a number ([link](https://github.com/ant-design/ant-design/pull/42361/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL9-R11))
* Improve the appearance and consistency of the color block component by making the background size responsive to the color block size using the modified `getTransBg` function with a percentage value in the `genColorBlockStyle` function ([link](https://github.com/ant-design/ant-design/pull/42361/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL24-R24))
* Maintain compatibility with the `getTransBg` function by updating the `genPickerStyle` function in `components/color-picker/style/picker.ts` to use a pixel value instead of a number as the parameter ([link](https://github.com/ant-design/ant-design/pull/42361/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L61-R61))
