### PR TITLE
docs(color-picker): update docs

### DIFF
--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -47,7 +47,7 @@ Used when the user needs to customize the color selection.
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - |
 | disabled | Disable ColorPicker | boolean | - |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` |
-| arrow | Configuration for popup arrow | `boolean | { pointAtCenter: boolean }` | `true` | - |
+| arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | `true` | - |
 
 ### Color
 

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -47,7 +47,7 @@ Used when the user needs to customize the color selection.
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - |
 | disabled | Disable ColorPicker | boolean | - |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` |
-| arrow | Configuration for popup arrow | boolean | `{ pointAtCenter: boolean }` | - |
+| arrow | Configuration for popup arrow | `boolean | { pointAtCenter: boolean }` | `true` | - |
 
 ### Color
 

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -48,7 +48,7 @@ group:
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - |
 | disabled | 禁用颜色选择器 | boolean | - |
 | placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` |
-| arrow | 配置弹出的箭头 | boolean | `{ pointAtCenter: boolean }` | - |
+| arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | `true` | - |
 
 ### Color
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<img width="1310" alt="image" src="https://github.com/ant-design/ant-design/assets/10286961/4e786b8a-68dd-4640-920d-3e232cc707c2">

to

![image](https://github.com/ant-design/ant-design/assets/10286961/ebbc500a-0917-4970-87b1-d88eb6470ebd)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  -   |
| 🇨🇳 Chinese | -  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cee17a</samp>

Updated the `arrow` prop type and default value for the ColorPicker component. This affects the files `components/color-picker/index.en-US.md` and `components/color-picker/index.zh-CN.md`, which document the component in English and Chinese respectively.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2cee17a</samp>

* Update the `arrow` prop type of the ColorPicker component to accept either a boolean or an object with a `pointAtCenter` property, and change the default value to `true` for better flexibility and usability ([link](https://github.com/ant-design/ant-design/pull/42372/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560L50-R50), [link](https://github.com/ant-design/ant-design/pull/42372/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249L51-R51))
* Apply the same change to the Chinese documentation file `index.zh-CN.md` to keep the documentation consistent across languages ([link](https://github.com/ant-design/ant-design/pull/42372/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249L51-R51))
