### PR TITLE
fix: Site link auto switch by locale

### DIFF
--- a/.dumi/rehypeAntd.ts
+++ b/.dumi/rehypeAntd.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { type HastRoot, type UnifiedTransformer, unistUtilVisit } from 'dumi';
+import { unistUtilVisit, type HastRoot, type UnifiedTransformer } from 'dumi';
 
 /**
  * plugin for modify hast tree when docs compiling
@@ -60,6 +60,9 @@ function rehypeAntd(): UnifiedTransformer<HastRoot> {
         if (!node.properties) return;
         node.properties.className ??= [];
         (node.properties.className as string[]).push('component-api-table');
+      } else if (node.type === 'element' && (node.tagName === 'Link' || node.tagName === 'a')) {
+        node.tagName = 'LocaleLink';
+        node.properties.sourceType = node.tagName;
       }
     });
   };

--- a/.dumi/rehypeAntd.ts
+++ b/.dumi/rehypeAntd.ts
@@ -61,8 +61,9 @@ function rehypeAntd(): UnifiedTransformer<HastRoot> {
         node.properties.className ??= [];
         (node.properties.className as string[]).push('component-api-table');
       } else if (node.type === 'element' && (node.tagName === 'Link' || node.tagName === 'a')) {
+        const { tagName } = node;
+        node.properties.sourceType = tagName;
         node.tagName = 'LocaleLink';
-        node.properties.sourceType = node.tagName;
       }
     });
   };

--- a/.dumi/theme/builtins/LocaleLink/index.tsx
+++ b/.dumi/theme/builtins/LocaleLink/index.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'dumi';
+import * as React from 'react';
+import useLocale from '../../../hooks/useLocale';
+
+type LinkProps = Parameters<typeof Link>[0];
+
+export interface LocaleLinkProps extends LinkProps {
+  sourceType: 'a' | 'Link';
+  children?: React.ReactNode;
+}
+
+export default function LocaleLink({ sourceType, to, ...props }: LocaleLinkProps) {
+  const Component = sourceType === 'a' ? 'a' : Link;
+
+  const [, localeType] = useLocale();
+
+  const localeTo = React.useMemo(() => {
+    if (!to || typeof to !== 'string') {
+      return to;
+    }
+
+    // Auto locale switch
+    const cells = to.match(/(\/[^#]*)(#.*)?/);
+    if (cells) {
+      let path = cells[1].replace(/\/$/, '');
+      const hash = cells[2] || '';
+
+      if (localeType === 'cn' && !path.endsWith('-cn')) {
+        path = `${path}-cn`;
+      } else if (localeType === 'en' && path.endsWith('-cn')) {
+        path = path.replace(/-cn$/, '');
+      }
+
+      return `${path}${hash}`;
+    }
+
+    return to;
+  }, [to]);
+
+  return <Component to={localeTo} {...props} />;
+}

--- a/.dumi/theme/builtins/LocaleLink/index.tsx
+++ b/.dumi/theme/builtins/LocaleLink/index.tsx
@@ -37,5 +37,13 @@ export default function LocaleLink({ sourceType, to, ...props }: LocaleLinkProps
     return to;
   }, [to]);
 
-  return <Component to={localeTo} {...props} />;
+  const linkProps: LocaleLinkProps = {
+    ...props,
+  } as LocaleLinkProps;
+
+  if (to) {
+    linkProps.to = localeTo;
+  }
+
+  return <Component {...linkProps} />;
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
+  "jsxSingleQuote": false,
   "trailingComma": "all",
   "printWidth": 100,
   "proseWrap": "never",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref #42373

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aefde97</samp>

Added a new `LocaleLink` component to the theme builtins and used it to replace `Link` and `a` elements in the documentation. This enables locale-aware links and improves code style consistency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aefde97</samp>

*  Add `LocaleLink` component to theme builtins to support locale-aware links in documentation ([link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-dd4fbb04412c4c400e21a6bb7028b5aea57fa845d2bf09a52af63ce56c128702R1-R49), [link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-f0d95b6f380e7a072830e7026f73450a2056d161a2b265783fa556338e677525R63-R66))
*  Modify `rehypeAntd` transformer to replace `Link` and `a` elements with `LocaleLink` and store original tag name as `sourceType` prop ([link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-f0d95b6f380e7a072830e7026f73450a2056d161a2b265783fa556338e677525R63-R66), [link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-dd4fbb04412c4c400e21a6bb7028b5aea57fa845d2bf09a52af63ce56c128702R1-R49))
*  Change import order of `unistUtilVisit` in `.dumi/rehypeAntd.ts` to follow alphabetical order ([link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-f0d95b6f380e7a072830e7026f73450a2056d161a2b265783fa556338e677525L2-R2))
*  Enforce double quotes for JSX attributes in `.prettierrc` to align with existing code style ([link](https://github.com/ant-design/ant-design/pull/42381/files?diff=unified&w=0#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R3))
