### PR TITLE
feat(ColorPicker): Optimize the display of ColorPicker pure panel

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -46,6 +46,7 @@ export interface ColorPickerProps
   onFormatChange?: (format: ColorFormat) => void;
   onChange?: (value: Color, hex: string) => void;
   getPopupContainer?: PopoverProps['getPopupContainer'];
+  autoAdjustOverflow?: PopoverProps['autoAdjustOverflow'];
 }
 
 type CompoundedComponent = React.FC<ColorPickerProps> & {
@@ -73,6 +74,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     onChange,
     onOpenChange,
     getPopupContainer,
+    autoAdjustOverflow = true,
   } = props;
 
   const { getPrefixCls, direction } = useContext<ConfigConsumerProps>(ConfigContext);
@@ -119,6 +121,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     arrow,
     rootClassName,
     getPopupContainer,
+    autoAdjustOverflow,
   };
 
   const colorBaseProps: ColorPickerBaseProps = {
@@ -161,7 +164,16 @@ if (process.env.NODE_ENV !== 'production') {
   ColorPicker.displayName = 'ColorPicker';
 }
 
-const PurePanel = genPurePanel(ColorPicker, 'color-picker', (prefixCls) => prefixCls);
+const PurePanel = genPurePanel(
+  ColorPicker,
+  'color-picker',
+  (prefixCls) => prefixCls,
+  (props: ColorPickerProps) => ({
+    ...props,
+    placement: 'bottom' as TriggerPlacement,
+    autoAdjustOverflow: false,
+  }),
+);
 
 ColorPicker._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
 

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3580,346 +3580,270 @@ Array [
 
 exports[`renders components/color-picker/demo/pure-panel.tsx extend context correctly 1`] = `
 <div
-  style="padding-bottom: 0px; position: relative; min-width: 0;"
+  style="padding-left: 100px;"
 >
   <div
-    class="ant-color-picker-trigger ant-popover-open ant-color-picker-trigger-active"
-    style="margin: 0px;"
+    style="padding-bottom: 0px; position: relative; min-width: 0;"
   >
     <div
-      class="ant-color-picker-color-block"
+      class="ant-color-picker-trigger ant-popover-open ant-color-picker-trigger-active"
+      style="margin: 0px;"
     >
       <div
-        class="ant-color-picker-color-block-inner"
-        style="background: rgb(22, 119, 255);"
-      />
-    </div>
-  </div>
-  <div
-    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-  >
-    <div
-      class="ant-popover-arrow"
-      style="position: absolute;"
-    />
-    <div
-      class="ant-popover-content"
-    >
-      <div
-        class="ant-popover-inner"
-        role="tooltip"
+        class="ant-color-picker-color-block"
       >
         <div
-          class="ant-popover-inner-content"
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottom"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute; top: 0px; left: 0px;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
         >
           <div
-            class="ant-color-picker-panel"
+            class="ant-popover-inner-content"
           >
             <div
-              class="ant-color-picker-inner-panel"
+              class="ant-color-picker-panel"
             >
               <div
-                class="ant-color-picker-select"
+                class="ant-color-picker-inner-panel"
               >
                 <div
-                  class="ant-color-picker-palette"
-                  style="position: relative;"
+                  class="ant-color-picker-select"
                 >
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
                   >
                     <div
-                      class="ant-color-picker-handler"
-                      style="background-color: rgb(22, 119, 255);"
+                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 0, 0);"
                     />
                   </div>
-                  <div
-                    class="ant-color-picker-saturation"
-                    style="background-color: rgb(0, 0, 0);"
-                  />
                 </div>
-              </div>
-              <div
-                class="ant-color-picker-slider-container"
-              >
                 <div
-                  class="ant-color-picker-slider-group"
+                  class="ant-color-picker-slider-container"
                 >
                   <div
-                    class="ant-color-picker-slider ant-color-picker-slider-hue"
+                    class="ant-color-picker-slider-group"
                   >
                     <div
-                      class="ant-color-picker-palette"
-                      style="position: relative;"
+                      class="ant-color-picker-slider ant-color-picker-slider-hue"
                     >
                       <div
-                        style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                      >
-                        <div
-                          class="ant-color-picker-handler ant-color-picker-handler-sm"
-                          style="background-color: rgb(0, 0, 0);"
-                        />
-                      </div>
-                      <div
-                        class="ant-color-picker-gradient"
-                        style="position: absolute; inset: 0;"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="ant-color-picker-slider ant-color-picker-slider-alpha"
-                  >
-                    <div
-                      class="ant-color-picker-palette"
-                      style="position: relative;"
-                    >
-                      <div
-                        style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                      >
-                        <div
-                          class="ant-color-picker-handler ant-color-picker-handler-sm"
-                          style="background-color: rgb(22, 119, 255);"
-                        />
-                      </div>
-                      <div
-                        class="ant-color-picker-gradient"
-                        style="position: absolute; inset: 0;"
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-color-block"
-                >
-                  <div
-                    class="ant-color-picker-color-block-inner"
-                    style="background: rgb(22, 119, 255);"
-                  />
-                </div>
-              </div>
-              <div
-                class="ant-color-picker-input-container"
-              >
-                <div
-                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
-                >
-                  <div
-                    class="ant-select-selector"
-                  >
-                    <span
-                      class="ant-select-selection-search"
-                    >
-                      <input
-                        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-                        aria-autocomplete="list"
-                        aria-controls="rc_select_TEST_OR_SSR_list"
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        aria-owns="rc_select_TEST_OR_SSR_list"
-                        autocomplete="off"
-                        class="ant-select-selection-search-input"
-                        id="rc_select_TEST_OR_SSR"
-                        readonly=""
-                        role="combobox"
-                        style="opacity: 0;"
-                        type="search"
-                        unselectable="on"
-                        value=""
-                      />
-                    </span>
-                    <span
-                      class="ant-select-selection-item"
-                      title="HEX"
-                    >
-                      HEX
-                    </span>
-                  </div>
-                  <div
-                    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
-                    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
-                  >
-                    <div>
-                      <div
-                        id="rc_select_TEST_OR_SSR_list"
-                        role="listbox"
-                        style="height: 0px; width: 0px; overflow: hidden;"
-                      >
-                        <div
-                          aria-label="HEX"
-                          aria-selected="true"
-                          id="rc_select_TEST_OR_SSR_list_0"
-                          role="option"
-                        >
-                          hex
-                        </div>
-                        <div
-                          aria-label="HSB"
-                          aria-selected="false"
-                          id="rc_select_TEST_OR_SSR_list_1"
-                          role="option"
-                        >
-                          hsb
-                        </div>
-                      </div>
-                      <div
-                        class="rc-virtual-list"
+                        class="ant-color-picker-palette"
                         style="position: relative;"
                       >
                         <div
-                          class="rc-virtual-list-holder"
-                          style="max-height: 256px; overflow-y: auto;"
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
-                          <div>
-                            <div
-                              class="rc-virtual-list-holder-inner"
-                              style="display: flex; flex-direction: column;"
-                            >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(0, 0, 0);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
+                        >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
                               <div
-                                aria-selected="true"
-                                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                                title="HEX"
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
                               >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
                                 >
-                                  HEX
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
-                              </div>
-                              <div
-                                aria-selected="false"
-                                class="ant-select-item ant-select-item-option"
-                                title="HSB"
-                              >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
                                 >
-                                  HSB
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
-                              </div>
-                              <div
-                                aria-selected="false"
-                                class="ant-select-item ant-select-item-option"
-                                title="RGB"
-                              >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
                                 >
-                                  RGB
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
                               </div>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <span
-                    aria-hidden="true"
-                    class="ant-select-arrow"
-                    style="user-select: none;"
-                    unselectable="on"
-                  >
                     <span
-                      aria-label="down"
-                      class="anticon anticon-down ant-select-suffix"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </div>
-                <div
-                  class="ant-color-picker-input"
-                >
-                  <span
-                    class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
-                  >
-                    <span
-                      class="ant-input-prefix"
-                    >
-                      #
-                    </span>
-                    <input
-                      class="ant-input ant-input-sm"
-                      type="text"
-                      value="1677FF"
-                    />
-                  </span>
-                </div>
-                <div
-                  class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
-                >
-                  <div
-                    class="ant-input-number-handler-wrap"
-                  >
-                    <span
-                      aria-disabled="true"
-                      aria-label="Increase Value"
-                      class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
-                      role="button"
-                      unselectable="on"
-                    >
-                      <span
-                        aria-label="up"
-                        class="anticon anticon-up ant-input-number-handler-up-inner"
-                        role="img"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          data-icon="up"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    <span
-                      aria-disabled="false"
-                      aria-label="Decrease Value"
-                      class="ant-input-number-handler ant-input-number-handler-down"
-                      role="button"
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
                       unselectable="on"
                     >
                       <span
                         aria-label="down"
-                        class="anticon anticon-down ant-input-number-handler-down-inner"
+                        class="anticon anticon-down ant-select-suffix"
                         role="img"
                       >
                         <svg
@@ -3939,18 +3863,98 @@ exports[`renders components/color-picker/demo/pure-panel.tsx extend context corr
                     </span>
                   </div>
                   <div
-                    class="ant-input-number-input-wrap"
+                    class="ant-color-picker-input"
                   >
-                    <input
-                      aria-valuemax="100"
-                      aria-valuemin="0"
-                      aria-valuenow="100"
-                      autocomplete="off"
-                      class="ant-input-number-input"
-                      role="spinbutton"
-                      step="1"
-                      value="100%"
-                    />
+                    <span
+                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677FF"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -207,19 +207,23 @@ exports[`renders components/color-picker/demo/presets.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/pure-panel.tsx correctly 1`] = `
 <div
-  style="padding-bottom:0;position:relative;min-width:0"
+  style="padding-left:100px"
 >
   <div
-    class="ant-color-picker-trigger"
-    style="margin:0"
+    style="padding-bottom:0;position:relative;min-width:0"
   >
     <div
-      class="ant-color-picker-color-block"
+      class="ant-color-picker-trigger"
+      style="margin:0"
     >
       <div
-        class="ant-color-picker-color-block-inner"
-        style="background:rgb(22, 119, 255)"
-      />
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22, 119, 255)"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/components/color-picker/demo/pure-panel.tsx
+++ b/components/color-picker/demo/pure-panel.tsx
@@ -8,5 +8,9 @@ export default () => {
   const { token } = theme.useToken();
   const [color, setColor] = useState<Color | string>(token.colorPrimary);
 
-  return <PureRenderColorPicker value={color} onChange={setColor} />;
+  return (
+    <div style={{ paddingLeft: 100 }}>
+      <PureRenderColorPicker value={color} onChange={setColor} />
+    </div>
+  );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Optimize the display of ColorPicker Pure panel

before:
![image](https://github.com/ant-design/ant-design/assets/10286961/ba3535f5-2a50-4806-afc4-eb26e9ee1667)

after:
<img width="989" alt="image" src="https://github.com/ant-design/ant-design/assets/10286961/88439c8e-715b-4a45-987f-5fc1393487e1">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize the display of ColorPicker Pure panel  demo |
| 🇨🇳 Chinese |  优化拾色器面板示例的展示   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9246d9</samp>

This pull request enhances the `ColorPicker` component by adding a new prop to adjust the popover position and improving the pure panel mode. It also updates the `pure-panel.tsx` demo file to add some padding to the `PureRenderColorPicker` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9246d9</samp>

*  Add `autoAdjustOverflow` prop to `ColorPickerProps` interface to control popover position ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR49))
*  Set default value of `autoAdjustOverflow` to `true` in `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR77))
*  Pass `autoAdjustOverflow` prop to `Popover` component inside `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR124))
*  Modify `PurePanel` component to accept custom props mapper function ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL164-R176))
*  Use custom props mapper function to set `placement` and `autoAdjustOverflow` props for pure panel ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL164-R176))
*  Add padding to `PureRenderColorPicker` component in `pure-panel.tsx` demo file ([link](https://github.com/ant-design/ant-design/pull/42388/files?diff=unified&w=0#diff-6dabc44dd1c0580b35bd42a19166f11319bc6ce63628f3065ae0193614b002bdL11-R15))
