### PR TITLE
fix: Popconfirm onVisibleChange trigger twice

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -35,9 +35,9 @@ describe('Popconfirm', () => {
 
     const wrapper = render(
       <Popconfirm
-        title={<span className='popconfirm-test'>Are you sure delete this task?</span>}
-        okText='Yes'
-        cancelText='No'
+        title={<span className="popconfirm-test">Are you sure delete this task?</span>}
+        okText="Yes"
+        cancelText="No"
         mouseEnterDelay={0}
         mouseLeaveDelay={0}
         onOpenChange={onOpenChange}
@@ -57,7 +57,7 @@ describe('Popconfirm', () => {
 
   it('should show overlay when trigger is clicked', async () => {
     const popconfirm = render(
-      <Popconfirm title='code' autoAdjustOverflow={false}>
+      <Popconfirm title="code" autoAdjustOverflow={false}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -100,14 +100,14 @@ describe('Popconfirm', () => {
   it('should be controlled by open', () => {
     jest.useFakeTimers();
     const popconfirm = render(
-      <Popconfirm title='code'>
+      <Popconfirm title="code">
         <span>show me your code</span>
       </Popconfirm>,
     );
 
     expect(popconfirm.container.querySelector('.ant-popover')).toBe(null);
     popconfirm.rerender(
-      <Popconfirm title='code' open>
+      <Popconfirm title="code" open>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -118,7 +118,7 @@ describe('Popconfirm', () => {
     );
 
     popconfirm.rerender(
-      <Popconfirm title='code' open={false}>
+      <Popconfirm title="code" open={false}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -136,7 +136,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const popconfirm = render(
-      <Popconfirm title='code' onConfirm={confirm} onCancel={cancel} onOpenChange={onOpenChange}>
+      <Popconfirm title="code" onConfirm={confirm} onCancel={cancel} onOpenChange={onOpenChange}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -165,7 +165,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const popconfirm = render(
-      <Popconfirm title='code' onConfirm={confirm} onOpenChange={onOpenChange}>
+      <Popconfirm title="code" onConfirm={confirm} onOpenChange={onOpenChange}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -181,7 +181,7 @@ describe('Popconfirm', () => {
 
   it('should support customize icon', () => {
     const popconfirm = render(
-      <Popconfirm title='code' icon={<span className='customize-icon'>custom-icon</span>}>
+      <Popconfirm title="code" icon={<span className="customize-icon">custom-icon</span>}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -196,8 +196,8 @@ describe('Popconfirm', () => {
     const wrapper = render(
       <Popconfirm
         open
-        title='x'
-        prefixCls='custom-popconfirm'
+        title="x"
+        prefixCls="custom-popconfirm"
         okButtonProps={{ prefixCls: btnPrefixCls }}
         cancelButtonProps={{ prefixCls: btnPrefixCls }}
       >
@@ -211,7 +211,7 @@ describe('Popconfirm', () => {
 
   it('should support defaultOpen', () => {
     const wrapper = render(
-      <Popconfirm title='code' defaultOpen>
+      <Popconfirm title="code" defaultOpen>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -220,7 +220,7 @@ describe('Popconfirm', () => {
 
   it('should not open in disabled', () => {
     const wrapper = render(
-      <Popconfirm title='code' disabled>
+      <Popconfirm title="code" disabled>
         <span>click me</span>
       </Popconfirm>,
     );
@@ -234,7 +234,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const wrapper = render(
-      <Popconfirm title='title' mouseEnterDelay={0} mouseLeaveDelay={0} onOpenChange={onOpenChange}>
+      <Popconfirm title="title" mouseEnterDelay={0} mouseLeaveDelay={0} onOpenChange={onOpenChange}>
         <span>Delete</span>
       </Popconfirm>,
     );
@@ -254,7 +254,7 @@ describe('Popconfirm', () => {
       if (show) {
         return (
           <Popconfirm
-            title='will unmount'
+            title="will unmount"
             onConfirm={() =>
               new Promise((resolve) => {
                 setTimeout(() => {
@@ -264,7 +264,7 @@ describe('Popconfirm', () => {
               })
             }
           >
-            <Button className='clickTarget'>Test</Button>
+            <Button className="clickTarget">Test</Button>
           </Popconfirm>
         );
       }
@@ -291,7 +291,7 @@ describe('Popconfirm', () => {
     const onPopupClick = jest.fn();
 
     const popconfirm = render(
-      <Popconfirm title='pop test' onPopupClick={onPopupClick}>
+      <Popconfirm title="pop test" onPopupClick={onPopupClick}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -309,11 +309,11 @@ describe('Popconfirm', () => {
 
     const { container } = render(
       <Popconfirm
-        title='will unmount'
+        title="will unmount"
         onOpenChange={onOpenChange}
         onVisibleChange={onVisibleChange}
       >
-        <span className='target' />
+        <span className="target" />
       </Popconfirm>,
     );
 

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -35,9 +35,9 @@ describe('Popconfirm', () => {
 
     const wrapper = render(
       <Popconfirm
-        title={<span className="popconfirm-test">Are you sure delete this task?</span>}
-        okText="Yes"
-        cancelText="No"
+        title={<span className='popconfirm-test'>Are you sure delete this task?</span>}
+        okText='Yes'
+        cancelText='No'
         mouseEnterDelay={0}
         mouseLeaveDelay={0}
         onOpenChange={onOpenChange}
@@ -57,7 +57,7 @@ describe('Popconfirm', () => {
 
   it('should show overlay when trigger is clicked', async () => {
     const popconfirm = render(
-      <Popconfirm title="code" autoAdjustOverflow={false}>
+      <Popconfirm title='code' autoAdjustOverflow={false}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -100,14 +100,14 @@ describe('Popconfirm', () => {
   it('should be controlled by open', () => {
     jest.useFakeTimers();
     const popconfirm = render(
-      <Popconfirm title="code">
+      <Popconfirm title='code'>
         <span>show me your code</span>
       </Popconfirm>,
     );
 
     expect(popconfirm.container.querySelector('.ant-popover')).toBe(null);
     popconfirm.rerender(
-      <Popconfirm title="code" open>
+      <Popconfirm title='code' open>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -118,7 +118,7 @@ describe('Popconfirm', () => {
     );
 
     popconfirm.rerender(
-      <Popconfirm title="code" open={false}>
+      <Popconfirm title='code' open={false}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -136,7 +136,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const popconfirm = render(
-      <Popconfirm title="code" onConfirm={confirm} onCancel={cancel} onOpenChange={onOpenChange}>
+      <Popconfirm title='code' onConfirm={confirm} onCancel={cancel} onOpenChange={onOpenChange}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -165,7 +165,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const popconfirm = render(
-      <Popconfirm title="code" onConfirm={confirm} onOpenChange={onOpenChange}>
+      <Popconfirm title='code' onConfirm={confirm} onOpenChange={onOpenChange}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -181,7 +181,7 @@ describe('Popconfirm', () => {
 
   it('should support customize icon', () => {
     const popconfirm = render(
-      <Popconfirm title="code" icon={<span className="customize-icon">custom-icon</span>}>
+      <Popconfirm title='code' icon={<span className='customize-icon'>custom-icon</span>}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -196,8 +196,8 @@ describe('Popconfirm', () => {
     const wrapper = render(
       <Popconfirm
         open
-        title="x"
-        prefixCls="custom-popconfirm"
+        title='x'
+        prefixCls='custom-popconfirm'
         okButtonProps={{ prefixCls: btnPrefixCls }}
         cancelButtonProps={{ prefixCls: btnPrefixCls }}
       >
@@ -211,7 +211,7 @@ describe('Popconfirm', () => {
 
   it('should support defaultOpen', () => {
     const wrapper = render(
-      <Popconfirm title="code" defaultOpen>
+      <Popconfirm title='code' defaultOpen>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -220,7 +220,7 @@ describe('Popconfirm', () => {
 
   it('should not open in disabled', () => {
     const wrapper = render(
-      <Popconfirm title="code" disabled>
+      <Popconfirm title='code' disabled>
         <span>click me</span>
       </Popconfirm>,
     );
@@ -234,7 +234,7 @@ describe('Popconfirm', () => {
       e?.persist?.();
     });
     const wrapper = render(
-      <Popconfirm title="title" mouseEnterDelay={0} mouseLeaveDelay={0} onOpenChange={onOpenChange}>
+      <Popconfirm title='title' mouseEnterDelay={0} mouseLeaveDelay={0} onOpenChange={onOpenChange}>
         <span>Delete</span>
       </Popconfirm>,
     );
@@ -254,7 +254,7 @@ describe('Popconfirm', () => {
       if (show) {
         return (
           <Popconfirm
-            title="will unmount"
+            title='will unmount'
             onConfirm={() =>
               new Promise((resolve) => {
                 setTimeout(() => {
@@ -264,7 +264,7 @@ describe('Popconfirm', () => {
               })
             }
           >
-            <Button className="clickTarget">Test</Button>
+            <Button className='clickTarget'>Test</Button>
           </Popconfirm>
         );
       }
@@ -291,7 +291,7 @@ describe('Popconfirm', () => {
     const onPopupClick = jest.fn();
 
     const popconfirm = render(
-      <Popconfirm title="pop test" onPopupClick={onPopupClick}>
+      <Popconfirm title='pop test' onPopupClick={onPopupClick}>
         <span>show me your code</span>
       </Popconfirm>,
     );
@@ -300,5 +300,27 @@ describe('Popconfirm', () => {
     await waitFakeTimer();
     fireEvent.click(popconfirm.container.querySelector('.ant-popover-inner-content')!);
     expect(onPopupClick).toHaveBeenCalled();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/42314
+  it('legacy onVisibleChange should only trigger once', async () => {
+    const onOpenChange = jest.fn();
+    const onVisibleChange = jest.fn();
+
+    const { container } = render(
+      <Popconfirm
+        title='will unmount'
+        onOpenChange={onOpenChange}
+        onVisibleChange={onVisibleChange}
+      >
+        <span className='target' />
+      </Popconfirm>,
+    );
+
+    fireEvent.click(container.querySelector('.target')!);
+    await waitFakeTimer();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onVisibleChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -38,6 +38,19 @@ export interface PopconfirmState {
 }
 
 const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    placement = 'top',
+    trigger = 'click',
+    okType = 'primary',
+    icon = <ExclamationCircleFilled />,
+    children,
+    overlayClassName,
+    onOpenChange,
+    onVisibleChange,
+    ...restProps
+  } = props;
+
   const { getPrefixCls } = React.useContext(ConfigContext);
   const [open, setOpen] = useMergedState(false, {
     value: props.open,
@@ -51,7 +64,8 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     e?: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLDivElement>,
   ) => {
     setOpen(value, true);
-    props.onOpenChange?.(value, e);
+    onVisibleChange?.(value);
+    onOpenChange?.(value, e);
   };
 
   const close = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -71,7 +85,7 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     }
   };
 
-  const onOpenChange = (value: boolean) => {
+  const onInternalOpenChange = (value: boolean) => {
     const { disabled = false } = props;
     if (disabled) {
       return;
@@ -79,16 +93,6 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
     settingOpen(value);
   };
 
-  const {
-    prefixCls: customizePrefixCls,
-    placement = 'top',
-    trigger = 'click',
-    okType = 'primary',
-    icon = <ExclamationCircleFilled />,
-    children,
-    overlayClassName,
-    ...restProps
-  } = props;
   const prefixCls = getPrefixCls('popconfirm', customizePrefixCls);
   const overlayClassNames = classNames(prefixCls, overlayClassName);
 
@@ -99,7 +103,7 @@ const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
       {...omit(restProps, ['title'])}
       trigger={trigger}
       placement={placement}
-      onOpenChange={onOpenChange}
+      onOpenChange={onInternalOpenChange}
       open={open}
       ref={ref}
       overlayClassName={overlayClassNames}

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "mode": "npm"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": "rome format --write",
+    "*.{ts,tsx,js,jsx}": "prettier --ignore-unknown --write",
     "*.{json,less,md}": "prettier --ignore-unknown --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "mode": "npm"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": "prettier --ignore-unknown --write",
+    "*.{ts,tsx,js,jsx}": "rome format --write",
     "*.{json,less,md}": "prettier --ignore-unknown --write"
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #42314
ref #42351

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Popconfirm trigger `onVisibleChange` twice.    |
| 🇨🇳 Chinese |     修复 Popconfirm 的 `onVisibleChange` 会重复触发的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bda5438</samp>

Refactor and test the Popconfirm component. Improve the code style and readability of `components/popconfirm/__tests__/index.test.tsx` and `components/popconfirm/index.tsx`. Ensure backward compatibility with the `onVisibleChange` prop.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bda5438</samp>

*  Simplify props destructuring and assign default values in `Popconfirm` component ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285R41-R53))
*  Support legacy prop `onVisibleChange` and trigger it along with `onOpenChange` in `handleVisibleChange` function ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L54-R68))
*  Rename `onOpenChange` function to `onInternalOpenChange` and remove props destructuring from it ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L74-R88), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L82-L91))
*  Replace `onOpenChange` prop with `onInternalOpenChange` function in `Popover` component ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L102-R106))
*  Replace double quotes with single quotes in test cases to follow code style ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L38-R40), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L60-R60), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L103-R103), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L110-R110), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L121-R121), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L139-R139), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L168-R168), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L184-R184), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L199-R200), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L214-R214), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L223-R223), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L237-R237), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L257-R257), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L267-R267), [link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L294-R294))
*  Add test case to check that `onVisibleChange` is only triggered once when popconfirm is opened or closed ([link](https://github.com/ant-design/ant-design/pull/42393/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362R304-R325))
