### PR TITLE
fix: Use visible first

### DIFF
--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -13,6 +13,7 @@ export interface PlacementsConfig {
   autoAdjustOverflow?: boolean | AdjustOverflow;
   offset: number;
   borderRadius: number;
+  visibleFirst?: boolean;
 }
 
 export function getOverflowOptions(
@@ -141,7 +142,8 @@ const DisableAutoArrowList: Set<keyof BuildInPlacements> = new Set([
 ]);
 
 export default function getPlacements(config: PlacementsConfig) {
-  const { arrowWidth, autoAdjustOverflow, arrowPointAtCenter, offset, borderRadius } = config;
+  const { arrowWidth, autoAdjustOverflow, arrowPointAtCenter, offset, borderRadius, visibleFirst } =
+    config;
   const halfArrowWidth = arrowWidth / 2;
 
   const placementMap: BuildInPlacements = {};
@@ -220,6 +222,11 @@ export default function getPlacements(config: PlacementsConfig) {
 
     // Overflow
     placementInfo.overflow = getOverflowOptions(key, arrowOffset, arrowWidth, autoAdjustOverflow);
+
+    // VisibleFirst
+    if (visibleFirst) {
+      placementInfo.htmlRegion = 'visibleFirst';
+    }
   });
 
   return placementMap;

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -291,6 +291,7 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
         arrowWidth: mergedShowArrow ? token.sizePopupArrow : 0,
         borderRadius: token.borderRadius,
         offset: token.marginXXS,
+        visibleFirst: true,
       })
     );
   }, [arrowPointAtCenter, arrow, builtinPlacements, token]);

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@rc-component/color-picker": "~1.0.0",
     "@rc-component/mutate-observer": "^1.0.0",
     "@rc-component/tour": "~1.8.0",
-    "@rc-component/trigger": "^1.12.0",
+    "@rc-component/trigger": "^1.13.0",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",
     "dayjs": "^1.11.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #42392

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjust Tooltip & Popover display logic. Now the first priority is to ensure that it will not be clipped by `overflow: hidden`, and the second is to ensure that it is displayed within the viewport as much as possible.       |
| 🇨🇳 Chinese |     调整 Tooltip 和 Popover 展示逻辑，现在会优先保证不会被 `overflow: hidden` 裁剪，其次保证尽可能在可见屏幕范围内展示。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d21be3</samp>

Added a `visibleFirst` feature to the tooltip and popover components, which makes them show the first possible placement when the preferred one is not available. Updated the `@rc-component/trigger` dependency to support this feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d21be3</samp>

*  Add `visibleFirst` property to `PlacementsConfig` interface and `getPlacements` function to control tooltip or popover placement when overflow occurs ([link](https://github.com/ant-design/ant-design/pull/42394/files?diff=unified&w=0#diff-070d8296fed37973d7c8a2606b58e5a87b7d40ccb36fcb41d099a51af601730eR16), [link](https://github.com/ant-design/ant-design/pull/42394/files?diff=unified&w=0#diff-070d8296fed37973d7c8a2606b58e5a87b7d40ccb36fcb41d099a51af601730eL144-R146), [link](https://github.com/ant-design/ant-design/pull/42394/files?diff=unified&w=0#diff-070d8296fed37973d7c8a2606b58e5a87b7d40ccb36fcb41d099a51af601730eR225-R229))
*  Enable `visibleFirst` feature for `Tooltip` component by setting it to true ([link](https://github.com/ant-design/ant-design/pull/42394/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966R294))
*  Update `@rc-component/trigger` dependency version to `^1.13.0` to use the new feature of `visibleFirst` in `rc-trigger` component ([link](https://github.com/ant-design/ant-design/pull/42394/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L119-R119))
