### PR TITLE
chore: rm rome to use prettier back

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "mode": "npm"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": "rome format --write",
+    "*.{ts,tsx,js,jsx}": "prettier --ignore-unknown --write",
     "*.{json,less,md}": "prettier --ignore-unknown --write"
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (about what?)

### 🔗 Related issue link

ref https://github.com/rome/tools/issues/4469

### 💡 Background and solution

Since latest rome will replace jsx to single quota which will mass commit history. Revert back to prettier in `lint-stage` tmp. Wait for `jsxSingleQouta` support.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |       -    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76a8fa8</samp>

Updated the lint-staged script to use `prettier` for formatting code. This improves consistency and avoids conflicts with `rome`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76a8fa8</samp>

* Replace rome with prettier for formatting TypeScript and JavaScript files in lint-staged script ([link](https://github.com/ant-design/ant-design/pull/42395/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L323-R323))
