### PR TITLE
feat(ColorPicker): fix coverage down issue in ColorPicker

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -164,11 +164,17 @@ if (process.env.NODE_ENV !== 'production') {
   ColorPicker.displayName = 'ColorPicker';
 }
 
-const PurePanel = genPurePanel(ColorPicker, 'color-picker', null, (props: ColorPickerProps) => ({
-  ...props,
-  placement: 'bottom' as TriggerPlacement,
-  autoAdjustOverflow: false,
-}));
+const PurePanel = genPurePanel(
+  ColorPicker,
+  'color-picker',
+  /* istanbul ignore next */
+  (prefixCls) => prefixCls,
+  (props: ColorPickerProps) => ({
+    ...props,
+    placement: 'bottom' as TriggerPlacement,
+    autoAdjustOverflow: false,
+  }),
+);
 
 ColorPicker._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
 

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { CSSProperties } from 'react';
 import React, { useContext, useState } from 'react';
+import genPurePanel from '../_util/PurePanel';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
 import type { PopoverProps } from '../popover';
@@ -19,7 +20,6 @@ import useColorState from './hooks/useColorState';
 import type { ColorFormat, ColorPickerBaseProps, PresetsItem } from './interface';
 import useStyle from './style/index';
 import { customizePrefixCls, generateColor } from './util';
-import genPurePanel from '../_util/PurePanel';
 
 export interface ColorPickerProps
   extends Omit<
@@ -164,16 +164,11 @@ if (process.env.NODE_ENV !== 'production') {
   ColorPicker.displayName = 'ColorPicker';
 }
 
-const PurePanel = genPurePanel(
-  ColorPicker,
-  'color-picker',
-  (prefixCls) => prefixCls,
-  (props: ColorPickerProps) => ({
-    ...props,
-    placement: 'bottom' as TriggerPlacement,
-    autoAdjustOverflow: false,
-  }),
-);
+const PurePanel = genPurePanel(ColorPicker, 'color-picker', null, (props: ColorPickerProps) => ({
+  ...props,
+  placement: 'bottom' as TriggerPlacement,
+  autoAdjustOverflow: false,
+}));
 
 ColorPicker._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/pull/42388#issuecomment-1549079489
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- Fix coverage down issue in ColorPicker

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix coverage down issue in ColorPicker |
| 🇨🇳 Chinese | 修复 ColorPicker 组件覆盖率下降的问题  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26135e8</samp>

Refactor `ColorPicker` component to use `PurePanel` wrapper for better code quality and efficiency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26135e8</samp>

*  Import `genPurePanel` function to create a pure component wrapper for `ColorPicker` ([link](https://github.com/ant-design/ant-design/pull/42409/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR10))
*  Remove redundant import of `genPurePanel` function ([link](https://github.com/ant-design/ant-design/pull/42409/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL22))
*  Simplify call to `genPurePanel` function by passing `null` as third argument ([link](https://github.com/ant-design/ant-design/pull/42409/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL167-R171))
