### PR TITLE
typescript: replace unknown & any with SliderRef

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
 import type { SliderProps as RcSliderProps } from 'rc-slider';
 import RcSlider from 'rc-slider';
-import * as React from 'react';
+import type { SliderRef } from 'rc-slider/lib/Slider';
+import React from 'react';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { TooltipPlacement } from '../tooltip';
-import warning from '../_util/warning';
 import SliderTooltip from './SliderTooltip';
-
 import useStyle from './style';
 
 export type SliderMarks = RcSliderProps['marks'];
@@ -97,156 +97,153 @@ interface SliderRange {
 
 export type Opens = { [index: number]: boolean };
 
-const Slider = React.forwardRef<unknown, SliderSingleProps | SliderRangeProps>(
-  (props, ref: any) => {
+const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    range,
+    className,
+    rootClassName,
+    // Deprecated Props
+    tooltipPrefixCls: legacyTooltipPrefixCls,
+    tipFormatter: legacyTipFormatter,
+    tooltipVisible: legacyTooltipVisible,
+    getTooltipPopupContainer: legacyGetTooltipPopupContainer,
+    tooltipPlacement: legacyTooltipPlacement,
+
+    ...restProps
+  } = props;
+
+  const { getPrefixCls, direction, getPopupContainer } = React.useContext(ConfigContext);
+  const [opens, setOpens] = React.useState<Opens>({});
+
+  const toggleTooltipOpen = (index: number, open: boolean) => {
+    setOpens((prev: Opens) => ({ ...prev, [index]: open }));
+  };
+
+  const getTooltipPlacement = (placement?: TooltipPlacement, vertical?: boolean) => {
+    if (placement) {
+      return placement;
+    }
+    if (!vertical) {
+      return 'top';
+    }
+    return direction === 'rtl' ? 'left' : 'right';
+  };
+
+  const prefixCls = getPrefixCls('slider', customizePrefixCls);
+
+  const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const cls = classNames(
+    className,
+    rootClassName,
+    {
+      [`${prefixCls}-rtl`]: direction === 'rtl',
+    },
+    hashId,
+  );
+
+  // make reverse default on rtl direction
+  if (direction === 'rtl' && !restProps.vertical) {
+    restProps.reverse = !restProps.reverse;
+  }
+
+  // Range config
+  const [mergedRange, draggableTrack] = React.useMemo(() => {
+    if (!range) {
+      return [false];
+    }
+
+    return typeof range === 'object' ? [true, range.draggableTrack] : [true, false];
+  }, [range]);
+
+  // Warning for deprecated usage
+  if (process.env.NODE_ENV !== 'production') {
+    [
+      ['tooltipPrefixCls', 'prefixCls'],
+      ['getTooltipPopupContainer', 'getPopupContainer'],
+      ['tipFormatter', 'formatter'],
+      ['tooltipPlacement', 'placement'],
+      ['tooltipVisible', 'open'],
+    ].forEach(([deprecatedName, newName]) => {
+      warning(
+        !(deprecatedName in props),
+        'Slider',
+        `\`${deprecatedName}\` is deprecated, please use \`tooltip.${newName}\` instead.`,
+      );
+    });
+  }
+
+  const handleRender: RcSliderProps['handleRender'] = (node, info) => {
+    const { index, dragging } = info;
+
+    const { tooltip = {}, vertical } = props;
+
+    const tooltipProps: SliderTooltipProps = {
+      ...tooltip,
+    };
     const {
-      prefixCls: customizePrefixCls,
-      range,
-      className,
-      rootClassName,
+      open: tooltipOpen,
+      placement: tooltipPlacement,
+      getPopupContainer: getTooltipPopupContainer,
+      prefixCls: customizeTooltipPrefixCls,
+      formatter: tipFormatter,
+    } = tooltipProps;
 
-      // Deprecated Props
-      tooltipPrefixCls: legacyTooltipPrefixCls,
-      tipFormatter: legacyTipFormatter,
-      tooltipVisible: legacyTooltipVisible,
-      getTooltipPopupContainer: legacyGetTooltipPopupContainer,
-      tooltipPlacement: legacyTooltipPlacement,
-
-      ...restProps
-    } = props;
-
-    const { getPrefixCls, direction, getPopupContainer } = React.useContext(ConfigContext);
-    const [opens, setOpens] = React.useState<Opens>({});
-
-    const toggleTooltipOpen = (index: number, open: boolean) => {
-      setOpens((prev: Opens) => ({ ...prev, [index]: open }));
-    };
-
-    const getTooltipPlacement = (placement?: TooltipPlacement, vertical?: boolean) => {
-      if (placement) {
-        return placement;
-      }
-      if (!vertical) {
-        return 'top';
-      }
-      return direction === 'rtl' ? 'left' : 'right';
-    };
-
-    const prefixCls = getPrefixCls('slider', customizePrefixCls);
-
-    const [wrapSSR, hashId] = useStyle(prefixCls);
-
-    const cls = classNames(
-      className,
-      rootClassName,
-      {
-        [`${prefixCls}-rtl`]: direction === 'rtl',
-      },
-      hashId,
-    );
-
-    // make reverse default on rtl direction
-    if (direction === 'rtl' && !restProps.vertical) {
-      restProps.reverse = !restProps.reverse;
+    let mergedTipFormatter;
+    if (tipFormatter || tipFormatter === null) {
+      mergedTipFormatter = tipFormatter;
+    } else if (legacyTipFormatter || legacyTipFormatter === null) {
+      mergedTipFormatter = legacyTipFormatter;
+    } else {
+      mergedTipFormatter = defaultFormatter;
     }
 
-    // Range config
-    const [mergedRange, draggableTrack] = React.useMemo(() => {
-      if (!range) {
-        return [false];
-      }
+    const isTipFormatter = mergedTipFormatter ? opens[index] || dragging : false;
+    const open =
+      tooltipOpen ?? legacyTooltipVisible ?? (tooltipOpen === undefined && isTipFormatter);
 
-      return typeof range === 'object' ? [true, range.draggableTrack] : [true, false];
-    }, [range]);
-
-    // Warning for deprecated usage
-    if (process.env.NODE_ENV !== 'production') {
-      [
-        ['tooltipPrefixCls', 'prefixCls'],
-        ['getTooltipPopupContainer', 'getPopupContainer'],
-        ['tipFormatter', 'formatter'],
-        ['tooltipPlacement', 'placement'],
-        ['tooltipVisible', 'open'],
-      ].forEach(([deprecatedName, newName]) => {
-        warning(
-          !(deprecatedName in props),
-          'Slider',
-          `\`${deprecatedName}\` is deprecated, please use \`tooltip.${newName}\` instead.`,
-        );
-      });
-    }
-
-    const handleRender: RcSliderProps['handleRender'] = (node, info) => {
-      const { index, dragging } = info;
-
-      const { tooltip = {}, vertical } = props;
-
-      const tooltipProps: SliderTooltipProps = {
-        ...tooltip,
-      };
-      const {
-        open: tooltipOpen,
-        placement: tooltipPlacement,
-        getPopupContainer: getTooltipPopupContainer,
-        prefixCls: customizeTooltipPrefixCls,
-        formatter: tipFormatter,
-      } = tooltipProps;
-
-      let mergedTipFormatter;
-      if (tipFormatter || tipFormatter === null) {
-        mergedTipFormatter = tipFormatter;
-      } else if (legacyTipFormatter || legacyTipFormatter === null) {
-        mergedTipFormatter = legacyTipFormatter;
-      } else {
-        mergedTipFormatter = defaultFormatter;
-      }
-
-      const isTipFormatter = mergedTipFormatter ? opens[index] || dragging : false;
-      const open =
-        tooltipOpen ?? legacyTooltipVisible ?? (tooltipOpen === undefined && isTipFormatter);
-
-      const passedProps = {
-        ...node.props,
-        onMouseEnter: () => toggleTooltipOpen(index, true),
-        onMouseLeave: () => toggleTooltipOpen(index, false),
-      };
-
-      const tooltipPrefixCls = getPrefixCls(
-        'tooltip',
-        customizeTooltipPrefixCls ?? legacyTooltipPrefixCls,
-      );
-
-      return (
-        <SliderTooltip
-          prefixCls={tooltipPrefixCls}
-          title={mergedTipFormatter ? mergedTipFormatter(info.value) : ''}
-          open={open}
-          placement={getTooltipPlacement(tooltipPlacement ?? legacyTooltipPlacement, vertical)}
-          key={index}
-          overlayClassName={`${prefixCls}-tooltip`}
-          getPopupContainer={
-            getTooltipPopupContainer || legacyGetTooltipPopupContainer || getPopupContainer
-          }
-        >
-          {React.cloneElement(node, passedProps)}
-        </SliderTooltip>
-      );
+    const passedProps = {
+      ...node.props,
+      onMouseEnter: () => toggleTooltipOpen(index, true),
+      onMouseLeave: () => toggleTooltipOpen(index, false),
     };
 
-    return wrapSSR(
-      <RcSlider
-        {...(restProps as SliderRangeProps)}
-        step={restProps.step!}
-        range={mergedRange}
-        draggableTrack={draggableTrack}
-        className={cls}
-        ref={ref}
-        prefixCls={prefixCls}
-        handleRender={handleRender}
-      />,
+    const tooltipPrefixCls = getPrefixCls(
+      'tooltip',
+      customizeTooltipPrefixCls ?? legacyTooltipPrefixCls,
     );
-  },
-);
+
+    return (
+      <SliderTooltip
+        prefixCls={tooltipPrefixCls}
+        title={mergedTipFormatter ? mergedTipFormatter(info.value) : ''}
+        open={open}
+        placement={getTooltipPlacement(tooltipPlacement ?? legacyTooltipPlacement, vertical)}
+        key={index}
+        overlayClassName={`${prefixCls}-tooltip`}
+        getPopupContainer={
+          getTooltipPopupContainer || legacyGetTooltipPopupContainer || getPopupContainer
+        }
+      >
+        {React.cloneElement(node, passedProps)}
+      </SliderTooltip>
+    );
+  };
+
+  return wrapSSR(
+    <RcSlider
+      {...restProps}
+      step={restProps.step}
+      range={mergedRange}
+      draggableTrack={draggableTrack}
+      className={cls}
+      ref={ref}
+      prefixCls={prefixCls}
+      handleRender={handleRender}
+    />,
+  );
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Slider.displayName = 'Slider';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | typescript: replace unknown & any with SliderRef |
| 🇨🇳 Chinese | 删除 unknown 和 any 类型，用 SliderRef  代替 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe031f5</samp>

This pull request fixes some type mismatches and removes unnecessary assertions in the `Slider` component. It aligns the `ref` and `step` types with the underlying `RcSlider` component and avoids using `!` to assert non-null values. This makes the code more consistent and reliable.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe031f5</samp>

*  Add `SliderRef` type to `ref` parameter of `Slider` component to improve type safety and readability ([link](https://github.com/ant-design/ant-design/pull/42420/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL4-R9), [link](https://github.com/ant-design/ant-design/pull/42420/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL100-R247))
*  Remove non-null assertion operator from `step` prop of `RcSlider` component to avoid potential errors and confusion ([link](https://github.com/ant-design/ant-design/pull/42420/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL100-R247))
