### PR TITLE
demo: update popconfirm demo

### DIFF
--- a/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -99,7 +99,7 @@ Array [
 exports[`renders components/popconfirm/demo/basic.tsx extend context correctly 1`] = `
 Array [
   <button
-    class="ant-btn ant-btn-link"
+    class="ant-btn ant-btn-default ant-btn-dangerous"
     type="button"
   >
     <span>
@@ -195,7 +195,7 @@ Array [
 exports[`renders components/popconfirm/demo/dynamic-trigger.tsx extend context correctly 1`] = `
 <div>
   <button
-    class="ant-btn ant-btn-link"
+    class="ant-btn ant-btn-default ant-btn-dangerous"
     type="button"
   >
     <span>
@@ -314,7 +314,7 @@ exports[`renders components/popconfirm/demo/dynamic-trigger.tsx extend context c
 exports[`renders components/popconfirm/demo/icon.tsx extend context correctly 1`] = `
 Array [
   <button
-    class="ant-btn ant-btn-link"
+    class="ant-btn ant-btn-default ant-btn-dangerous"
     type="button"
   >
     <span>
@@ -414,7 +414,7 @@ Array [
 exports[`renders components/popconfirm/demo/locale.tsx extend context correctly 1`] = `
 Array [
   <button
-    class="ant-btn ant-btn-link"
+    class="ant-btn ant-btn-default ant-btn-dangerous"
     type="button"
   >
     <span>
@@ -1846,6 +1846,117 @@ Array [
                   </svg>
                 </span>
               </span>
+              <div
+                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+              >
+                Are you OK?
+              </div>
+            </div>
+            <div
+              class="ant-popconfirm-description"
+            >
+              Does this look good?
+            </div>
+            <div
+              class="ant-popconfirm-buttons"
+            >
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-popconfirm-inner-content"
+          >
+            <div
+              class="ant-popconfirm-message"
+            >
+              <div
+                class="ant-popconfirm-message-title"
+              >
+                Are you OK?
+              </div>
+            </div>
+            <div
+              class="ant-popconfirm-buttons"
+            >
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-popconfirm-inner-content"
+          >
+            <div
+              class="ant-popconfirm-message"
+            >
               <div
                 class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
               >

--- a/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders components/popconfirm/demo/async.tsx correctly 1`] = `
 
 exports[`renders components/popconfirm/demo/basic.tsx correctly 1`] = `
 <button
-  class="ant-btn ant-btn-link"
+  class="ant-btn ant-btn-default ant-btn-dangerous"
   type="button"
 >
   <span>
@@ -25,7 +25,7 @@ exports[`renders components/popconfirm/demo/basic.tsx correctly 1`] = `
 exports[`renders components/popconfirm/demo/dynamic-trigger.tsx correctly 1`] = `
 <div>
   <button
-    class="ant-btn ant-btn-link"
+    class="ant-btn ant-btn-default ant-btn-dangerous"
     type="button"
   >
     <span>
@@ -60,7 +60,7 @@ exports[`renders components/popconfirm/demo/dynamic-trigger.tsx correctly 1`] = 
 
 exports[`renders components/popconfirm/demo/icon.tsx correctly 1`] = `
 <button
-  class="ant-btn ant-btn-link"
+  class="ant-btn ant-btn-default ant-btn-dangerous"
   type="button"
 >
   <span>
@@ -71,7 +71,7 @@ exports[`renders components/popconfirm/demo/icon.tsx correctly 1`] = `
 
 exports[`renders components/popconfirm/demo/locale.tsx correctly 1`] = `
 <button
-  class="ant-btn ant-btn-link"
+  class="ant-btn ant-btn-default ant-btn-dangerous"
   type="button"
 >
   <span>
@@ -338,6 +338,117 @@ Array [
                   </svg>
                 </span>
               </span>
+              <div
+                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+              >
+                Are you OK?
+              </div>
+            </div>
+            <div
+              class="ant-popconfirm-description"
+            >
+              Does this look good?
+            </div>
+            <div
+              class="ant-popconfirm-buttons"
+            >
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-popconfirm-inner-content"
+          >
+            <div
+              class="ant-popconfirm-message"
+            >
+              <div
+                class="ant-popconfirm-message-title"
+              >
+                Are you OK?
+              </div>
+            </div>
+            <div
+              class="ant-popconfirm-buttons"
+            >
+              <button
+                class="ant-btn ant-btn-default ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+              </button>
+              <button
+                class="ant-btn ant-btn-primary ant-btn-sm"
+                type="button"
+              >
+                <span>
+                  OK
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-popconfirm-inner-content"
+          >
+            <div
+              class="ant-popconfirm-message"
+            >
               <div
                 class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
               >

--- a/components/popconfirm/demo/basic.tsx
+++ b/components/popconfirm/demo/basic.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => (
     okText="Yes"
     cancelText="No"
   >
-    <Button type="link">Delete</Button>
+    <Button danger>Delete</Button>
   </Popconfirm>
 );
 

--- a/components/popconfirm/demo/dynamic-trigger.tsx
+++ b/components/popconfirm/demo/dynamic-trigger.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { Button, message, Popconfirm, Switch } from 'antd';
+import React, { useState } from 'react';
 
 const App: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -45,7 +45,7 @@ const App: React.FC = () => {
         okText="Yes"
         cancelText="No"
       >
-        <Button type="link">Delete a task</Button>
+        <Button danger>Delete a task</Button>
       </Popconfirm>
       <br />
       <br />

--- a/components/popconfirm/demo/icon.tsx
+++ b/components/popconfirm/demo/icon.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Popconfirm } from 'antd';
+import React from 'react';
 
 const App: React.FC = () => (
   <Popconfirm
@@ -8,7 +8,7 @@ const App: React.FC = () => (
     description="Are you sure to delete this task?"
     icon={<QuestionCircleOutlined style={{ color: 'red' }} />}
   >
-    <Button type="link">Delete</Button>
+    <Button danger>Delete</Button>
   </Popconfirm>
 );
 

--- a/components/popconfirm/demo/locale.tsx
+++ b/components/popconfirm/demo/locale.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Button, Popconfirm } from 'antd';
+import React from 'react';
 
 const App: React.FC = () => (
   <Popconfirm
@@ -8,7 +8,7 @@ const App: React.FC = () => (
     okText="Yes"
     cancelText="No"
   >
-    <Button type="link">Delete</Button>
+    <Button danger>Delete</Button>
   </Popconfirm>
 );
 

--- a/components/popconfirm/demo/render-panel.tsx
+++ b/components/popconfirm/demo/render-panel.tsx
@@ -12,6 +12,7 @@ const App: React.FC = () => (
       placement="bottomRight"
       style={{ width: 250 }}
     />
+    <InternalPopconfirm icon={null} title="Are you OK?" />
     <InternalPopconfirm icon={null} title="Are you OK?" description="Does this look good?" />
   </>
 );

--- a/components/popconfirm/demo/render-panel.tsx
+++ b/components/popconfirm/demo/render-panel.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Popconfirm } from 'antd';
+import React from 'react';
 
 const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPopconfirm } = Popconfirm;
 
@@ -12,6 +12,7 @@ const App: React.FC = () => (
       placement="bottomRight"
       style={{ width: 250 }}
     />
+    <InternalPopconfirm icon={null} title="Are you OK?" description="Does this look good?" />
   </>
 );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d693f7</samp>

The pull request improves the popconfirm component demos by using the new icon and button props, changing the button types to danger where appropriate, and following the import order convention. It also adds a new demo of `PopconfirmPanel` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d693f7</samp>

* Change the button type from link to danger in four popconfirm examples to improve visibility and consistency ([link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-661442229d2d6d561e8842c81f83c4baa43ab7d6071a6d1ddc2f91427a4a8d8bL23-R23), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-875fcb50b8b6f5fc48a4ba54dffdf71ac9fc4c0c553415de0ca836af4f2c6349L48-R48), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-6b357e8694b3776456d247762954cc0b721b1f91009a8f3efdc1a562bd1dbf66L11-R11), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-d7f0a163fc26f16c7f2e8d0dcd98a084b3989d8323aa69ebb5f6dca3e4feb844L11-R11))
* Reorder the import statements in five files to follow the ESLint rule of placing external imports before internal imports (`basic.tsx`, `dynamic-trigger.tsx`, `icon.tsx`, `locale.tsx`, `render-panel.tsx`) ([link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-875fcb50b8b6f5fc48a4ba54dffdf71ac9fc4c0c553415de0ca836af4f2c6349L1-R2), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-6b357e8694b3776456d247762954cc0b721b1f91009a8f3efdc1a562bd1dbf66L1-R3), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-d7f0a163fc26f16c7f2e8d0dcd98a084b3989d8323aa69ebb5f6dca3e4feb844L1-R2), [link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-e75a89b208e3f8d696bb8d55bb0d3b20254ed72a5b88afa09b1d1a11756afe16L1-R2))
* Add a new example of using the internal popconfirm panel in `render-panel.tsx` to demonstrate its usage and props ([link](https://github.com/ant-design/ant-design/pull/42429/files?diff=unified&w=0#diff-e75a89b208e3f8d696bb8d55bb0d3b20254ed72a5b88afa09b1d1a11756afe16R15))
