### PR TITLE
feat: Calendar `onSelect` support `info.source` param

### DIFF
--- a/components/calendar/Header.tsx
+++ b/components/calendar/Header.tsx
@@ -5,7 +5,7 @@ import { useContext, useMemo } from 'react';
 import { FormItemInputContext } from '../form/context';
 import { Button, Group } from '../radio';
 import Select from '../select';
-import type { CalendarMode } from './generateCalendar';
+import type { CalendarMode, SelectInfo } from './generateCalendar';
 
 const YearSelectOffset = 10;
 const YearSelectTotal = 20;
@@ -147,7 +147,7 @@ export interface CalendarHeaderProps<DateType> {
   locale: Locale;
   mode: CalendarMode;
   fullscreen: boolean;
-  onChange: (date: DateType) => void;
+  onChange: (date: DateType, source: SelectInfo['source']) => void;
   onModeChange: (mode: CalendarMode) => void;
 }
 function CalendarHeader<DateType>(props: CalendarHeaderProps<DateType>) {
@@ -165,7 +165,6 @@ function CalendarHeader<DateType>(props: CalendarHeaderProps<DateType>) {
 
   const sharedProps = {
     ...props,
-    onChange,
     fullscreen,
     divRef,
   };
@@ -173,8 +172,20 @@ function CalendarHeader<DateType>(props: CalendarHeaderProps<DateType>) {
   return (
     <div className={`${prefixCls}-header`} ref={divRef}>
       <FormItemInputContext.Provider value={mergedFormItemInputContext}>
-        <YearSelect {...sharedProps} />
-        {mode === 'month' && <MonthSelect {...sharedProps} />}
+        <YearSelect
+          {...sharedProps}
+          onChange={(v) => {
+            onChange(v, 'year');
+          }}
+        />
+        {mode === 'month' && (
+          <MonthSelect
+            {...sharedProps}
+            onChange={(v) => {
+              onChange(v, 'month');
+            }}
+          />
+        )}
       </FormItemInputContext.Provider>
       <ModeSwitch {...sharedProps} onModeChange={onModeChange} />
     </div>

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -76,7 +76,7 @@ describe('Calendar', () => {
     const { container } = render(<Calendar onSelect={onSelect} onChange={onChange} />);
 
     fireEvent.click(container.querySelector('.ant-picker-cell')!);
-    expect(onSelect).toHaveBeenCalledWith(expect.anything());
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'date' });
 
     const value = onSelect.mock.calls[0][0];
     expect(Dayjs.isDayjs(value)).toBe(true);
@@ -270,7 +270,7 @@ describe('Calendar', () => {
     const end = Dayjs('2019-11-01');
     const onValueChange = jest.fn();
     createWrapper(start, end, value, onValueChange);
-    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(3));
+    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(3), 'year');
   });
 
   it('if start.month > value.month, set value.month to start.month', () => {
@@ -279,7 +279,7 @@ describe('Calendar', () => {
     const end = Dayjs('2019-03-01');
     const onValueChange = jest.fn();
     createWrapper(start, end, value, onValueChange);
-    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(10));
+    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(10), 'year');
   });
 
   it('if change year and month > end month, set value.month to end.month', () => {
@@ -302,7 +302,7 @@ describe('Calendar', () => {
     fireEvent.click(
       Array.from(wrapper.container.querySelectorAll('.ant-select-item-option')).at(-1)!,
     );
-    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(2));
+    expect(onValueChange).toHaveBeenCalledWith(value.year(2019).month(2), 'year');
   });
 
   it('onMonthChange should work correctly', () => {
@@ -324,7 +324,7 @@ describe('Calendar', () => {
     );
     openSelect(wrapper.container, '.ant-picker-calendar-month-select');
     clickSelectItem(wrapper.container);
-    expect(onValueChange).toHaveBeenCalledWith(value.month(10));
+    expect(onValueChange).toHaveBeenCalledWith(value.month(10), 'month');
   });
 
   it('onTypeChange should work correctly', () => {

--- a/components/calendar/__tests__/select.test.tsx
+++ b/components/calendar/__tests__/select.test.tsx
@@ -47,6 +47,31 @@ describe('Calendar.onSelect', () => {
     expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'month' });
   });
 
+  it('source of customize', async () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Calendar
+        onSelect={onSelect}
+        headerRender={({ onChange }) => (
+          <button
+            className="bamboo"
+            type="button"
+            onClick={() => {
+              onChange(Dayjs('1999-01-01'));
+            }}
+          >
+            Trigger
+          </button>
+        )}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.bamboo')!);
+    await waitFakeTimer();
+
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'customize' });
+  });
+
   it('source of date', () => {
     const onSelect = jest.fn();
     const { container } = render(<Calendar onSelect={onSelect} />);

--- a/components/calendar/__tests__/select.test.tsx
+++ b/components/calendar/__tests__/select.test.tsx
@@ -1,0 +1,70 @@
+import Dayjs from 'dayjs';
+import 'dayjs/locale/zh-cn';
+import MockDate from 'mockdate';
+import { resetWarned } from 'rc-util/lib/warning';
+import React from 'react';
+import Calendar from '..';
+import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+
+describe('Calendar.onSelect', () => {
+  beforeAll(() => {
+    MockDate.set(Dayjs('2000-01-01').valueOf());
+  });
+
+  beforeEach(() => {
+    resetWarned();
+    jest.useFakeTimers();
+    jest.clearAllTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('source of year select', async () => {
+    const onSelect = jest.fn();
+    const { container } = render(<Calendar onSelect={onSelect} />);
+
+    fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
+    await waitFakeTimer();
+
+    fireEvent.click(container.querySelector('.ant-select-item-option')!);
+    await waitFakeTimer();
+
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'year' });
+  });
+
+  it('source of month select', async () => {
+    const onSelect = jest.fn();
+    const { container } = render(<Calendar onSelect={onSelect} />);
+
+    fireEvent.mouseDown(container.querySelectorAll('.ant-select-selector')[1]!);
+    await waitFakeTimer();
+
+    fireEvent.click(container.querySelector('.ant-select-item-option')!);
+    await waitFakeTimer();
+
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'month' });
+  });
+
+  it('source of date', () => {
+    const onSelect = jest.fn();
+    const { container } = render(<Calendar onSelect={onSelect} />);
+
+    fireEvent.click(container.querySelector('.ant-picker-cell')!);
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'date' });
+  });
+
+  it('source of date with month panel', async () => {
+    const onSelect = jest.fn();
+    const onPanelChange = jest.fn();
+    const { container } = render(<Calendar onSelect={onSelect} onPanelChange={onPanelChange} />);
+
+    // Click year radio
+    fireEvent.click(container.querySelectorAll('.ant-radio-button-input')[1]!);
+    expect(onPanelChange).toHaveBeenCalledWith(expect.anything(), 'year');
+
+    fireEvent.click(container.querySelector('.ant-picker-cell')!);
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), { source: 'date' });
+  });
+});

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
 import { PickerPanel as RCPickerPanel } from 'rc-picker';
-import type { GenerateConfig } from 'rc-picker/lib/generate';
-import type { CellRenderInfo } from 'rc-picker/lib/interface';
 import type {
   PickerPanelBaseProps as RCPickerPanelBaseProps,
   PickerPanelDateProps as RCPickerPanelDateProps,
   PickerPanelTimeProps as RCPickerPanelTimeProps,
 } from 'rc-picker/lib/PickerPanel';
+import type { GenerateConfig } from 'rc-picker/lib/generate';
+import type { CellRenderInfo } from 'rc-picker/lib/interface';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
 import { ConfigContext } from '../config-provider';
@@ -14,8 +14,8 @@ import { useLocale } from '../locale';
 import CalendarHeader from './Header';
 import enUS from './locale/en_US';
 
-import useStyle from './style';
 import warning from '../_util/warning';
+import useStyle from './style';
 
 type InjectDefaultProps<Props> = Omit<
   Props,
@@ -43,6 +43,10 @@ export type HeaderRender<DateType> = (config: {
   onTypeChange: (type: CalendarMode) => void;
 }) => React.ReactNode;
 
+export interface SelectInfo {
+  source: 'year' | 'month' | 'date' | 'customize';
+}
+
 export interface CalendarProps<DateType> {
   prefixCls?: string;
   className?: string;
@@ -68,7 +72,7 @@ export interface CalendarProps<DateType> {
   fullscreen?: boolean;
   onChange?: (date: DateType) => void;
   onPanelChange?: (date: DateType, mode: CalendarMode) => void;
-  onSelect?: (date: DateType) => void;
+  onSelect?: (date: DateType, selectInfo: SelectInfo) => void;
 }
 
 function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
@@ -198,10 +202,10 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
       triggerPanelChange(mergedValue, newMode);
     };
 
-    const onInternalSelect = (date: DateType) => {
+    const onInternalSelect = (date: DateType, source: SelectInfo['source']) => {
       triggerChange(date);
 
-      onSelect?.(date);
+      onSelect?.(date, { source });
     };
 
     // ====================== Locale ======================
@@ -310,7 +314,9 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
           headerRender({
             value: mergedValue,
             type: mergedMode,
-            onChange: onInternalSelect,
+            onChange: (nextDate) => {
+              onInternalSelect(nextDate, 'customize');
+            },
             onTypeChange: triggerModeChange,
           })
         ) : (
@@ -332,7 +338,9 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
           locale={contextLocale?.lang}
           generateConfig={generateConfig}
           cellRender={mergedCellRender}
-          onSelect={onInternalSelect}
+          onSelect={(nextDate) => {
+            onInternalSelect(nextDate, 'date');
+          }}
           mode={panelMode}
           picker={panelMode}
           disabledDate={mergedDisabledDate}

--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -55,7 +55,7 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 | value | The current selected date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback for when date changes | function(date: Dayjs) | - |  |
 | onPanelChange | Callback for when panel changes | function(date: Dayjs, mode: string) | - |  |
-| onSelect | Callback for when a date is selected | function(date: Dayjs） | - |  |
+| onSelect | Callback for when a date is selected, include source info | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 |
 
 ## Design Token
 

--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -74,3 +74,17 @@ See [How to set locale for date-related components](/components/date-picker/#loc
 ### Date-related components locale is not working?
 
 See FAQ [Date-related-components-locale-is-not-working?](/docs/react/faq#date-related-components-locale-is-not-working)
+
+### How to get date from panel click?
+
+`onSelect` provide `info.source` to help on this:
+
+```tsx
+<Calendar
+  onSelect={(date, { source }) => {
+    if (source === 'date') {
+      console.log('Panel Select:', source);
+    }
+  }}
+/>
+```

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -60,7 +60,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-p-wQLik200AAA
 | value | 展示日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 日期变化回调 | function(date: Dayjs) | - |  |
 | onPanelChange | 日期面板变化回调 | function(date: Dayjs, mode: string) | - |  |
-| onSelect | 点击选择日期回调 | function(date: Dayjs） | - |  |
+| onSelect | 选择日期回调，包含来源信息 | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 |
 
 ## Design Token
 

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -79,3 +79,17 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-p-wQLik200AAA
 ### 为什么时间类组件的国际化 locale 设置不生效？
 
 参考 FAQ [为什么时间类组件的国际化 locale 设置不生效？](/docs/react/faq#为什么时间类组件的国际化-locale-设置不生效)。
+
+### 如何仅获取来自面板点击的日期？
+
+`onSelect` 事件提供额外的来源信息，你可以通过 `info.source` 来判断来源：
+
+```tsx
+<Calendar
+  onSelect={(date, { source }) => {
+    if (source === 'date') {
+      console.log('Panel Select:', source);
+    }
+  }}
+/>
+```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

resolve #39801
resolve #40407
close #41553
close #42412

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Calendar `onSelect` support `info.source` param to help get select source.       |
| 🇨🇳 Chinese |    Calendar `onSelect` 支持 `info.source` 参数以获取选择来源。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80c155a</samp>

Added a new feature to the `Calendar` component that allows users to access the source of the date selection, such as 'date', 'keyboard', or 'customize'. Enhanced the `onSelect` and `onValueChange` props with a second parameter `info` of type `SelectInfo` to pass the source information. Updated the tests and the documentation accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80c155a</samp>

*  Add a second parameter to the `onSelect` prop of the `Calendar` component to indicate the source of the date selection ([link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L71-R75), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L201-R208), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L313-R319), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L335-R343), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L8-R8), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L150-R150), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-fbade99cf5fe70d3001d5570bf707ff05eaa054eb251848d924e7f65e789b807L176-R188), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-8fab8ed47a3daf0635a3eb887b1fd4fdb984ec4daba5af51505fea4a5d87051bL58-R58), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-8fab8ed47a3daf0635a3eb887b1fd4fdb984ec4daba5af51505fea4a5d87051bR77-R90), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-58e290dfe67aeb90a9d97d4e3e8a790c9aa964113593229b7f2637b66f0c8a50L63-R63), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-58e290dfe67aeb90a9d97d4e3e8a790c9aa964113593229b7f2637b66f0c8a50R82-R95))
*  Update the test cases for the `Calendar` component to pass the second parameter to the `onSelect` prop ([link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL79-R79), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL273-R273), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL282-R282), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL305-R305), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-0a5821c1b32fdf9bf1d3bb55702937aead9206b6762df0497ff7b030f405a21aL327-R327), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-1adf6928f2944623fff32ce60656db37caf630f5931f17db876c1308f0ffa84aR1-R95))
*  Reorder some imports in `generateCalendar.tsx` and `Header.tsx` to follow the alphabetical order ([link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L3-L4), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2R8-R9), [link](https://github.com/ant-design/ant-design/pull/42432/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L17-R18))
