### PR TITLE
fix: Popconfirm margin problem when icon is null

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -21039,7 +21039,7 @@ exports[`ConfigProvider components Popconfirm configProvider 1`] = `
                 </span>
               </span>
               <div
-                class="config-popconfirm-message-title"
+                class="config-popconfirm-message-text"
               />
             </div>
             <div
@@ -21125,7 +21125,7 @@ exports[`ConfigProvider components Popconfirm configProvider componentDisabled 1
                 </span>
               </span>
               <div
-                class="config-popconfirm-message-title"
+                class="config-popconfirm-message-text"
               />
             </div>
             <div
@@ -21213,7 +21213,7 @@ exports[`ConfigProvider components Popconfirm configProvider componentSize large
                 </span>
               </span>
               <div
-                class="config-popconfirm-message-title"
+                class="config-popconfirm-message-text"
               />
             </div>
             <div
@@ -21299,7 +21299,7 @@ exports[`ConfigProvider components Popconfirm configProvider componentSize middl
                 </span>
               </span>
               <div
-                class="config-popconfirm-message-title"
+                class="config-popconfirm-message-text"
               />
             </div>
             <div
@@ -21385,7 +21385,7 @@ exports[`ConfigProvider components Popconfirm configProvider componentSize small
                 </span>
               </span>
               <div
-                class="config-popconfirm-message-title"
+                class="config-popconfirm-message-text"
               />
             </div>
             <div
@@ -21471,7 +21471,7 @@ exports[`ConfigProvider components Popconfirm normal 1`] = `
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               />
             </div>
             <div
@@ -21557,7 +21557,7 @@ exports[`ConfigProvider components Popconfirm prefixCls 1`] = `
                 </span>
               </span>
               <div
-                class="prefix-Popconfirm-message-title"
+                class="prefix-Popconfirm-message-text"
               />
             </div>
             <div

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -59,22 +59,20 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const [contextLocale] = useLocale('Popconfirm', defaultLocale.Popconfirm);
+  const renderTitle = getRenderPropValue(title);
+  const renderDescription = getRenderPropValue(description);
 
   return (
     <div className={`${prefixCls}-inner-content`} onClick={onPopupClick}>
       <div className={`${prefixCls}-message`}>
         {icon && <span className={`${prefixCls}-message-icon`}>{icon}</span>}
-        <div
-          className={classNames(`${prefixCls}-message-title`, {
-            [`${prefixCls}-message-title-only`]: !!description,
-          })}
-        >
-          {getRenderPropValue(title)}
+        <div className={`${prefixCls}-message-text`}>
+          {title && <div className={classNames(`${prefixCls}-title`)}>{renderTitle}</div>}
+          {renderDescription && (
+            <div className={`${prefixCls}-description`}>{renderDescription}</div>
+          )}
         </div>
       </div>
-      {description && (
-        <div className={`${prefixCls}-description`}>{getRenderPropValue(description)}</div>
-      )}
       <div className={`${prefixCls}-buttons`}>
         {showCancel && (
           <Button onClick={onCancel} size="small" {...cancelButtonProps}>

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -59,18 +59,16 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const [contextLocale] = useLocale('Popconfirm', defaultLocale.Popconfirm);
-  const renderTitle = getRenderPropValue(title);
-  const renderDescription = getRenderPropValue(description);
+  const theTitle = getRenderPropValue(title);
+  const theDescription = getRenderPropValue(description);
 
   return (
     <div className={`${prefixCls}-inner-content`} onClick={onPopupClick}>
       <div className={`${prefixCls}-message`}>
         {icon && <span className={`${prefixCls}-message-icon`}>{icon}</span>}
         <div className={`${prefixCls}-message-text`}>
-          {title && <div className={classNames(`${prefixCls}-title`)}>{renderTitle}</div>}
-          {renderDescription && (
-            <div className={`${prefixCls}-description`}>{renderDescription}</div>
-          )}
+          {theTitle && <div className={classNames(`${prefixCls}-title`)}>{theTitle}</div>}
+          {theDescription && <div className={`${prefixCls}-description`}>{theDescription}</div>}
         </div>
       </div>
       <div className={`${prefixCls}-buttons`}>

--- a/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -58,15 +58,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Title
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Title
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Open Popconfirm with async logic
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Open Popconfirm with async logic
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -154,15 +158,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Delete the task
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Delete the task
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Are you sure to delete this task?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Are you sure to delete this task?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -250,15 +258,19 @@ exports[`renders components/popconfirm/demo/dynamic-trigger.tsx extend context c
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Delete the task
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Delete the task
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Are you sure to delete this task?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Are you sure to delete this task?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -373,15 +385,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Delete the task
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Delete the task
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Are you sure to delete this task?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Are you sure to delete this task?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -469,15 +485,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Delete the task
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Delete the task
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Are you sure to delete this task?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Are you sure to delete this task?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -568,15 +588,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -659,15 +683,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -750,15 +778,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -845,15 +877,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -936,15 +972,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1027,15 +1067,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1122,15 +1166,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1213,15 +1261,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1304,15 +1356,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1399,15 +1455,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1490,15 +1550,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1581,15 +1645,19 @@ Array [
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure to delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure to delete this task?
+                  </div>
+                  <div
+                    class="ant-popconfirm-description"
+                  >
+                    Delete the task
+                  </div>
                 </div>
-              </div>
-              <div
-                class="ant-popconfirm-description"
-              >
-                Delete the task
               </div>
               <div
                 class="ant-popconfirm-buttons"
@@ -1678,15 +1746,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Title
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Title
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Open Popconfirm with Promise
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Open Popconfirm with Promise
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -1764,15 +1836,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -1847,15 +1923,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -2044,9 +2124,13 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div
@@ -2122,9 +2206,13 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div

--- a/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1985,9 +1985,13 @@ Array [
               class="ant-popconfirm-message"
             >
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div
@@ -2038,15 +2042,19 @@ Array [
               class="ant-popconfirm-message"
             >
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"

--- a/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
@@ -256,15 +256,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -339,15 +343,19 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"
@@ -536,9 +544,13 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div
@@ -614,9 +626,13 @@ Array [
                 </span>
               </span>
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div

--- a/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo.test.tsx.snap
@@ -405,9 +405,13 @@ Array [
               class="ant-popconfirm-message"
             >
               <div
-                class="ant-popconfirm-message-title"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
               </div>
             </div>
             <div
@@ -458,15 +462,19 @@ Array [
               class="ant-popconfirm-message"
             >
               <div
-                class="ant-popconfirm-message-title ant-popconfirm-message-title-only"
+                class="ant-popconfirm-message-text"
               >
-                Are you OK?
+                <div
+                  class="ant-popconfirm-title"
+                >
+                  Are you OK?
+                </div>
+                <div
+                  class="ant-popconfirm-description"
+                >
+                  Does this look good?
+                </div>
               </div>
-            </div>
-            <div
-              class="ant-popconfirm-description"
-            >
-              Does this look good?
             </div>
             <div
               class="ant-popconfirm-buttons"

--- a/components/popconfirm/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,9 +2,90 @@
 
 exports[`Popconfirm rtl render component should be rendered correctly in RTL direction 1`] = `<span />`;
 
-exports[`Popconfirm should show overlay when trigger is clicked 1`] = `"<div class="ant-popover-arrow" style="position: absolute; bottom: 0px; left: 0px;"></div><div class="ant-popover-content"><div class="ant-popover-inner" role="tooltip"><div class="ant-popover-inner-content"><div class="ant-popconfirm-inner-content"><div class="ant-popconfirm-message"><span class="ant-popconfirm-message-icon"><span role="img" aria-label="exclamation-circle" class="anticon anticon-exclamation-circle"><svg viewBox="64 64 896 896" focusable="false" data-icon="exclamation-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path></svg></span></span><div class="ant-popconfirm-message-title">code</div></div><div class="ant-popconfirm-buttons"><button type="button" class="ant-btn ant-btn-default ant-btn-sm"><span>Cancel</span></button><button type="button" class="ant-btn ant-btn-primary ant-btn-sm"><span>OK</span></button></div></div></div></div></div>"`;
-
-exports[`Popconfirm should show overlay when trigger is clicked 2`] = `"<div class="ant-popover-arrow" style="position: absolute; bottom: 0px; left: 0px;"></div><div class="ant-popover-content"><div class="ant-popover-inner" role="tooltip"><div class="ant-popover-inner-content"><div class="ant-popconfirm-inner-content"><div class="ant-popconfirm-message"><span class="ant-popconfirm-message-icon"><span role="img" aria-label="exclamation-circle" class="anticon anticon-exclamation-circle"><svg viewBox="64 64 896 896" focusable="false" data-icon="exclamation-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path></svg></span></span><div class="ant-popconfirm-message-title">code</div></div><div class="ant-popconfirm-buttons"><button type="button" class="ant-btn ant-btn-default ant-btn-sm"><span>Cancel</span></button><button type="button" class="ant-btn ant-btn-primary ant-btn-sm"><span>OK</span></button></div></div></div></div></div>"`;
+exports[`Popconfirm should show overlay when trigger is clicked 1`] = `
+<div
+  class="ant-popover ant-popconfirm ant-popover-placement-top"
+  style="--arrow-x: 0px; --arrow-y: 6px; left: 0px; top: -12px; box-sizing: border-box;"
+>
+  <div
+    class="ant-popover-arrow"
+    style="position: absolute; bottom: 0px; left: 0px;"
+  />
+  <div
+    class="ant-popover-content"
+  >
+    <div
+      class="ant-popover-inner"
+      role="tooltip"
+    >
+      <div
+        class="ant-popover-inner-content"
+      >
+        <div
+          class="ant-popconfirm-inner-content"
+        >
+          <div
+            class="ant-popconfirm-message"
+          >
+            <span
+              class="ant-popconfirm-message-icon"
+            >
+              <span
+                aria-label="exclamation-circle"
+                class="anticon anticon-exclamation-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="exclamation-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <div
+              class="ant-popconfirm-message-text"
+            >
+              <div
+                class="ant-popconfirm-title"
+              >
+                code
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-popconfirm-buttons"
+          >
+            <button
+              class="ant-btn ant-btn-default ant-btn-sm"
+              type="button"
+            >
+              <span>
+                Cancel
+              </span>
+            </button>
+            <button
+              class="ant-btn ant-btn-primary ant-btn-sm"
+              type="button"
+            >
+              <span>
+                OK
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`Popconfirm shows content for render functions 1`] = `
 <div
@@ -55,9 +136,13 @@ exports[`Popconfirm shows content for render functions 1`] = `
               </span>
             </span>
             <div
-              class="ant-popconfirm-message-title"
+              class="ant-popconfirm-message-text"
             >
-              some-title
+              <div
+                class="ant-popconfirm-title"
+              >
+                some-title
+              </div>
             </div>
           </div>
           <div

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -73,8 +73,7 @@ describe('Popconfirm', () => {
     expect(popconfirm.container.querySelector('.ant-popover')?.className).toContain(
       'ant-popover-placement-top',
     );
-    expect(popconfirm.container.querySelector('.ant-popover')?.innerHTML).toMatchSnapshot();
-    expect(popconfirm.container.querySelector('.ant-popover')?.innerHTML).toMatchSnapshot();
+    expect(popconfirm.container.querySelector('.ant-popover')).toMatchSnapshot();
   });
 
   it('shows content for render functions', async () => {

--- a/components/popconfirm/style/index.tsx
+++ b/components/popconfirm/style/index.tsx
@@ -24,13 +24,9 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
   return {
     [componentCls]: {
       zIndex: zIndexPopup,
-
-      [`${componentCls}-inner-content`]: {
-        color: colorText,
-      },
+      color: colorText,
 
       [`${componentCls}-message`]: {
-        position: 'relative',
         marginBottom: marginXS,
         display: 'flex',
         flexWrap: 'nowrap',
@@ -39,13 +35,11 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
         [`> ${componentCls}-message-icon ${iconCls}`]: {
           color: colorWarning,
           fontSize,
-          flex: 'none',
           lineHeight: 1,
           marginInlineEnd: marginXS,
         },
 
         [`${componentCls}-title`]: {
-          flex: 'auto',
           fontWeight: fontWeightStrong,
 
           '&:only-child': {
@@ -54,9 +48,7 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
         },
 
         [`${componentCls}-description`]: {
-          position: 'relative',
           marginTop: marginXXS,
-          color: colorText,
         },
       },
 

--- a/components/popconfirm/style/index.tsx
+++ b/components/popconfirm/style/index.tsx
@@ -15,10 +15,10 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
     zIndexPopup,
     colorText,
     colorWarning,
+    marginXXS,
     marginXS,
     fontSize,
     fontWeightStrong,
-    lineHeight,
   } = token;
 
   return {
@@ -32,8 +32,6 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
       [`${componentCls}-message`]: {
         position: 'relative',
         marginBottom: marginXS,
-        color: colorText,
-        fontSize,
         display: 'flex',
         flexWrap: 'nowrap',
         alignItems: 'start',
@@ -43,25 +41,23 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
           fontSize,
           flex: 'none',
           lineHeight: 1,
-          paddingTop: (Math.round(fontSize * lineHeight) - fontSize) / 2,
+          marginInlineEnd: marginXS,
         },
 
-        '&-title': {
+        [`${componentCls}-title`]: {
           flex: 'auto',
-          marginInlineStart: marginXS,
-        },
-
-        '&-title-only': {
           fontWeight: fontWeightStrong,
-        },
-      },
 
-      [`${componentCls}-description`]: {
-        position: 'relative',
-        marginInlineStart: fontSize + marginXS,
-        marginBottom: marginXS,
-        color: colorText,
-        fontSize,
+          '&:only-child': {
+            fontWeight: 'normal',
+          },
+        },
+
+        [`${componentCls}-description`]: {
+          position: 'relative',
+          marginTop: marginXXS,
+          color: colorText,
+        },
       },
 
       [`${componentCls}-buttons`]: {

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -291,9 +291,13 @@ exports[`renders components/space/demo/base.tsx extend context correctly 1`] = `
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure delete this task?
+                  </div>
                 </div>
               </div>
               <div
@@ -15369,9 +15373,13 @@ exports[`renders components/space/demo/debug.tsx extend context correctly 1`] = 
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure delete this task?
+                  </div>
                 </div>
               </div>
               <div
@@ -15467,9 +15475,13 @@ exports[`renders components/space/demo/debug.tsx extend context correctly 1`] = 
                   </span>
                 </span>
                 <div
-                  class="ant-popconfirm-message-title"
+                  class="ant-popconfirm-message-text"
                 >
-                  Are you sure delete this task?
+                  <div
+                    class="ant-popconfirm-title"
+                  >
+                    Are you sure delete this task?
+                  </div>
                 </div>
               </div>
               <div

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4814,9 +4814,13 @@ exports[`renders components/table/demo/edit-cell.tsx extend context correctly 1`
                                     </span>
                                   </span>
                                   <div
-                                    class="ant-popconfirm-message-title"
+                                    class="ant-popconfirm-message-text"
                                   >
-                                    Sure to delete?
+                                    <div
+                                      class="ant-popconfirm-title"
+                                    >
+                                      Sure to delete?
+                                    </div>
                                   </div>
                                 </div>
                                 <div
@@ -4924,9 +4928,13 @@ exports[`renders components/table/demo/edit-cell.tsx extend context correctly 1`
                                     </span>
                                   </span>
                                   <div
-                                    class="ant-popconfirm-message-title"
+                                    class="ant-popconfirm-message-text"
                                   >
-                                    Sure to delete?
+                                    <div
+                                      class="ant-popconfirm-title"
+                                    >
+                                      Sure to delete?
+                                    </div>
                                   </div>
                                 </div>
                                 <div


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/42417#issuecomment-1550637349

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

重构了 Popconfirm 的 dom 结构，如果手动覆盖样式可能会被影响。

核心改动在：https://github.com/ant-design/ant-design/pull/42433/files#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770

| before | after |
| --- | --- |
| ![图片](https://github.com/ant-design/ant-design/assets/507615/6074b57e-e8c8-4374-91cd-112c0becdef6) | <img alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/b2e5ff56-cf71-4435-a6f5-a7d21a1a5c1c">  |

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Refactor Popconfirm DOM structure to fix extra margin before `title` and `description` when `icon={null}`.           |
| 🇨🇳 Chinese | 重构 Popconfirm DOM 结构以解决 `icon={null}` 时 `title` 和 `description` 的多余 margin 问题。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69e3c73</samp>

This pull request enhances the popconfirm component by refactoring its message rendering, improving its style and alignment, and fixing a test file typo. It affects the files `components/popconfirm/PurePanel.tsx`, `components/popconfirm/style/index.tsx`, and `components/popconfirm/__tests__/index.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69e3c73</samp>

*  Simplify and improve the rendering and styling of the popconfirm message ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770R62-R63), [link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L67-R75), [link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L18-R21), [link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L35-L36), [link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L46-R62))
  - Extract renderTitle and renderDescription variables from title and description props in `PurePanel.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770R62-R63))
  - Wrap title and description in a separate div with the class `${prefixCls}-message-text` and render them only if truthy in `PurePanel.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L67-R75))
  - Add marginXXS token to the token object in `style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L18-R21))
  - Remove redundant color and fontSize styles from the `${componentCls}-message` selector in `style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L35-L36))
  - Adjust margin and font-weight of the icon, title, and description elements in `style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66L46-R62))
* Fix a typo and remove unnecessary innerHTML property in the test file `__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L76-R76))
  - Replace the duplicated snapshot assertion with the correct one ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L76-R76))
  - Remove innerHTML from the querySelector argument, since the snapshot matcher can handle the whole element ([link](https://github.com/ant-design/ant-design/pull/42433/files?diff=unified&w=0#diff-dfb6f01788186a5363498f0b24d48dbb55493cc5de43b306f1ad5e730b8df362L76-R76))
