### PR TITLE
Fix a typo in migration-v5.en-US.md

### DIFF
--- a/docs/react/migration-v5.en-US.md
+++ b/docs/react/migration-v5.en-US.md
@@ -216,7 +216,7 @@ module.exports = {
 };
 ```
 
-Ant then remove antd less reference in your less file:
+And then remove antd less reference in your less file:
 
 ```diff
 // Your less file


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- Nothing

### 💡 Background and solution
- Nothing but just a typo

### 📝 Changelog
- Not needed

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8e2b83</samp>

Fixed a typo in the migration guide for version 5 of the React component library. Changed `Ant` to `And` in `docs/react/migration-v5.en-US.md`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8e2b83</samp>

* Fix a typo in the migration guide ([link](https://github.com/ant-design/ant-design/pull/42481/files?diff=unified&w=0#diff-033acb976299eed208dd3c83e92cc43ab9cd315fd15e60373b2e41a1e293a8e3L219-R219))
