### PR TITLE
feat(notification): support role prop

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
-import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
-import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
-import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
-import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
+import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import { Notice } from 'rc-notification';
+import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
+import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
+import { Notice } from 'rc-notification';
 import type { NoticeProps } from 'rc-notification/lib/Notice';
-import useStyle from './style';
+import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { IconType } from './interface';
+import useStyle from './style';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,
@@ -54,7 +54,7 @@ export function PureContent({
   message,
   description,
   btn,
-  role,
+  role = 'alert',
 }: PureContentProps) {
   let iconNode: React.ReactNode = null;
   if (icon) {
@@ -70,7 +70,7 @@ export function PureContent({
       className={classNames({
         [`${prefixCls}-with-icon`]: iconNode,
       })}
-      role={role || 'alert'}
+      role={role}
     >
       {iconNode}
       <div className={`${prefixCls}-message`}>{message}</div>

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -1,16 +1,16 @@
-import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
-import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
-import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
-import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
-import classNames from 'classnames';
-import { Notice } from 'rc-notification';
-import type { NoticeProps } from 'rc-notification/lib/Notice';
 import * as React from 'react';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
+import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
+import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
+import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
+import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import { Notice } from 'rc-notification';
+import classNames from 'classnames';
+import type { NoticeProps } from 'rc-notification/lib/Notice';
+import useStyle from './style';
 import { ConfigContext } from '../config-provider';
 import type { IconType } from './interface';
-import useStyle from './style';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
-import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
-import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
-import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
-import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
+import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import { Notice } from 'rc-notification';
+import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
+import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
+import { Notice } from 'rc-notification';
 import type { NoticeProps } from 'rc-notification/lib/Notice';
-import useStyle from './style';
+import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { IconType } from './interface';
+import useStyle from './style';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,
@@ -37,6 +37,7 @@ export interface PureContentProps {
   description?: React.ReactNode;
   btn?: React.ReactNode;
   type?: IconType;
+  role?: 'alert' | 'status';
 }
 
 const typeToIcon = {
@@ -53,6 +54,7 @@ export function PureContent({
   message,
   description,
   btn,
+  role,
 }: PureContentProps) {
   let iconNode: React.ReactNode = null;
   if (icon) {
@@ -68,7 +70,7 @@ export function PureContent({
       className={classNames({
         [`${prefixCls}-with-icon`]: iconNode,
       })}
-      role="alert"
+      role={role || 'alert'}
     >
       {iconNode}
       <div className={`${prefixCls}-message`}>{message}</div>

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { UserOutlined } from '@ant-design/icons';
+import React from 'react';
 import notification, { actWrapper } from '..';
-import ConfigProvider from '../../config-provider';
 import { act, fireEvent } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 import { awaitPromise, triggerMotionEnd } from './util';
 
 describe('notification', () => {
@@ -300,5 +300,17 @@ describe('notification', () => {
     });
 
     expect(document.querySelectorAll("[data-testid='test-notification']").length).toBe(1);
+  });
+
+  it('support role', async () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        duration: 0,
+        role: 'status',
+      });
+    });
+
+    expect(document.querySelectorAll('[role="status"]').length).toBe(1);
   });
 });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -1,8 +1,8 @@
-import { UserOutlined } from '@ant-design/icons';
 import React from 'react';
+import { UserOutlined } from '@ant-design/icons';
 import notification, { actWrapper } from '..';
-import { act, fireEvent } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import { act, fireEvent } from '../../../tests/utils';
 import { awaitPromise, triggerMotionEnd } from './util';
 
 describe('notification', () => {

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -44,22 +44,22 @@ To display a notification message at any of the four corners of the viewport. Ty
 
 The properties of config are as follows:
 
-| Property | Description | Type | Default |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| btn | Customized close button | ReactNode | - |
-| className | Customized CSS class | string | - |
-| closeIcon | Custom close icon | ReactNode | - |
-| description | The content of notification box (required) | ReactNode | - |
-| duration | Time in seconds before Notification is closed. When set to 0 or null, it will never be closed automatically | number | 4.5 |
-| icon | Customized icon | ReactNode | - |
-| key | The unique identifier of the Notification | string | - |
-| message | The title of notification box (required) | ReactNode | - |
-| placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
-| style | Customized inline style | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
+| btn | Customized close button | ReactNode | - | - |
+| className | Customized CSS class | string | - | - |
+| closeIcon | Custom close icon | ReactNode | - | - |
+| description | The content of notification box (required) | ReactNode | - | - |
+| duration | Time in seconds before Notification is closed. When set to 0 or null, it will never be closed automatically | number | 4.5 | - |
+| icon | Customized icon | ReactNode | - | - |
+| key | The unique identifier of the Notification | string | - | - |
+| message | The title of notification box (required) | ReactNode | - | - |
+| placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` | - |
+| style | Customized inline style | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - | - |
 | role | The semantics of notification content recognized by screen readers. The default value is `alert`. When set as the default value, the screen reader will promptly interrupt any ongoing content reading and prioritize the notification content for immediate attention. | `alert \| status` | `alert` | 5.6.0 |
-| onClick | Specify a function that will be called when the notification is clicked | function | - |
-| onClose | Trigger when notification closed | function | - |
-| props | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. | Object | - |
+| onClick | Specify a function that will be called when the notification is clicked | function | - | - |
+| onClose | Trigger when notification closed | function | - | - |
+| props | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. | Object | - | - |
 
 - `notification.useNotification(config)`
 

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -45,7 +45,7 @@ To display a notification message at any of the four corners of the viewport. Ty
 The properties of config are as follows:
 
 | Property | Description | Type | Default |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | btn | Customized close button | ReactNode | - |
 | className | Customized CSS class | string | - |
 | closeIcon | Custom close icon | ReactNode | - |
@@ -56,7 +56,7 @@ The properties of config are as follows:
 | message | The title of notification box (required) | ReactNode | - |
 | placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
 | style | Customized inline style | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
-| role | The semantics of notification content recognized by screen readers. The default value is `alert`. When set as the default value, the screen reader will promptly interrupt any ongoing content reading and prioritize the notification content for immediate attention. | `alert \| status` | `alert` |
+| role | The semantics of notification content recognized by screen readers. The default value is `alert`. When set as the default value, the screen reader will promptly interrupt any ongoing content reading and prioritize the notification content for immediate attention. | `alert \| status` | `alert` | 5.6.0 |
 | onClick | Specify a function that will be called when the notification is clicked | function | - |
 | onClose | Trigger when notification closed | function | - |
 | props | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. | Object | - |

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -56,6 +56,7 @@ The properties of config are as follows:
 | message | The title of notification box (required) | ReactNode | - |
 | placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
 | style | Customized inline style | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
+| role | The semantics of notification content recognized by screen readers. The default value is `alert`. When set as the default value, the screen reader will promptly interrupt any ongoing content reading and prioritize the notification content for immediate attention. | `alert \| status` | `alert` |
 | onClick | Specify a function that will be called when the notification is clicked | function | - |
 | onClose | Trigger when notification closed | function | - |
 | props | An object that can contain `data-*`, `aria-*`, or `role` props, to be put on the notification `div`. This currently only allows `data-testid` instead of `data-*` in TypeScript. See https://github.com/microsoft/TypeScript/issues/28960. | Object | - |

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -46,7 +46,7 @@ demo:
 config 参数如下：
 
 | 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | btn | 自定义关闭按钮 | ReactNode | - |
 | className | 自定义 CSS class | string | - |
 | closeIcon | 自定义关闭图标 | ReactNode | - |
@@ -57,7 +57,7 @@ config 参数如下：
 | message | 通知提醒标题，必选 | ReactNode | - |
 | placement | 弹出位置，可选 `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
 | style | 自定义内联样式 | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
-| role | 供屏幕阅读器识别的通知内容语义，默认为 `alert`。此情况下屏幕阅读器会立即打断当前正在阅读的其他内容，转而阅读通知内容 | `alert \| status` | `alert` |
+| role | 供屏幕阅读器识别的通知内容语义，默认为 `alert`。此情况下屏幕阅读器会立即打断当前正在阅读的其他内容，转而阅读通知内容 | `alert \| status` | `alert` | 5.6.0 |
 | onClick | 点击通知时触发的回调函数 | function | - |
 | onClose | 当通知关闭时触发 | function | - |
 | props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -45,22 +45,22 @@ demo:
 
 config 参数如下：
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- | --- |
-| btn | 自定义关闭按钮 | ReactNode | - |
-| className | 自定义 CSS class | string | - |
-| closeIcon | 自定义关闭图标 | ReactNode | - |
-| description | 通知提醒内容，必选 | ReactNode | - |
-| duration | 默认 4.5 秒后自动关闭，配置为 null 则不自动关闭 | number | 4.5 |
-| icon | 自定义图标 | ReactNode | - |
-| key | 当前通知唯一标志 | string | - |
-| message | 通知提醒标题，必选 | ReactNode | - |
-| placement | 弹出位置，可选 `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
-| style | 自定义内联样式 | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- | --- |
+| btn | 自定义关闭按钮 | ReactNode | - | - |
+| className | 自定义 CSS class | string | - | - |
+| closeIcon | 自定义关闭图标 | ReactNode | - | - |
+| description | 通知提醒内容，必选 | ReactNode | - | - |
+| duration | 默认 4.5 秒后自动关闭，配置为 null 则不自动关闭 | number | 4.5 | - |
+| icon | 自定义图标 | ReactNode | - | - |
+| key | 当前通知唯一标志 | string | - | - |
+| message | 通知提醒标题，必选 | ReactNode | - | - |
+| placement | 弹出位置，可选 `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` | - | s |
+| style | 自定义内联样式 | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - | - |
 | role | 供屏幕阅读器识别的通知内容语义，默认为 `alert`。此情况下屏幕阅读器会立即打断当前正在阅读的其他内容，转而阅读通知内容 | `alert \| status` | `alert` | 5.6.0 |
-| onClick | 点击通知时触发的回调函数 | function | - |
-| onClose | 当通知关闭时触发 | function | - |
-| props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |
+| onClick | 点击通知时触发的回调函数 | function | - | - |
+| onClose | 当通知关闭时触发 | function | - | - |
+| props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - | - |
 
 - `notification.useNotification(config)`
 

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -46,7 +46,7 @@ demo:
 config 参数如下：
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | btn | 自定义关闭按钮 | ReactNode | - | - |
 | className | 自定义 CSS class | string | - | - |
 | closeIcon | 自定义关闭图标 | ReactNode | - | - |

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -57,6 +57,7 @@ config 参数如下：
 | message | 通知提醒标题，必选 | ReactNode | - |
 | placement | 弹出位置，可选 `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |
 | style | 自定义内联样式 | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - |
+| role | 供屏幕阅读器识别的通知内容语义，默认为 `alert`。此情况下屏幕阅读器会立即打断当前正在阅读的其他内容，转而阅读通知内容 | `alert \| status` | `alert` |
 | onClick | 点击通知时触发的回调函数 | function | - |
 | onClose | 当通知关闭时触发 | function | - |
 | props | 透传至通知 `div` 上的 props 对象，支持传入 `data-*` `aria-*` 或 `role` 作为对象的属性。需要注意的是，虽然在 TypeScript 类型中声明的类型支持传入 `data-*` 作为对象的属性，但目前只允许传入 `data-testid` 作为对象的属性。 详见 https://github.com/microsoft/TypeScript/issues/28960 | Object | - |

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -29,6 +29,7 @@ export interface ArgsProps {
   onClick?: () => void;
   closeIcon?: React.ReactNode;
   props?: DivProps;
+  role?: 'alert' | 'status';
 }
 
 type StaticFn = (args: ArgsProps) => void;

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
+import classNames from 'classnames';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-import classNames from 'classnames';
-import { ConfigContext } from '../config-provider';
-import type {
-  NotificationInstance,
-  ArgsProps,
-  NotificationPlacement,
-  NotificationConfig,
-} from './interface';
-import { getPlacementStyle, getMotion } from './util';
+import * as React from 'react';
 import warning from '../_util/warning';
+import { ConfigContext } from '../config-provider';
+import { PureContent, getCloseIcon } from './PurePanel';
+import type {
+  ArgsProps,
+  NotificationConfig,
+  NotificationInstance,
+  NotificationPlacement,
+} from './interface';
 import useStyle from './style';
-import { getCloseIcon, PureContent } from './PurePanel';
+import { getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -105,7 +105,16 @@ export function useInternalNotification(
       const { open: originOpen, prefixCls, hashId } = holderRef.current;
       const noticePrefixCls = `${prefixCls}-notice`;
 
-      const { message, description, icon, type, btn, className, role, ...restConfig } = config;
+      const {
+        message,
+        description,
+        icon,
+        type,
+        btn,
+        className,
+        role = 'alert',
+        ...restConfig
+      } = config;
 
       return originOpen({
         placement: 'topRight',

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,18 +1,18 @@
-import classNames from 'classnames';
+import * as React from 'react';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-import * as React from 'react';
-import warning from '../_util/warning';
+import classNames from 'classnames';
 import { ConfigContext } from '../config-provider';
-import { PureContent, getCloseIcon } from './PurePanel';
 import type {
-  ArgsProps,
-  NotificationConfig,
   NotificationInstance,
+  ArgsProps,
   NotificationPlacement,
+  NotificationConfig,
 } from './interface';
+import { getPlacementStyle, getMotion } from './util';
+import warning from '../_util/warning';
 import useStyle from './style';
-import { getMotion, getPlacementStyle } from './util';
+import { getCloseIcon, PureContent } from './PurePanel';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
+import classNames from 'classnames';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-import classNames from 'classnames';
-import { ConfigContext } from '../config-provider';
-import type {
-  NotificationInstance,
-  ArgsProps,
-  NotificationPlacement,
-  NotificationConfig,
-} from './interface';
-import { getPlacementStyle, getMotion } from './util';
+import * as React from 'react';
 import warning from '../_util/warning';
+import { ConfigContext } from '../config-provider';
+import { PureContent, getCloseIcon } from './PurePanel';
+import type {
+  ArgsProps,
+  NotificationConfig,
+  NotificationInstance,
+  NotificationPlacement,
+} from './interface';
 import useStyle from './style';
-import { getCloseIcon, PureContent } from './PurePanel';
+import { getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -105,7 +105,7 @@ export function useInternalNotification(
       const { open: originOpen, prefixCls, hashId } = holderRef.current;
       const noticePrefixCls = `${prefixCls}-notice`;
 
-      const { message, description, icon, type, btn, className, ...restConfig } = config;
+      const { message, description, icon, type, btn, className, role, ...restConfig } = config;
 
       return originOpen({
         placement: 'topRight',
@@ -118,6 +118,7 @@ export function useInternalNotification(
             message={message}
             description={description}
             btn={btn}
+            role={role}
           />
         ),
         className: classNames(type && `${noticePrefixCls}-${type}`, hashId, className),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

1. close #39568 

### 💡 Background and solution

- ref: #39611

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Adds role props to Notification    |
| 🇨🇳 Chinese |     添加 role props 到 Notification     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7986c4</samp>

Add `role` prop to notification component to improve accessibility. The prop allows users to specify the semantics of the notification content for screen readers, and is supported by the `useNotification` hook, the `PurePanel` component, and the documentation files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7986c4</samp>

*  Add `role` prop to notification component to support screen reader semantics ([link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-c80bd08ac7a1f6a8ae2046fe84cc562807b2d11b1a63316286546b888a86ed08R32), [link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccR40), [link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL108-R108), [link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfR121))
*  Render notification content with `role` attribute based on `role` prop or default to `alert` ([link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccR57), [link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL71-R73))
*  Document `role` prop in English and Chinese API sections of `index.en-US.md` and `index.zh-CN.md` files ([link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-9b1700ccbd4da0f60742ae024592c27e0118d7307f5a9ed69a91c560c374749fR59), [link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-9954e364a4a4121f77d3f9f87225ef361d39c004720443dd896bb31cfe3c6d22R60))
*  Test that notification component renders `role` attribute correctly in `index.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/42484/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690R304-R315))
