### PR TITLE
Fix DatePicker not using custom dateFormat from locale

### DIFF
--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -55,7 +55,12 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           ...restProps
         } = props;
 
-        const { getPrefixCls, direction, getPopupContainer } = useContext(ConfigContext);
+        const {
+          getPrefixCls,
+          direction,
+          getPopupContainer,
+          locale: ctxLocale,
+        } = useContext(ConfigContext);
         const prefixCls = getPrefixCls('picker', customizePrefixCls);
         const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
         const innerRef = React.useRef<RCPicker<DateType>>(null);
@@ -120,7 +125,10 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           </>
         );
 
-        const [contextLocale] = useLocale('DatePicker', enUS);
+        const [contextLocale] = useLocale('DatePicker', {
+          ...(ctxLocale?.DatePicker ?? enUS),
+          dateFormat: ctxLocale?.dateFormat,
+        });
 
         const locale = { ...contextLocale, ...props.locale! };
 
@@ -137,6 +145,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
             superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
             allowClear
             transitionName={`${rootPrefixCls}-slide-up`}
+            format={locale!.dateFormat}
             {...additionalProps}
             {...restProps}
             {...additionalOverrideProps}

--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -20,6 +20,7 @@ export const ANT_MARK = 'internalMark';
 
 export interface Locale {
   locale: string;
+  dateFormat: string;
   Pagination?: PaginationLocale;
   DatePicker?: DatePickerLocale;
   TimePicker?: Record<string, any>;


### PR DESCRIPTION
### 🤔 This is a ...
- [x] Bug fix

### 🔗 Related issue link

1. https://github.com/ant-design/ant-design/issues/42119

### 💡 Background and solution

This issue is that the locale and context locale was not being considered in the code, so I added the code to merge locales and use it in the date format by the `format` prop. the order of priority in the locale is: `componentProp` > `localeProp` > `localeContext`

### I will write some tests/demo for this if this is the right behavior!

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9183c64</samp>

Added global configuration for date format in `Locale` and used it in `DatePicker`. This enables consistent and customizable formatting of dates across components and locales.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9183c64</samp>

* Add `dateFormat` property to `Locale` interface to allow custom date format for components ([link](https://github.com/ant-design/ant-design/pull/42485/files?diff=unified&w=0#diff-3534e5ff6dff91b165dbf0fe6e1a6ce5dc623601cf689e56d7075a75de9ddaebR23))
* Use `ConfigContext` to get global locale and date format for `DatePicker` component ([link](https://github.com/ant-design/ant-design/pull/42485/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL58-R63), [link](https://github.com/ant-design/ant-design/pull/42485/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL123-R131))
* Pass `format` prop to `Picker` component to display date according to locale and date format ([link](https://github.com/ant-design/ant-design/pull/42485/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bR148))
