### PR TITLE
chore: rename sorterOrder to sortOrder

### DIFF
--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -356,11 +356,11 @@ describe('Table.sorter', () => {
   });
 
   it('renders custome sort icon correctly', () => {
-    const sortIcon = ({ sorterOrder }: { sorterOrder?: SortOrder }): React.ReactNode => {
+    const sortIcon = ({ sortOrder }: { sortOrder?: SortOrder }): React.ReactNode => {
       let text: string;
-      if (sorterOrder === undefined) {
+      if (sortOrder === undefined) {
         text = 'unsorted';
-      } else if (sorterOrder === 'descend') {
+      } else if (sortOrder === 'descend') {
         text = 'sortDescend';
       } else {
         text = 'sortAscend';
@@ -889,7 +889,7 @@ describe('Table.sorter', () => {
     expect(container.querySelectorAll('th.ant-table-column-sort')).toHaveLength(1);
   });
 
-  it('surger should support sorterOrder', () => {
+  it('surger should support sortOrder', () => {
     const { container } = render(
       <Table>
         <Table.Column key="name" title="Name" dataIndex="name" sortOrder="ascend" sorter />

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -125,24 +125,24 @@ function injectSorter<RecordType>(
           : newColumn.showSorterTooltip;
       const columnKey = getColumnKey(newColumn, columnPos);
       const sorterState = sorterStates.find(({ key }) => key === columnKey);
-      const sorterOrder = sorterState ? sorterState.sortOrder : null;
-      const nextSortOrder = nextSortDirection(sortDirections, sorterOrder);
+      const sortOrder = sorterState ? sorterState.sortOrder : null;
+      const nextSortOrder = nextSortDirection(sortDirections, sortOrder);
 
       let sorter: React.ReactNode;
       if (column.sortIcon) {
-        sorter = column.sortIcon({ sorterOrder });
+        sorter = column.sortIcon({ sortOrder });
       } else {
         const upNode: React.ReactNode = sortDirections.includes(ASCEND) && (
           <CaretUpOutlined
             className={classNames(`${prefixCls}-column-sorter-up`, {
-              active: sorterOrder === ASCEND,
+              active: sortOrder === ASCEND,
             })}
           />
         );
         const downNode: React.ReactNode = sortDirections.includes(DESCEND) && (
           <CaretDownOutlined
             className={classNames(`${prefixCls}-column-sorter-down`, {
-              active: sorterOrder === DESCEND,
+              active: sortOrder === DESCEND,
             })}
           />
         );
@@ -171,7 +171,7 @@ function injectSorter<RecordType>(
         typeof showSorterTooltip === 'object' ? showSorterTooltip : { title: sortTip };
       newColumn = {
         ...newColumn,
-        className: classNames(newColumn.className, { [`${prefixCls}-column-sort`]: sorterOrder }),
+        className: classNames(newColumn.className, { [`${prefixCls}-column-sort`]: sortOrder }),
         title: (renderProps: ColumnTitleProps<RecordType>) => {
           const renderSortTitle = (
             <div className={`${prefixCls}-column-sorters`}>
@@ -217,8 +217,8 @@ function injectSorter<RecordType>(
           const displayTitle = renderTitle?.toString();
 
           // Inform the screen-reader so it can tell the visually impaired user which column is sorted
-          if (sorterOrder) {
-            cell['aria-sort'] = sorterOrder === 'ascend' ? 'ascending' : 'descending';
+          if (sortOrder) {
+            cell['aria-sort'] = sortOrder === 'ascend' ? 'ascending' : 'descending';
           } else {
             cell['aria-label'] = displayTitle || '';
           }

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -194,7 +194,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | sortDirections | Supported sort way, override `sortDirections` in `Table`, could be `ascend`, `descend` | Array | \[`ascend`, `descend`] |  |
 | sorter | Sort function for local sort, see [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)'s compareFunction. If you need sort buttons only, set to `true` | function \| boolean | - |  |
 | sortOrder | Order of sorted values: `ascend` `descend` `null` | `ascend` \| `descend` \| null | - |  |
-| sortIcon | Customized sort icon | (props: { sorterOrder }) => ReactNode | - | 5.6.0 |
+| sortIcon | Customized sort icon | (props: { sortOrder }) => ReactNode | - | 5.6.0 |
 | title | Title of this column | ReactNode \| ({ sortOrder, sortColumn, filters }) => ReactNode | - |  |
 | width | Width of this column ([width not working?](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)) | string \| number | - |  |
 | onCell | Set props on per cell | function(record, rowIndex) | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -196,7 +196,7 @@ const columns = [
 | sortDirections | 支持的排序方式，覆盖 `Table` 中 `sortDirections`， 取值为 `ascend` `descend` | Array | \[`ascend`, `descend`] |  |
 | sorter | 排序函数，本地排序使用一个函数(参考 [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) 的 compareFunction)，需要服务端排序可设为 true | function \| boolean | - |  |
 | sortOrder | 排序的受控属性，外界可用此控制列的排序，可设置为 `ascend` `descend` `null` | `ascend` \| `descend` \| null | - |  |
-| sortIcon | 自定义 sort 图标 | (props: { sorterOrder }) => ReactNode | - | 5.6.0 |
+| sortIcon | 自定义 sort 图标 | (props: { sortOrder }) => ReactNode | - | 5.6.0 |
 | title | 列头显示文字（函数用法 `3.10.0` 后支持） | ReactNode \| ({ sortOrder, sortColumn, filters }) => ReactNode | - |  |
 | width | 列宽度（[指定了也不生效？](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)） | string \| number | - |  |
 | onCell | 设置单元格属性 | function(record, rowIndex) | - |  |

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -119,7 +119,7 @@ export interface ColumnType<RecordType> extends Omit<RcColumnType<RecordType>, '
   sortOrder?: SortOrder;
   defaultSortOrder?: SortOrder;
   sortDirections?: SortOrder[];
-  sortIcon?: (props: { sorterOrder: SortOrder }) => React.ReactNode;
+  sortIcon?: (props: { sortOrder: SortOrder }) => React.ReactNode;
   showSorterTooltip?: boolean | TooltipProps;
 
   // Filter


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | rename sorterOrder to sortOrder for arguement of sortIcon |
| 🇨🇳 Chinese | 将 sorterOrder 重命名为 sortOrder 用于 sortIcon 的争论 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3de3d7f</samp>

Renamed the `sorterOrder` prop to `sortOrder` in the table component and its related files. This makes the prop name consistent with the API and the state, and avoids confusion with the `sorter` prop. Updated the documentation and the test cases accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3de3d7f</samp>

*  Rename `sorterOrder` prop to `sortOrder` in `Column` component and related functions to avoid confusion and improve consistency ([link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-42a0123b4da3518218b3261eab843f62cf855d913ae11baa9b6094bbdb33baf0L359-R363), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-42a0123b4da3518218b3261eab843f62cf855d913ae11baa9b6094bbdb33baf0L892-R892), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L128-R138), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L145-R145), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L174-R174), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L220-R221), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9L197-R197), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209L199-R199), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9L122-R122))
  * Update test case description in `components/table/__tests__/Table.sorter.test.tsx` to reflect prop name change ([link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-42a0123b4da3518218b3261eab843f62cf855d913ae11baa9b6094bbdb33baf0L892-R892))
  * Update `sortIcon` prop documentation in `components/table/index.en-US.md` and `components/table/index.zh-CN.md` to reflect prop name change ([link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9L197-R197), [link](https://github.com/ant-design/ant-design/pull/42519/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209L199-R199))
