### PR TITLE
fix: global token in Component Token override should be respected

### DIFF
--- a/components/message/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/message/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,40 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders components/message/demo/component-token.tsx extend context correctly 1`] = `
-<div
-  class="ant-message-notice ant-message-notice-pure-panel"
->
+Array [
   <div
-    class="ant-message-notice-content"
+    class="ant-message-notice ant-message-notice-pure-panel"
   >
     <div
-      class="ant-message-custom-content ant-message-error"
+      class="ant-message-notice-content"
     >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle"
-        role="img"
+      <div
+        class="ant-message-custom-content ant-message-error"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
         >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-          />
-        </svg>
-      </span>
-      <span>
-        Hello World!
-      </span>
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+        <span>
+          Hello World!
+        </span>
+      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <div
+    class="ant-message-notice ant-message-notice-pure-panel"
+  >
+    <div
+      class="ant-message-notice-content"
+    >
+      <div
+        class="ant-message-custom-content ant-message-error"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+        <span>
+          Hello World!
+        </span>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/message/demo/custom-style.tsx extend context correctly 1`] = `

--- a/components/message/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/message/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,40 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders components/message/demo/component-token.tsx correctly 1`] = `
-<div
-  class="ant-message-notice ant-message-notice-pure-panel"
->
+Array [
   <div
-    class="ant-message-notice-content"
+    class="ant-message-notice ant-message-notice-pure-panel"
   >
     <div
-      class="ant-message-custom-content ant-message-error"
+      class="ant-message-notice-content"
     >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle"
-        role="img"
+      <div
+        class="ant-message-custom-content ant-message-error"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
         >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
-          />
-        </svg>
-      </span>
-      <span>
-        Hello World!
-      </span>
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+        <span>
+          Hello World!
+        </span>
+      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <div
+    class="ant-message-notice ant-message-notice-pure-panel"
+  >
+    <div
+      class="ant-message-notice-content"
+    >
+      <div
+        class="ant-message-custom-content ant-message-error"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"
+            />
+          </svg>
+        </span>
+        <span>
+          Hello World!
+        </span>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/message/demo/custom-style.tsx correctly 1`] = `

--- a/components/message/demo/component-token.tsx
+++ b/components/message/demo/component-token.tsx
@@ -1,20 +1,33 @@
-import React from 'react';
 import { ConfigProvider, message } from 'antd';
+import React from 'react';
 
 /** Test usage. Do not use in your production. */
 const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = message;
 
 export default () => (
-  <ConfigProvider
-    theme={{
-      components: {
-        Message: {
-          contentPadding: 40,
-          contentBg: '#e6f4ff',
+  <>
+    <ConfigProvider
+      theme={{
+        components: {
+          Message: {
+            contentPadding: 40,
+            contentBg: '#e6f4ff',
+          },
         },
-      },
-    }}
-  >
-    <InternalPanel content="Hello World!" type="error" />
-  </ConfigProvider>
+      }}
+    >
+      <InternalPanel content="Hello World!" type="error" />
+    </ConfigProvider>
+    <ConfigProvider
+      theme={{
+        components: {
+          Message: {
+            colorBgElevated: '#e6f4ff',
+          },
+        },
+      }}
+    >
+      <InternalPanel content="Hello World!" type="error" />
+    </ConfigProvider>
+  </>
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/42533
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix that global token should be able to override component style.        |
| 🇨🇳 Chinese |    修复部分全局 Token 无法覆盖组件样式的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16b99ce</samp>

Added a new demo for customizing the Message component with theme tokens, and improved the type safety and flexibility of the `genComponentStyleHook` function.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 16b99ce</samp>

* Import the OverrideToken type and add the ComponentToken type alias to handle custom tokens for each component ([link](https://github.com/ant-design/ant-design/pull/42535/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL7-R7),[link](https://github.com/ant-design/ant-design/pull/42535/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacR16-R20))
* Change the merging logic of default and custom tokens to use the mergeToken function and pass the merged values to the getDefaultToken function ([link](https://github.com/ant-design/ant-design/pull/42535/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL73-R83))
* Swap the import order of React and antd in `component-token.tsx` to follow the convention ([link](https://github.com/ant-design/ant-design/pull/42535/files?diff=unified&w=0#diff-d3b10c09e0fea9643ada85519d76c70c53e1ede68daa19366ae3c57be794f6feL1-R2))
* Add a second ConfigProvider in `component-token.tsx` to demonstrate the usage of the new colorBgElevated token for the Message component ([link](https://github.com/ant-design/ant-design/pull/42535/files?diff=unified&w=0#diff-d3b10c09e0fea9643ada85519d76c70c53e1ede68daa19366ae3c57be794f6feL8-R32))
