### PR TITLE
[WIP] Just follow 42545, DO NOT MERGE

### DIFF
--- a/components/checkbox/__tests__/group.test.tsx
+++ b/components/checkbox/__tests__/group.test.tsx
@@ -5,9 +5,9 @@ import { fireEvent, render } from '../../../tests/utils';
 import Collapse from '../../collapse';
 import Input from '../../input';
 import Table from '../../table';
-import Checkbox from '../index';
 import type { CheckboxValueType } from '../Group';
 import type { CheckboxGroupProps } from '../index';
+import Checkbox from '../index';
 
 describe('CheckboxGroup', () => {
   mountTest(Checkbox.Group);
@@ -167,13 +167,20 @@ describe('CheckboxGroup', () => {
   it('should work when checkbox is wrapped by other components', () => {
     const { container } = render(
       <Checkbox.Group>
-        <Collapse bordered={false}>
-          <Collapse.Panel key="test panel" header="test panel">
-            <div>
-              <Checkbox value="1">item</Checkbox>
-            </div>
-          </Collapse.Panel>
-        </Collapse>
+        <Collapse
+          items={[
+            {
+              key: 'test panel',
+              label: 'test panel',
+              children: (
+                <div>
+                  <Checkbox value="1">item</Checkbox>
+                </div>
+              ),
+            },
+          ]}
+          bordered={false}
+        />
       </Checkbox.Group>,
     );
 

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -127,7 +127,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
         if (child.props?.disabled) {
           const key = child.key ?? String(index);
           const { disabled, collapsible } = child.props;
-          const childProps: CollapseProps & { key: React.Key } = {
+          const childProps: Omit<CollapseProps, 'items'> & { key: React.Key } = {
             ...omit(child.props, ['disabled']),
             key,
             collapsible: collapsible ?? (disabled ? 'disabled' : undefined),

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -1,5 +1,6 @@
 import RightOutlined from '@ant-design/icons/RightOutlined';
 import classNames from 'classnames';
+import type { CollapseProps as OriCollapseProps } from 'rc-collapse';
 import RcCollapse from 'rc-collapse';
 import type { CSSMotionProps } from 'rc-motion';
 import toArray from 'rc-util/lib/Children/toArray';
@@ -20,6 +21,7 @@ type ExpandIconPositionLegacy = 'left' | 'right';
 export type ExpandIconPosition = 'start' | 'end' | ExpandIconPositionLegacy | undefined;
 
 export interface CollapseProps {
+  items: OriCollapseProps['items'];
   activeKey?: Array<string | number> | string | number;
   defaultActiveKey?: Array<string | number> | string | number;
   /** 手风琴效果 */

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -1,6 +1,6 @@
 import RightOutlined from '@ant-design/icons/RightOutlined';
 import classNames from 'classnames';
-import type { CollapseProps as OriCollapseProps } from 'rc-collapse';
+import type { CollapseProps as RcCollapseProps } from 'rc-collapse';
 import RcCollapse from 'rc-collapse';
 import type { CSSMotionProps } from 'rc-motion';
 import toArray from 'rc-util/lib/Children/toArray';
@@ -21,7 +21,7 @@ type ExpandIconPositionLegacy = 'left' | 'right';
 export type ExpandIconPosition = 'start' | 'end' | ExpandIconPositionLegacy | undefined;
 
 export interface CollapseProps {
-  items: OriCollapseProps['items'];
+  items: RcCollapseProps['items'];
   activeKey?: Array<string | number> | string | number;
   defaultActiveKey?: Array<string | number> | string | number;
   /** 手风琴效果 */
@@ -38,6 +38,9 @@ export interface CollapseProps {
   ghost?: boolean;
   size?: SizeType;
   collapsible?: CollapsibleType;
+  /**
+   * @deprecated use `items` instead
+   */
   children?: React.ReactNode;
 }
 

--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -21,9 +21,7 @@ export interface CollapsePanelProps {
   collapsible?: CollapsibleType;
   children?: React.ReactNode;
 }
-/**
- * @deprecated use `items` instead
- */
+
 const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((props, ref) => {
   warning(
     !('disabled' in props),

--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import RcCollapse from 'rc-collapse';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
 import warning from '../_util/warning';
+import { ConfigContext } from '../config-provider';
 
 export type CollapsibleType = 'header' | 'icon' | 'disabled';
 
@@ -21,6 +21,9 @@ export interface CollapsePanelProps {
   collapsible?: CollapsibleType;
   children?: React.ReactNode;
 }
+/**
+ * @deprecated use `items` instead
+ */
 const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((props, ref) => {
   warning(
     !('disabled' in props),

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -319,13 +319,11 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
       <div
         class="ant-collapse-content-box"
       >
-        <p />
         <p
           style="padding-left: 24px;"
         >
           A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
         </p>
-        <p />
       </div>
     </div>
   </div>
@@ -414,136 +412,176 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
 
 exports[`renders components/collapse/demo/collapsible.tsx extend context correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start"
+  class="ant-space ant-space-vertical"
 >
   <div
-    class="ant-collapse-item ant-collapse-item-active"
+    class="ant-space-item"
+    style="margin-bottom: 8px;"
   >
     <div
-      aria-disabled="false"
-      aria-expanded="true"
-      class="ant-collapse-header ant-collapse-header-collapsible-only"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-active"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="false"
+          aria-expanded="true"
+          class="ant-collapse-header ant-collapse-header-collapsible-only"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            style="transform: rotate(90deg);"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
-      </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can only be collapsed by clicking text
-      </span>
-    </div>
-    <div
-      class="ant-collapse-content ant-collapse-content-active"
-    >
-      <div
-        class="ant-collapse-content-box"
-      >
-        <p>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="transform: rotate(90deg);"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can only be collapsed by clicking text
+          </span>
+        </div>
+        <div
+          class="ant-collapse-content ant-collapse-content-active"
+        >
+          <div
+            class="ant-collapse-content-box"
+          >
+            <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-        </p>
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
-    class="ant-collapse-item"
+    class="ant-space-item"
+    style="margin-bottom: 8px;"
   >
     <div
-      aria-disabled="false"
-      aria-expanded="false"
-      class="ant-collapse-header ant-collapse-icon-collapsible-only"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-active"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="false"
+          aria-expanded="true"
+          class="ant-collapse-header ant-collapse-icon-collapsible-only"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="transform: rotate(90deg);"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can only be collapsed by clicking icon
+          </span>
+        </div>
+        <div
+          class="ant-collapse-content ant-collapse-content-active"
+        >
+          <div
+            class="ant-collapse-content-box"
+          >
+            <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+            </p>
+          </div>
+        </div>
       </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can only be collapsed by clicking icon
-      </span>
     </div>
   </div>
   <div
-    class="ant-collapse-item ant-collapse-item-disabled"
+    class="ant-space-item"
   >
     <div
-      aria-disabled="true"
-      aria-expanded="false"
-      class="ant-collapse-header"
-      role="button"
-      tabindex="-1"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-disabled"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="true"
+          aria-expanded="false"
+          class="ant-collapse-header"
+          role="button"
+          tabindex="-1"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can't be collapsed
+          </span>
+        </div>
       </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can't be collapsed
-      </span>
     </div>
   </div>
 </div>

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -319,11 +319,13 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
       <div
         class="ant-collapse-content-box"
       >
+        <p />
         <p
           style="padding-left: 24px;"
         >
           A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
         </p>
+        <p />
       </div>
     </div>
   </div>
@@ -412,176 +414,136 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
 
 exports[`renders components/collapse/demo/collapsible.tsx extend context correctly 1`] = `
 <div
-  class="ant-space ant-space-vertical"
+  class="ant-collapse ant-collapse-icon-position-start"
 >
   <div
-    class="ant-space-item"
-    style="margin-bottom: 8px;"
+    class="ant-collapse-item ant-collapse-item-active"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header ant-collapse-header-collapsible-only"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-active"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="false"
-          aria-expanded="true"
-          class="ant-collapse-header ant-collapse-header-collapsible-only"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                style="transform: rotate(90deg);"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can only be collapsed by clicking text
-          </span>
-        </div>
-        <div
-          class="ant-collapse-content ant-collapse-content-active"
-        >
-          <div
-            class="ant-collapse-content-box"
-          >
-            <p>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can only be collapsed by clicking text
+      </span>
+    </div>
+    <div
+      class="ant-collapse-content ant-collapse-content-active"
+    >
+      <div
+        class="ant-collapse-content-box"
+      >
+        <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-            </p>
-          </div>
-        </div>
+        </p>
       </div>
     </div>
   </div>
   <div
-    class="ant-space-item"
-    style="margin-bottom: 8px;"
+    class="ant-collapse-item"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header ant-collapse-icon-collapsible-only"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-active"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="false"
-          aria-expanded="true"
-          class="ant-collapse-header ant-collapse-icon-collapsible-only"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                style="transform: rotate(90deg);"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can only be collapsed by clicking icon
-          </span>
-        </div>
-        <div
-          class="ant-collapse-content ant-collapse-content-active"
-        >
-          <div
-            class="ant-collapse-content-box"
-          >
-            <p>
-  A dog is a type of domesticated animal.
-  Known for its loyalty and faithfulness,
-  it can be found as a welcome guest in many households across the world.
-            </p>
-          </div>
-        </div>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
       </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can only be collapsed by clicking icon
+      </span>
     </div>
   </div>
   <div
-    class="ant-space-item"
+    class="ant-collapse-item ant-collapse-item-disabled"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="true"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="-1"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-disabled"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="true"
-          aria-expanded="false"
-          class="ant-collapse-header"
-          role="button"
-          tabindex="-1"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can't be collapsed
-          </span>
-        </div>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
       </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can't be collapsed
+      </span>
     </div>
   </div>
 </div>
@@ -807,11 +769,11 @@ Array [
         <div
           class="ant-collapse-content-box"
         >
-          <div>
+          <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-          </div>
+          </p>
         </div>
       </div>
     </div>
@@ -1420,7 +1382,7 @@ exports[`renders components/collapse/demo/noarrow.tsx extend context correctly 1
     </div>
   </div>
   <div
-    class="ant-collapse-item ant-collapse-no-arrow"
+    class="ant-collapse-item"
   >
     <div
       aria-disabled="false"

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -807,11 +807,11 @@ Array [
         <div
           class="ant-collapse-content-box"
         >
-          <p>
+          <div>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-          </p>
+          </div>
         </div>
       </div>
     </div>

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -319,11 +319,13 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
       <div
         class="ant-collapse-content-box"
       >
+        <p />
         <p
           style="padding-left:24px"
         >
           A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
         </p>
+        <p />
       </div>
     </div>
   </div>
@@ -412,176 +414,136 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
 
 exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
 <div
-  class="ant-space ant-space-vertical"
+  class="ant-collapse ant-collapse-icon-position-start"
 >
   <div
-    class="ant-space-item"
-    style="margin-bottom:8px"
+    class="ant-collapse-item ant-collapse-item-active"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header ant-collapse-header-collapsible-only"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-active"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="false"
-          aria-expanded="true"
-          class="ant-collapse-header ant-collapse-header-collapsible-only"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can only be collapsed by clicking text
-          </span>
-        </div>
-        <div
-          class="ant-collapse-content ant-collapse-content-active"
-        >
-          <div
-            class="ant-collapse-content-box"
-          >
-            <p>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can only be collapsed by clicking text
+      </span>
+    </div>
+    <div
+      class="ant-collapse-content ant-collapse-content-active"
+    >
+      <div
+        class="ant-collapse-content-box"
+      >
+        <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-            </p>
-          </div>
-        </div>
+        </p>
       </div>
     </div>
   </div>
   <div
-    class="ant-space-item"
-    style="margin-bottom:8px"
+    class="ant-collapse-item"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header ant-collapse-icon-collapsible-only"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-active"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="false"
-          aria-expanded="true"
-          class="ant-collapse-header ant-collapse-icon-collapsible-only"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can only be collapsed by clicking icon
-          </span>
-        </div>
-        <div
-          class="ant-collapse-content ant-collapse-content-active"
-        >
-          <div
-            class="ant-collapse-content-box"
-          >
-            <p>
-  A dog is a type of domesticated animal.
-  Known for its loyalty and faithfulness,
-  it can be found as a welcome guest in many households across the world.
-            </p>
-          </div>
-        </div>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
       </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can only be collapsed by clicking icon
+      </span>
     </div>
   </div>
   <div
-    class="ant-space-item"
+    class="ant-collapse-item ant-collapse-item-disabled"
   >
     <div
-      class="ant-collapse ant-collapse-icon-position-start"
+      aria-disabled="true"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="-1"
     >
       <div
-        class="ant-collapse-item ant-collapse-item-disabled"
+        class="ant-collapse-expand-icon"
       >
-        <div
-          aria-disabled="true"
-          aria-expanded="false"
-          class="ant-collapse-header"
-          role="button"
-          tabindex="-1"
+        <span
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
         >
-          <div
-            class="ant-collapse-expand-icon"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <span
-              aria-label="right"
-              class="anticon anticon-right ant-collapse-arrow"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="right"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                />
-              </svg>
-            </span>
-          </div>
-          <span
-            class="ant-collapse-header-text"
-          >
-            This panel can't be collapsed
-          </span>
-        </div>
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
       </div>
+      <span
+        class="ant-collapse-header-text"
+      >
+        This panel can't be collapsed
+      </span>
     </div>
   </div>
 </div>
@@ -807,11 +769,11 @@ Array [
         <div
           class="ant-collapse-content-box"
         >
-          <div>
+          <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-          </div>
+          </p>
         </div>
       </div>
     </div>
@@ -1339,7 +1301,7 @@ exports[`renders components/collapse/demo/noarrow.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-collapse-item ant-collapse-no-arrow"
+    class="ant-collapse-item"
   >
     <div
       aria-disabled="false"

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -807,11 +807,11 @@ Array [
         <div
           class="ant-collapse-content-box"
         >
-          <p>
+          <div>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-          </p>
+          </div>
         </div>
       </div>
     </div>

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -319,13 +319,11 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
       <div
         class="ant-collapse-content-box"
       >
-        <p />
         <p
           style="padding-left:24px"
         >
           A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.
         </p>
-        <p />
       </div>
     </div>
   </div>
@@ -414,136 +412,176 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
 
 exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
 <div
-  class="ant-collapse ant-collapse-icon-position-start"
+  class="ant-space ant-space-vertical"
 >
   <div
-    class="ant-collapse-item ant-collapse-item-active"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <div
-      aria-disabled="false"
-      aria-expanded="true"
-      class="ant-collapse-header ant-collapse-header-collapsible-only"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-active"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="false"
+          aria-expanded="true"
+          class="ant-collapse-header ant-collapse-header-collapsible-only"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
-      </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can only be collapsed by clicking text
-      </span>
-    </div>
-    <div
-      class="ant-collapse-content ant-collapse-content-active"
-    >
-      <div
-        class="ant-collapse-content-box"
-      >
-        <p>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can only be collapsed by clicking text
+          </span>
+        </div>
+        <div
+          class="ant-collapse-content ant-collapse-content-active"
+        >
+          <div
+            class="ant-collapse-content-box"
+          >
+            <p>
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
-        </p>
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
-    class="ant-collapse-item"
+    class="ant-space-item"
+    style="margin-bottom:8px"
   >
     <div
-      aria-disabled="false"
-      aria-expanded="false"
-      class="ant-collapse-header ant-collapse-icon-collapsible-only"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-active"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="false"
+          aria-expanded="true"
+          class="ant-collapse-header ant-collapse-icon-collapsible-only"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can only be collapsed by clicking icon
+          </span>
+        </div>
+        <div
+          class="ant-collapse-content ant-collapse-content-active"
+        >
+          <div
+            class="ant-collapse-content-box"
+          >
+            <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+            </p>
+          </div>
+        </div>
       </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can only be collapsed by clicking icon
-      </span>
     </div>
   </div>
   <div
-    class="ant-collapse-item ant-collapse-item-disabled"
+    class="ant-space-item"
   >
     <div
-      aria-disabled="true"
-      aria-expanded="false"
-      class="ant-collapse-header"
-      role="button"
-      tabindex="-1"
+      class="ant-collapse ant-collapse-icon-position-start"
     >
       <div
-        class="ant-collapse-expand-icon"
+        class="ant-collapse-item ant-collapse-item-disabled"
       >
-        <span
-          aria-label="right"
-          class="anticon anticon-right ant-collapse-arrow"
-          role="img"
+        <div
+          aria-disabled="true"
+          aria-expanded="false"
+          class="ant-collapse-header"
+          role="button"
+          tabindex="-1"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <div
+            class="ant-collapse-expand-icon"
           >
-            <path
-              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-            />
-          </svg>
-        </span>
+            <span
+              aria-label="right"
+              class="anticon anticon-right ant-collapse-arrow"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="right"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                />
+              </svg>
+            </span>
+          </div>
+          <span
+            class="ant-collapse-header-text"
+          >
+            This panel can't be collapsed
+          </span>
+        </div>
       </div>
-      <span
-        class="ant-collapse-header-text"
-      >
-        This panel can't be collapsed
-      </span>
     </div>
   </div>
 </div>

--- a/components/collapse/demo/accordion.tsx
+++ b/components/collapse/demo/accordion.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
@@ -9,18 +8,24 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
-const App: React.FC = () => (
-  <Collapse accordion>
-    <Panel header="This is panel header 1" key="1">
-      <p>{text}</p>
-    </Panel>
-    <Panel header="This is panel header 2" key="2">
-      <p>{text}</p>
-    </Panel>
-    <Panel header="This is panel header 3" key="3">
-      <p>{text}</p>
-    </Panel>
-  </Collapse>
-);
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+  },
+];
+
+const App: React.FC = () => <Collapse accordion items={items} />;
 
 export default App;

--- a/components/collapse/demo/basic.tsx
+++ b/components/collapse/demo/basic.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
@@ -9,24 +8,30 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+  },
+];
+
 const App: React.FC = () => {
   const onChange = (key: string | string[]) => {
     console.log(key);
   };
 
-  return (
-    <Collapse defaultActiveKey={['1']} onChange={onChange}>
-      <Panel header="This is panel header 1" key="1">
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 2" key="2">
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 3" key="3">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-  );
+  return <Collapse items={items} defaultActiveKey={['1']} onChange={onChange} />;
 };
 
 export default App;

--- a/components/collapse/demo/borderless.tsx
+++ b/components/collapse/demo/borderless.tsx
@@ -13,17 +13,17 @@ const items: CollapseProps['items'] = [
   {
     key: '1',
     label: 'This is panel header 1',
-    children: <p>{text}</p>,
+    children: text,
   },
   {
     key: '2',
     label: 'This is panel header 2',
-    children: <p>{text}</p>,
+    children: text,
   },
   {
     key: '3',
     label: 'This is panel header 3',
-    children: <p>{text}</p>,
+    children: text,
   },
 ];
 

--- a/components/collapse/demo/borderless.tsx
+++ b/components/collapse/demo/borderless.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = (
   <p style={{ paddingLeft: 24 }}>
@@ -10,18 +9,24 @@ const text = (
   </p>
 );
 
-const App: React.FC = () => (
-  <Collapse bordered={false} defaultActiveKey={['1']}>
-    <Panel header="This is panel header 1" key="1">
-      {text}
-    </Panel>
-    <Panel header="This is panel header 2" key="2">
-      {text}
-    </Panel>
-    <Panel header="This is panel header 3" key="3">
-      {text}
-    </Panel>
-  </Collapse>
-);
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+  },
+];
+
+const App: React.FC = () => <Collapse items={items} bordered={false} defaultActiveKey={['1']} />;
 
 export default App;

--- a/components/collapse/demo/collapsible.tsx
+++ b/components/collapse/demo/collapsible.tsx
@@ -1,7 +1,6 @@
+import type { CollapseProps } from 'antd';
+import { Collapse } from 'antd';
 import React from 'react';
-import { Collapse, Space } from 'antd';
-
-const { Panel } = Collapse;
 
 const text = `
   A dog is a type of domesticated animal.
@@ -9,24 +8,29 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This panel can only be collapsed by clicking text',
+    children: <p>{text}</p>,
+    collapsible: 'header',
+  },
+  {
+    key: '2',
+    label: 'This panel can only be collapsed by clicking icon',
+    children: <p>{text}</p>,
+    collapsible: 'icon',
+  },
+  {
+    key: '3',
+    label: "This panel can't be collapsed",
+    children: <p>{text}</p>,
+    collapsible: 'disabled',
+  },
+];
+
 const App: React.FC = () => (
-  <Space direction="vertical">
-    <Collapse collapsible="header" defaultActiveKey={['1']}>
-      <Panel header="This panel can only be collapsed by clicking text" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-    <Collapse collapsible="icon" defaultActiveKey={['1']}>
-      <Panel header="This panel can only be collapsed by clicking icon" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-    <Collapse collapsible="disabled">
-      <Panel header="This panel can't be collapsed" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-  </Space>
+  <Collapse items={items} collapsible="header" defaultActiveKey={['1']} />
 );
 
 export default App;

--- a/components/collapse/demo/collapsible.tsx
+++ b/components/collapse/demo/collapsible.tsx
@@ -1,5 +1,4 @@
-import type { CollapseProps } from 'antd';
-import { Collapse } from 'antd';
+import { Collapse, Space } from 'antd';
 import React from 'react';
 
 const text = `
@@ -8,29 +7,41 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
-const items: CollapseProps['items'] = [
-  {
-    key: '1',
-    label: 'This panel can only be collapsed by clicking text',
-    children: <p>{text}</p>,
-    collapsible: 'header',
-  },
-  {
-    key: '2',
-    label: 'This panel can only be collapsed by clicking icon',
-    children: <p>{text}</p>,
-    collapsible: 'icon',
-  },
-  {
-    key: '3',
-    label: "This panel can't be collapsed",
-    children: <p>{text}</p>,
-    collapsible: 'disabled',
-  },
-];
-
 const App: React.FC = () => (
-  <Collapse items={items} collapsible="header" defaultActiveKey={['1']} />
+  <Space direction="vertical">
+    <Collapse
+      collapsible="header"
+      defaultActiveKey={['1']}
+      items={[
+        {
+          key: '1',
+          label: 'This panel can only be collapsed by clicking text',
+          children: <p>{text}</p>,
+        },
+      ]}
+    />
+    <Collapse
+      collapsible="icon"
+      defaultActiveKey={['1']}
+      items={[
+        {
+          key: '1',
+          label: 'This panel can only be collapsed by clicking icon',
+          children: <p>{text}</p>,
+        },
+      ]}
+    />
+    <Collapse
+      collapsible="disabled"
+      items={[
+        {
+          key: '1',
+          label: "This panel can't be collapsed",
+          children: <p>{text}</p>,
+        },
+      ]}
+    />
+  </Space>
 );
 
 export default App;

--- a/components/collapse/demo/custom.tsx
+++ b/components/collapse/demo/custom.tsx
@@ -1,14 +1,35 @@
-import React from 'react';
 import { CaretRightOutlined } from '@ant-design/icons';
+import type { CollapseProps } from 'antd';
 import { Collapse, theme } from 'antd';
-
-const { Panel } = Collapse;
+import type { CSSProperties } from 'react';
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,
   it can be found as a welcome guest in many households across the world.
 `;
+
+const getItems: (panelStyle: CSSProperties) => CollapseProps['items'] = (panelStyle) => [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <p>{text}</p>,
+    style: panelStyle,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+    style: panelStyle,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+    style: panelStyle,
+  },
+];
 
 const App: React.FC = () => {
   const { token } = theme.useToken();
@@ -26,17 +47,8 @@ const App: React.FC = () => {
       defaultActiveKey={['1']}
       expandIcon={({ isActive }) => <CaretRightOutlined rotate={isActive ? 90 : 0} />}
       style={{ background: token.colorBgContainer }}
-    >
-      <Panel header="This is panel header 1" key="1" style={panelStyle}>
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 2" key="2" style={panelStyle}>
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 3" key="3" style={panelStyle}>
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
+      items={getItems(panelStyle)}
+    />
   );
 };
 

--- a/components/collapse/demo/extra.tsx
+++ b/components/collapse/demo/extra.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
 import { SettingOutlined } from '@ant-design/icons';
+import type { CollapseProps } from 'antd';
 import { Collapse, Select } from 'antd';
+import React, { useState } from 'react';
 
 const { Panel } = Collapse;
 const { Option } = Select;
@@ -33,23 +34,35 @@ const App: React.FC = () => {
     />
   );
 
+  const items: CollapseProps['items'] = [
+    {
+      key: '1',
+      label: 'This is panel header 1',
+      children: <p>{text}</p>,
+      extra: genExtra(),
+    },
+    {
+      key: '2',
+      label: 'This is panel header 2',
+      children: <p>{text}</p>,
+      extra: genExtra(),
+    },
+    {
+      key: '3',
+      label: 'This is panel header 3',
+      children: <p>{text}</p>,
+      extra: genExtra(),
+    },
+  ];
+
   return (
     <>
       <Collapse
         defaultActiveKey={['1']}
         onChange={onChange}
         expandIconPosition={expandIconPosition}
-      >
-        <Panel header="This is panel header 1" key="1" extra={genExtra()}>
-          <div>{text}</div>
-        </Panel>
-        <Panel header="This is panel header 2" key="2" extra={genExtra()}>
-          <div>{text}</div>
-        </Panel>
-        <Panel header="This is panel header 3" key="3" extra={genExtra()}>
-          <div>{text}</div>
-        </Panel>
-      </Collapse>
+        items={items}
+      />
       <br />
       <span>Expand Icon Position: </span>
       <Select value={expandIconPosition} style={{ margin: '0 8px' }} onChange={onPositionChange}>

--- a/components/collapse/demo/extra.tsx
+++ b/components/collapse/demo/extra.tsx
@@ -37,19 +37,19 @@ const App: React.FC = () => {
     {
       key: '1',
       label: 'This is panel header 1',
-      children: <p>{text}</p>,
+      children: <div>{text}</div>,
       extra: genExtra(),
     },
     {
       key: '2',
       label: 'This is panel header 2',
-      children: <p>{text}</p>,
+      children: <div>{text}</div>,
       extra: genExtra(),
     },
     {
       key: '3',
       label: 'This is panel header 3',
-      children: <p>{text}</p>,
+      children: <div>{text}</div>,
       extra: genExtra(),
     },
   ];

--- a/components/collapse/demo/extra.tsx
+++ b/components/collapse/demo/extra.tsx
@@ -3,7 +3,6 @@ import type { CollapseProps } from 'antd';
 import { Collapse, Select } from 'antd';
 import React, { useState } from 'react';
 
-const { Panel } = Collapse;
 const { Option } = Select;
 
 const text = `

--- a/components/collapse/demo/ghost.tsx
+++ b/components/collapse/demo/ghost.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
@@ -9,18 +8,24 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
-const App: React.FC = () => (
-  <Collapse defaultActiveKey={['1']} ghost>
-    <Panel header="This is panel header 1" key="1">
-      <p>{text}</p>
-    </Panel>
-    <Panel header="This is panel header 2" key="2">
-      <p>{text}</p>
-    </Panel>
-    <Panel header="This is panel header 3" key="3">
-      <p>{text}</p>
-    </Panel>
-  </Collapse>
-);
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+  },
+];
+
+const App: React.FC = () => <Collapse defaultActiveKey={['1']} ghost items={items} />;
 
 export default App;

--- a/components/collapse/demo/mix.tsx
+++ b/components/collapse/demo/mix.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
@@ -9,28 +8,38 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
+const itemsNest: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel nest panel',
+    children: <p>{text}</p>,
+  },
+];
+
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header 1',
+    children: <Collapse defaultActiveKey="1" items={itemsNest} />,
+  },
+  {
+    key: '2',
+    label: 'This is panel header 2',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '3',
+    label: 'This is panel header 3',
+    children: <p>{text}</p>,
+  },
+];
+
 const App: React.FC = () => {
   const onChange = (key: string | string[]) => {
     console.log(key);
   };
 
-  return (
-    <Collapse onChange={onChange}>
-      <Panel header="This is panel header 1" key="1">
-        <Collapse defaultActiveKey="1">
-          <Panel header="This is panel nest panel" key="1">
-            <p>{text}</p>
-          </Panel>
-        </Collapse>
-      </Panel>
-      <Panel header="This is panel header 2" key="2">
-        <p>{text}</p>
-      </Panel>
-      <Panel header="This is panel header 3" key="3">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-  );
+  return <Collapse onChange={onChange} items={items} />;
 };
 
 export default App;

--- a/components/collapse/demo/noarrow.tsx
+++ b/components/collapse/demo/noarrow.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
+import React from 'react';
 
 const { Panel } = Collapse;
 
@@ -9,21 +10,26 @@ const text = `
   it can be found as a welcome guest in many households across the world.
 `;
 
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: 'This is panel header with arrow icon',
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: 'This is panel header with no arrow icon',
+    children: <p>{text}</p>,
+    showArrow: false,
+  },
+];
+
 const App: React.FC = () => {
   const onChange = (key: string | string[]) => {
     console.log(key);
   };
 
-  return (
-    <Collapse defaultActiveKey={['1']} onChange={onChange}>
-      <Panel header="This is panel header with arrow icon" key="1">
-        <p>{text}</p>
-      </Panel>
-      <Panel showArrow={false} header="This is panel header with no arrow icon" key="2">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
-  );
+  return <Collapse defaultActiveKey={['1']} onChange={onChange} items={items} />;
 };
 
 export default App;

--- a/components/collapse/demo/noarrow.tsx
+++ b/components/collapse/demo/noarrow.tsx
@@ -2,8 +2,6 @@ import type { CollapseProps } from 'antd';
 import { Collapse } from 'antd';
 import React from 'react';
 
-const { Panel } = Collapse;
-
 const text = `
   A dog is a type of domesticated animal.
   Known for its loyalty and faithfulness,

--- a/components/collapse/demo/size.tsx
+++ b/components/collapse/demo/size.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
 import { Collapse, Divider } from 'antd';
-
-const { Panel } = Collapse;
+import React from 'react';
 
 const text = `
   A dog is a type of domesticated animal.
@@ -12,23 +10,19 @@ const text = `
 const App: React.FC = () => (
   <>
     <Divider orientation="left">Default Size</Divider>
-    <Collapse>
-      <Panel header="This is default size panel header" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
+    <Collapse
+      items={[{ key: '1', label: 'This is default size panel header', children: <p>{text}</p> }]}
+    />
     <Divider orientation="left">Small Size</Divider>
-    <Collapse size="small">
-      <Panel header="This is small size panel header" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
+    <Collapse
+      size="small"
+      items={[{ key: '1', label: 'This is small size panel header', children: <p>{text}</p> }]}
+    />
     <Divider orientation="left">Large Size</Divider>
-    <Collapse size="large">
-      <Panel header="This is large size panel header" key="1">
-        <p>{text}</p>
-      </Panel>
-    </Collapse>
+    <Collapse
+      size="large"
+      items={[{ key: '1', label: 'This is large size panel header', children: <p>{text}</p> }]}
+    />
   </>
 );
 

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -48,7 +48,7 @@ A content area which can be collapsed and expanded.
 
 ### Collapse.Panel
 
-<Alert message="&gt; 5.6.0 configure the panel by `items`."></Alert>
+<Alert message="&gt;= 5.6.0 configure the panel by `items`."></Alert>
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -44,8 +44,11 @@ A content area which can be collapsed and expanded.
 | ghost | Make the collapse borderless and its background transparent | boolean | false | 4.4.0 |
 | size | Set the size of collapse | `large` \| `middle` \| `small` | `middle` | 5.2.0 |
 | onChange | Callback function executed when active panel is changed | function | - |  |
+| items | collapse items content | [ItemType](https://github.com/react-component/collapse/blob/27250ca5415faab16db412b9bff2c131bb4f32fc/src/interface.ts#L6) | - | 5.6.0 |
 
 ### Collapse.Panel
+
+<Alert message="&gt; 5.6.0 configure the panel by `items`."></Alert>
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -45,8 +45,11 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 | ghost | 使折叠面板透明且无边框 | boolean | false | 4.4.0 |
 | size | 设置折叠面板大小 | `large` \| `middle` \| `small` | `middle` | 5.2.0 |
 | onChange | 切换面板的回调 | function | - |  |
+| items | 折叠项目内容 | [ItemType](https://github.com/react-component/collapse/blob/27250ca5415faab16db412b9bff2c131bb4f32fc/src/interface.ts#L6) | - | 5.6.0 |
 
 ### Collapse.Panel
+
+<Alert message="&gt; 5.6.0 请使用 items 方式配置面板."></Alert>
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -49,7 +49,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 
 ### Collapse.Panel
 
-<Alert message="&gt; 5.6.0 请使用 items 方式配置面板."></Alert>
+<Alert message="&gt;= 5.6.0 请使用 items 方式配置面板."></Alert>
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -39,6 +39,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
     marginSM,
     paddingSM,
     paddingLG,
+    paddingXS,
     motionDurationSlow,
     fontSizeIcon,
   } = token;
@@ -147,6 +148,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
         [`> ${componentCls}-item`]: {
           [`> ${componentCls}-header`]: {
             padding: collapseHeaderPaddingSM,
+            paddingInlineStart: paddingSM - paddingXS,
           },
           [`> ${componentCls}-content > ${componentCls}-content-box`]: {
             padding: paddingSM,
@@ -160,6 +162,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
 
           [`> ${componentCls}-header`]: {
             padding: collapseHeaderPaddingLG,
+            paddingInlineStart: paddingLG - padding,
 
             [`> ${componentCls}-expand-icon`]: {
               height: fontSizeLG * lineHeight,

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -1,7 +1,7 @@
+import { resetComponent, resetIcon } from '../../style';
 import { genCollapseMotion } from '../../style/motion';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { resetComponent, resetIcon } from '../../style';
 
 export interface ComponentToken {}
 
@@ -73,6 +73,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
           flexWrap: 'nowrap',
           alignItems: 'flex-start',
           padding: collapseHeaderPadding,
+          paddingInlineStart: paddingSM,
           color: colorTextHeading,
           lineHeight,
           cursor: 'pointer',
@@ -92,6 +93,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
             display: 'flex',
             alignItems: 'center',
             paddingInlineEnd: marginSM,
+            marginInlineStart: padding - paddingSM,
           },
 
           [`${componentCls}-arrow`]: {
@@ -123,12 +125,6 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
 
           [`${componentCls}-expand-icon`]: {
             cursor: 'pointer',
-          },
-        },
-
-        [`&${componentCls}-no-arrow`]: {
-          [`> ${componentCls}-header`]: {
-            paddingInlineStart: paddingSM,
           },
         },
       },

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -94,6 +94,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
             display: 'flex',
             alignItems: 'center',
             paddingInlineEnd: marginSM,
+            // Arrow offset
             marginInlineStart: padding - paddingSM,
           },
 

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -3,13 +3,12 @@ import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
+import type { CollapseProps } from '../../collapse';
 import Collapse from '../../collapse';
 import { useLocale } from '../../locale';
 import type { Color } from '../color';
 import type { ColorPickerBaseProps, PresetsItem } from '../interface';
 import { generateColor } from '../util';
-
-const { Panel } = Collapse;
 
 interface ColorPresetsProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
   presets: PresetsItem[];
@@ -48,36 +47,39 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
     onChange?.(colorValue);
   };
 
+  const items: CollapseProps['items'] = useMemo(
+    () =>
+      presetsValue.map((preset) => ({
+        key: `panel-${preset.label}`,
+        label: <div className={`${colorPresetsPrefixCls}-label`}>{preset?.label}</div>,
+        children: (
+          <div className={`${colorPresetsPrefixCls}-items`}>
+            {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
+              preset.colors.map((presetColor: Color) => (
+                <ColorBlock
+                  key={`preset-${presetColor.toHexString()}`}
+                  color={generateColor(presetColor).toRgbString()}
+                  prefixCls={prefixCls}
+                  className={classNames(`${colorPresetsPrefixCls}-color`, {
+                    [`${colorPresetsPrefixCls}-color-checked`]:
+                      presetColor.toHexString() === color?.toHexString(),
+                    [`${colorPresetsPrefixCls}-color-bright`]: isBright(presetColor),
+                  })}
+                  onClick={() => handleClick(presetColor)}
+                />
+              ))
+            ) : (
+              <span className={`${colorPresetsPrefixCls}-empty`}>{locale.presetEmpty}</span>
+            )}
+          </div>
+        ),
+      })),
+    [],
+  );
+
   return (
     <div className={colorPresetsPrefixCls}>
-      <Collapse defaultActiveKey={activeKeys} ghost>
-        {presetsValue.map((preset) => (
-          <Panel
-            header={<div className={`${colorPresetsPrefixCls}-label`}>{preset?.label}</div>}
-            key={`panel-${preset?.label}`}
-          >
-            <div className={`${colorPresetsPrefixCls}-items`}>
-              {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
-                preset.colors.map((presetColor: Color) => (
-                  <ColorBlock
-                    key={`preset-${presetColor.toHexString()}`}
-                    color={generateColor(presetColor).toRgbString()}
-                    prefixCls={prefixCls}
-                    className={classNames(`${colorPresetsPrefixCls}-color`, {
-                      [`${colorPresetsPrefixCls}-color-checked`]:
-                        presetColor.toHexString() === color?.toHexString(),
-                      [`${colorPresetsPrefixCls}-color-bright`]: isBright(presetColor),
-                    })}
-                    onClick={() => handleClick(presetColor)}
-                  />
-                ))
-              ) : (
-                <span className={`${colorPresetsPrefixCls}-empty`}>{locale.presetEmpty}</span>
-              )}
-            </div>
-          </Panel>
-        ))}
-      </Collapse>
+      <Collapse defaultActiveKey={activeKeys} ghost items={items} />
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "qrcode.react": "^3.1.0",
     "rc-cascader": "~3.12.0",
     "rc-checkbox": "~3.0.0",
-    "rc-collapse": "3.6.0",
+    "rc-collapse": "~3.6.0",
     "rc-dialog": "~9.1.0",
     "rc-drawer": "~6.1.1",
     "rc-dropdown": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "qrcode.react": "^3.1.0",
     "rc-cascader": "~3.12.0",
     "rc-checkbox": "~3.0.0",
-    "rc-collapse": "~3.5.2",
+    "rc-collapse": "3.6.0",
     "rc-dialog": "~9.1.0",
     "rc-drawer": "~6.1.1",
     "rc-dropdown": "~4.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Collapse support configure panel content by items  |
| 🇨🇳 Chinese |  折叠面板支持通过 items 配置面板内容   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27e3857</samp>

This pull request refactors the Collapse component and its demos to use the new `items` prop instead of the deprecated `Panel` component. It also updates the type definitions, the documentation, and the `rc-collapse` dependency to support a new feature for the expand icon position.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27e3857</samp>

*  Import the type definition of `CollapseProps` from the `rc-collapse` package in `Collapse.tsx` and the demo files, which is used to specify the props of the `Collapse` component. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R3), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-a2f709a1721eac15b6d70715382d8e3437c3c47fbc24d91970643602a987681bL1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-e68c02a5815e5a9c6a7851ad90c20cd1d4f4103e3c132d156bc77afea77fee2bL1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-833be645f48f81985c9a8c7aec835b5c7a9bdde11295e31450b42bc3f541a1a1L1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-d8ede31f882f5473fab952ec6f7bc407690b8683099d02de7e6fdabf976401bdL1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-d8cf3c5489f44133d1e8c087f5e923cb1cc93aa64ef2d53a1923a578f65d9c42L1-R6), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-2bf4f723b58175f0bfa95045cc92a868ef5195a840b86dbb342125f610978c17L1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-601a0d21ce6b45dc31970b5e2a346e6531918bb71ec634dc7e49ccf8a79cb472L1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-1058d770ba3b1820615351e9c61975d65401af0e8de615c1a90203767f02c907L1-R4), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-235242af85a91b896ab25b465c57a45d895a7ea2a4ba33822742789b430c0aecL1-R3))
* Add the `items` prop to the `ExpandIconPosition` type in `Collapse.tsx`, which is used to indicate the position of the expand icon in the `Collapse` component. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R24))
* Replace the use of `Panel` components with the `items` prop in the `Collapse` component in the demo files, which simplifies the code and avoids the deprecation warning of the `Panel` component. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-a2f709a1721eac15b6d70715382d8e3437c3c47fbc24d91970643602a987681bL12-R30), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-e68c02a5815e5a9c6a7851ad90c20cd1d4f4103e3c132d156bc77afea77fee2bL17-R34), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-833be645f48f81985c9a8c7aec835b5c7a9bdde11295e31450b42bc3f541a1a1L13-R31), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-d8ede31f882f5473fab952ec6f7bc407690b8683099d02de7e6fdabf976401bdL12-R33), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-d8cf3c5489f44133d1e8c087f5e923cb1cc93aa64ef2d53a1923a578f65d9c42L29-R51), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-2bf4f723b58175f0bfa95045cc92a868ef5195a840b86dbb342125f610978c17L42-R65), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-601a0d21ce6b45dc31970b5e2a346e6531918bb71ec634dc7e49ccf8a79cb472L12-R30), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-1058d770ba3b1820615351e9c61975d65401af0e8de615c1a90203767f02c907L17-R42), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-235242af85a91b896ab25b465c57a45d895a7ea2a4ba33822742789b430c0aecL17-R32), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-e2edbfbc0753c99cabe338132ec93b4aa3eec72256672343b815e160a2bd1a2cL15-R25))
* Add a deprecation warning to the `CollapsePanel` component in `CollapsePanel.tsx`, which is no longer recommended to use since the `Collapse` component supports the `items` prop to configure the panels. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-7b26d89bc5d6c4b0c3933b263e17bb939b25f88b0e51e76014a3a29ae22ca223R24-R26))
* Move the import of `ConfigContext` from `CollapsePanel.tsx` to `Collapse.tsx`, since the latter uses the `ConfigContext` to get the `prefixCls` and `direction` values. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-7b26d89bc5d6c4b0c3933b263e17bb939b25f88b0e51e76014a3a29ae22ca223L4-R5))
* Update the version of the `rc-collapse` dependency from 3.5.2 to 3.6.0 in `package.json`, which supports the `items` prop in the `Collapse` component. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L126-R126))
* Add the documentation of the `items` prop in the `Collapse` component, and links to the `ItemType` interface from the `rc-collapse` package in `index.en-US.md` and `index.zh-CN.md`. It also adds an alert message to inform the users to use the `items` prop instead of the `Panel` component. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-80196f1c3a222b13f4be47d5ed6461a8767e35482104430410405c1bc047af75L47-R52), [link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-d54c8a5b222ce1fa0e8d1043fc79b037bc9eb27d38bd30409d690c8275ac2c62L48-R53))
* Remove the unused import of `Panel` from the `size.tsx` demo file, since the `Panel` component is no longer used. ([link](https://github.com/ant-design/ant-design/pull/42545/files?diff=unified&w=0#diff-e2edbfbc0753c99cabe338132ec93b4aa3eec72256672343b815e160a2bd1a2cL1-R3))
