### PR TITLE
site: optimize the website arrow style

### DIFF
--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightOutlined } from '@ant-design/icons';
+import { RightOutlined } from '@ant-design/icons';
 import { css } from '@emotion/react';
 import { ConfigProvider, Table } from 'antd';
 import { getDesignToken } from 'antd-token-previewer';
@@ -97,7 +97,7 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({ defaultOpen, tokens, titl
   return (
     <div>
       <div css={tableTitle} onClick={() => setOpen(!open)}>
-        <ArrowRightOutlined css={arrowIcon} rotate={open ? 90 : 0} />
+        <RightOutlined css={arrowIcon} rotate={open ? 90 : 0} />
         <h3>{title}</h3>
       </div>
       {open && (

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -25,7 +25,7 @@ const locales = {
   },
 };
 
-const useStyle = () => ({
+const useStyle = (open: boolean) => ({
   tableTitle: css`
     position: relative;
     display: flex;
@@ -36,8 +36,7 @@ const useStyle = () => ({
     position: relative;
     width: 10px;
     height: 0;
-    margin-right: 8px;
-
+    margin-right: 12px;
     &:before,
     &:after {
       position: absolute;
@@ -53,22 +52,23 @@ const useStyle = () => ({
       content: '';
     }
   `,
-  openIcon: css`
-    &:before {
-      transform: rotate(-45deg) translateX(2.5px);
-    }
-    &:after {
-      transform: rotate(45deg) translateX(-2.5px);
-    }
-  `,
-  closeIcon: css`
-    &:before {
-      transform: rotate(45deg) translateX(2.5px);
-    }
-    &:after {
-      transform: rotate(-45deg) translateX(-2.5px);
-    }
-  `,
+  toogleIcon: open
+    ? css`
+        &:before {
+          transform: rotate(-45deg) translateX(2.5px);
+        }
+        &:after {
+          transform: rotate(45deg) translateX(-2.5px);
+        }
+      `
+    : css`
+        &:before {
+          transform: rotate(45deg) translateX(2.5px);
+        }
+        &:after {
+          transform: rotate(-45deg) translateX(-2.5px);
+        }
+      `,
 });
 
 interface SubTokenTableProps {
@@ -82,9 +82,9 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({ defaultOpen, tokens, titl
   const { token } = useSiteToken();
   const columns = useColumns();
 
-  const { tableTitle, arrowIcon, openIcon, closeIcon } = useStyle();
-
   const [open, setOpen] = React.useState(defaultOpen || process.env.NODE_ENV !== 'production');
+
+  const { tableTitle, arrowIcon, toogleIcon } = useStyle(open);
 
   if (!tokens.length) {
     return null;
@@ -123,8 +123,8 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({ defaultOpen, tokens, titl
 
   return (
     <div>
-      <div css={[tableTitle]} onClick={() => setOpen(!open)}>
-        <i css={[arrowIcon, open ? openIcon : closeIcon]} />
+      <div css={tableTitle} onClick={() => setOpen(!open)}>
+        <i css={[arrowIcon, toogleIcon]} />
         <h3>{title}</h3>
       </div>
       {open && (

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -31,6 +31,7 @@ const useStyle = (open: boolean) => ({
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    line-height: 40px;
   `,
   arrowIcon: css`
     position: relative;

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -1,9 +1,10 @@
+import { ArrowRightOutlined } from '@ant-design/icons';
 import { css } from '@emotion/react';
 import { ConfigProvider, Table } from 'antd';
 import { getDesignToken } from 'antd-token-previewer';
 import tokenMeta from 'antd/es/version/token-meta.json';
 import tokenData from 'antd/es/version/token.json';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import useLocale from '../../../hooks/useLocale';
 import useSiteToken from '../../../hooks/useSiteToken';
 import { useColumns } from '../TokenTable';
@@ -25,8 +26,9 @@ const locales = {
   },
 };
 
-const useStyle = (open: boolean) => ({
+const useStyle = () => ({
   tableTitle: css`
+    cursor: pointer;
     position: relative;
     display: flex;
     align-items: center;
@@ -34,42 +36,12 @@ const useStyle = (open: boolean) => ({
     line-height: 40px;
   `,
   arrowIcon: css`
-    position: relative;
-    width: 10px;
-    height: 0;
-    margin-right: 12px;
-    &:before,
-    &:after {
-      position: absolute;
-      display: block;
-      width: 6px;
-      height: 1.5px;
-      background-color: currentcolor;
-      border-radius: 6px;
-      transition: background-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
-        transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
-        top 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
-        color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
-      content: '';
+    font-size: 16px;
+    margin-right: 8px;
+    & svg {
+      transition: all 0.3s;
     }
   `,
-  toogleIcon: open
-    ? css`
-        &:before {
-          transform: rotate(-45deg) translateX(2.5px);
-        }
-        &:after {
-          transform: rotate(45deg) translateX(-2.5px);
-        }
-      `
-    : css`
-        &:before {
-          transform: rotate(45deg) translateX(2.5px);
-        }
-        &:after {
-          transform: rotate(-45deg) translateX(-2.5px);
-        }
-      `,
 });
 
 interface SubTokenTableProps {
@@ -83,9 +55,9 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({ defaultOpen, tokens, titl
   const { token } = useSiteToken();
   const columns = useColumns();
 
-  const [open, setOpen] = React.useState(defaultOpen || process.env.NODE_ENV !== 'production');
+  const [open, setOpen] = useState<boolean>(defaultOpen || process.env.NODE_ENV !== 'production');
 
-  const { tableTitle, arrowIcon, toogleIcon } = useStyle(open);
+  const { tableTitle, arrowIcon } = useStyle();
 
   if (!tokens.length) {
     return null;
@@ -125,7 +97,7 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({ defaultOpen, tokens, titl
   return (
     <div>
       <div css={tableTitle} onClick={() => setOpen(!open)}>
-        <i css={[arrowIcon, toogleIcon]} />
+        <ArrowRightOutlined css={arrowIcon} rotate={open ? 90 : 0} />
         <h3>{title}</h3>
       </div>
       {open && (
@@ -150,7 +122,7 @@ export interface ComponentTokenTableProps {
 }
 
 const ComponentTokenTable: React.FC<ComponentTokenTableProps> = ({ component }) => {
-  const [mergedGlobalTokens] = React.useMemo(() => {
+  const [mergedGlobalTokens] = useMemo(() => {
     const globalTokenSet = new Set<string>();
     let componentTokens: Record<string, string> = {};
 
@@ -168,7 +140,7 @@ const ComponentTokenTable: React.FC<ComponentTokenTableProps> = ({ component }) 
       };
     });
 
-    return [Array.from(globalTokenSet), componentTokens];
+    return [Array.from(globalTokenSet), componentTokens] as const;
   }, [component]);
 
   return <SubTokenTable title="Global Token" tokens={mergedGlobalTokens} />;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

### before:

https://github.com/ant-design/ant-design/assets/49217418/ecaee6a4-4a33-4769-9c39-5858506706b0

### after:

https://github.com/ant-design/ant-design/assets/49217418/e49bf004-1ca1-40c4-abd1-8da4a86d3dd7

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | site: optimize the website arrow style |
| 🇨🇳 Chinese | 优化官网箭头样式，无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62fa80f</samp>

Refactor and improve `ComponentTokenTable` component. Use `@emotion/react` for styling and add collapsible sub-tables. Remove unused code.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62fa80f</samp>

*  Import `css` function from `@emotion/react` to style components with `css` prop ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L1-R1))
*  Define `useStyle` hook to generate `css` objects for table title and arrow icon based on `open` state ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93R28-R73))
*  Convert `SubTokenTable` and `ComponentTokenTable` components to function expressions with `React.FC` type annotation ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L34-R88), [link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L105-R151))
*  Add `open` state and `setOpen` function to `SubTokenTable` component to control table visibility ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L34-R88))
*  Replace `details` and `summary` elements with `div` and `i` elements for table title and arrow icon in `SubTokenTable` component ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R145))
*  Add `onClick` handler to table title in `SubTokenTable` component to toggle `open` state ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R145))
*  Wrap table in conditional rendering based on `open` state in `SubTokenTable` component ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R145))
*  Remove `as any` cast from `value` property of data source in `SubTokenTable` component ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R145))
*  Simplify `filter` callback to use `Boolean` as a shorthand for truthy values in `SubTokenTable` component ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R145))
*  Remove commented out code and fragment element from `.dumi/theme/builtins/ComponentTokenTable/index.tsx` file ([link](https://github.com/ant-design/ant-design/pull/42591/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L127-R174))
