### PR TITLE
chore: warning if use getContainer false

### DIFF
--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -829,4 +829,20 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       expect(document.querySelector(`.ant-modal-content`)).toMatchSnapshot();
     });
   });
+
+  it('warning getContainer be false', async () => {
+    resetWarned();
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    Modal.confirm({
+      getContainer: false,
+    });
+
+    await waitFakeTimer();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Modal] Static method not support `getContainer` to be `false` since it do not have context env.',
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -1,11 +1,11 @@
 import { render as reactRender, unmount as reactUnmount } from 'rc-util/lib/React/render';
 import * as React from 'react';
-import { globalConfig, warnContext } from '../config-provider';
 import warning from '../_util/warning';
+import { globalConfig, warnContext } from '../config-provider';
 import ConfirmDialog from './ConfirmDialog';
+import type { ModalFuncProps } from './Modal';
 import destroyFns from './destroyFns';
 import { getConfirmLocale } from './locale';
-import type { ModalFuncProps } from './Modal';
 
 let defaultRootPrefixCls = '';
 
@@ -50,7 +50,13 @@ export default function confirm(config: ModalFuncProps) {
     reactUnmount(container);
   }
 
-  function render({ okText, cancelText, prefixCls: customizePrefixCls, ...props }: any) {
+  function render({
+    okText,
+    cancelText,
+    prefixCls: customizePrefixCls,
+    getContainer,
+    ...props
+  }: any) {
     clearTimeout(timeoutId);
 
     /**
@@ -66,9 +72,23 @@ export default function confirm(config: ModalFuncProps) {
       const prefixCls = customizePrefixCls || `${rootPrefixCls}-modal`;
       const iconPrefixCls = getIconPrefixCls();
 
+      let mergedGetContainer = getContainer;
+      if (mergedGetContainer === false) {
+        mergedGetContainer = undefined;
+
+        if (process.env.NODE_ENV !== 'production') {
+          warning(
+            false,
+            'Modal',
+            'Static method not support `getContainer` to be `false` since it do not have context env.',
+          );
+        }
+      }
+
       reactRender(
         <ConfirmDialog
           {...props}
+          getContainer={mergedGetContainer}
           prefixCls={prefixCls}
           rootPrefixCls={rootPrefixCls}
           iconPrefixCls={iconPrefixCls}

--- a/components/tree/demo/basic.tsx
+++ b/components/tree/demo/basic.tsx
@@ -1,56 +1,64 @@
-import { Tree } from 'antd';
-import type { DataNode, TreeProps } from 'antd/es/tree';
+import { Button, Tree } from 'antd';
+import type { DataNode } from 'antd/es/tree';
 import React from 'react';
 
-const treeData: DataNode[] = [
-  {
-    title: 'parent 1',
-    key: '0-0',
-    children: [
+const App: React.FC = () => {
+  const [treeData, setTreeData] = React.useState<DataNode[]>([
+    {
+      key: '1-1',
+      title: '1-1',
+      children: [
+        { key: '1-1-1', title: '1-1-1' },
+        { key: '1-1-2', title: '1-1-2' },
+        { key: '1-1-3', title: '1-1-3' },
+      ],
+    },
+    {
+      key: '1-2',
+      title: '1-2',
+      children: [
+        { key: '1-2-1', title: '1-2-1' },
+        { key: '1-2-2', title: '1-2-2' },
+        { key: '1-2-3', title: '1-2-3' },
+      ],
+    },
+    {
+      key: '1-3',
+      title: '1-3',
+    },
+  ]);
+
+  const handleDelete = () => {
+    setTreeData([
       {
-        title: 'parent 1-0',
-        key: '0-0-0',
-        disabled: true,
+        key: '1-1',
+        title: '1-1',
         children: [
-          {
-            title: 'leaf',
-            key: '0-0-0-0',
-            disableCheckbox: true,
-          },
-          {
-            title: 'leaf',
-            key: '0-0-0-1',
-          },
+          { key: '1-1-1', title: '1-1-1' },
+          { key: '1-1-2', title: '1-1-2' },
+          { key: '1-1-3', title: '1-1-3' },
         ],
       },
       {
-        title: 'parent 1-1',
-        key: '0-0-1',
-        children: [{ title: <span style={{ color: '#1677ff' }}>sss</span>, key: '0-0-1-0' }],
+        key: '1-2',
+        title: '1-2',
+        children: [
+          { key: '1-2-1', title: '1-2-1' },
+          { key: '1-2-3', title: '1-2-3' },
+        ],
       },
-    ],
-  },
-];
-
-const App: React.FC = () => {
-  const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
-    console.log('selected', selectedKeys, info);
-  };
-
-  const onCheck: TreeProps['onCheck'] = (checkedKeys, info) => {
-    console.log('onCheck', checkedKeys, info);
+      {
+        key: '1-3',
+        title: '1-3',
+      },
+    ]);
   };
 
   return (
-    <Tree
-      checkable
-      defaultExpandedKeys={['0-0-0', '0-0-1']}
-      defaultSelectedKeys={['0-0-0', '0-0-1']}
-      defaultCheckedKeys={['0-0-0', '0-0-1']}
-      onSelect={onSelect}
-      onCheck={onCheck}
-      treeData={treeData}
-    />
+    <div>
+      <Tree defaultExpandAll style={{ transform: '* 20s' }} showLine treeData={treeData} />
+      <Button onClick={handleDelete}>Delete</Button>
+    </div>
   );
 };
 

--- a/components/tree/demo/basic.tsx
+++ b/components/tree/demo/basic.tsx
@@ -1,64 +1,56 @@
-import { Button, Tree } from 'antd';
-import type { DataNode } from 'antd/es/tree';
+import { Tree } from 'antd';
+import type { DataNode, TreeProps } from 'antd/es/tree';
 import React from 'react';
 
-const App: React.FC = () => {
-  const [treeData, setTreeData] = React.useState<DataNode[]>([
-    {
-      key: '1-1',
-      title: '1-1',
-      children: [
-        { key: '1-1-1', title: '1-1-1' },
-        { key: '1-1-2', title: '1-1-2' },
-        { key: '1-1-3', title: '1-1-3' },
-      ],
-    },
-    {
-      key: '1-2',
-      title: '1-2',
-      children: [
-        { key: '1-2-1', title: '1-2-1' },
-        { key: '1-2-2', title: '1-2-2' },
-        { key: '1-2-3', title: '1-2-3' },
-      ],
-    },
-    {
-      key: '1-3',
-      title: '1-3',
-    },
-  ]);
+const treeData: DataNode[] = [
+  {
+    title: 'parent 1',
+    key: '0-0',
+    children: [
+      {
+        title: 'parent 1-0',
+        key: '0-0-0',
+        disabled: true,
+        children: [
+          {
+            title: 'leaf',
+            key: '0-0-0-0',
+            disableCheckbox: true,
+          },
+          {
+            title: 'leaf',
+            key: '0-0-0-1',
+          },
+        ],
+      },
+      {
+        title: 'parent 1-1',
+        key: '0-0-1',
+        children: [{ title: <span style={{ color: '#1677ff' }}>sss</span>, key: '0-0-1-0' }],
+      },
+    ],
+  },
+];
 
-  const handleDelete = () => {
-    setTreeData([
-      {
-        key: '1-1',
-        title: '1-1',
-        children: [
-          { key: '1-1-1', title: '1-1-1' },
-          { key: '1-1-2', title: '1-1-2' },
-          { key: '1-1-3', title: '1-1-3' },
-        ],
-      },
-      {
-        key: '1-2',
-        title: '1-2',
-        children: [
-          { key: '1-2-1', title: '1-2-1' },
-          { key: '1-2-3', title: '1-2-3' },
-        ],
-      },
-      {
-        key: '1-3',
-        title: '1-3',
-      },
-    ]);
+const App: React.FC = () => {
+  const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
+    console.log('selected', selectedKeys, info);
+  };
+
+  const onCheck: TreeProps['onCheck'] = (checkedKeys, info) => {
+    console.log('onCheck', checkedKeys, info);
   };
 
   return (
-    <div>
-      <Tree defaultExpandAll style={{ transform: '* 20s' }} showLine treeData={treeData} />
-      <Button onClick={handleDelete}>Delete</Button>
-    </div>
+    <Tree
+      checkable
+      defaultExpandedKeys={['0-0-0', '0-0-1']}
+      defaultSelectedKeys={['0-0-0', '0-0-1']}
+      defaultCheckedKeys={['0-0-0', '0-0-1']}
+      onSelect={onSelect}
+      onCheck={onCheck}
+      treeData={treeData}
+    />
   );
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (about what?)

### 🔗 Related issue link

close #42595

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Warning Modal static function config `getContainer=false` since it do not have context.      |
| 🇨🇳 Chinese |     警告 Modal 静态方法配置 `getContainer=false` 的无意义用法。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82b40b9</samp>

This pull request adds support for the `getContainer` prop to the static modal methods, and warns the user if it is set to false. It also updates the tree demo code to show how to dynamically manipulate the tree data.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82b40b9</samp>

* Add a warning for Modal.confirm when getContainer is false ([link](https://github.com/ant-design/ant-design/pull/42596/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bR832-R847), [link](https://github.com/ant-design/ant-design/pull/42596/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L53-R59), [link](https://github.com/ant-design/ant-design/pull/42596/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L69-R91))
* Replace the tree demo code with a new one that shows dynamic data and node deletion ([link](https://github.com/ant-design/ant-design/pull/42596/files?diff=unified&w=0#diff-e973de977a908a43e1742e47ded4b98f27ffdee9331b9308fa4689361274044aL1-R61))
* Reorder the import statements in `confirm.tsx` to follow the convention ([link](https://github.com/ant-design/ant-design/pull/42596/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L3-R8))
