### PR TITLE
fix: segmented bg color

### DIFF
--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -12,8 +12,8 @@ export interface ComponentToken {
 }
 
 interface SegmentedToken extends FullToken<'Segmented'> {
-  padding: number;
-  bgColor: string;
+  segmentedPadding: number;
+  segmentedBgColor: string;
   segmentedPaddingHorizontal: number;
   segmentedPaddingHorizontalSM: number;
 }
@@ -50,9 +50,9 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
       ...resetComponent(token),
 
       display: 'inline-block',
-      padding: token.padding,
+      padding: token.segmentedPadding,
       color: token.itemColor,
-      backgroundColor: token.bgColor,
+      backgroundColor: token.segmentedBgColor,
       borderRadius: token.borderRadius,
       transition: `all ${token.motionDurationMid} ${token.motionEaseInOut}`,
 
@@ -120,8 +120,8 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
         },
 
         '&-label': {
-          minHeight: token.controlHeight - token.padding * 2,
-          lineHeight: `${token.controlHeight - token.padding * 2}px`,
+          minHeight: token.controlHeight - token.segmentedPadding * 2,
+          lineHeight: `${token.controlHeight - token.segmentedPadding * 2}px`,
           padding: `0 ${token.segmentedPaddingHorizontal}px`,
           ...segmentedTextEllipsisCss,
         },
@@ -164,8 +164,8 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
       [`&${componentCls}-lg`]: {
         borderRadius: token.borderRadiusLG,
         [`${componentCls}-item-label`]: {
-          minHeight: token.controlHeightLG - token.padding * 2,
-          lineHeight: `${token.controlHeightLG - token.padding * 2}px`,
+          minHeight: token.controlHeightLG - token.segmentedPadding * 2,
+          lineHeight: `${token.controlHeightLG - token.segmentedPadding * 2}px`,
           padding: `0 ${token.segmentedPaddingHorizontal}px`,
           fontSize: token.fontSizeLG,
         },
@@ -177,8 +177,8 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
       [`&${componentCls}-sm`]: {
         borderRadius: token.borderRadiusSM,
         [`${componentCls}-item-label`]: {
-          minHeight: token.controlHeightSM - token.padding * 2,
-          lineHeight: `${token.controlHeightSM - token.padding * 2}px`,
+          minHeight: token.controlHeightSM - token.segmentedPadding * 2,
+          lineHeight: `${token.controlHeightSM - token.segmentedPadding * 2}px`,
           padding: `0 ${token.segmentedPaddingHorizontalSM}px`,
         },
         [`${componentCls}-item, ${componentCls}-thumb`]: {
@@ -203,10 +203,11 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 export default genComponentStyleHook(
   'Segmented',
   (token) => {
-    const { lineWidth, lineWidthBold } = token;
+    const { lineWidth, lineWidthBold, colorBgLayout } = token;
 
     const segmentedToken = mergeToken<SegmentedToken>(token, {
-      padding: lineWidthBold,
+      segmentedPadding: lineWidthBold,
+      segmentedBgColor: colorBgLayout,
       segmentedPaddingHorizontal: token.controlPaddingHorizontal - lineWidth,
       segmentedPaddingHorizontalSM: token.controlPaddingHorizontalSM - lineWidth,
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -      |
| 🇨🇳 Chinese |    修复 `feature` 分支问题，不计入 changelog      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d89f24e</samp>

Refactored `SegmentedToken` interface and related code in `components/segmented/style/index.tsx` to improve readability and consistency. Added a new token for segmented background color.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d89f24e</samp>

*  Rename `SegmentedToken` interface to `ComponentToken` and prefix `padding` and `bgColor` properties with `segmented` to avoid confusion with global token properties ([link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL15-R16))
*  Update `genSegmentedStyle` function to use the renamed properties `segmentedPadding` and `segmentedBgColor` instead of `padding` and `bgColor` for the segmented style generation ([link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL53-R55), [link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL123-R124), [link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL167-R168), [link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL180-R181))
*  Update `useComponentToken` hook to use the renamed property `segmentedPadding` instead of `padding` and to add a new property `segmentedBgColor` with the value of `colorBgLayout` for the segmented background color ([link](https://github.com/ant-design/ant-design/pull/42601/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL206-R210))
