### PR TITLE
refactor: ConfigProvider form dependency inversion

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -1,8 +1,8 @@
 import { createTheme } from '@ant-design/cssinjs';
 import IconContext from '@ant-design/icons/lib/components/Context';
 import type { ValidateMessages } from 'rc-field-form/lib/interface';
-import { setValues } from 'rc-field-form/lib/utils/valueUtil';
 import useMemo from 'rc-util/lib/hooks/useMemo';
+import { merge } from 'rc-util/lib/utils/set';
 import type { ReactElement } from 'react';
 import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
@@ -293,8 +293,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 
   const validateMessages = React.useMemo(
     () =>
-      setValues(
-        {},
+      merge(
         defaultLocale.Form?.defaultValidateMessages || {},
         memoedConfig.locale?.Form?.defaultValidateMessages || {},
         form?.validateMessages || {},

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -1,6 +1,5 @@
 import { createTheme } from '@ant-design/cssinjs';
 import IconContext from '@ant-design/icons/lib/components/Context';
-import { FormProvider as RcFormProvider } from 'rc-field-form';
 import type { ValidateMessages } from 'rc-field-form/lib/interface';
 import { setValues } from 'rc-field-form/lib/utils/valueUtil';
 import useMemo from 'rc-util/lib/hooks/useMemo';
@@ -8,6 +7,7 @@ import type { ReactElement } from 'react';
 import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
 import warning from '../_util/warning';
+import { ValidateMessagesContext } from '../form/context';
 import type { RequiredMark } from '../form/Form';
 import type { Locale } from '../locale';
 import LocaleProvider, { ANT_MARK } from '../locale';
@@ -303,7 +303,11 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   );
 
   if (Object.keys(validateMessages).length > 0) {
-    childNode = <RcFormProvider validateMessages={validateMessages}>{children}</RcFormProvider>;
+    childNode = (
+      <ValidateMessagesContext.Provider value={validateMessages}>
+        {children}
+      </ValidateMessagesContext.Provider>
+    );
   }
 
   if (locale) {

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -12,7 +12,7 @@ import { SizeContextProvider } from '../config-provider/SizeContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { ColProps } from '../grid/col';
 import type { FormContextProps } from './context';
-import { FormContext } from './context';
+import { FormContext, FormProvider, ValidateMessagesContext } from './context';
 import useForm, { type FormInstance } from './hooks/useForm';
 import useFormWarning from './hooks/useFormWarning';
 import type { FormLabelAlign } from './interface';
@@ -66,6 +66,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   } = props;
 
   const mergedSize = useSize(size);
+
+  const contextValidateMessages = React.useContext(ValidateMessagesContext);
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -158,16 +160,23 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   return wrapSSR(
     <DisabledContextProvider disabled={disabled}>
       <SizeContextProvider size={mergedSize}>
-        <FormContext.Provider value={formContextValue}>
-          <FieldForm
-            id={name}
-            {...restFormProps}
-            name={name}
-            onFinishFailed={onInternalFinishFailed}
-            form={wrapForm}
-            className={formClassName}
-          />
-        </FormContext.Provider>
+        <FormProvider
+          {...{
+            // This is not list in API, we pass with spread
+            validateMessages: contextValidateMessages,
+          }}
+        >
+          <FormContext.Provider value={formContextValue}>
+            <FieldForm
+              id={name}
+              {...restFormProps}
+              name={name}
+              onFinishFailed={onInternalFinishFailed}
+              form={wrapForm}
+              className={formClassName}
+            />
+          </FormContext.Provider>
+        </FormProvider>
       </SizeContextProvider>
     </DisabledContextProvider>,
   );

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -1,6 +1,6 @@
 import { FormProvider as RcFormProvider } from 'rc-field-form';
 import type { FormProviderProps as RcFormProviderProps } from 'rc-field-form/lib/FormContext';
-import type { Meta } from 'rc-field-form/lib/interface';
+import type { Meta, ValidateMessages } from 'rc-field-form/lib/interface';
 import omit from 'rc-util/lib/omit';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import * as React from 'react';
@@ -92,3 +92,5 @@ export const NoFormStyle: FC<NoFormStyleProps> = ({ children, status, override }
     </FormItemInputContext.Provider>
   );
 };
+
+export const ValidateMessagesContext = React.createContext<ValidateMessages | undefined>(undefined);

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "rc-tree": "~5.7.4",
     "rc-tree-select": "~5.9.0",
     "rc-upload": "~4.3.0",
-    "rc-util": "^5.27.0",
+    "rc-util": "^5.32.0",
     "scroll-into-view-if-needed": "^3.0.3",
     "throttle-debounce": "^5.0.0"
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ConfigProvider makes Form component in the bundle even not use it.       |
| 🇨🇳 Chinese |   修复使用 ConfigProvider 会导致未使用的 Form 组件也被打包的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4790b2</samp>

Added a new feature to customize form validation messages using `ValidateMessagesContext` and `FormProvider`. Refactored `components/config-provider/index.tsx` to use the new context instead of `RcFormProvider`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d4790b2</samp>

* Remove unused import of `RcFormProvider` from `components/config-provider/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L3))
* Add import of `ValidateMessagesContext` from `../form/context` to `components/config-provider/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R10))
* Replace wrapping children with `RcFormProvider` with wrapping them with `ValidateMessagesContext.Provider` in `components/config-provider/index.tsx` to avoid creating multiple `RcFormProvider` instances and use the context-based approach for passing the validate messages ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L306-R310))
* Add import of `ValidateMessages` type from `rc-field-form/lib/interface` to `components/form/context.tsx` to define the type of the `ValidateMessagesContext` value ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-dd4af975179f53bbabb7df046daec948d8fa4edfc012ef190b20a2de743e3ca9L3-R3))
* Add `ValidateMessagesContext` to `components/form/context.tsx` to export the context for the validate messages with an undefined default value ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-dd4af975179f53bbabb7df046daec948d8fa4edfc012ef190b20a2de743e3ca9R95-R96))
* Add import of `FormProvider` and `ValidateMessagesContext` from `./context` to `components/form/Form.tsx` to wrap the form component with the context providers ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL15-R15))
* Add `contextValidateMessages` variable to `components/form/Form.tsx` to store the value of the `ValidateMessagesContext` and use it as a fallback for the validate messages prop ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eR70-R71))
* Add `FormProvider` component to wrap the `FormContext.Provider` component in `components/form/Form.tsx` and pass the `validateMessages` prop or the `contextValidateMessages` value to the `RcFormProvider` component internally to simplify the API and avoid passing the `validateMessages` prop to multiple form components ([link](https://github.com/ant-design/ant-design/pull/42604/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL161-R179))
