### PR TITLE
fix(ColorPicker): should not trigger onChange when click clear after clearing

### DIFF
--- a/components/color-picker/ColorPickerPanel.tsx
+++ b/components/color-picker/ColorPickerPanel.tsx
@@ -24,6 +24,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
     onClear,
     onChangeComplete,
     color,
+    colorCleared,
     ...injectProps
   } = props;
   const colorPickerPanelPrefixCls = `${prefixCls}-inner-panel`;
@@ -34,6 +35,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
         <ColorClear
           prefixCls={prefixCls}
           value={color}
+          colorCleared={colorCleared}
           onChange={(clearColor) => {
             onChange?.(clearColor);
             onClear?.();

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -277,6 +277,16 @@ describe('ColorPicker', () => {
     ).toEqual('background: rgb(99, 22, 22);');
   });
 
+  it('Should not trigger onChange when click clear after clearing', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<ColorPicker allowClear onChange={onChange} />);
+    fireEvent.click(container.querySelector('.ant-color-picker-trigger')!);
+    fireEvent.click(container.querySelector('.ant-color-picker-clear')!);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('.ant-popover .ant-color-picker-clear')!);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it('Should fix hover boundary issues', async () => {
     spyElementPrototypes(HTMLElement, {
       getBoundingClientRect: () => ({

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -4,14 +4,14 @@ import type { Color } from '../color';
 import type { ColorPickerBaseProps } from '../interface';
 import { generateColor } from '../util';
 
-interface ColorClearProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
+interface ColorClearProps extends Pick<ColorPickerBaseProps, 'prefixCls' | 'colorCleared'> {
   value?: Color;
   onChange?: (value: Color) => void;
 }
 
-const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange }) => {
+const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, colorCleared, onChange }) => {
   const handleClick = () => {
-    if (value) {
+    if (value && !colorCleared) {
       const hsba = value.toHsb();
       hsba.a = 0;
       const genColor = generateColor(hsba);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

一直点击清除，会一直触发 onChange。

### 💡 Background and solution

清除后再点击清除不再触发

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     should not trigger onChange when click clear after clearing    |
| 🇨🇳 Chinese |      清除后再点击清除不触发 onChange   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60d2a7c</samp>

Improved the performance and usability of the `ColorPicker` component by removing redundant `useEffect` hooks and adding a new prop `colorCleared` to handle the color clearing logic. Updated the test cases accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60d2a7c</samp>

*  Add `colorCleared` prop to `ColorPickerPanel` and `ColorClear` components to control the alpha value and the `onChange` callback when the color is cleared by the user ([link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-3abf1a34a643a7087dfbaf3039447778574de2b61e627f4c1218297fb961c70fL18-R19), [link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-3abf1a34a643a7087dfbaf3039447778574de2b61e627f4c1218297fb961c70fR28), [link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-de1c965f7020c4d435101e0a3cdddbfc71a53cd91a51aa56426cdd81d5a33d09L7-R14))
* Remove `useEffect` hook from `ColorPicker` component that closed the popup when the color was cleared as it was redundant and caused a flicker effect ([link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL8-R8), [link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL143-L148))
* Remove irrelevant and inconsistent test cases from `index.test.tsx` that checked for the `.ant-popover-hidden` class and the alpha input value when the color was cleared ([link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4L91), [link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4L99-L104))
* Add test case to `index.test.tsx` that checked that the `onChange` callback was not triggered when the color was cleared twice ([link](https://github.com/ant-design/ant-design/pull/42643/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4R253-R262))
