### PR TITLE
fix: dropdown onOpenChange missing trigger

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import type { TriggerProps } from '@rc-component/trigger';
-import Dropdown from '..';
+import React from 'react';
 import type { DropDownProps } from '..';
+import Dropdown from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
@@ -251,5 +251,30 @@ describe('Dropdown', () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it('click item should trigger onOpenChange', () => {
+    const onOpenChange = jest.fn();
+
+    const { container } = render(
+      <Dropdown
+        open
+        onOpenChange={onOpenChange}
+        menu={{
+          items: [
+            {
+              label: <div className="bamboo" />,
+              key: 'bamboo',
+            },
+          ],
+        }}
+      >
+        <a className="little" />
+      </Dropdown>,
+    );
+
+    fireEvent.click(container.querySelector('.bamboo')!);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -30,7 +30,7 @@ const Placements = [
   'bottom',
 ] as const;
 
-type Placement = typeof Placements[number];
+type Placement = (typeof Placements)[number];
 type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter'>;
 
 type OverlayFunc = () => React.ReactElement;
@@ -214,7 +214,7 @@ const Dropdown: CompoundedComponent = (props) => {
     value: open ?? visible,
   });
 
-  const onInnerOpenChange = useEvent((nextOpen: boolean) => {
+  const triggerOpen = useEvent((nextOpen: boolean) => {
     onOpenChange?.(nextOpen);
     onVisibleChange?.(nextOpen);
     setOpen(nextOpen);
@@ -234,7 +234,7 @@ const Dropdown: CompoundedComponent = (props) => {
   });
 
   const onMenuClick = React.useCallback(() => {
-    setOpen(false);
+    triggerOpen(false);
   }, []);
 
   const renderOverlay = () => {
@@ -298,7 +298,7 @@ const Dropdown: CompoundedComponent = (props) => {
       trigger={triggerActions}
       overlay={renderOverlay}
       placement={memoPlacement}
-      onVisibleChange={onInnerOpenChange}
+      onVisibleChange={triggerOpen}
     >
       {dropdownTrigger}
     </RcDropdown>,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #42610

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Dropdown click item not trigger `onOpenChange` event.       |
| 🇨🇳 Chinese |   修复 Dropdown 点击菜单关闭时没有触发 `onOpenChange` 的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d42b86</samp>

Fixed type and bug issues in the `Dropdown` component and added a test case. The changes improve the functionality and reliability of the component and its usage.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d42b86</samp>

* Fix type issue and improve compatibility with different TypeScript versions by changing `Placement` type definition to use brackets instead of `as const` ([link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL33-R33))
* Rename internal event handler for `onVisibleChange` prop from `onInnerOpenChange` to `triggerOpen` to avoid confusion with `onOpenChange` prop ([link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL217-R217), [link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL301-R301))
* Fix bug and ensure consistency of component's behavior by using `triggerOpen` event handler instead of `setOpen` state setter to close the menu when clicking on an item and call both `onOpenChange` and `onVisibleChange` props ([link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL237-R237), [link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL301-R301))
* Enhance test coverage and verify expected behavior of component by adding a new test case to check that clicking on a menu item triggers the `onOpenChange` prop of the `Dropdown` component in `components/dropdown/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-a5e933ff15a7392fe4b00b0eb3b62fc823173b3ec9c87dda164f0e03488cf738R255-R279))
* Reorder import statements to follow the convention of importing types first, then React, then other modules and components in `components/dropdown/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42655/files?diff=unified&w=0#diff-a5e933ff15a7392fe4b00b0eb3b62fc823173b3ec9c87dda164f0e03488cf738L1-R4))
