### PR TITLE
chore: Update Lithuanian locale

### DIFF
--- a/components/date-picker/locale/lt_LT.ts
+++ b/components/date-picker/locale/lt_LT.ts
@@ -12,6 +12,7 @@ const locale: PickerLocale = {
     weekPlaceholder: 'Pasirinkite savaitę',
     rangePlaceholder: ['Pradžios data', 'Pabaigos data'],
     rangeYearPlaceholder: ['Pradžios metai', 'Pabaigos metai'],
+    rangeQuarterPlaceholder: ['Pradžios ketvirtis', 'Pabaigos ketvirtis'],
     rangeMonthPlaceholder: ['Pradžios mėnesis', 'Pabaigos mėnesis'],
     rangeWeekPlaceholder: ['Pradžios savaitė', 'Pabaigos savaitė'],
     ...CalendarLocale,

--- a/components/locale/lt_LT.ts
+++ b/components/locale/lt_LT.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
-
 import Pagination from 'rc-pagination/lib/locale/lt_LT';
+import type { Locale } from '.';
 import Calendar from '../calendar/locale/lt_LT';
 import DatePicker from '../date-picker/locale/lt_LT';
-import type { Locale } from '.';
 import TimePicker from '../time-picker/locale/lt_LT';
 
 const typeTemplate: string = '${label} neatitinka tipo ${type}';
@@ -14,14 +13,20 @@ const localeValues: Locale = {
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Pasirinkite',
+  },
   Table: {
     filterTitle: 'Filtras',
     filterConfirm: 'Gerai',
     filterReset: 'Atstatyti',
     filterEmptyText: 'Be filtrų',
+    filterCheckall: 'Pasirinkti visus',
+    filterSearchPlaceholder: 'Ieškoti filtruose',
     emptyText: 'Nėra duomenų',
     selectAll: 'Pasirinkti viską',
     selectInvert: 'Apversti pasirinkimą',
+    selectNone: 'Išvalyti visus',
     selectionAll: 'Rinktis visus',
     sortTitle: 'Rikiavimas',
     expand: 'Išskleisti',
@@ -29,6 +34,11 @@ const localeValues: Locale = {
     triggerDesc: 'Spustelėkite norėdami rūšiuoti mažėjančia tvarka',
     triggerAsc: 'Spustelėkite norėdami rūšiuoti didėjančia tvarka',
     cancelSort: 'Spustelėkite, kad atšauktumėte rūšiavimą',
+  },
+  Tour: {
+    Next: 'Kitas',
+    Previous: 'Ankstesnis',
+    Finish: 'Baigti',
   },
   Modal: {
     okText: 'Taip',
@@ -45,18 +55,18 @@ const localeValues: Locale = {
     itemUnit: 'vnt.',
     itemsUnit: 'vnt.',
     remove: 'Pašalinti',
-    selectAll: 'Pasirinkti visus',
-    selectCurrent: 'Pasirinkite dabartinį puslapį',
-    selectInvert: 'Atkeist pasirinkimą',
-    removeAll: 'Ištrinti visus duomenis',
+    selectCurrent: 'Pasirinkti dabartinį puslapį',
     removeCurrent: 'Ištrinti dabartinį puslapį',
+    selectAll: 'Pasirinkti viską',
+    removeAll: 'Ištrinti viską',
+    selectInvert: 'Apversti pasirinkimą',
   },
   Upload: {
-    uploading: 'Gaunami duomenys...',
+    uploading: 'Įkeliami duomenys...',
     removeFile: 'Ištrinti failą',
     uploadError: 'Įkeliant įvyko klaida',
     previewFile: 'Failo peržiūra',
-    downloadFile: 'Įkelti failą',
+    downloadFile: 'Atsisiųsti failą',
   },
   Empty: {
     description: 'Nėra duomenų',
@@ -74,11 +84,12 @@ const localeValues: Locale = {
     back: 'Atgal',
   },
   Form: {
+    optional: '(neprivaloma)',
     defaultValidateMessages: {
-      default: 'Laukelio klaida ${label}',
+      default: 'Klaida laukelyje ${label}',
       required: 'Prašome įvesti ${label}',
-      enum: '${label} turėtu būti vienas iš [${enum}]',
-      whitespace: '${label} negali likti tuščiu',
+      enum: '${label} turi būti vienas iš [${enum}]',
+      whitespace: '${label} negali likti tuščias',
       date: {
         format: '${label} neteisingas datos formatas',
         parse: '${label} negali būti konvertuotas į datą',
@@ -101,25 +112,36 @@ const localeValues: Locale = {
       },
       string: {
         len: '${label} turi būti ${len} simbolių',
-        min: '${label} turi būti ilgesnis nei ${min} simbolių',
-        max: '${label} turi būti ne trumpesnis ${max} simbolių',
-        range: 'Lauko ${label} reikšmės ribos ${min}-${max} simbolių',
+        min: '${label} turi būti bent ${min} simbolių',
+        max: '${label} turi būti ne ilgesnis nei ${max} simbolių',
+        range: 'Laukelio ${label} reikšmės ribos ${min}-${max} simbolių',
       },
       number: {
         len: '${label} turi būti lygi ${len}',
-        min: '${label} turi būti lygus arba didesnis ${min}',
-        max: '${label} turi būti lygus arba mažesnis ${max}',
+        min: '${label} turi būti lygus arba didesnis už ${min}',
+        max: '${label} turi būti lygus arba mažesnis už ${max}',
+        range: '${label} turi būti tarp ${min}-${max}',
       },
       array: {
         len: 'Pasirinktas kiekis ${label} turi būti lygus ${len}',
-        min: 'Pasirinktas kiekis ${label} turi būti lygus arba didesnis ${min}',
-        max: 'Pasirinktas kiekis ${label} turi būti lygus arba mažesnis ${max}',
-        range: 'Pasirinktas kiekis ${label} turi būti tarp ${min} и ${max}',
+        min: 'Pasirinktas kiekis ${label} turi būti bent ${min}',
+        max: 'Pasirinktas kiekis ${label} turi būti ne ilgesnis nei ${max}',
+        range: 'Pasirinktas ${label} kiekis turi būti tarp ${min}-${max}',
       },
       pattern: {
         mismatch: '${label} neatitinka modelio ${pattern}',
       },
     },
+  },
+  Image: {
+    preview: 'Peržiūrėti',
+  },
+  QRCode: {
+    expired: 'QR kodo galiojimas baigėsi',
+    refresh: 'Atnaujinti',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tuščia',
   },
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
There are missing translations and some translations are not accurate.

What has been changed:
- Missing translations added
- Several translation errors corrected and minor improvements
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add missing i18n for `lt_LT` locale        |
| 🇨🇳 Chinese |    为 `lt_LT` 添加缺失的部分 i18n     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 387b217</samp>

This pull request improves the localization of various components in Lithuanian language. It updates the `components/locale/lt_LT.ts` file with more consistent and accurate texts, and adds a new property `rangeQuarterPlaceholder` to the `components/date-picker/locale/lt_LT.ts` file to support the quarter range picker.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 387b217</samp>

*  Add and modify translations for various components in Lithuanian language ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-6b8f03a29976e06facd3d830cb34f015b5da24fc509fa0c68d680e4ffd2ee174R15), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL2-R5), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR16-R18), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL22-R29), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR38-R42), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL48-R69), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL77-R92), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL104-R129), [link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR136-R145))
  * Add a new property `rangeQuarterPlaceholder` to the `locale` object in `components/date-picker/locale/lt_LT.ts` to provide a localized placeholder for the quarter range picker ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-6b8f03a29976e06facd3d830cb34f015b5da24fc509fa0c68d680e4ffd2ee174R15))
  * Add a new property `global` to the `localeValues` object in `components/locale/lt_LT.ts` to provide a localized placeholder for the select component ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR16-R18))
  * Add a new property `Tour` to the `localeValues` object in `components/locale/lt_LT.ts` to provide localized texts for the tour component ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR38-R42))
  * Add a new property `optional` to the `Form` property of the `localeValues` object in `components/locale/lt_LT.ts` to provide a localized label for the optional form fields ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL77-R92))
  * Add three new properties `Image`, `QRCode`, and `ColorPicker` to the `localeValues` object in `components/locale/lt_LT.ts` to provide localized texts for the image, QR code, and color picker components ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR136-R145))
  * Modify the `table` property of the `localeValues` object in `components/locale/lt_LT.ts` to add two new properties `filterCheckall` and `filterSearchPlaceholder` and modify the `selectNone` property for the table filters ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL22-R29))
  * Modify the `transfer` property of the `localeValues` object in `components/locale/lt_LT.ts` to use different verb forms for the `uploading` and `downloadFile` properties ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL48-R69))
  * Modify the `default` property of the `defaultValidateMessages` object in the `Form` property of the `localeValues` object in `components/locale/lt_LT.ts` to use a different wording for the default validation error message ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL77-R92))
  * Modify the `string`, `number`, and `array` properties of the `defaultValidateMessages` object in the `Form` property of the `localeValues` object in `components/locale/lt_LT.ts` to use different prepositions and wordings for the `min`, `max`, and `range` properties ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL104-R129))
* Reorder the import statements in `components/locale/lt_LT.ts` to follow the convention of importing types first, then other modules ([link](https://github.com/ant-design/ant-design/pull/42664/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL2-R5))
