### PR TITLE
chore: feature merge master

### DIFF
--- a/.github/workflows/pr-stat.yml
+++ b/.github/workflows/pr-stat.yml
@@ -1,0 +1,12 @@
+name: Pull Request Stats
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@master

--- a/.github/workflows/pr-stat.yml
+++ b/.github/workflows/pr-stat.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stats:
+    if: github.repository == 'ant-design/ant-design'
     runs-on: ubuntu-latest
     steps:
       - name: Run pull request stats

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -224,6 +224,7 @@ const genCardLoadingStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 // ============================== Basic ==============================
 const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
   const {
+    antCls,
     componentCls,
     cardShadow,
     cardHeadPadding,
@@ -268,7 +269,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
           width: '100%',
         },
 
-        img: {
+        [`img, img + ${antCls}-image-mask`]: {
           borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
         },
       },

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -406,24 +406,50 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       </span>
     </label>
   </div>
-  <label
-    class="ant-checkbox-wrapper"
-  >
-    <span
-      class="ant-checkbox"
+  <div>
+    <label
+      class="ant-checkbox-wrapper"
     >
-      <input
-        class="ant-checkbox-input"
-        type="checkbox"
-      />
       <span
-        class="ant-checkbox-inner"
-      />
-    </span>
-    <span>
-      Aligned
-    </span>
-  </label>
+        class="ant-checkbox"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+        />
+        <span
+          class="ant-checkbox-inner"
+        />
+      </span>
+      <span>
+        Aligned
+      </span>
+    </label>
+  </div>
+  <div>
+    <label
+      class="ant-checkbox-wrapper"
+    >
+      <span
+        class="ant-checkbox"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+        />
+        <span
+          class="ant-checkbox-inner"
+        />
+      </span>
+      <span>
+        <span
+          style="font-size: 32px;"
+        >
+          Aligned
+        </span>
+      </span>
+    </label>
+  </div>
 </div>
 `;
 

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -383,24 +383,50 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       </span>
     </label>
   </div>
-  <label
-    class="ant-checkbox-wrapper"
-  >
-    <span
-      class="ant-checkbox"
+  <div>
+    <label
+      class="ant-checkbox-wrapper"
     >
-      <input
-        class="ant-checkbox-input"
-        type="checkbox"
-      />
       <span
-        class="ant-checkbox-inner"
-      />
-    </span>
-    <span>
-      Aligned
-    </span>
-  </label>
+        class="ant-checkbox"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+        />
+        <span
+          class="ant-checkbox-inner"
+        />
+      </span>
+      <span>
+        Aligned
+      </span>
+    </label>
+  </div>
+  <div>
+    <label
+      class="ant-checkbox-wrapper"
+    >
+      <span
+        class="ant-checkbox"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+        />
+        <span
+          class="ant-checkbox-inner"
+        />
+      </span>
+      <span>
+        <span
+          style="font-size:32px"
+        >
+          Aligned
+        </span>
+      </span>
+    </label>
+  </div>
 </div>
 `;
 

--- a/components/checkbox/demo/debug-line.tsx
+++ b/components/checkbox/demo/debug-line.tsx
@@ -44,15 +44,23 @@ const App: React.FC = () => (
       <Radio value="little">Little</Radio>
     </div>
 
-    <ConfigProvider
-      theme={{
-        token: {
-          controlHeight: 48,
-        },
-      }}
-    >
-      <Checkbox>Aligned</Checkbox>
-    </ConfigProvider>
+    <div>
+      <ConfigProvider
+        theme={{
+          token: {
+            controlHeight: 48,
+          },
+        }}
+      >
+        <Checkbox>Aligned</Checkbox>
+      </ConfigProvider>
+    </div>
+
+    <div>
+      <Checkbox>
+        <span style={{ fontSize: 32 }}>Aligned</span>
+      </Checkbox>
+    </div>
   </div>
 );
 

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -83,13 +83,9 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         lineHeight: 1,
         cursor: 'pointer',
 
-        alignSelf: 'start',
-        // https://github.com/ant-design/ant-design/issues/41564
-        // Since `checkboxSize` is dynamic which should align with the text box,
-        // We need do calculation here for offset.
-        transform: `translate(0, ${
-          (token.lineHeight * token.fontSize) / 2 - token.checkboxSize / 2
-        }px)`,
+        // To make alignment right when `controlHeight` is changed
+        // Ref: https://github.com/ant-design/ant-design/issues/41564
+        alignSelf: 'center',
 
         // Wrapper > Checkbox > input
         [`${checkboxCls}-input`]: {

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4737,3 +4737,385 @@ Array [
   </div>,
 ]
 `;
+
+exports[`renders components/color-picker/demo/trigger-event.tsx extend context correctly 1`] = `
+Array [
+  <div
+    class="ant-color-picker-trigger"
+  >
+    <div
+      class="ant-color-picker-color-block"
+    >
+      <div
+        class="ant-color-picker-color-block-inner"
+        style="background: rgb(22, 119, 255);"
+      />
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div
+      class="ant-popover-arrow"
+      style="position: absolute;"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-color-picker-panel"
+          >
+            <div
+              class="ant-color-picker-inner-panel"
+            >
+              <div
+                class="ant-color-picker-select"
+              >
+                <div
+                  class="ant-color-picker-palette"
+                  style="position: relative;"
+                >
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                  >
+                    <div
+                      class="ant-color-picker-handler"
+                      style="background-color: rgb(22, 119, 255);"
+                    />
+                  </div>
+                  <div
+                    class="ant-color-picker-saturation"
+                    style="background-color: rgb(0, 0, 0);"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-slider-container"
+              >
+                <div
+                  class="ant-color-picker-slider-group"
+                >
+                  <div
+                    class="ant-color-picker-slider ant-color-picker-slider-hue"
+                  >
+                    <div
+                      class="ant-color-picker-palette"
+                      style="position: relative;"
+                    >
+                      <div
+                        style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                      >
+                        <div
+                          class="ant-color-picker-handler ant-color-picker-handler-sm"
+                          style="background-color: rgb(0, 0, 0);"
+                        />
+                      </div>
+                      <div
+                        class="ant-color-picker-gradient"
+                        style="position: absolute; inset: 0;"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                  >
+                    <div
+                      class="ant-color-picker-palette"
+                      style="position: relative;"
+                    >
+                      <div
+                        style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                      >
+                        <div
+                          class="ant-color-picker-handler ant-color-picker-handler-sm"
+                          style="background-color: rgb(22, 119, 255);"
+                        />
+                      </div>
+                      <div
+                        class="ant-color-picker-gradient"
+                        style="position: absolute; inset: 0;"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-color-block"
+                >
+                  <div
+                    class="ant-color-picker-color-block-inner"
+                    style="background: rgb(22, 119, 255);"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-input-container"
+              >
+                <div
+                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                >
+                  <div
+                    class="ant-select-selector"
+                  >
+                    <span
+                      class="ant-select-selection-search"
+                    >
+                      <input
+                        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                        aria-autocomplete="list"
+                        aria-controls="rc_select_TEST_OR_SSR_list"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="rc_select_TEST_OR_SSR_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="rc_select_TEST_OR_SSR"
+                        readonly=""
+                        role="combobox"
+                        style="opacity: 0;"
+                        type="search"
+                        unselectable="on"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="ant-select-selection-item"
+                      title="HEX"
+                    >
+                      HEX
+                    </span>
+                  </div>
+                  <div
+                    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                  >
+                    <div>
+                      <div
+                        id="rc_select_TEST_OR_SSR_list"
+                        role="listbox"
+                        style="height: 0px; width: 0px; overflow: hidden;"
+                      >
+                        <div
+                          aria-label="HEX"
+                          aria-selected="true"
+                          id="rc_select_TEST_OR_SSR_list_0"
+                          role="option"
+                        >
+                          hex
+                        </div>
+                        <div
+                          aria-label="HSB"
+                          aria-selected="false"
+                          id="rc_select_TEST_OR_SSR_list_1"
+                          role="option"
+                        >
+                          hsb
+                        </div>
+                      </div>
+                      <div
+                        class="rc-virtual-list"
+                        style="position: relative;"
+                      >
+                        <div
+                          class="rc-virtual-list-holder"
+                          style="max-height: 256px; overflow-y: auto;"
+                        >
+                          <div>
+                            <div
+                              class="rc-virtual-list-holder-inner"
+                              style="display: flex; flex-direction: column;"
+                            >
+                              <div
+                                aria-selected="true"
+                                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                title="HEX"
+                              >
+                                <div
+                                  class="ant-select-item-option-content"
+                                >
+                                  HEX
+                                </div>
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-select-item-option-state"
+                                  style="user-select: none;"
+                                  unselectable="on"
+                                />
+                              </div>
+                              <div
+                                aria-selected="false"
+                                class="ant-select-item ant-select-item-option"
+                                title="HSB"
+                              >
+                                <div
+                                  class="ant-select-item-option-content"
+                                >
+                                  HSB
+                                </div>
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-select-item-option-state"
+                                  style="user-select: none;"
+                                  unselectable="on"
+                                />
+                              </div>
+                              <div
+                                aria-selected="false"
+                                class="ant-select-item ant-select-item-option"
+                                title="RGB"
+                              >
+                                <div
+                                  class="ant-select-item-option-content"
+                                >
+                                  RGB
+                                </div>
+                                <span
+                                  aria-hidden="true"
+                                  class="ant-select-item-option-state"
+                                  style="user-select: none;"
+                                  unselectable="on"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    aria-hidden="true"
+                    class="ant-select-arrow"
+                    style="user-select: none;"
+                    unselectable="on"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down ant-select-suffix"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="ant-color-picker-input"
+                >
+                  <span
+                    class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                  >
+                    <span
+                      class="ant-input-prefix"
+                    >
+                      #
+                    </span>
+                    <input
+                      class="ant-input ant-input-sm"
+                      type="text"
+                      value="1677FF"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                >
+                  <div
+                    class="ant-input-number-handler-wrap"
+                  >
+                    <span
+                      aria-disabled="true"
+                      aria-label="Increase Value"
+                      class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="up"
+                        class="anticon anticon-up ant-input-number-handler-up-inner"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="up"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                    <span
+                      aria-disabled="false"
+                      aria-label="Decrease Value"
+                      class="ant-input-number-handler ant-input-number-handler-down"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-input-number-handler-down-inner"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number-input-wrap"
+                  >
+                    <input
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="100"
+                      autocomplete="off"
+                      class="ant-input-number-input"
+                      role="spinbutton"
+                      step="1"
+                      value="100%"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -265,3 +265,18 @@ exports[`renders components/color-picker/demo/trigger.tsx correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders components/color-picker/demo/trigger-event.tsx correctly 1`] = `
+<div
+  class="ant-color-picker-trigger"
+>
+  <div
+    class="ant-color-picker-color-block"
+  >
+    <div
+      class="ant-color-picker-color-block-inner"
+      style="background:rgb(22, 119, 255)"
+    />
+  </div>
+</div>
+`;

--- a/components/color-picker/demo/trigger-event.md
+++ b/components/color-picker/demo/trigger-event.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义颜色面板的触发事件，提供 `click` 和 `hover` 两个选项。
+
+## en-US
+
+Triggers event for customizing color panels.

--- a/components/color-picker/demo/trigger-event.tsx
+++ b/components/color-picker/demo/trigger-event.tsx
@@ -1,0 +1,6 @@
+import { ColorPicker } from 'antd';
+import React from 'react';
+
+const Demo = () => <ColorPicker trigger="hover" />;
+
+export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -24,6 +24,7 @@ Used when the user needs to customize the color selection.
 <code src="./demo/disabled.tsx" debug>Disable</code>
 <code src="./demo/allowClear.tsx">Clear Color</code>
 <code src="./demo/trigger.tsx">Custom Trigger</code>
+<code src="./demo/trigger-event.tsx">Custom Trigger Event</code>
 <code src="./demo/format.tsx">Color Format</code>
 <code src="./demo/presets.tsx">Preset Colors</code>
 <code src="./demo/pure-panel.tsx" debug>Pure Render</code>

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -25,6 +25,7 @@ group:
 <code src="./demo/disabled.tsx" debug>禁用</code>
 <code src="./demo/allowClear.tsx">清除颜色</code>
 <code src="./demo/trigger.tsx">自定义触发器</code>
+<code src="./demo/trigger-event.tsx">自定义触发事件</code>
 <code src="./demo/format.tsx">颜色编码</code>
 <code src="./demo/presets.tsx">预设颜色</code>
 <code src="./demo/pure-panel.tsx" debug>Pure Render</code>

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -1,13 +1,13 @@
 import { createTheme } from '@ant-design/cssinjs';
 import IconContext from '@ant-design/icons/lib/components/Context';
-import { FormProvider as RcFormProvider } from 'rc-field-form';
 import type { ValidateMessages } from 'rc-field-form/lib/interface';
-import { setValues } from 'rc-field-form/lib/utils/valueUtil';
 import useMemo from 'rc-util/lib/hooks/useMemo';
+import { merge } from 'rc-util/lib/utils/set';
 import type { ReactElement } from 'react';
 import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
 import warning from '../_util/warning';
+import { ValidateMessagesContext } from '../form/context';
 import type { RequiredMark } from '../form/Form';
 import type { Locale } from '../locale';
 import LocaleProvider, { ANT_MARK } from '../locale';
@@ -293,8 +293,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 
   const validateMessages = React.useMemo(
     () =>
-      setValues(
-        {},
+      merge(
         defaultLocale.Form?.defaultValidateMessages || {},
         memoedConfig.locale?.Form?.defaultValidateMessages || {},
         form?.validateMessages || {},
@@ -303,7 +302,11 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   );
 
   if (Object.keys(validateMessages).length > 0) {
-    childNode = <RcFormProvider validateMessages={validateMessages}>{children}</RcFormProvider>;
+    childNode = (
+      <ValidateMessagesContext.Provider value={validateMessages}>
+        {children}
+      </ValidateMessagesContext.Provider>
+    );
   }
 
   if (locale) {

--- a/components/date-picker/locale/lt_LT.ts
+++ b/components/date-picker/locale/lt_LT.ts
@@ -12,6 +12,7 @@ const locale: PickerLocale = {
     weekPlaceholder: 'Pasirinkite savaitę',
     rangePlaceholder: ['Pradžios data', 'Pabaigos data'],
     rangeYearPlaceholder: ['Pradžios metai', 'Pabaigos metai'],
+    rangeQuarterPlaceholder: ['Pradžios ketvirtis', 'Pabaigos ketvirtis'],
     rangeMonthPlaceholder: ['Pradžios mėnesis', 'Pabaigos mėnesis'],
     rangeWeekPlaceholder: ['Pradžios savaitė', 'Pabaigos savaitė'],
     ...CalendarLocale,

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -12,7 +12,7 @@ import { SizeContextProvider } from '../config-provider/SizeContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { ColProps } from '../grid/col';
 import type { FormContextProps } from './context';
-import { FormContext } from './context';
+import { FormContext, FormProvider, ValidateMessagesContext } from './context';
 import useForm, { type FormInstance } from './hooks/useForm';
 import useFormWarning from './hooks/useFormWarning';
 import type { FormLabelAlign } from './interface';
@@ -66,6 +66,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   } = props;
 
   const mergedSize = useSize(size);
+
+  const contextValidateMessages = React.useContext(ValidateMessagesContext);
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -158,16 +160,23 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   return wrapSSR(
     <DisabledContextProvider disabled={disabled}>
       <SizeContextProvider size={mergedSize}>
-        <FormContext.Provider value={formContextValue}>
-          <FieldForm
-            id={name}
-            {...restFormProps}
-            name={name}
-            onFinishFailed={onInternalFinishFailed}
-            form={wrapForm}
-            className={formClassName}
-          />
-        </FormContext.Provider>
+        <FormProvider
+          {...{
+            // This is not list in API, we pass with spread
+            validateMessages: contextValidateMessages,
+          }}
+        >
+          <FormContext.Provider value={formContextValue}>
+            <FieldForm
+              id={name}
+              {...restFormProps}
+              name={name}
+              onFinishFailed={onInternalFinishFailed}
+              form={wrapForm}
+              className={formClassName}
+            />
+          </FormContext.Provider>
+        </FormProvider>
       </SizeContextProvider>
     </DisabledContextProvider>,
   );

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -1,6 +1,6 @@
 import { FormProvider as RcFormProvider } from 'rc-field-form';
 import type { FormProviderProps as RcFormProviderProps } from 'rc-field-form/lib/FormContext';
-import type { Meta } from 'rc-field-form/lib/interface';
+import type { Meta, ValidateMessages } from 'rc-field-form/lib/interface';
 import omit from 'rc-util/lib/omit';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import * as React from 'react';
@@ -92,3 +92,5 @@ export const NoFormStyle: FC<NoFormStyleProps> = ({ children, status, override }
     </FormItemInputContext.Provider>
   );
 };
+
+export const ValidateMessagesContext = React.createContext<ValidateMessages | undefined>(undefined);

--- a/components/locale/lt_LT.ts
+++ b/components/locale/lt_LT.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
-
 import Pagination from 'rc-pagination/lib/locale/lt_LT';
+import type { Locale } from '.';
 import Calendar from '../calendar/locale/lt_LT';
 import DatePicker from '../date-picker/locale/lt_LT';
-import type { Locale } from '.';
 import TimePicker from '../time-picker/locale/lt_LT';
 
 const typeTemplate: string = '${label} neatitinka tipo ${type}';
@@ -14,14 +13,20 @@ const localeValues: Locale = {
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Pasirinkite',
+  },
   Table: {
     filterTitle: 'Filtras',
     filterConfirm: 'Gerai',
     filterReset: 'Atstatyti',
     filterEmptyText: 'Be filtrų',
+    filterCheckall: 'Pasirinkti visus',
+    filterSearchPlaceholder: 'Ieškoti filtruose',
     emptyText: 'Nėra duomenų',
     selectAll: 'Pasirinkti viską',
     selectInvert: 'Apversti pasirinkimą',
+    selectNone: 'Išvalyti visus',
     selectionAll: 'Rinktis visus',
     sortTitle: 'Rikiavimas',
     expand: 'Išskleisti',
@@ -29,6 +34,11 @@ const localeValues: Locale = {
     triggerDesc: 'Spustelėkite norėdami rūšiuoti mažėjančia tvarka',
     triggerAsc: 'Spustelėkite norėdami rūšiuoti didėjančia tvarka',
     cancelSort: 'Spustelėkite, kad atšauktumėte rūšiavimą',
+  },
+  Tour: {
+    Next: 'Kitas',
+    Previous: 'Ankstesnis',
+    Finish: 'Baigti',
   },
   Modal: {
     okText: 'Taip',
@@ -45,18 +55,18 @@ const localeValues: Locale = {
     itemUnit: 'vnt.',
     itemsUnit: 'vnt.',
     remove: 'Pašalinti',
-    selectAll: 'Pasirinkti visus',
-    selectCurrent: 'Pasirinkite dabartinį puslapį',
-    selectInvert: 'Atkeist pasirinkimą',
-    removeAll: 'Ištrinti visus duomenis',
+    selectCurrent: 'Pasirinkti dabartinį puslapį',
     removeCurrent: 'Ištrinti dabartinį puslapį',
+    selectAll: 'Pasirinkti viską',
+    removeAll: 'Ištrinti viską',
+    selectInvert: 'Apversti pasirinkimą',
   },
   Upload: {
-    uploading: 'Gaunami duomenys...',
+    uploading: 'Įkeliami duomenys...',
     removeFile: 'Ištrinti failą',
     uploadError: 'Įkeliant įvyko klaida',
     previewFile: 'Failo peržiūra',
-    downloadFile: 'Įkelti failą',
+    downloadFile: 'Atsisiųsti failą',
   },
   Empty: {
     description: 'Nėra duomenų',
@@ -74,11 +84,12 @@ const localeValues: Locale = {
     back: 'Atgal',
   },
   Form: {
+    optional: '(neprivaloma)',
     defaultValidateMessages: {
-      default: 'Laukelio klaida ${label}',
+      default: 'Klaida laukelyje ${label}',
       required: 'Prašome įvesti ${label}',
-      enum: '${label} turėtu būti vienas iš [${enum}]',
-      whitespace: '${label} negali likti tuščiu',
+      enum: '${label} turi būti vienas iš [${enum}]',
+      whitespace: '${label} negali likti tuščias',
       date: {
         format: '${label} neteisingas datos formatas',
         parse: '${label} negali būti konvertuotas į datą',
@@ -101,25 +112,36 @@ const localeValues: Locale = {
       },
       string: {
         len: '${label} turi būti ${len} simbolių',
-        min: '${label} turi būti ilgesnis nei ${min} simbolių',
-        max: '${label} turi būti ne trumpesnis ${max} simbolių',
-        range: 'Lauko ${label} reikšmės ribos ${min}-${max} simbolių',
+        min: '${label} turi būti bent ${min} simbolių',
+        max: '${label} turi būti ne ilgesnis nei ${max} simbolių',
+        range: 'Laukelio ${label} reikšmės ribos ${min}-${max} simbolių',
       },
       number: {
         len: '${label} turi būti lygi ${len}',
-        min: '${label} turi būti lygus arba didesnis ${min}',
-        max: '${label} turi būti lygus arba mažesnis ${max}',
+        min: '${label} turi būti lygus arba didesnis už ${min}',
+        max: '${label} turi būti lygus arba mažesnis už ${max}',
+        range: '${label} turi būti tarp ${min}-${max}',
       },
       array: {
         len: 'Pasirinktas kiekis ${label} turi būti lygus ${len}',
-        min: 'Pasirinktas kiekis ${label} turi būti lygus arba didesnis ${min}',
-        max: 'Pasirinktas kiekis ${label} turi būti lygus arba mažesnis ${max}',
-        range: 'Pasirinktas kiekis ${label} turi būti tarp ${min} и ${max}',
+        min: 'Pasirinktas kiekis ${label} turi būti bent ${min}',
+        max: 'Pasirinktas kiekis ${label} turi būti ne ilgesnis nei ${max}',
+        range: 'Pasirinktas ${label} kiekis turi būti tarp ${min}-${max}',
       },
       pattern: {
         mismatch: '${label} neatitinka modelio ${pattern}',
       },
     },
+  },
+  Image: {
+    preview: 'Peržiūrėti',
+  },
+  QRCode: {
+    expired: 'QR kodo galiojimas baigėsi',
+    refresh: 'Atnaujinti',
+  },
+  ColorPicker: {
+    presetEmpty: 'Tuščia',
   },
 };
 

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -829,4 +829,20 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       expect(document.querySelector(`.ant-modal-content`)).toMatchSnapshot();
     });
   });
+
+  it('warning getContainer be false', async () => {
+    resetWarned();
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    Modal.confirm({
+      getContainer: false,
+    });
+
+    await waitFakeTimer();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Modal] Static method not support `getContainer` to be `false` since it do not have context env.',
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -1,11 +1,11 @@
 import { render as reactRender, unmount as reactUnmount } from 'rc-util/lib/React/render';
 import * as React from 'react';
-import { globalConfig, warnContext } from '../config-provider';
 import warning from '../_util/warning';
+import { globalConfig, warnContext } from '../config-provider';
 import ConfirmDialog from './ConfirmDialog';
+import type { ModalFuncProps } from './Modal';
 import destroyFns from './destroyFns';
 import { getConfirmLocale } from './locale';
-import type { ModalFuncProps } from './Modal';
 
 let defaultRootPrefixCls = '';
 
@@ -50,7 +50,13 @@ export default function confirm(config: ModalFuncProps) {
     reactUnmount(container);
   }
 
-  function render({ okText, cancelText, prefixCls: customizePrefixCls, ...props }: any) {
+  function render({
+    okText,
+    cancelText,
+    prefixCls: customizePrefixCls,
+    getContainer,
+    ...props
+  }: any) {
     clearTimeout(timeoutId);
 
     /**
@@ -66,9 +72,23 @@ export default function confirm(config: ModalFuncProps) {
       const prefixCls = customizePrefixCls || `${rootPrefixCls}-modal`;
       const iconPrefixCls = getIconPrefixCls();
 
+      let mergedGetContainer = getContainer;
+      if (mergedGetContainer === false) {
+        mergedGetContainer = undefined;
+
+        if (process.env.NODE_ENV !== 'production') {
+          warning(
+            false,
+            'Modal',
+            'Static method not support `getContainer` to be `false` since it do not have context env.',
+          );
+        }
+      }
+
       reactRender(
         <ConfirmDialog
           {...props}
+          getContainer={mergedGetContainer}
           prefixCls={prefixCls}
           rootPrefixCls={rootPrefixCls}
           iconPrefixCls={iconPrefixCls}

--- a/components/select/style/multiple.tsx
+++ b/components/select/style/multiple.tsx
@@ -72,6 +72,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           width: 0,
           margin: `${FIXED_ITEM_MARGIN}px 0`,
           lineHeight: `${selectItemHeight}px`,
+          visibility: 'hidden',
           content: '"\\a0"',
         },
       },

--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -321,6 +321,46 @@ Array [
       style="margin-right: 0px; padding-bottom: 8px;"
     >
       <span
+        class="ant-tag ant-tag-processing ant-tag-borderless"
+      >
+        processing
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right: 0px; padding-bottom: 8px;"
+    >
+      <span
+        class="ant-tag ant-tag-success ant-tag-borderless"
+      >
+        success
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right: 0px; padding-bottom: 8px;"
+    >
+      <span
+        class="ant-tag ant-tag-error ant-tag-borderless"
+      >
+        error
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right: 0px; padding-bottom: 8px;"
+    >
+      <span
+        class="ant-tag ant-tag-warning ant-tag-borderless"
+      >
+        warning
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right: 0px; padding-bottom: 8px;"
+    >
+      <span
         class="ant-tag ant-tag-magenta ant-tag-borderless"
       >
         magenta

--- a/components/tag/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.ts.snap
@@ -321,6 +321,46 @@ Array [
       style="margin-right:0;padding-bottom:8px"
     >
       <span
+        class="ant-tag ant-tag-processing ant-tag-borderless"
+      >
+        processing
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:0;padding-bottom:8px"
+    >
+      <span
+        class="ant-tag ant-tag-success ant-tag-borderless"
+      >
+        success
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:0;padding-bottom:8px"
+    >
+      <span
+        class="ant-tag ant-tag-error ant-tag-borderless"
+      >
+        error
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:0;padding-bottom:8px"
+    >
+      <span
+        class="ant-tag ant-tag-warning ant-tag-borderless"
+      >
+        warning
+      </span>
+    </div>
+    <div
+      class="ant-space-item"
+      style="margin-right:0;padding-bottom:8px"
+    >
+      <span
         class="ant-tag ant-tag-magenta ant-tag-borderless"
       >
         magenta

--- a/components/tag/demo/borderless.tsx
+++ b/components/tag/demo/borderless.tsx
@@ -15,6 +15,18 @@ const App: React.FC = () => (
     </Space>
     <Divider />
     <Space size={[0, 'small']} wrap>
+      <Tag bordered={false} color="processing">
+        processing
+      </Tag>
+      <Tag bordered={false} color="success">
+        success
+      </Tag>
+      <Tag bordered={false} color="error">
+        error
+      </Tag>
+      <Tag bordered={false} color="warning">
+        warning
+      </Tag>
       <Tag bordered={false} color="magenta">
         magenta
       </Tag>

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -32,6 +32,9 @@ const genTagStatusStyle = (
       color: token[`color${cssVariableType}`],
       background: token[`color${capitalizedCssVariableType}Bg`],
       borderColor: token[`color${capitalizedCssVariableType}Border`],
+      [`&${token.componentCls}-borderless`]: {
+        borderColor: 'transparent',
+      },
     },
   };
 };

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -1,10 +1,10 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import { Keyframes } from '@ant-design/cssinjs';
-import { genCollapseMotion } from '../../style/motion';
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
+import { genFocusOutline, resetComponent } from '../../style';
+import { genCollapseMotion } from '../../style/motion';
 import type { DerivativeToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { genFocusOutline, resetComponent } from '../../style';
 
 // ============================ Keyframes =============================
 const treeNodeFX = new Keyframes('ant-tree-node-fx-do-not-use', {
@@ -63,16 +63,7 @@ type TreeToken = DerivativeToken & {
 };
 
 export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => {
-  const {
-    treeCls,
-    treeNodeCls,
-    controlInteractiveSize: checkboxSize,
-    treeNodePadding,
-    treeTitleHeight,
-  } = token;
-  // Ref: https://github.com/ant-design/ant-design/issues/41564
-  const checkBoxOffset = (token.lineHeight * token.fontSize) / 2 - checkboxSize / 2;
-  const treeCheckBoxMarginVertical = (treeTitleHeight - token.fontSizeLG) / 2 - checkBoxOffset;
+  const { treeCls, treeNodeCls, treeNodePadding, treeTitleHeight } = token;
   const treeCheckBoxMarginHorizontal = token.paddingXS;
 
   return {
@@ -269,7 +260,6 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeCls}-checkbox`]: {
         top: 'initial',
         marginInlineEnd: treeCheckBoxMarginHorizontal,
-        marginBlockStart: treeCheckBoxMarginVertical,
       },
 
       // >>> Title

--- a/docs/react/contributing.en-US.md
+++ b/docs/react/contributing.en-US.md
@@ -62,6 +62,12 @@ Since antd's components are based on react-component, sometimes you may need to 
 
 ## Development Workflow
 
+Before you can start you must run the following command to enable [corepack](https://nodejs.org/api/corepack.html)。
+
+```bash
+corepack enable
+```
+
 After cloning antd, run `npm install` to fetch its dependencies. Then, you can run several commands:
 
 1. `npm start` runs Ant Design website locally.

--- a/docs/react/contributing.zh-CN.md
+++ b/docs/react/contributing.zh-CN.md
@@ -62,6 +62,12 @@ Ant Design 团队会关注所有的 pull request，我们会 review 以及合并
 
 ## 开发流程
 
+在开始之前，请先执行下面的命令启用 [corepack](https://nodejs.org/api/corepack.html)。
+
+```bash
+corepack enable
+```
+
 在你 clone 了 antd 的代码并且使用 `npm install` 安装完依赖后，你还可以运行下面几个常用的命令：
 
 1. `npm start` 在本地运行 Ant Design 的网站。

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "jest-environment-jsdom": "^29.0.1",
     "jest-environment-node": "^29.0.0",
     "jest-image-snapshot": "^6.0.0",
-    "jest-puppeteer": "^8.0.4",
+    "jest-puppeteer": "^9.0.0",
     "jquery": "^3.4.1",
     "jsdom": "^22.0.0",
     "jsonml-to-react-element": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "rc-tree": "~5.7.4",
     "rc-tree-select": "~5.9.0",
     "rc-upload": "~4.3.0",
-    "rc-util": "^5.27.0",
+    "rc-util": "^5.31.2",
     "scroll-into-view-if-needed": "^3.0.3",
     "throttle-debounce": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "rc-tree": "~5.7.4",
     "rc-tree-select": "~5.9.0",
     "rc-upload": "~4.3.0",
-    "rc-util": "^5.31.2",
+    "rc-util": "^5.32.0",
     "scroll-into-view-if-needed": "^3.0.3",
     "throttle-debounce": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "rc-dialog": "~9.1.0",
     "rc-drawer": "~6.1.1",
     "rc-dropdown": "~4.1.0",
-    "rc-field-form": "~1.31.0",
+    "rc-field-form": "~1.32.0",
     "rc-image": "~5.16.0",
     "rc-input": "~1.0.4",
     "rc-input-number": "~7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "antd",
   "version": "5.5.1",
+  "packageManager": "^npm@9.0.0",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4876c6</samp>

This pull request improves the style, functionality, and performance of several components, such as card, form, modal, color picker, checkbox, and tag. It also adds new features, such as custom trigger event for color picker, custom container for modal, and custom validate messages for form. It also updates the locale files for Lithuanian language and adds a new GitHub action for pull request stats. It also refactors some code and removes some unnecessary files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4876c6</samp>

*  Add a new demo and documentation for the color picker component to show how to customize the trigger event for the color panel ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-6da2aaf1643b5ff2d039dbfcec10916b71b14ea64abc1e4a0673ffd704e8cf02R1-R7), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-ed47d85df8868cab33de153e85588979000246ff0a11983fa0b343cb2ccd2690R1-R6), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560R27), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249R28))
*  Add a new GitHub action to run pull request stats using the `flowwer-dev/pull-request-stats` action ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-5856a97b7054878d3fb4c5ef4bf3bb6cb47d84ea804493adcdbd752628d819c0R1-R13))
*  Add a new `.npmrc` file to set the `package-lock` option to `false` ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL1-L-1))
*  Add and update the locale values for the Lithuanian language, including the placeholder text for the range quarter picker, the global values, the table filters, the tour component, the transfer component, the optional mark, the validation messages, and the image, QR code, and color picker components ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-6b8f03a29976e06facd3d830cb34f015b5da24fc509fa0c68d680e4ffd2ee174R15), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL2-R5), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR16-R18), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL22-R29), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR38-R42), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL48-R69), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL77-R92), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eL104-R129), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-7e7f1ab8dd9a7f210f9f318af508a4ec3e0aee8e67b985d869194a81cc53de7eR136-R145))
*  Refactor the config provider component to use the `merge` function instead of the `setValues` function to combine the default and custom validate messages for the form component, and to use the `ValidateMessagesContext.Provider` component instead of the `RcFormProvider` component to pass the validate messages to the form component ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L3-R10), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L296-R296), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L306-R309))
*  Refactor the form component to use the `FormProvider` component instead of the `RcFormProvider` component to wrap the form component and pass the validate messages from the config provider component, and to use the `ValidateMessagesContext` component to get the validate messages from the config provider component ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL15-R15), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eR70-R71), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL161-R179))
*  Add a new `ValidateMessagesContext` component to the form context to provide the validate messages for the form component ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-dd4af975179f53bbabb7df046daec948d8fa4edfc012ef190b20a2de743e3ca9L3-R3), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-dd4af975179f53bbabb7df046daec948d8fa4edfc012ef190b20a2de743e3ca9R95-R96))
*  Add a custom style for the table title and the arrow icon in the `SubTokenTable` component of the component token table, and use the `useState` and `useStyle` hooks to manage the open state and the style of the component ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L1-R7), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93R29-R46), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L34-R61), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R118))
*  Refactor the `ComponentTokenTable` component to use a functional component instead of a regular function, and to use the `useMemo` hook instead of the `React.useMemo` hook ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L105-R125), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L124-R147))
*  Add a warning message when the `getContainer` prop is set to `false` for the static modal methods, such as `Modal.confirm`, and add a test case to check the warning ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L3-R8), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L53-R59), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-c7a9fd7c1b9a94593453f0d8e7c3c4f53726bf923570cd1e7ad429ffb312a298L69-R91), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bR832-R847))
*  Add four more examples of tags with different colors and the `bordered` prop set to `false` to the tag demo ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-dc53dc1260f4f0bd2795d9f45df6f718ba958f7f0e1182dd28cd5db91213a134R18-R29))
*  Add the `antCls` variable to the `genCardStyle` function to get the prefix class name for the card component, and use a selector that matches both the `img` element and the `img + ${antCls}-image-mask` element to apply the same border radius style ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8R227), [link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L271-R272))
*  Remove the `transform` property and use the `alignSelf` property instead to make the alignment of the checkbox right when the `controlHeight` token is changed ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL86-R88))
*  Add two more examples of checkboxes with different font sizes to the checkbox demo, and wrap each checkbox in a `div` element to separate them visually ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-97b787afa8f6dec869cf8e78a17ea86e2923a8f80347fdd3810160e9b1c66588L47-R63))
*  Add the `visibility` property with the value of `hidden` to the `input` element of the multiple select component to hide the input element when the component is disabled or readonly ([link](https://github.com/ant-design/ant-design/pull/42668/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5R75))
