### PR TITLE
demo: update docs & demo

### DIFF
--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4351,25 +4351,15 @@ exports[`renders components/color-picker/demo/pure-panel.tsx extend context corr
 
 exports[`renders components/color-picker/demo/trigger.tsx extend context correctly 1`] = `
 Array [
-  <div
-    class="ant-space ant-space-horizontal ant-space-align-center"
+  <button
+    class="ant-btn ant-btn-primary"
+    style="background-color: rgb(22, 119, 255);"
+    type="button"
   >
-    <div
-      class="ant-space-item"
-      style="margin-right: 8px;"
-    >
-      <div
-        style="width: 20px; height: 20px; border-radius: 4px; background-color: rgb(22, 119, 255);"
-      />
-    </div>
-    <div
-      class="ant-space-item"
-    >
-      <span>
-        #1677ff
-      </span>
-    </div>
-  </div>,
+    <span>
+      open
+    </span>
+  </button>,
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -245,25 +245,15 @@ exports[`renders components/color-picker/demo/pure-panel.tsx correctly 1`] = `
 `;
 
 exports[`renders components/color-picker/demo/trigger.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-horizontal ant-space-align-center"
+<button
+  class="ant-btn ant-btn-primary"
+  style="background-color:#1677ff"
+  type="button"
 >
-  <div
-    class="ant-space-item"
-    style="margin-right:8px"
-  >
-    <div
-      style="width:20px;height:20px;border-radius:4px;background-color:#1677ff"
-    />
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <span>
-      #1677ff
-    </span>
-  </div>
-</div>
+  <span>
+    open
+  </span>
+</button>
 `;
 
 exports[`renders components/color-picker/demo/trigger-event.tsx correctly 1`] = `

--- a/components/color-picker/demo/trigger-event.md
+++ b/components/color-picker/demo/trigger-event.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Triggers event for customizing color panels.
+Triggers event for customizing color panels, provide options `click` and `hover`.

--- a/components/color-picker/demo/trigger.tsx
+++ b/components/color-picker/demo/trigger.tsx
@@ -1,8 +1,8 @@
-import { ColorPicker, Space, theme } from 'antd';
+import { Button, ColorPicker, theme } from 'antd';
 import type { Color } from 'antd/es/color-picker';
 import React, { useMemo, useState } from 'react';
 
-export default () => {
+const Demo: React.FC = () => {
   const { token } = theme.useToken();
   const [color, setColor] = useState<Color | string>(token.colorPrimary);
 
@@ -11,19 +11,17 @@ export default () => {
     [color],
   );
 
-  const divStyle: React.CSSProperties = {
-    width: token.sizeMD,
-    height: token.sizeMD,
-    borderRadius: token.borderRadiusSM,
+  const btnStyle: React.CSSProperties = {
     backgroundColor: bgColor,
   };
 
   return (
     <ColorPicker value={color} onChange={setColor}>
-      <Space>
-        <div style={divStyle} />
-        <span>{bgColor}</span>
-      </Space>
+      <Button type="primary" style={btnStyle}>
+        open
+      </Button>
     </ColorPicker>
   );
 };
+
+export default Demo;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | demo: update docs & demo |
| 🇨🇳 Chinese | 无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7370a7</samp>

Improved the `trigger` demo and documentation for the `ColorPicker` component. Added `click` and `hover` options to the `trigger` prop and used a `Button` component to display the selected color.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7370a7</samp>

* Update the documentation and demo for the `trigger` prop of the `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-6da2aaf1643b5ff2d039dbfcec10916b71b14ea64abc1e4a0673ffd704e8cf02L7-R7), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L1-R5), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L14-R14), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L23-R27))
  - Add `click` and `hover` as possible options for the `trigger` prop in `trigger-event.md` ([link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-6da2aaf1643b5ff2d039dbfcec10916b71b14ea64abc1e4a0673ffd704e8cf02L7-R7))
  - Use a `Button` component with the selected color as the background to open the color panel in `trigger.tsx` ([link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L1-R5), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L14-R14), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L23-R27))
  - Wrap the demo in a `Demo` component and export it as the default export in `trigger.tsx` ([link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L1-R5), [link](https://github.com/ant-design/ant-design/pull/42681/files?diff=unified&w=0#diff-10f03910a0035197acf062a84465dfde362e5130bd9b6ac22b7363d3911004c2L23-R27))