### PR TITLE
fix: overflowed submenu should have classes with customized class

### DIFF
--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -8,12 +8,13 @@ import {
 import React, { useMemo, useState } from 'react';
 import type { MenuProps, MenuRef } from '..';
 import Menu from '..';
+import { TriggerMockContext } from '../../../tests/shared/demoTestContext';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
-import Layout from '../../layout';
 import initCollapseMotion from '../../_util/motion';
 import { noop } from '../../_util/warning';
+import Layout from '../../layout';
 
 Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
   writable: true,
@@ -824,7 +825,7 @@ describe('Menu', () => {
     const onOpen = jest.fn();
     const onClose = jest.fn();
     const Demo: React.FC = () => {
-      const menuProps = useMemo<MenuProps>(() => ({ onOpen, onClose }) as MenuProps, []);
+      const menuProps = useMemo<MenuProps>(() => ({ onOpen, onClose } as MenuProps), []);
       return (
         <Menu
           {...menuProps}
@@ -859,7 +860,7 @@ describe('Menu', () => {
   it('should keep selectedKeys in state when collapsed to 0px', () => {
     jest.useFakeTimers();
     const Demo: React.FC<MenuProps> = (props) => {
-      const menuProps = useMemo<MenuProps>(() => ({ collapsedWidth: 0 }) as MenuProps, []);
+      const menuProps = useMemo<MenuProps>(() => ({ collapsedWidth: 0 } as MenuProps), []);
       return (
         <Menu
           mode="inline"
@@ -1098,5 +1099,28 @@ describe('Menu', () => {
       'opacity',
       '0',
     );
+  });
+
+  it('Overflow indicator className should not override menu class', () => {
+    const { container } = render(
+      <TriggerMockContext.Provider value={{ popupVisible: true }}>
+        <Menu
+          items={[
+            { key: '1', label: 'Option 1' },
+            { key: '2', label: 'Option 1' },
+            { key: '3', label: 'Option 1' },
+            { key: '4', label: 'Option 1' },
+            { key: '5', label: 'Option 1' },
+            { key: '6', label: 'Option 1' },
+            { key: '7', label: 'Option 1' },
+            { key: '8', label: 'Option 1' },
+          ]}
+          mode="horizontal"
+          overflowedIndicatorPopupClassName="custom-popover"
+          getPopupContainer={(node) => node.parentElement!}
+        />
+      </TriggerMockContext.Provider>,
+    );
+    expect(container.querySelector('.ant-menu.ant-menu-light.custom-popover')).toBeTruthy();
   });
 });

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -1,22 +1,22 @@
+import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
+import classNames from 'classnames';
 import type { MenuProps as RcMenuProps, MenuRef as RcMenuRef } from 'rc-menu';
 import RcMenu from 'rc-menu';
+import useEvent from 'rc-util/lib/hooks/useEvent';
+import omit from 'rc-util/lib/omit';
 import * as React from 'react';
 import { forwardRef } from 'react';
-import omit from 'rc-util/lib/omit';
-import useEvent from 'rc-util/lib/hooks/useEvent';
-import classNames from 'classnames';
-import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
-import warning from '../_util/warning';
 import initCollapseMotion from '../_util/motion';
 import { cloneElement } from '../_util/reactNode';
-import type { SiderContextProps } from '../layout/Sider';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
-import useStyle from './style';
-import OverrideContext from './OverrideContext';
-import useItems from './hooks/useItems';
-import type { ItemType } from './hooks/useItems';
+import type { SiderContextProps } from '../layout/Sider';
+import type { MenuContextProps, MenuTheme } from './MenuContext';
 import MenuContext from './MenuContext';
-import type { MenuTheme, MenuContextProps } from './MenuContext';
+import OverrideContext from './OverrideContext';
+import type { ItemType } from './hooks/useItems';
+import useItems from './hooks/useItems';
+import useStyle from './style';
 
 export interface MenuProps extends Omit<RcMenuProps, 'items'> {
   theme?: MenuTheme;
@@ -59,6 +59,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     mode,
     selectable,
     onClick,
+    overflowedIndicatorPopupClassName,
     ...restProps
   } = props;
 
@@ -152,7 +153,11 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
         <RcMenu
           getPopupContainer={getPopupContainer}
           overflowedIndicator={<EllipsisOutlined />}
-          overflowedIndicatorPopupClassName={classNames(prefixCls, `${prefixCls}-${theme}`)}
+          overflowedIndicatorPopupClassName={classNames(
+            prefixCls,
+            `${prefixCls}-${theme}`,
+            overflowedIndicatorPopupClassName,
+          )}
           mode={mergedMode}
           selectable={mergedSelectable}
           onClick={onItemClick}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Menu that `overflowedIndicatorClassName` should not override origin classes.        |
| 🇨🇳 Chinese |    修复 Menu 组件 `overflowedIndicatorClassName` 覆盖了原本的 class 的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 895a119</samp>

This pull request enhances the `Menu` component and its tests. It adds a prop to customize the overflowed indicator popup class name, and updates the tests to use a mock context and type assertions. It also fixes the import order in `menu.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 895a119</samp>

*  Add `overflowedIndicatorPopupClassName` prop to `InternalMenu` and `RcMenu` components to customize the popup class name of the overflowed indicator ([link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43R62), [link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L155-R160))
*  Import `TriggerMockContext` from `demoTestContext` to provide a mock context for testing the menu component with trigger events ([link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-1cad196e610d68ddf06e127c070d41cb9e4bfa00016e77c472841f261f154433L11-R17))
*  Use `as` keyword instead of `()` to cast object literals to `MenuProps` type in test cases, for readability and consistency ([link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-1cad196e610d68ddf06e127c070d41cb9e4bfa00016e77c472841f261f154433L827-R828), [link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-1cad196e610d68ddf06e127c070d41cb9e4bfa00016e77c472841f261f154433L862-R863))
*  Add a test case to check that `overflowedIndicatorPopupClassName` prop does not override the menu class when the menu items overflow in horizontal mode ([link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-1cad196e610d68ddf06e127c070d41cb9e4bfa00016e77c472841f261f154433R1103-R1125))
*  Reorder import statements to group type imports together and separate them from default imports, following ESLint rule `import/order` ([link](https://github.com/ant-design/ant-design/pull/42692/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L1-R19))
