### PR TITLE
fix: Popover maxWidth break when parent has limitation

### DIFF
--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -15,7 +15,7 @@
   top: 0;
   left: 0;
   z-index: @zindex-popover;
-  max-width: 100%;
+  max-width: 100vw;
   font-weight: normal;
   white-space: normal;
   text-align: left;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link


https://codesandbox.io/s/ji-ben-antd-4-24-10-forked-u2hckv?file=/demo.tsx

ref https://github.com/ant-design/ant-design/pull/41953/files#r1187799096

### 💡 Background and solution

When parent is relative, `max-width: 100%` will break not using window width.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Popover with `getPopupContainer` sometime makes width too narrow.     |
| 🇨🇳 Chinese |    修复 Popover 设置 `getPopupContainer` 后，某些时候宽度会过窄的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f99533c</samp>

Fixed a bug that caused popover to overflow the viewport width. Changed `max-width` of `.ant-popover` in `components/popover/style/index.less` to `100vw`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f99533c</samp>

* Fix popover container overflow issue by changing `max-width` from `100%` to `100vw` ([link](https://github.com/ant-design/ant-design/pull/42697/files?diff=unified&w=0#diff-fe80c5b599638edd09552f7dc17f380ddfbbbbd33690688f99fcddb516590071L18-R18))
