### PR TITLE
docs(auto-complete): supplement bordered document

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -95,6 +95,53 @@ Array [
 ]
 `;
 
+exports[`renders components/auto-complete/demo/borderless.tsx extend context correctly 1`] = `
+<div
+  class="ant-select ant-select-borderless ant-select-auto-complete ant-select-single ant-select-show-search"
+  style="width: 200px;"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-activedescendant="rc_select_TEST_OR_SSR_list_-1"
+        aria-autocomplete="list"
+        aria-controls="rc_select_TEST_OR_SSR_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="rc_select_TEST_OR_SSR_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        id="rc_select_TEST_OR_SSR"
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      Borderless
+    </span>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        class="ant-select-item-empty"
+        id="rc_select_TEST_OR_SSR_list"
+        role="listbox"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/auto-complete/demo/certain-category.tsx extend context correctly 1`] = `
 <div
   class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.ts.snap
@@ -69,6 +69,40 @@ Array [
 ]
 `;
 
+exports[`renders components/auto-complete/demo/borderless.tsx correctly 1`] = `
+<div
+  class="ant-select ant-select-borderless ant-select-auto-complete ant-select-single ant-select-show-search"
+  style="width:200px"
+>
+  <div
+    class="ant-select-selector"
+  >
+    <span
+      class="ant-select-selection-search"
+    >
+      <input
+        aria-activedescendant="undefined_list_0"
+        aria-autocomplete="list"
+        aria-controls="undefined_list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="undefined_list"
+        autocomplete="off"
+        class="ant-select-selection-search-input"
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-select-selection-placeholder"
+    >
+      Borderless
+    </span>
+  </div>
+</div>
+`;
+
 exports[`renders components/auto-complete/demo/certain-category.tsx correctly 1`] = `
 <div
   class="ant-select ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"

--- a/components/auto-complete/demo/borderless.md
+++ b/components/auto-complete/demo/borderless.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+没有边框。
+
+## en-US
+
+No border.

--- a/components/auto-complete/demo/borderless.tsx
+++ b/components/auto-complete/demo/borderless.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
       style={{ width: 200 }}
       placeholder="Borderless"
       onSearch={(text) => setOptions(getPanelValue(text))}
-      onSelect={window.console.log}
+      onSelect={globalThis.console.log}
       bordered={false}
     />
   );

--- a/components/auto-complete/demo/borderless.tsx
+++ b/components/auto-complete/demo/borderless.tsx
@@ -1,0 +1,26 @@
+import { AutoComplete } from 'antd';
+import React, { useState } from 'react';
+
+const mockVal = (str: string, repeat = 1) => ({
+  value: str.repeat(repeat),
+});
+
+const App: React.FC = () => {
+  const [options, setOptions] = useState<{ value: string }[]>([]);
+
+  const getPanelValue = (searchText: string) =>
+    !searchText ? [] : [mockVal(searchText), mockVal(searchText, 2), mockVal(searchText, 3)];
+
+  return (
+    <AutoComplete
+      options={options}
+      style={{ width: 200 }}
+      placeholder="Borderless"
+      onSearch={(text) => setOptions(getPanelValue(text))}
+      onSelect={window.console.log}
+      bordered={false}
+    />
+  );
+};
+
+export default App;

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -32,6 +32,7 @@ The differences with Select are:
 <code src="./demo/certain-category.tsx">Lookup-Patterns - Certain Category</code>
 <code src="./demo/uncertain-category.tsx">Lookup-Patterns - Uncertain Category</code>
 <code src="./demo/status.tsx">Status</code>
+<code src="./demo/borderless.tsx">Borderless</code>
 <code src="./demo/form-debug.tsx" debug>Debug in Form</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 
@@ -42,6 +43,7 @@ The differences with Select are:
 | allowClear | Show clear button | boolean | false |  |
 | autoFocus | If get focus when component mounted | boolean | false |  |
 | backfill | If backfill selected item the input when using keyboard | boolean | false |  |
+| bordered | Whether has border style | boolean | true |  |
 | children (for customize input element) | Customize input element | HTMLInputElement \| HTMLTextAreaElement \| React.ReactElement&lt;InputProps> | &lt;Input /> |  |
 | children (for dataSource) | Data source to auto complete | React.ReactElement&lt;OptionProps> \| Array&lt;React.ReactElement&lt;OptionProps>> | - |  |
 | defaultActiveFirstOption | Whether active first option by default | boolean | true |  |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -33,6 +33,7 @@ demo:
 <code src="./demo/certain-category.tsx">查询模式 - 确定类目</code>
 <code src="./demo/uncertain-category.tsx">查询模式 - 不确定类目</code>
 <code src="./demo/status.tsx">自定义状态</code>
+<code src="./demo/borderless.tsx">无边框</code>
 <code src="./demo/form-debug.tsx" debug>在 Form 中 Debug</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
@@ -43,6 +44,7 @@ demo:
 | allowClear | 支持清除 | boolean | false |  |
 | autoFocus | 自动获取焦点 | boolean | false |  |
 | backfill | 使用键盘选择选项的时候把选中项回填到输入框中 | boolean | false |  |
+| bordered | 是否有边框 | boolean | true |  |
 | children (自动完成的数据源) | 自动完成的数据源 | React.ReactElement&lt;OptionProps> \| Array&lt;React.ReactElement&lt;OptionProps>> | - |  |
 | children (自定义输入框) | 自定义输入框 | HTMLInputElement \| HTMLTextAreaElement \| React.ReactElement&lt;InputProps> | &lt;Input /> |  |
 | defaultActiveFirstOption | 是否默认高亮第一个选项 | boolean | true |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

计划把 《数据录入的所有组件 bordered 都跟踪一遍》之补充 `AutoComplete` 组件的 `bordered` 文档

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       --    |
| 🇨🇳 Chinese |     --     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 167ede7</samp>

This pull request adds a new `bordered` prop to the `AutoComplete` component, which allows users to control the border style of the input. It also updates the documentation and adds a demo for the borderless option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 167ede7</samp>

* Add the `bordered` prop to the AutoComplete component to control the border style of the input ([link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-059a01a00b173bd8359275664da42d505d67e2b7cb1bfa7eec46c732356e3b03R1-R26), [link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-f04508ef988a95e022e0488be2b02506610901732efa4dfba77f7ac6e1ae65d1R46), [link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-54fefadfae27caa4550cb59eb92b84d4a0ec3b9b17bb56f9ec3cae2948886db3R47))
* Create a borderless demo of the AutoComplete component using the `bordered` prop and add it to the Examples section of the English and Chinese documentation ([link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-0b78aefcdc381a7603e04566d2c8e87af5124867f7ba1989aa59ec4218ab7175R1-R7), [link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-059a01a00b173bd8359275664da42d505d67e2b7cb1bfa7eec46c732356e3b03R1-R26), [link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-f04508ef988a95e022e0488be2b02506610901732efa4dfba77f7ac6e1ae65d1R35), [link](https://github.com/ant-design/ant-design/pull/42714/files?diff=unified&w=0#diff-54fefadfae27caa4550cb59eb92b84d4a0ec3b9b17bb56f9ec3cae2948886db3R36))
