### PR TITLE
feat: static getDesignToken

### DIFF
--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import theme from '..';
 import { render, renderHook } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import type { ThemeConfig } from '../../config-provider/context';
 import Row from '../../row';
 import genRadius from '../themes/shared/genRadius';
 
@@ -220,5 +221,59 @@ describe('Theme', () => {
     );
 
     expect(container.querySelector('.duration')?.textContent).toEqual('0s');
+  });
+
+  describe('getDesignToken', () => {
+    const getHookToken = (config?: ThemeConfig) => {
+      let token: any;
+      const Demo = () => {
+        const { token: hookToken } = useToken();
+        token = hookToken;
+        return null;
+      };
+      render(
+        <ConfigProvider theme={config}>
+          <Demo />
+        </ConfigProvider>,
+      );
+      delete token._hashId;
+      delete token._tokenKey;
+      return token;
+    };
+
+    it('default', () => {
+      const token = theme.getDesignToken();
+      const hookToken = getHookToken();
+      expect(token).toEqual(hookToken);
+    });
+
+    it('with custom token', () => {
+      const config: ThemeConfig = {
+        token: {
+          colorPrimary: '#189cff',
+          borderRadius: 8,
+          fontSizeLG: 20,
+        },
+      };
+      const token = theme.getDesignToken(config);
+      const hookToken = getHookToken(config);
+      expect(token).toEqual(hookToken);
+      expect(token.colorPrimary).toEqual('#189cff');
+    });
+
+    it('with custom algorithm', () => {
+      const config: ThemeConfig = {
+        token: {
+          colorPrimary: '#1677ff',
+          borderRadius: 8,
+          fontSizeLG: 20,
+        },
+        algorithm: [theme.darkAlgorithm, theme.compactAlgorithm],
+      };
+      const token = theme.getDesignToken(config);
+      const hookToken = getHookToken(config);
+      expect(token).toEqual(hookToken);
+      expect(token.colorPrimary).toEqual('#1668dc');
+    });
   });
 });

--- a/components/theme/getDesignToken.ts
+++ b/components/theme/getDesignToken.ts
@@ -1,0 +1,19 @@
+import { createTheme } from '@ant-design/cssinjs';
+import type { ThemeConfig } from '../config-provider/context';
+import type { AliasToken } from './interface';
+import defaultDerivative from './themes/default';
+import seedToken from './themes/seed';
+import formatToken from './util/alias';
+
+const getDesignToken = (config?: ThemeConfig): AliasToken => {
+  const theme = config?.algorithm ? createTheme(config.algorithm) : createTheme(defaultDerivative);
+  const mergedToken = { ...seedToken, ...config?.token };
+  const mapToken = theme.getDerivativeToken(mergedToken);
+  const mergedMapToken = {
+    ...mapToken,
+    override: config?.token,
+  };
+  return formatToken(mergedMapToken);
+};
+
+export default getDesignToken;

--- a/components/theme/getDesignToken.ts
+++ b/components/theme/getDesignToken.ts
@@ -1,4 +1,4 @@
-import { createTheme } from '@ant-design/cssinjs';
+import { createTheme, getComputedToken } from '@ant-design/cssinjs';
 import type { ThemeConfig } from '../config-provider/context';
 import type { AliasToken } from './interface';
 import defaultDerivative from './themes/default';
@@ -7,13 +7,11 @@ import formatToken from './util/alias';
 
 const getDesignToken = (config?: ThemeConfig): AliasToken => {
   const theme = config?.algorithm ? createTheme(config.algorithm) : createTheme(defaultDerivative);
-  const mergedToken = { ...seedToken, ...config?.token };
-  const mapToken = theme.getDerivativeToken(mergedToken);
-  const mergedMapToken = {
-    ...mapToken,
-    override: config?.token,
+  const mergedToken = {
+    ...seedToken,
+    ...config?.token,
   };
-  return formatToken(mergedMapToken);
+  return getComputedToken(mergedToken, { override: config?.token }, theme, formatToken);
 };
 
 export default getDesignToken;

--- a/components/theme/index.ts
+++ b/components/theme/index.ts
@@ -1,9 +1,10 @@
 /* eslint-disable import/prefer-default-export */
-import { defaultConfig, useToken as useInternalToken } from './internal';
+import getDesignToken from './getDesignToken';
 import type { GlobalToken } from './interface';
-import defaultAlgorithm from './themes/default';
-import darkAlgorithm from './themes/dark';
+import { defaultConfig, useToken as useInternalToken } from './internal';
 import compactAlgorithm from './themes/compact';
+import darkAlgorithm from './themes/dark';
+import defaultAlgorithm from './themes/default';
 
 // ZombieJ: We export as object to user but array in internal.
 // This is used to minimize the bundle size for antd package but safe to refactor as object also.
@@ -28,4 +29,5 @@ export default {
   defaultAlgorithm,
   darkAlgorithm,
   compactAlgorithm,
+  getDesignToken,
 };

--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -160,9 +160,41 @@ When you need token out of React life cycle, you can use static function to get 
 ```jsx
 import { theme } from 'antd';
 
-const { defaultAlgorithm, defaultSeed } = theme;
+const { getDesignToken } = theme;
 
-const mapToken = defaultAlgorithm(defaultSeed);
+const globalToken = getDesignToken();
+```
+
+Same as ConfigProvider, `getDesignToken` could also accept a config object as `theme`:
+
+```tsx
+import type { ThemeConfig } from 'antd';
+import { theme } from 'antd';
+import { createRoot } from 'react-dom/client';
+
+const { getDesignToken, useToken } = theme;
+
+const config: ThemeConfig = {
+  token: {
+    colorPrimary: '#1890ff',
+  },
+};
+
+// By static function
+const globalToken = getDesignToken(config);
+
+// By hook
+const App = () => {
+  const { token } = useToken();
+  return null;
+};
+
+// Example for rendering
+createRoot(document.getElementById('#app')).render(
+  <ConfigProvider theme={config}>
+    <App />
+  </ConfigProvider>,
+);
 ```
 
 If you want to use in preprocess style framework like less, use less-loader for injection:

--- a/docs/react/customize-theme.zh-CN.md
+++ b/docs/react/customize-theme.zh-CN.md
@@ -155,14 +155,46 @@ export default App;
 
 ### 静态消费（如 less）
 
-当你需要非 React 生命周期消费 Token 变量时，可以通过静态方法将其导出：
+当你需要非 React 生命周期消费 Token 变量时，可以通过静态方法 `getDesignToken` 将其导出：
 
 ```jsx
 import { theme } from 'antd';
 
-const { defaultAlgorithm, defaultSeed } = theme;
+const { getDesignToken } = theme;
 
-const mapToken = defaultAlgorithm(defaultSeed);
+const globalToken = getDesignToken();
+```
+
+`getDesignToken` 和 ConfigProvider 一样，支持传入 `theme` 属性，用于获取指定主题的 Design Token。
+
+```tsx
+import type { ThemeConfig } from 'antd';
+import { theme } from 'antd';
+import { createRoot } from 'react-dom/client';
+
+const { getDesignToken, useToken } = theme;
+
+const config: ThemeConfig = {
+  token: {
+    colorPrimary: '#1890ff',
+  },
+};
+
+// 通过静态方法获取
+const globalToken = getDesignToken(config);
+
+// 通过 hook 获取
+const App = () => {
+  const { token } = useToken();
+  return null;
+};
+
+// 渲染示意
+createRoot(document.getElementById('#app')).render(
+  <ConfigProvider theme={config}>
+    <App />
+  </ConfigProvider>,
+);
 ```
 
 如果需要将其应用到静态样式编译框架，如 less 可以通过 less-loader 注入：

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^7.0.0",
-    "@ant-design/cssinjs": "^1.9.1",
+    "@ant-design/cssinjs": "^1.10.1",
     "@ant-design/icons": "^5.1.0",
     "@ant-design/react-slick": "~1.0.0",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Add static function `getDesignToken` to access full Design Token.     |
| 🇨🇳 Chinese |      新增静态方法 `getDesignToken` 用于获取完整的主题 token。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de2e4c8</samp>

This pull request adds a new function `getDesignToken` to the `theme` module, which allows users to access the design token object based on the theme configuration. It also adds type and test support for the function, and updates the documentation in both English and Chinese to reflect the new usage.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de2e4c8</samp>

*  Implement and export `getDesignToken` function to return design token object based on theme configuration ([link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-bfc52d09323f24b5d3cbf6edb9fe8991c8b8fd1daa73c21e4b054bbc69413783R1-R19), [link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-a1691067c7ae7cc4ec252c57ae55fccd18ee928b026091db042495c6cd43e049R32))
*  Import `ThemeConfig` type from `config-provider` context module to use in `getDesignToken` function and test suite ([link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-37ce89d0868e7510a9c83f58a4d4a2cba035535684d5585549df8962f6a7e421R6))
*  Add test suite for `getDesignToken` function using custom render function and `useToken` hook ([link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-37ce89d0868e7510a9c83f58a4d4a2cba035535684d5585549df8962f6a7e421R225-R278))
*  Reorder imports in `theme` module to follow convention ([link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-a1691067c7ae7cc4ec252c57ae55fccd18ee928b026091db042495c6cd43e049L2-R7))
*  Update documentation for `theme` module in English and Chinese versions, replacing `defaultAlgorithm` and `defaultSeed` with `getDesignToken` function and adding example of usage with `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-e12721e5a68f1eaac8d53987399a4d6eb6c7e4e6bb59fed4ffb73c7967079090L163-R199), [link](https://github.com/ant-design/ant-design/pull/42723/files?diff=unified&w=0#diff-7238b66024192aa79bff8e41259edd3a2c30155c7422b58c53e6fc63d679a4afL158-R199))
