### PR TITLE
feat: ConfigProvider support Space classNames and styles properties

### DIFF
--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -6,8 +6,9 @@ import mountTest from '../../../tests/shared/mountTest';
 import { fireEvent, render } from '../../../tests/utils';
 import Button from '../../button';
 import Input from '../../input';
-import Table from '../../table';
 import Select from '../../select';
+import Space from '../../space';
+import Table from '../../table';
 
 describe('ConfigProvider', () => {
   mountTest(() => (
@@ -122,5 +123,45 @@ describe('ConfigProvider', () => {
 
     expect(rendered).toBeTruthy();
     expect(cacheRenderEmpty).toBeFalsy();
+  });
+
+  it('Should Space classNames works', () => {
+    const { container } = render(
+      <ConfigProvider
+        space={{
+          classNames: {
+            item: 'test-classNames',
+          },
+        }}
+      >
+        <Space>
+          <span>Text1</span>
+          <span>Text2</span>
+        </Space>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-space-item.test-classNames')).toBeTruthy();
+  });
+
+  it('Should Space styles works', () => {
+    const { container } = render(
+      <ConfigProvider
+        space={{
+          styles: {
+            item: {
+              color: 'red',
+            },
+          },
+        }}
+      >
+        <Space>
+          <span>Text1</span>
+          <span>Text2</span>
+        </Space>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-space-item')?.getAttribute('style')).toEqual(
+      'margin-right: 8px; color: red;',
+    );
   });
 });

--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -143,6 +143,22 @@ describe('ConfigProvider', () => {
     expect(container.querySelector('.ant-space-item.test-classNames')).toBeTruthy();
   });
 
+  it('Should Space className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        space={{
+          className: 'test-classNames',
+        }}
+      >
+        <Space>
+          <span>Text1</span>
+          <span>Text2</span>
+        </Space>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-space.test-classNames')).toBeTruthy();
+  });
+
   it('Should Space styles works', () => {
     const { container } = render(
       <ConfigProvider
@@ -163,5 +179,23 @@ describe('ConfigProvider', () => {
     expect(container.querySelector('.ant-space-item')?.getAttribute('style')).toEqual(
       'margin-right: 8px; color: red;',
     );
+  });
+
+  it('Should Space style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        space={{
+          style: {
+            color: 'red',
+          },
+        }}
+      >
+        <Space>
+          <span>Text1</span>
+          <span>Text2</span>
+        </Space>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-space')?.getAttribute('style')).toEqual('color: red;');
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -69,7 +69,9 @@ export interface ConfigConsumerProps {
   direction?: DirectionType;
   space?: {
     size?: SizeType | number;
+    className?: SpaceProps['className'];
     classNames?: SpaceProps['classNames'];
+    style?: SpaceProps['style'];
     styles?: SpaceProps['styles'];
   };
   virtual?: boolean;

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -4,6 +4,7 @@ import type { Options } from 'scroll-into-view-if-needed';
 import type { ButtonProps } from '../button';
 import type { RequiredMark } from '../form/Form';
 import type { Locale } from '../locale';
+import type { SpaceProps } from '../space';
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from '../theme/interface';
 import type { SizeType } from './SizeContext';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
@@ -68,6 +69,8 @@ export interface ConfigConsumerProps {
   direction?: DirectionType;
   space?: {
     size?: SizeType | number;
+    classNames?: SpaceProps['classNames'];
+    styles?: SpaceProps['styles'];
   };
   virtual?: boolean;
   popupMatchSelectWidth?: boolean;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -67,7 +67,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | locale | Language package setting, you can find the packages in [antd/locale](http://unpkg.com/antd/locale/) | object | - |  |
 | prefixCls | Set prefix className | string | `ant` |  |
 | renderEmpty | Set empty content of components. Ref [Empty](/components/empty/) | function(componentName: string): ReactNode | - |  |
-| space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties }, className?: string, style?: React.CSSProperties } | - | 5.6.0 |
+| space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | theme | Set theme, ref [Customize Theme](/docs/react/customize-theme) | - | - | 5.0.0 |
 | virtual | Disable virtual scroll when set to `false` | boolean | - | 4.3.0 |
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -67,7 +67,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | locale | Language package setting, you can find the packages in [antd/locale](http://unpkg.com/antd/locale/) | object | - |  |
 | prefixCls | Set prefix className | string | `ant` |  |
 | renderEmpty | Set empty content of components. Ref [Empty](/components/empty/) | function(componentName: string): ReactNode | - |  |
-| space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
+| space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties }, className?: string, style?: React.CSSProperties } | - | 5.6.0 |
 | theme | Set theme, ref [Customize Theme](/docs/react/customize-theme) | - | - | 5.0.0 |
 | virtual | Disable virtual scroll when set to `false` | boolean | - | 4.3.0 |
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -67,7 +67,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | locale | Language package setting, you can find the packages in [antd/locale](http://unpkg.com/antd/locale/) | object | - |  |
 | prefixCls | Set prefix className | string | `ant` |  |
 | renderEmpty | Set empty content of components. Ref [Empty](/components/empty/) | function(componentName: string): ReactNode | - |  |
-| space | Set Space `size`, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number` } | - | 4.1.0 |
+| space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | theme | Set theme, ref [Customize Theme](/docs/react/customize-theme) | - | - | 5.0.0 |
 | virtual | Disable virtual scroll when set to `false` | boolean | - | 4.3.0 |
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -14,6 +14,7 @@ import LocaleProvider, { ANT_MARK } from '../locale';
 import type { LocaleContextProps } from '../locale/context';
 import LocaleContext from '../locale/context';
 import defaultLocale from '../locale/en_US';
+import type { SpaceProps } from '../space';
 import { DesignTokenContext } from '../theme/internal';
 import defaultSeedToken from '../theme/themes/seed';
 import type {
@@ -123,6 +124,8 @@ export interface ConfigProviderProps {
   direction?: DirectionType;
   space?: {
     size?: SizeType | number;
+    classNames?: SpaceProps['classNames'];
+    styles?: SpaceProps['styles'];
   };
   virtual?: boolean;
   /** @deprecated Please use `popupMatchSelectWidth` instead */

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -124,7 +124,9 @@ export interface ConfigProviderProps {
   direction?: DirectionType;
   space?: {
     size?: SizeType | number;
+    className?: SpaceProps['className'];
     classNames?: SpaceProps['classNames'];
+    style?: SpaceProps['style'];
     styles?: SpaceProps['styles'];
   };
   virtual?: boolean;

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -64,11 +64,11 @@ export default Demo;
 | iconPrefixCls | 设置图标统一样式前缀 | string | `anticon` | 4.11.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string } | - | 4.2.0 |
 | select | 设置 Select 组件的通用属性 | { showSearch?: boolean } | - |  |
-| button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties }, className?: string, style?: React.CSSProperties } | - | 5.6.0 |
+| button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | locale | 语言包配置，语言包可到 [antd/locale](http://unpkg.com/antd/locale/) 目录下寻找 | object | - |  |
 | prefixCls | 设置统一样式前缀 | string | `ant` |  |
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty-cn) | function(componentName: string): ReactNode | - |  |
-| space | 设置 Space 组件的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
+| space | 设置 Space 的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | theme | 设置主题，参考 [定制主题](/docs/react/customize-theme-cn) | - | - | 5.0.0 |
 | virtual | 设置 `false` 时关闭虚拟滚动 | boolean | - | 4.3.0 |
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -68,7 +68,7 @@ export default Demo;
 | locale | 语言包配置，语言包可到 [antd/locale](http://unpkg.com/antd/locale/) 目录下寻找 | object | - |  |
 | prefixCls | 设置统一样式前缀 | string | `ant` |  |
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty-cn) | function(componentName: string): ReactNode | - |  |
-| space | 设置 Space 的 `size`，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number` } | - | 4.1.0 |
+| space | 设置 Space 组件的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | theme | 设置主题，参考 [定制主题](/docs/react/customize-theme-cn) | - | - | 5.0.0 |
 | virtual | 设置 `false` 时关闭虚拟滚动 | boolean | - | 4.3.0 |
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -64,7 +64,7 @@ export default Demo;
 | iconPrefixCls | 设置图标统一样式前缀 | string | `anticon` | 4.11.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string } | - | 4.2.0 |
 | select | 设置 Select 组件的通用属性 | { showSearch?: boolean } | - |  |
-| button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
+| button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties }, className?: string, style?: React.CSSProperties } | - | 5.6.0 |
 | locale | 语言包配置，语言包可到 [antd/locale](http://unpkg.com/antd/locale/) 目录下寻找 | object | - |  |
 | prefixCls | 设置统一样式前缀 | string | `ant` |  |
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty-cn) | function(componentName: string): ReactNode | - |  |

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -86,7 +86,7 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
       [`${prefixCls}-rtl`]: directionConfig === 'rtl',
       [`${prefixCls}-align-${mergedAlign}`]: mergedAlign,
     },
-    className,
+    className ?? space?.className,
     rootClassName,
   );
 
@@ -153,6 +153,7 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
       ref={ref}
       className={cn}
       style={{
+        ...space?.style,
         ...gapStyle,
         ...style,
       }}

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -90,7 +90,10 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
     rootClassName,
   );
 
-  const itemClassName = classNames(`${prefixCls}-item`, customClassNames?.item);
+  const itemClassName = classNames(
+    `${prefixCls}-item`,
+    customClassNames?.item ?? space?.classNames?.item,
+  );
 
   const marginDirection = directionConfig === 'rtl' ? 'marginLeft' : 'marginRight';
 
@@ -112,7 +115,7 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
         marginDirection={marginDirection}
         split={split}
         wrap={wrap}
-        style={styles?.item}
+        style={styles?.item ?? space?.styles?.item}
       >
         {child}
       </Item>

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -153,8 +153,8 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
       ref={ref}
       className={cn}
       style={{
-        ...space?.style,
         ...gapStyle,
+        ...space?.style,
         ...style,
       }}
       {...otherProps}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
#42618
#42743
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     `ConfigProvider` support `Space` `classNames` and `styles` properties      |
| 🇨🇳 Chinese |       `ConfigProvider` 支持 `Space` 组件的 `classNames` 和 `styles` 属性     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9a28d8</samp>

Enhanced the `Space` component to support customizing the `className` and `style` of its items through the `ConfigProvider` context. Added the `space` prop to the `ConfigProvider` component and updated the documentation and tests accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9a28d8</samp>

*  Add `classNames` and `styles` props to the `ConfigProvider` component and context to allow customizing the `Space` component ([link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR72-R73), [link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R127-R128))
*  Import the `SpaceProps` type from `../space` in the `ConfigProvider` component and context files ([link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR7), [link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R17))
*  Update the `ConfigProvider` documentation in English and Chinese to reflect the new `space` prop that can accept `classNames` and `styles` as well as `size` ([link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L70-R70), [link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L71-R71))
*  Modify the `Space` component to use the `classNames` and `styles` props from the `ConfigProvider` context if the `customClassNames` and `styles` props are not provided ([link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L93-R96), [link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-d42c3072a5016964aad21722cb773b77e6fc5824adf56dc16efaecff82aab948L115-R118))
*  Import the `Space` component from `../../space` and add two test cases to check if the `ConfigProvider` component can pass custom `classNames` and `styles` props to the `Space` component ([link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5L9-R11), [link](https://github.com/ant-design/ant-design/pull/42748/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R127-R166))
