### PR TITLE
fix: notification should hide close icon when closeIcon={null}

### DIFF
--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -272,6 +272,30 @@ describe('notification', () => {
     expect(document.querySelectorAll('.test-customize-icon').length).toBe(1);
   });
 
+  it('support closeIcon to be null', () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        duration: 0,
+        closeIcon: null,
+      });
+    });
+
+    expect(document.querySelectorAll('.test-customize-icon').length).toBe(0);
+  });
+
+  it('support closeIcon to be false', () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        duration: 0,
+        closeIcon: false,
+      });
+    });
+
+    expect(document.querySelectorAll('.test-customize-icon').length).toBe(0);
+  });
+
   it('support config closeIcon', () => {
     notification.config({
       closeIcon: <span className="test-customize-icon" />,

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -252,11 +252,14 @@ function getRCNoticeProps(args: ArgsProps, prefixCls: string, iconPrefixCls?: st
     });
   }
 
-  const closeIconToRender = (
-    <span className={`${prefixCls}-close-x`}>
-      {closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
-    </span>
-  );
+  const closeIconToRender =
+    typeof closeIcon === 'undefined' ? (
+      <span className={`${prefixCls}-close-x`}>
+        <CloseOutlined className={`${prefixCls}-close-icon`} />
+      </span>
+    ) : (
+      closeIcon
+    );
 
   const autoMarginTag =
     !description && iconNode ? (


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/42736

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix notification cannot hide close icon by `closeIcon={null}`.          |
| 🇨🇳 Chinese |  修复 notification 设置 `closeIcon={null}` 时关闭图标没有消失的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12ca386</samp>

This pull request improves the `notification` component by fixing a bug in the `closeIcon` prop and adding more test cases. It also applies some code style preferences to the code base, such as using single quotes and parentheses around arrow function parameters. The main files affected are `components/notification/__tests__/index.test.tsx` and `components/notification/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12ca386</samp>

*  Fix a bug where falsy values for `closeIcon` prop would still render the default close icon in `notification` component ([link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L255-R262))
* Add test cases for `notification.open` method when `closeIcon` prop is set to `null` or `false` ([link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L275-R301),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L284-R308))
* Replace double quotes with single quotes for attribute values in `components/notification/__tests__/index.test.tsx` and `components/notification/index.tsx` to follow code style rules ([link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L268-R268),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L284-R308),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L269-R272))
* Add parentheses around arrow function parameters in `components/notification/__tests__/index.test.tsx` and `components/notification/index.tsx` to follow code style rules ([link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L217-R217),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L223-R223),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L241-R241),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L247-R247),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L303-R327),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690L309-R333),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L166-R166),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L177-R177),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L186-R186),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L303-R307),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L311-R315),[link](https://github.com/ant-design/ant-design/pull/42791/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L320-R323))
