### PR TITLE
fix(Image): reset transform when switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "rc-drawer": "~6.2.0",
     "rc-dropdown": "~4.1.0",
     "rc-field-form": "~1.32.0",
-    "rc-image": "~5.16.0",
+    "rc-image": "~5.17.1",
     "rc-input": "~1.0.4",
     "rc-input-number": "~7.4.0",
     "rc-mentions": "~2.2.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/42693

### 💡 Background and solution

via https://github.com/react-component/image/pull/237

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Image.PreviewGroup not reset image state when switch it.     |
| 🇨🇳 Chinese |    修复 Image.PreviewGroup 预览时图片切换后状态没有重置的问题。   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 142a483</samp>

Updated `rc-image` dependency to fix a bug with image preview mask. The bug affected the image component and was reported in issue #31403.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 142a483</samp>

* Update the `rc-image` dependency to fix the preview mask bug of the image component ([link](https://github.com/ant-design/ant-design/pull/42793/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L132-R132))
