### PR TITLE
fix: fix divider component innerStyle style error

### DIFF
--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -34,7 +34,7 @@ A divider line separates different content.
 | className | The className of container | string | - |  |
 | dashed | Whether line is dashed | boolean | false |  |
 | orientation | The position of title inside divider | `left` \| `right` \| `center` | `center` |  |
-| orientationMargin | The margin-left/right between the title and its closest border, while the `orientation` must be `left` or `right` | string \| number | - |  |
+| orientationMargin | The margin-left/right between the title and its closest border, while the `orientation` must be `left` or `right`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | type | The direction type of divider | `horizontal` \| `vertical` | `horizontal` |  |

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -60,9 +60,8 @@ const Divider: React.FC<DividerProps> = (props) => {
   function convertToNumberIfPureNumber(str: string) {
     if (/^\d+$/.test(str)) {
       return Number(str);
-    } else {
-      return str;
     }
+    return str;
   }
 
   function convertToNumberOrReturn() {
@@ -95,9 +94,5 @@ const Divider: React.FC<DividerProps> = (props) => {
     </div>,
   );
 };
-
-if (process.env.NODE_ENV !== 'production') {
-  Divider.displayName = 'Divider';
-}
 
 export default Divider;

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -82,7 +82,7 @@ const Divider: React.FC<DividerProps> = (props) => {
   );
 
   function toNumber() {
-    return typeof orientationMargin === 'string' ? parseInt(orientationMargin) : orientationMargin;
+    return typeof orientationMargin === 'string' ? Number(orientationMargin) : orientationMargin;
   }
 };
 

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -57,22 +57,19 @@ const Divider: React.FC<DividerProps> = (props) => {
     rootClassName,
   );
 
-  function convertToNumberIfPureNumber(str: string) {
-    if (/^\d+$/.test(str)) {
-      return Number(str);
+  const memoizedOrientationMargin = React.useMemo<string | number>(() => {
+    if (typeof orientationMargin === 'number') {
+      return orientationMargin;
     }
-    return str;
-  }
-
-  function convertToNumberOrReturn() {
-    return typeof orientationMargin === 'string'
-      ? convertToNumberIfPureNumber(orientationMargin)
-      : orientationMargin;
-  }
+    if (/^\d+$/.test(orientationMargin!)) {
+      return Number(orientationMargin);
+    }
+    return orientationMargin!;
+  }, [orientationMargin]);
 
   const innerStyle: React.CSSProperties = {
-    ...(hasCustomMarginLeft && { marginLeft: convertToNumberOrReturn() }),
-    ...(hasCustomMarginRight && { marginRight: convertToNumberOrReturn() }),
+    ...(hasCustomMarginLeft && { marginLeft: memoizedOrientationMargin }),
+    ...(hasCustomMarginRight && { marginRight: memoizedOrientationMargin }),
   };
 
   // Warning children not work in vertical mode

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -57,13 +57,23 @@ const Divider: React.FC<DividerProps> = (props) => {
     rootClassName,
   );
 
-  function toNumber() {
-    return typeof orientationMargin === 'string' ? Number(orientationMargin) : orientationMargin;
+  function convertToNumberIfPureNumber(str: string) {
+    if (/^\d+$/.test(str)) {
+      return Number(str);
+    } else {
+      return str;
+    }
+  }
+
+  function convertToNumberOrReturn() {
+    return typeof orientationMargin === 'string'
+      ? convertToNumberIfPureNumber(orientationMargin)
+      : orientationMargin;
   }
 
   const innerStyle: React.CSSProperties = {
-    ...(hasCustomMarginLeft && { marginLeft: toNumber() }),
-    ...(hasCustomMarginRight && { marginRight: toNumber() }),
+    ...(hasCustomMarginLeft && { marginLeft: convertToNumberOrReturn() }),
+    ...(hasCustomMarginRight && { marginRight: convertToNumberOrReturn() }),
   };
 
   // Warning children not work in vertical mode

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -58,8 +58,8 @@ const Divider: React.FC<DividerProps> = (props) => {
   );
 
   const innerStyle: React.CSSProperties = {
-    ...(hasCustomMarginLeft && { marginLeft: orientationMargin }),
-    ...(hasCustomMarginRight && { marginRight: orientationMargin }),
+    ...(hasCustomMarginLeft && { marginLeft: toNumber() }),
+    ...(hasCustomMarginRight && { marginRight: toNumber() }),
   };
 
   // Warning children not work in vertical mode
@@ -80,6 +80,10 @@ const Divider: React.FC<DividerProps> = (props) => {
       )}
     </div>,
   );
+
+  function toNumber() {
+    return typeof orientationMargin === 'string' ? parseInt(orientationMargin) : orientationMargin;
+  }
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -57,6 +57,10 @@ const Divider: React.FC<DividerProps> = (props) => {
     rootClassName,
   );
 
+  function toNumber() {
+    return typeof orientationMargin === 'string' ? Number(orientationMargin) : orientationMargin;
+  }
+
   const innerStyle: React.CSSProperties = {
     ...(hasCustomMarginLeft && { marginLeft: toNumber() }),
     ...(hasCustomMarginRight && { marginRight: toNumber() }),
@@ -80,10 +84,6 @@ const Divider: React.FC<DividerProps> = (props) => {
       )}
     </div>,
   );
-
-  function toNumber() {
-    return typeof orientationMargin === 'string' ? Number(orientationMargin) : orientationMargin;
-  }
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -92,4 +92,8 @@ const Divider: React.FC<DividerProps> = (props) => {
   );
 };
 
+if (process.env.NODE_ENV !== 'production') {
+  Divider.displayName = 'Divider';
+}
+
 export default Divider;

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -35,7 +35,7 @@ group:
 | className | 分割线样式类 | string | - |  |
 | dashed | 是否虚线 | boolean | false |  |
 | orientation | 分割线标题的位置 | `left` \| `right` \| `center` | `center` |  |
-| orientationMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 必须为 `left` 或 `right` | string \| number | - |  |
+| orientationMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 必须为 `left` 或 `right`。如果传入 `string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | type | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
- fix #42796  

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix divider component's style error  |
| 🇨🇳 Chinese |  修复Divider组件的样式问题        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

I use a `toNumber` function to convert  string into number to make sure Divider's innerStyle can operate normally.

```tsx

// Type Define
export interface DividerProps {
  ...
  orientationMargin?: string | number;
 ...
}
// Before
 const innerStyle: React.CSSProperties = {
    ...(hasCustomMarginLeft && { marginLeft: orientationMargin  }), // orientationMargin may be string,
    ...(hasCustomMarginRight && { marginRight: orientationMargin  }),
  };

// Fix
 const innerStyle: React.CSSProperties = {
  ...(hasCustomMarginLeft && { marginLeft: toNumber() }),
  ...(hasCustomMarginRight && { marginRight: toNumber() }),
};

function toNumber() {
    return typeof orientationMargin === 'string' ? Number(orientationMargin) : orientationMargin;
}
```
