### PR TITLE
feat: steps support for circular progress bar

### DIFF
--- a/components/progress/Circle.tsx
+++ b/components/progress/Circle.tsx
@@ -29,6 +29,7 @@ const Circle: React.FC<CircleProps> = (props) => {
     children,
     success,
     size = originWidth,
+    steps,
   } = props;
 
   const [width, height] = getSize(size, 'circle');
@@ -51,6 +52,7 @@ const Circle: React.FC<CircleProps> = (props) => {
     return undefined;
   }, [gapDegree, type]);
 
+  const percentArray = getPercentage(props);
   const gapPos = gapPosition || (type === 'dashboard' && 'bottom') || undefined;
 
   // using className to style stroke color
@@ -63,10 +65,11 @@ const Circle: React.FC<CircleProps> = (props) => {
 
   const circleContent = (
     <RCCircle
-      percent={getPercentage(props)}
+      steps={steps}
+      percent={steps ? percentArray[1] : percentArray}
       strokeWidth={strokeWidth}
       trailWidth={strokeWidth}
-      strokeColor={strokeColor}
+      strokeColor={steps ? strokeColor[1] : strokeColor}
       strokeLinecap={strokeLinecap}
       trailColor={trailColor}
       prefixCls={prefixCls}

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -633,6 +633,204 @@ exports[`renders components/progress/demo/circle-mini.tsx extend context correct
 </div>
 `;
 
+exports[`renders components/progress/demo/circle-steps.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+  style="flex-wrap: wrap; margin-bottom: -8px;"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right: 8px; padding-bottom: 8px;"
+  >
+    <div
+      aria-valuenow="50"
+      class="ant-progress ant-progress-circle ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+      role="progressbar"
+    >
+      <div
+        class="ant-progress-inner"
+        style="width: 120px; height: 120px; font-size: 24px;"
+      >
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="-50 -50 100 100"
+        >
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(127.5deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(163.125deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(198.74999999999997deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(234.37499999999994deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke: rgba(0, 0, 0, 0.06); stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(269.99999999999994deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke: rgba(0, 0, 0, 0.06); stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(305.625deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke: rgba(0, 0, 0, 0.06); stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(341.24999999999994deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke: rgba(0, 0, 0, 0.06); stroke-dasharray: 198.96753472735355px 251.32741228718345; stroke-dashoffset: 176.09659288643437; transform: rotate(376.87499999999994deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+        </svg>
+        <span
+          class="ant-progress-text"
+          title="50%"
+        >
+          50%
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+    style="padding-bottom: 8px;"
+  >
+    <div
+      aria-valuenow="100"
+      class="ant-progress ant-progress-circle ant-progress-steps ant-progress-status-success ant-progress-show-info ant-progress-default"
+      role="progressbar"
+    >
+      <div
+        class="ant-progress-inner"
+        style="width: 120px; height: 120px; font-size: 24px;"
+      >
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="-50 -50 100 100"
+        >
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 251.32741228718345px 251.32741228718345; stroke-dashoffset: 213.06192982974676; transform: rotate(-90deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 251.32741228718345px 251.32741228718345; stroke-dashoffset: 213.06192982974676; transform: rotate(-18deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 251.32741228718345px 251.32741228718345; stroke-dashoffset: 213.06192982974676; transform: rotate(54deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 251.32741228718345px 251.32741228718345; stroke-dashoffset: 213.06192982974676; transform: rotate(126deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray: 251.32741228718345px 251.32741228718345; stroke-dashoffset: 213.06192982974676; transform: rotate(198deg); transform-origin: 0 0; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+        </svg>
+        <span
+          class="ant-progress-text"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/progress/demo/dashboard.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -609,6 +609,204 @@ exports[`renders components/progress/demo/circle-mini.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/progress/demo/circle-steps.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+  style="flex-wrap:wrap;margin-bottom:-8px"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px;padding-bottom:8px"
+  >
+    <div
+      aria-valuenow="50"
+      class="ant-progress ant-progress-circle ant-progress-steps ant-progress-status-normal ant-progress-show-info ant-progress-default"
+      role="progressbar"
+    >
+      <div
+        class="ant-progress-inner"
+        style="width:120px;height:120px;font-size:24px"
+      >
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="-50 -50 100 100"
+        >
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(127.5deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(163.125deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(198.74999999999997deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(234.37499999999994deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke:rgba(0, 0, 0, 0.06);stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(269.99999999999994deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke:rgba(0, 0, 0, 0.06);stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(305.625deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke:rgba(0, 0, 0, 0.06);stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(341.24999999999994deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke:rgba(0, 0, 0, 0.06);stroke-dasharray:198.96753472735355px 251.32741228718345;stroke-dashoffset:176.09659288643437;transform:rotate(376.87499999999994deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+        </svg>
+        <span
+          class="ant-progress-text"
+          title="50%"
+        >
+          50%
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+    style="padding-bottom:8px"
+  >
+    <div
+      aria-valuenow="100"
+      class="ant-progress ant-progress-circle ant-progress-steps ant-progress-status-success ant-progress-show-info ant-progress-default"
+      role="progressbar"
+    >
+      <div
+        class="ant-progress-inner"
+        style="width:120px;height:120px;font-size:24px"
+      >
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="-50 -50 100 100"
+        >
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:251.32741228718345px 251.32741228718345;stroke-dashoffset:213.06192982974676;transform:rotate(-90deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:251.32741228718345px 251.32741228718345;stroke-dashoffset:213.06192982974676;transform:rotate(-18deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:251.32741228718345px 251.32741228718345;stroke-dashoffset:213.06192982974676;transform:rotate(54deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:251.32741228718345px 251.32741228718345;stroke-dashoffset:213.06192982974676;transform:rotate(126deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="0"
+            cy="0"
+            opacity="1"
+            r="40"
+            stroke-width="20"
+            style="stroke-dasharray:251.32741228718345px 251.32741228718345;stroke-dashoffset:213.06192982974676;transform:rotate(198deg);transform-origin:0 0;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+        </svg>
+        <span
+          class="ant-progress-text"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/progress/demo/circle-steps.md
+++ b/components/progress/demo/circle-steps.md
@@ -1,0 +1,9 @@
+## zh-CN
+
+该模式下`strokeLinecap`强制为`butt`
+
+使用`Math.round()`决定高亮的格子数
+
+## en-US
+
+A circular progress bar.

--- a/components/progress/demo/circle-steps.tsx
+++ b/components/progress/demo/circle-steps.tsx
@@ -1,0 +1,26 @@
+import { Progress, Space } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Space wrap>
+    <Progress
+      type="dashboard"
+      steps={8}
+      percent={50}
+      trailColor="rgba(0, 0, 0, 0.06)"
+      strokeWidth={20}
+    />
+    <Progress
+      type="circle"
+      percent={100}
+      steps={{
+        count: 5,
+        space: 12,
+      }}
+      trailColor="rgba(0, 0, 0, 0.06)"
+      strokeWidth={20}
+    />
+  </Space>
+);
+
+export default App;

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -33,6 +33,7 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 <code src="./demo/linecap.tsx">Stroke Linecap</code>
 <code src="./demo/gradient-line.tsx">Custom line gradient</code>
 <code src="./demo/steps.tsx">Progress bar with steps</code>
+<code src="./demo/circle-steps.tsx">Circular progress bar whit steps</code>
 <code src="./demo/size.tsx">Progress size</code>
 
 ## API
@@ -51,12 +52,12 @@ Properties that shared by all types.
 | trailColor | The color of unfilled part | string | - | - |
 | type | To set the type, options: `line` `circle` `dashboard` | string | `line` |
 | size | Progress size | number \| \[number, number] \| "small" \| "default" | "default" | v5.3.0 |
+| steps | The total step count | number \| { count: number, space: number } | - | object: 5.5.3 |
 
 ### `type="line"`
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| steps | The total step count | number | - | - |
 | strokeColor | The color of progress bar, render `linear-gradient` when passing an object, could accept `string[]` when has `steps`. | string \| string[] \| { from: string; to: string; direction: string } | - | 4.21.0: `string[]` |
 
 ### `type="circle"`

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -34,6 +34,7 @@ demo:
 <code src="./demo/linecap.tsx">边缘形状</code>
 <code src="./demo/gradient-line.tsx">自定义进度条渐变色</code>
 <code src="./demo/steps.tsx">步骤进度条</code>
+<code src="./demo/circle-steps.tsx">步骤进度圈</code>
 <code src="./demo/size.tsx">尺寸</code>
 
 ## API
@@ -52,12 +53,12 @@ demo:
 | trailColor | 未完成的分段的颜色 | string | - | - |
 | type | 类型，可选 `line` `circle` `dashboard` | string | `line` | - |
 | size | 进度条的尺寸 | number \| \[number, number] \| "small" \| "default" | "default" | v5.3.0 |
+| steps | 进度条总共步数 | number \| { count: number, space: number } | - | object: 5.5.3 |
 
 ### `type="line"`
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| steps | 进度条总共步数 | number | - | - |
 | strokeColor | 进度条的色彩，传入 object 时为渐变。当有 `steps` 时支持传入一个数组。 | string \| string[] \| { from: string; to: string; direction: string } | - | 4.21.0: `string[]` |
 
 ### `type="circle"`

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -51,7 +51,7 @@ export interface ProgressProps extends ProgressAriaProps {
   gapDegree?: number;
   gapPosition?: 'top' | 'bottom' | 'left' | 'right';
   size?: number | [number, number] | ProgressSize;
-  steps?: number;
+  steps?: number | { count: number; space: number };
   /** @deprecated Use `success` instead */
   successPercent?: number;
   children?: React.ReactNode;
@@ -131,7 +131,12 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
   // Render progress shape
   if (type === 'line') {
     progress = steps ? (
-      <Steps {...props} strokeColor={strokeColorNotGradient} prefixCls={prefixCls} steps={steps}>
+      <Steps
+        {...props}
+        strokeColor={strokeColorNotGradient}
+        prefixCls={prefixCls}
+        steps={typeof steps === 'object' ? steps.count : steps}
+      >
         {progressInfo}
       </Steps>
     ) : (
@@ -161,7 +166,9 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     prefixCls,
     {
       [`${prefixCls}-inline-circle`]: type === 'circle' && getSize(size, 'circle')[0] <= 20,
-      [`${prefixCls}-${(type === 'dashboard' && 'circle') || (steps && 'steps') || type}`]: true,
+      [`${prefixCls}-${(type === 'dashboard' && 'circle') || type}`]: type !== 'line',
+      [`${prefixCls}-line`]: !steps && type === 'line',
+      [`${prefixCls}-steps`]: steps,
       [`${prefixCls}-status-${progressStatus}`]: true,
       [`${prefixCls}-show-info`]: showInfo,
       [`${prefixCls}-${size}`]: typeof size === 'string',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/35802

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |steps support for circular progress bar           |
| 🇨🇳 Chinese |Progress: circle模式下支持steps           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85b58aa</samp>

This pull request adds a new feature to the `Progress` component, which allows rendering a circular progress bar with steps. It modifies the `steps` prop, updates the documentation and the styles, and adds a demo for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85b58aa</samp>

*  Add the `steps` prop to the `Progress` component, which allows the user to specify the total step count for the circular or linear progress bar. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-8e2505ff307fc9096c36d6e175bde7ef8750d4caaef32c930e809b4483e7a4aaR32), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL54-R54))
*  Modify the `Progress` value or function to render the `Progress` component based on the `steps` prop. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL134-R139), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL164-R171))
*  Modify the `Circle` component to render the `RCCircle` component from the `rc-progress` library with the `steps` prop and the `percentArray` variable, which contains an array of percentages for the progress bar. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-8e2505ff307fc9096c36d6e175bde7ef8750d4caaef32c930e809b4483e7a4aaR55), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-8e2505ff307fc9096c36d6e175bde7ef8750d4caaef32c930e809b4483e7a4aaL66-R72))
*  Add a demo for the circular progress bar with steps in the `components/progress/demo` folder, which renders two examples of the circular progress bar with steps, one with the `dashboard` type and one with the `circle` type. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-be09355126aad10e535669fde2deb475cbdccec0bab2789f53ccd2cd2c2241f6R1-R9), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-11dc9a368d3395b2b72019300e7837ff1d2553e16f1994419704feca9c9420f7R1-R26))
*  Add a code block to the `Examples` section of the English and Chinese documentation for the `Progress` component, which references the demo file for the circular progress bar with steps. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-665865f861f3d35f0b0015cbda87052e798a0cac0c445644036750759eec1d6bR36), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-bc17738f93f52688339916ab8d5ca2963cbef403a143b26a40743c1a83dbd2ffR37))
*  Add a row to the `API` table of the English and Chinese documentation for the `Progress` component, which describes the `steps` prop for the `Progress` component. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-665865f861f3d35f0b0015cbda87052e798a0cac0c445644036750759eec1d6bR55), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-bc17738f93f52688339916ab8d5ca2963cbef403a143b26a40743c1a83dbd2ffR56))
*  Remove a row from the `type="line"` subsection of the `API` table of the English and Chinese documentation for the `Progress` component, which describes the `steps` prop for the `Progress` component, but is redundant since the `steps` prop is now applicable to all types of the `Progress` component. ([link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-665865f861f3d35f0b0015cbda87052e798a0cac0c445644036750759eec1d6bL59), [link](https://github.com/ant-design/ant-design/pull/42815/files?diff=unified&w=0#diff-bc17738f93f52688339916ab8d5ca2963cbef403a143b26a40743c1a83dbd2ffL60))
