### PR TITLE
docs: fix PrevAndNext icons RTL

### DIFF
--- a/.dumi/theme/common/PrevAndNext.tsx
+++ b/.dumi/theme/common/PrevAndNext.tsx
@@ -94,13 +94,16 @@ const flattenMenu = (menuItems: MenuProps['items']): MenuProps['items'] | null =
   return null;
 };
 
-const PrevAndNext: React.FC = () => {
+const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
   const { styles } = useStyle();
 
-  const [menuItems, selectedKey] = useMenu({
-    before: <LeftOutlined className="footer-nav-icon-before" />,
-    after: <RightOutlined className="footer-nav-icon-after" />,
-  });
+  const beforeProps = { className: 'footer-nav-icon-before' };
+  const afterProps = { className: 'footer-nav-icon-after' };
+
+  const before = rtl ? <RightOutlined {...beforeProps} /> : <LeftOutlined {...beforeProps} />;
+  const after = rtl ? <LeftOutlined {...afterProps} /> : <RightOutlined {...afterProps} />;
+
+  const [menuItems, selectedKey] = useMenu({ before, after });
 
   const [prev, next] = useMemo(() => {
     const flatMenu = flattenMenu(menuItems);

--- a/.dumi/theme/common/PrevAndNext.tsx
+++ b/.dumi/theme/common/PrevAndNext.tsx
@@ -100,7 +100,7 @@ const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
   const beforeProps = { className: 'footer-nav-icon-before' };
   const afterProps = { className: 'footer-nav-icon-after' };
 
-  const before = rtl ? <RightOutlined {...beforeProps} /> : <LeftOutlined {...beforeProps} />;
+  const before = rtl ? <LeftOutlined {...beforeProps} /> : <RightOutlined {...beforeProps} />;
   const after = rtl ? <LeftOutlined {...afterProps} /> : <RightOutlined {...afterProps} />;
 
   const [menuItems, selectedKey] = useMenu({ before, after });

--- a/.dumi/theme/common/PrevAndNext.tsx
+++ b/.dumi/theme/common/PrevAndNext.tsx
@@ -101,7 +101,7 @@ const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
   const afterProps = { className: 'footer-nav-icon-after' };
 
   const before = rtl ? <LeftOutlined {...beforeProps} /> : <RightOutlined {...beforeProps} />;
-  const after = rtl ? <LeftOutlined {...afterProps} /> : <RightOutlined {...afterProps} />;
+  const after = rtl ? <RightOutlined {...afterProps} /> : <LeftOutlined {...afterProps} />;
 
   const [menuItems, selectedKey] = useMenu({ before, after });
 

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -303,7 +303,7 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
             />
           )}
         </article>
-        <PrevAndNext />
+        <PrevAndNext rtl={isRTL} />
         <Footer />
       </Col>
     </DemoContext.Provider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect prev and next icons of footer in RTL |
| 🇨🇳 Chinese | 修复在 RTL 时页脚上/下一章图标错误的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23798ed</samp>

This pull request adds support for right-to-left languages in the documentation theme by passing an `rtl` prop to the `PrevAndNext` component and using appropriate icons for navigation. The changes affect the files `.dumi/theme/common/PrevAndNext.tsx` and `.dumi/theme/slots/Content/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23798ed</samp>

*  Add support for right-to-left languages in the documentation theme
  - Pass `rtl` prop to `PrevAndNext` component in `Content` component ([link](https://github.com/ant-design/ant-design/pull/42822/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L306-R306))
  - Use conditional rendering to assign appropriate icons to `before` and `after` props of `useMenu` hook in `PrevAndNext` component ([link](https://github.com/ant-design/ant-design/pull/42822/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L97-R107))
