### PR TITLE
fix: ColorPicker UI in Dark Mode

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -4,6 +4,8 @@ import React, { useMemo, useState } from 'react';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { waitFakeTimer } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import theme from '../../theme';
 import ColorPicker from '../ColorPicker';
 import type { Color } from '../color';
 
@@ -298,5 +300,23 @@ describe('ColorPicker', () => {
     fireEvent.mouseLeave(container.querySelector('.ant-color-picker-trigger')!);
     await waitFakeTimer();
     expect(container.querySelector('.ant-popover-hidden')).toBeTruthy();
+  });
+
+  it('Should work at dark mode', async () => {
+    const { container } = render(
+      <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+        <ColorPicker
+          open
+          presets={[
+            {
+              label: 'test',
+              colors: ['#0000001A'],
+            },
+          ]}
+        />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-color-picker-presets-color-bright')).toBeFalsy();
   });
 });

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -1,10 +1,11 @@
-import { ColorBlock } from '@rc-component/color-picker';
+import { ColorBlock, Color as RcColor } from '@rc-component/color-picker';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import Collapse from '../../collapse';
 import { useLocale } from '../../locale';
+import theme from '../../theme';
 import type { Color } from '../color';
 import type { ColorPickerBaseProps, PresetsItem } from '../interface';
 import { generateColor } from '../util';
@@ -23,16 +24,21 @@ const genPresetColor = (list: PresetsItem[]) =>
     return value;
   });
 
-const isBright = (value: Color) => {
+const isBright = (value: Color, bgColorToken: string) => {
   const { r, g, b, a } = value.toRgb();
+  const hsv = new RcColor(value.toRgbString()).onBackground(bgColorToken).toHsv();
   if (a <= 0.5) {
-    return true;
+    // Adapted to dark mode
+    return hsv.v > 0.5;
   }
   return r * 0.299 + g * 0.587 + b * 0.114 > 192;
 };
 
 const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color, onChange }) => {
   const [locale] = useLocale('ColorPicker');
+  const {
+    token: { colorBgElevated },
+  } = theme.useToken();
   const [presetsValue] = useMergedState(genPresetColor(presets), {
     value: genPresetColor(presets),
     postState: genPresetColor,
@@ -66,7 +72,10 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
                     className={classNames(`${colorPresetsPrefixCls}-color`, {
                       [`${colorPresetsPrefixCls}-color-checked`]:
                         presetColor.toHexString() === color?.toHexString(),
-                      [`${colorPresetsPrefixCls}-color-bright`]: isBright(presetColor),
+                      [`${colorPresetsPrefixCls}-color-bright`]: isBright(
+                        presetColor,
+                        colorBgElevated,
+                      ),
                     })}
                     onClick={() => handleClick(presetColor)}
                   />

--- a/components/color-picker/style/color-block.ts
+++ b/components/color-picker/style/color-block.ts
@@ -1,13 +1,11 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import type { ColorPickerToken } from './index';
 
-const TRANSPARENT_DOT_COLOR = '#EEE';
-
 /**
  * @private Internal usage only
  */
-export const getTransBg = (size: string): CSSObject => ({
-  backgroundImage: `conic-gradient(${TRANSPARENT_DOT_COLOR} 0 25%, transparent 0 50%, ${TRANSPARENT_DOT_COLOR} 0 75%, transparent 0)`,
+export const getTransBg = (size: string, colorFill: string): CSSObject => ({
+  backgroundImage: `conic-gradient(${colorFill} 0 25%, transparent 0 50%, ${colorFill} 0 75%, transparent 0)`,
   backgroundSize: `${size} ${size}`,
 });
 
@@ -21,7 +19,7 @@ const genColorBlockStyle = (token: ColorPickerToken, size: number): CSSObject =>
       width: size,
       height: size,
       boxShadow: colorPickerInsetShadow,
-      ...getTransBg('50%'),
+      ...getTransBg('50%', token.colorFillSecondary),
       [`${componentCls}-color-block-inner`]: {
         width: '100%',
         height: '100%',

--- a/components/color-picker/style/picker.ts
+++ b/components/color-picker/style/picker.ts
@@ -58,7 +58,7 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         borderRadius: colorPickerSliderHeight / 2,
         boxShadow: colorPickerInsetShadow,
       },
-      '&-alpha': getTransBg(`${colorPickerSliderHeight}px`),
+      '&-alpha': getTransBg(`${colorPickerSliderHeight}px`, token.colorFillSecondary),
       marginBottom: marginSM,
     },
 

--- a/components/color-picker/style/presets.ts
+++ b/components/color-picker/style/presets.ts
@@ -16,7 +16,6 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
     borderRadius,
     colorFill,
     colorWhite,
-    colorTextTertiary,
     marginXXS,
     paddingXS,
   } = token;
@@ -74,7 +73,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
             boxSizing: 'border-box',
             position: 'absolute',
             top: '50%',
-            insetInlineStart: '21.5%',
+            insetInlineStart: '22.5%',
             display: 'table',
             width: (colorPickerPresetColorSize / 13) * 5,
             height: (colorPickerPresetColorSize / 13) * 8,
@@ -96,7 +95,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
             },
             [`&${componentCls}-presets-color-bright`]: {
               '&::after': {
-                borderColor: colorTextTertiary,
+                borderColor: 'rgba(0, 0, 0, 0.45)',
               },
             },
           },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
Before：
![image](https://github.com/ant-design/ant-design/assets/21119589/fd9b6ac6-bf47-47e9-834c-36cc024dd105)
After: 
![image](https://github.com/ant-design/ant-design/assets/21119589/0a9bb503-c503-4649-be20-a8a374f13fbf)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix the problem of abnormal style of color selector in dark mode       |
| 🇨🇳 Chinese |    修复在暗黑模式下颜色选择器的样式异常的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85a6607</samp>

Improved the color picker component's contrast and visibility in different color themes. Adjusted the color values of the presets based on the `theme` module and the `colorFillSecondary` token. Refactored and moved some style functions and removed unused code.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85a6607</samp>

* Import `Color` type from `@rc-component/color-picker` as `RcColor` and `theme` module in `ColorPresets.tsx` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L1-R1),[link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822R8))
* Modify `isBright` function to take `bgColorToken` parameter and use `onBackground` method from `RcColor` to adjust color value based on background color in `ColorPresets.tsx` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L26-R32))
* Destructure `colorBgElevated` theme token from `useToken` hook and pass it to `isBright` function in `ColorPresets.tsx` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822R39-R41))
* Update `isBright` function call to include `colorBgElevated` parameter in `ColorPresets.tsx` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L69-R78))
* Move `getTransBg` function from `color-block.ts` to `ColorPresets.tsx` and modify it to take `colorFill` parameter for the fill color of the transparent dots ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL4-R8))
* Update `getTransBg` function call to include `colorFillSecondary` theme token as `colorFill` parameter in `color-block.ts` and `picker.ts` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL24-R22),[link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L61-R61))
* Adjust `insetInlineStart` property of the `&-color-checked::after` selector to align the check mark icon with the center of the color preset in `presets.ts` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L77-R76))
* Change `borderColor` property of the `&-color-bright::after` selector from `colorTextTertiary` to `rgba(0, 0, 0, 0.45)` to make the check mark icon more visible on bright colors in `presets.ts` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L99-R98))
* Remove unused `colorTextTertiary` theme token from `genPresetsStyle` function in `presets.ts` ([link](https://github.com/ant-design/ant-design/pull/42827/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L19))
