### PR TITLE
fix: use colorTextHeading

### DIFF
--- a/components/alert/style/index.ts
+++ b/components/alert/style/index.ts
@@ -1,7 +1,7 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { resetComponent } from '../../style';
 
 export interface ComponentToken {}
 
@@ -41,6 +41,7 @@ export const genBaseStyle: GenerateStyle<AlertToken> = (token: AlertToken): CSSO
     alertPaddingHorizontal,
     paddingMD,
     paddingContentHorizontalLG,
+    colorTextHeading,
   } = token;
 
   return {
@@ -108,7 +109,7 @@ export const genBaseStyle: GenerateStyle<AlertToken> = (token: AlertToken): CSSO
       [`${componentCls}-message`]: {
         display: 'block',
         marginBottom: marginXS,
-        color: colorText,
+        color: colorTextHeading,
         fontSize: fontSizeLG,
       },
 

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -45,6 +45,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
     lineHeight,
     width,
     notificationIconSize,
+    colorText,
   } = token;
 
   const noticeCls = `${componentCls}-notice`;
@@ -111,6 +112,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 
     [`${noticeCls}-description`]: {
       fontSize,
+      color: colorText,
     },
 
     [`&${noticeCls}-closable ${noticeCls}-message`]: {

--- a/components/popconfirm/style/index.tsx
+++ b/components/popconfirm/style/index.tsx
@@ -19,6 +19,7 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
     marginXS,
     fontSize,
     fontWeightStrong,
+    colorTextHeading,
   } = token;
 
   return {
@@ -41,6 +42,7 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
 
         [`${componentCls}-title`]: {
           fontWeight: fontWeightStrong,
+          color: colorTextHeading,
 
           '&:only-child': {
             fontWeight: 'normal',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Popconfirm, Alert and Notification that `colorTextHeading` and `colorText` usage.        |
| 🇨🇳 Chinese |     修复 Popconfirm、Alert 和 Notification 组件 `colorTextHeading` 和 `colorText` 误用问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f38f59a</samp>

Added a new feature to allow customizing the popconfirm heading text color. Modified `components/popconfirm/style/index.tsx` to use a theme property for the text color.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f38f59a</samp>

*  Add `colorTextHeading` variable to `genBaseStyle` function to store user-defined color for popconfirm heading text ([link](https://github.com/ant-design/ant-design/pull/42839/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66R22))
*  Apply `colorTextHeading` variable to `.ant-popover-inner-title` class to customize popconfirm heading color ([link](https://github.com/ant-design/ant-design/pull/42839/files?diff=unified&w=0#diff-a6dc7f42c927c99f13026e3643a664c670f818173ebe7b5bc7e98571abc1ea66R45))
