### PR TITLE
refactor: solve modal circular dependency issue

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -7,8 +7,8 @@ import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { NoFormStyle } from '../form/context';
 import { NoCompactStyle } from '../space/Compact';
-import { Footer, renderCloseIcon } from './PurePanel';
 import type { ModalProps, MousePosition } from './interface';
+import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
 
 let mousePosition: MousePosition;

--- a/components/modal/PurePanel.tsx
+++ b/components/modal/PurePanel.tsx
@@ -1,16 +1,13 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
+
 import classNames from 'classnames';
 import { Panel } from 'rc-dialog';
 import type { PanelProps } from 'rc-dialog/lib/Dialog/Content/Panel';
 import * as React from 'react';
-import Button from '../button';
-import { convertLegacyProps } from '../button/button';
 import { ConfigContext } from '../config-provider';
-import { useLocale } from '../locale';
 import { ConfirmContent } from './ConfirmDialog';
-import type { ModalFuncProps, ModalProps } from './interface';
-import { getConfirmLocale } from './locale';
+import type { ModalFuncProps } from './interface';
+import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
 
 export interface PurePanelProps
@@ -19,62 +16,6 @@ export interface PurePanelProps
   prefixCls?: string;
   style?: React.CSSProperties;
 }
-
-export function renderCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) {
-  return (
-    <span className={`${prefixCls}-close-x`}>
-      {closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
-    </span>
-  );
-}
-
-interface FooterProps {
-  onOk?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
-  onCancel?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
-}
-
-export const Footer: React.FC<
-  FooterProps &
-    Pick<
-      ModalProps,
-      | 'footer'
-      | 'okText'
-      | 'okType'
-      | 'cancelText'
-      | 'confirmLoading'
-      | 'okButtonProps'
-      | 'cancelButtonProps'
-    >
-> = (props) => {
-  const {
-    okText,
-    okType = 'primary',
-    cancelText,
-    confirmLoading,
-    onOk,
-    onCancel,
-    okButtonProps,
-    cancelButtonProps,
-  } = props;
-
-  const [locale] = useLocale('Modal', getConfirmLocale());
-
-  return (
-    <>
-      <Button onClick={onCancel} {...cancelButtonProps}>
-        {cancelText || locale?.cancelText}
-      </Button>
-      <Button
-        {...convertLegacyProps(okType)}
-        loading={confirmLoading}
-        onClick={onOk}
-        {...okButtonProps}
-      >
-        {okText || locale?.okText}
-      </Button>
-    </>
-  );
-};
 
 const PurePanel: React.FC<PurePanelProps> = (props) => {
   const {

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -1,0 +1,63 @@
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import React from 'react';
+import Button from '../button';
+import { convertLegacyProps } from '../button/button';
+import { useLocale } from '../locale';
+import type { ModalProps } from './interface';
+import { getConfirmLocale } from './locale';
+
+export function renderCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) {
+  return (
+    <span className={`${prefixCls}-close-x`}>
+      {closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
+    </span>
+  );
+}
+
+interface FooterProps {
+  onOk?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+  onCancel?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+}
+
+export const Footer: React.FC<
+  FooterProps &
+    Pick<
+      ModalProps,
+      | 'footer'
+      | 'okText'
+      | 'okType'
+      | 'cancelText'
+      | 'confirmLoading'
+      | 'okButtonProps'
+      | 'cancelButtonProps'
+    >
+> = (props) => {
+  const {
+    okText,
+    okType = 'primary',
+    cancelText,
+    confirmLoading,
+    onOk,
+    onCancel,
+    okButtonProps,
+    cancelButtonProps,
+  } = props;
+
+  const [locale] = useLocale('Modal', getConfirmLocale());
+
+  return (
+    <>
+      <Button onClick={onCancel} {...cancelButtonProps}>
+        {cancelText || locale?.cancelText}
+      </Button>
+      <Button
+        {...convertLegacyProps(okType)}
+        loading={confirmLoading}
+        onClick={onOk}
+        {...okButtonProps}
+      >
+        {okText || locale?.okText}
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [X] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/pull/42750

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

solve modal circular dependency issue
- (undefined) Circular dependency detected:
components/modal/ConfirmDialog.tsx -> components/modal/Modal.tsx -> components/modal/PurePanel.tsx -> components/modal/ConfirmDialog.tsx
- (undefined) Circular dependency detected:
components/modal/Modal.tsx -> components/modal/PurePanel.tsx -> components/modal/ConfirmDialog.tsx -> components/modal/Modal.tsx
- (undefined) Circular dependency detected:
components/modal/PurePanel.tsx -> components/modal/ConfirmDialog.tsx -> components/modal/Modal.tsx -> components/modal/PurePanel.tsx

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | solve modal circular dependency issue |
| 🇨🇳 Chinese | 解决弹窗组件循环依赖问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c0ae79</samp>

Renamed and refactored modal components to improve code structure and reusability. Moved `renderCloseIcon` and `Footer` to `shared.tsx` and renamed `PurePanel.tsx` to `Modal.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c0ae79</samp>

*  Rename `components/modal/PurePanel.tsx` to `components/modal/Modal.tsx` and remove unused imports ([link](https://github.com/ant-design/ant-design/pull/42841/files?diff=unified&w=0#diff-9103d37c6668043c170813d54cb43ca28bc6cf111eedfc6718aeae7f540a0b27L2-R10))
*  Move `renderCloseIcon` and `Footer` components from `Modal.tsx` to a new file `components/modal/shared.tsx` to avoid duplication and improve code organization ([link](https://github.com/ant-design/ant-design/pull/42841/files?diff=unified&w=0#diff-9103d37c6668043c170813d54cb43ca28bc6cf111eedfc6718aeae7f540a0b27L23-L78), [link](https://github.com/ant-design/ant-design/pull/42841/files?diff=unified&w=0#diff-28fe880db90aca35d37607b3087393a1815128428f281a9a8394d5dc34475371R1-R63))
*  Update the import of `renderCloseIcon` and `Footer` in `Modal.tsx` to use `shared.tsx` instead of `PurePanel.tsx` ([link](https://github.com/ant-design/ant-design/pull/42841/files?diff=unified&w=0#diff-a3edcd43b644d0539a67f65e68ba30d6acb77a12531a6a71d1e26a008a9d752cL10-R11))
