### PR TITLE
docs: update docs about getContainer

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -48,7 +48,7 @@ Previewable image.
 {
   visible?: boolean;
   onVisibleChange?: (visible, prevVisible, current: number) => void; // `current` only support after v5.3.0
-  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0
+  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0 The mounted node for preview dialog but still display at fullScreen
   src?: string; // v4.10.0
   mask?: ReactNode; // v4.9.0
   maskClassName?: string; // v4.11.0

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -49,7 +49,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 {
   visible?: boolean;
   onVisibleChange?: (visible, prevVisible, current: number) => void; // current 参数 v5.3.0 后支持
-  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0
+  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0 指定预览窗口挂载的节点，但依旧为全屏展示
   src?: string; // v4.10.0
   mask?: ReactNode; // v4.9.0
   maskClassName?: string; // v4.11.0

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -103,7 +103,7 @@ message.config({
 | Argument | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | duration | Time before auto-dismiss, in seconds | number | 3 |  |
-| getContainer | Return the mount node for Message | () => HTMLElement | () => document.body |  |
+| getContainer | Return the mount node for Message, but still display at fullScreen | () => HTMLElement | () => document.body |  |
 | maxCount | Max message show, drop oldest if exceed limit | number | - |  |
 | prefixCls | The prefix className of message node | string | `ant-message` | 4.5.0 |
 | rtl | Whether to enable RTL mode | boolean | false |  |

--- a/components/message/index.zh-CN.md
+++ b/components/message/index.zh-CN.md
@@ -104,7 +104,7 @@ message.config({
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | duration | 默认自动关闭延时，单位秒 | number | 3 |  |
-| getContainer | 配置渲染节点的输出位置 | () => HTMLElement | () => document.body |  |
+| getContainer | 配置渲染节点的输出位置，但依旧为全屏展示 | () => HTMLElement | () => document.body |  |
 | maxCount | 最大显示数, 超过限制时，最早的消息会被自动关闭 | number | - |  |
 | prefixCls | 消息节点的 className 前缀 | string | `ant-message` | 4.5.0 |
 | rtl | 是否开启 RTL 模式 | boolean | false |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -55,7 +55,7 @@ demo:
 | focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true | 4.9.0 |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |  |
 | forceRender | 强制渲染 Modal | boolean | false |  |
-| getContainer | 指定 Modal 挂载的节点，但依旧为全局展示，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
+| getContainer | 指定 Modal 挂载的节点，但依旧为全屏展示，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
 | mask | 是否展示遮罩 | boolean | true |  |
 | maskClosable | 点击蒙层是否允许关闭 | boolean | true |  |

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -69,7 +69,7 @@ The properties of config are as follows:
 | --- | --- | --- | --- | --- |
 | bottom | Distance from the bottom of the viewport, when `placement` is `bottomRight` or `bottomLeft` (unit: pixels) | number | 24 |  |
 | closeIcon | Custom close icon | ReactNode | - |  |
-| getContainer | Return the mount node for Notification | () => HTMLNode | () => document.body |  |
+| getContainer | Return the mount node for Notification, but still display at fullScreen | () => HTMLNode | () => document.body |  |
 | placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |  |
 | rtl | Whether to enable RTL mode | boolean | false |  |
 | top | Distance from the top of the viewport, when `placement` is `topRight` or `topLeft` (unit: pixels) | number | 24 |  |
@@ -101,7 +101,7 @@ notification.config({
 | bottom | Distance from the bottom of the viewport, when `placement` is `bottomRight` or `bottomLeft` (unit: pixels) | number | 24 |  |
 | closeIcon | Custom close icon | ReactNode | - |  |
 | duration | Time in seconds before Notification is closed. When set to 0 or null, it will never be closed automatically | number | 4.5 |  |
-| getContainer | Return the mount node for Notification | () => HTMLNode | () => document.body |  |
+| getContainer | Return the mount node for Notification, but still display at fullScreen | () => HTMLNode | () => document.body |  |
 | placement | Position of Notification, can be one of `topLeft` `topRight` `bottomLeft` `bottomRight` | string | `topRight` |  |
 | rtl | Whether to enable RTL mode | boolean | false |  |
 | top | Distance from the top of the viewport, when `placement` is `topRight` or `topLeft` (unit: pixels) | number | 24 |  |

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -46,7 +46,7 @@ demo:
 config 参数如下：
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | btn | 自定义关闭按钮 | ReactNode | - | - |
 | className | 自定义 CSS class | string | - | - |
 | closeIcon | 自定义关闭图标 | ReactNode | - | - |
@@ -70,7 +70,7 @@ config 参数如下：
 | --- | --- | --- | --- | --- |
 | bottom | 消息从底部弹出时，距离底部的位置，单位像素 | number | 24 |  |
 | closeIcon | 自定义关闭图标 | ReactNode | - |  |
-| getContainer | 配置渲染节点的输出位置 | () => HTMLNode | () => document.body |  |
+| getContainer | 配置渲染节点的输出位置，但依旧为全屏展示 | () => HTMLNode | () => document.body |  |
 | placement | 弹出位置，可选 `top` `topLeft` `topRight` `bottom` `bottomLeft` `bottomRight` | string | `topRight` |  |
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |  |
@@ -102,7 +102,7 @@ notification.config({
 | bottom | 消息从底部弹出时，距离底部的位置，单位像素 | number | 24 |  |
 | closeIcon | 自定义关闭图标 | ReactNode | - |  |
 | duration | 默认自动关闭延时，单位秒 | number | 4.5 |  |
-| getContainer | 配置渲染节点的输出位置 | () => HTMLNode | () => document.body |  |
+| getContainer | 配置渲染节点的输出位置，但依旧为全屏展示 | () => HTMLNode | () => document.body |  |
 | placement | 弹出位置，可选 `top` `topLeft` `topRight` `bottom` `bottomLeft` `bottomRight` | string | `topRight` |  |
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- update docs about getContainer

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update docs about getContainer |
| 🇨🇳 Chinese | 更新 getContainer 相关文档  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d65840</samp>

This pull request improves the documentation of the `getContainer` property for the Image, Message, Modal, and Notification components in both English and Chinese. It adds comments to the relevant files to explain that the property returns the mount node for the component, but does not affect its full-screen display.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d65840</samp>

*  Add comments to the `getContainer` property of various components to clarify that they still display at fullScreen ([link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L51-R51), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281L52-R52), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-de241cebff0141f80c65af1345bdfcebc23897cd4d0380161a09234079605dcbL106-R106), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-e806e8697391b559d536849650f46fe5e8368556ed033816ed2a8587675c9cb3L107-R107), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L58-R58), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-9b1700ccbd4da0f60742ae024592c27e0118d7307f5a9ed69a91c560c374749fL72-R72), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-9b1700ccbd4da0f60742ae024592c27e0118d7307f5a9ed69a91c560c374749fL104-R104), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-9954e364a4a4121f77d3f9f87225ef361d39c004720443dd896bb31cfe3c6d22L73-R73), [link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-9954e364a4a4121f77d3f9f87225ef361d39c004720443dd896bb31cfe3c6d22L105-R105))
* Fix a missing column separator in the table header of the `API` interface in the `components/notification/index.zh-CN.md` file ([link](https://github.com/ant-design/ant-design/pull/42885/files?diff=unified&w=0#diff-9954e364a4a4121f77d3f9f87225ef361d39c004720443dd896bb31cfe3c6d22L49-R49))
