### PR TITLE
fix(Drawer): add max width to prevent width overflow for small screens

### DIFF
--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -79,7 +79,7 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
       [wrapperCls]: {
         position: 'absolute',
         zIndex: zIndexPopup,
-        maxWidth: '100%',
+        maxWidth: '100vw',
         transition: `all ${motionDurationSlow}`,
 
         '&-hidden': {

--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -79,6 +79,7 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
       [wrapperCls]: {
         position: 'absolute',
         zIndex: zIndexPopup,
+        maxWidth: '100%',
         transition: `all ${motionDurationSlow}`,
 
         '&-hidden': {


### PR DESCRIPTION
### 💡 Background and solution
`<Drawer />` component like `<Modal />` accepts width, however unlike modal it does not have `max-width` for cases when screen width is lower than drawer width.
![ezgif-1-6749806e42](https://github.com/ant-design/ant-design/assets/64708228/09fddc5a-2429-4c77-8a38-10c22eb41a17)

This pull request set the `max-width` to `100%` for drawer wrapper in drawer styles file.

The result will be:
![Screenshot from 2023-06-07 23-52-13](https://github.com/ant-design/ant-design/assets/64708228/c5a3624a-3221-449c-8e46-ce3004eb7efd)


<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00d404b</samp>

Fix drawer overflow bug on small devices by adding `maxWidth` to drawer style. Update `components/drawer/style/index.ts` to implement this change.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00d404b</samp>

* Add `maxWidth` property to drawer style to prevent overflow on small screens ([link](https://github.com/ant-design/ant-design/pull/42914/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3R82))
