### PR TITLE
fix(Button): button's children should be disabled when button is disabled

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -336,12 +336,9 @@ describe('Button', () => {
   });
 
   it("should prevent children's event when button is disabled", () => {
-    const onClick = jest.fn();
     const { container } = render(
       <Button disabled>
-        <a id="link" onClick={onClick}>
-          test
-        </a>
+        <a id="link">test</a>
       </Button>,
     );
     expect(window.getComputedStyle(container.querySelector('#link')!).pointerEvents).toBe('none');

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -334,4 +334,16 @@ describe('Button', () => {
     );
     expect(wrapper.container.firstChild).toMatchSnapshot();
   });
+
+  it("should prevent children's event when button is disabled", () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Button disabled>
+        <a id="link" onClick={onClick}>
+          test
+        </a>
+      </Button>,
+    );
+    expect(window.getComputedStyle(container.querySelector('#link')!).pointerEvents).toBe('none');
+  });
 });

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -38,6 +38,10 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
       lineHeight: token.lineHeight,
       color: token.colorText,
 
+      '&:disabled > *': {
+        pointerEvents: 'none',
+      },
+
       '> span': {
         display: 'inline-block',
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #42948
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- button's children should be disabled when button is disabled

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | button's children should be disabled when button is disabled |
| 🇨🇳 Chinese | 当按钮被禁用时，子节点也应该被禁用 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 608fdc6</samp>

Fix loading icon bug on disabled buttons by disabling pointer events on button children. Update `components/button/style/index.ts` with the new CSS rule.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 608fdc6</samp>

* Disable pointer events on children of disabled buttons to prevent hover or click effects ([link](https://github.com/ant-design/ant-design/pull/42949/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R41-R44))
