### PR TITLE
refactor(Alert): refactor closeIcon

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -576,31 +576,6 @@ exports[`renders components/alert/demo/closable.tsx extend context correctly 1`]
 </div>
 `;
 
-exports[`renders components/alert/demo/close-text.tsx extend context correctly 1`] = `
-<div
-  class="ant-alert ant-alert-info ant-alert-no-icon"
-  data-show="true"
-  role="alert"
->
-  <div
-    class="ant-alert-content"
-  >
-    <div
-      class="ant-alert-message"
-    >
-      Info Text
-    </div>
-  </div>
-  <button
-    class="ant-alert-close-icon"
-    tabindex="0"
-    type="button"
-  >
-    Close Now
-  </button>
-</div>
-`;
-
 exports[`renders components/alert/demo/custom-icon.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -596,11 +596,7 @@ exports[`renders components/alert/demo/close-text.tsx extend context correctly 1
     tabindex="0"
     type="button"
   >
-    <span
-      class="ant-alert-close-text"
-    >
-      Close Now
-    </span>
+    Close Now
   </button>
 </div>
 `;

--- a/components/alert/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.ts.snap
@@ -576,31 +576,6 @@ exports[`renders components/alert/demo/closable.tsx correctly 1`] = `
 </div>
 `;
 
-exports[`renders components/alert/demo/close-text.tsx correctly 1`] = `
-<div
-  class="ant-alert ant-alert-info ant-alert-no-icon"
-  data-show="true"
-  role="alert"
->
-  <div
-    class="ant-alert-content"
-  >
-    <div
-      class="ant-alert-message"
-    >
-      Info Text
-    </div>
-  </div>
-  <button
-    class="ant-alert-close-icon"
-    tabindex="0"
-    type="button"
-  >
-    Close Now
-  </button>
-</div>
-`;
-
 exports[`renders components/alert/demo/custom-icon.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/alert/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.ts.snap
@@ -596,11 +596,7 @@ exports[`renders components/alert/demo/close-text.tsx correctly 1`] = `
     tabindex="0"
     type="button"
   >
-    <span
-      class="ant-alert-close-text"
-    >
-      Close Now
-    </span>
+    Close Now
   </button>
 </div>
 `;

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -156,11 +156,13 @@ describe('Alert', () => {
   it('should warning when using closeText', () => {
     const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    render(<Alert closeText="close" />);
+    const { container } = render(<Alert closeText="close" />);
 
     expect(warnSpy).toHaveBeenCalledWith(
       `Warning: [antd: Alert] \`closeText\` is deprecated. Please use \`closeIcon\` instead.`,
     );
+
+    expect(container.querySelector('.ant-alert-close-icon')?.textContent).toBe('close');
 
     warnSpy.mockRestore();
   });

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event';
+import { resetWarned } from 'rc-util/lib/warning';
 import React from 'react';
 import Alert from '..';
 import accessibilityTest from '../../../tests/shared/accessibilityTest';
@@ -144,16 +145,17 @@ describe('Alert', () => {
 
   it('close button should be hidden when closeIcon setting to null or false', () => {
     const { container, rerender } = render(<Alert closeIcon={null} />);
-    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+    expect(container.querySelector('.ant-alert-close-icon')).toBeFalsy();
     rerender(<Alert closeIcon={false} />);
-    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+    expect(container.querySelector('.ant-alert-close-icon')).toBeFalsy();
     rerender(<Alert closeIcon />);
-    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(1);
+    expect(container.querySelector('.ant-alert-close-icon')).toBeTruthy();
     rerender(<Alert />);
-    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+    expect(container.querySelector('.ant-alert-close-icon')).toBeFalsy();
   });
 
   it('should warning when using closeText', () => {
+    resetWarned();
     const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const { container } = render(<Alert closeText="close" />);

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -141,4 +141,27 @@ describe('Alert', () => {
     const { container } = render(<Alert description="description" />);
     expect(!!container.querySelector('.ant-alert-message')).toBe(false);
   });
+
+  it('close button should be hidden when closeIcon setting to null or false', () => {
+    const { container, rerender } = render(<Alert closeIcon={null} />);
+    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+    rerender(<Alert closeIcon={false} />);
+    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+    rerender(<Alert closeIcon />);
+    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(1);
+    rerender(<Alert />);
+    expect(container.querySelectorAll('.ant-alert-close-icon').length).toBe(0);
+  });
+
+  it('should warning when using closeText', () => {
+    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Alert closeText="close" />);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Warning: [antd: Alert] \`closeText\` is deprecated. Please use \`closeIcon\` instead.`,
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/components/alert/demo/closable.tsx
+++ b/components/alert/demo/closable.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Alert, Space } from 'antd';
+import React from 'react';
 
 const onClose = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
   console.log(e, 'I was closed.');
@@ -10,14 +10,14 @@ const App: React.FC = () => (
     <Alert
       message="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
       type="warning"
-      closable
+      closeIcon
       onClose={onClose}
     />
     <Alert
       message="Error Text"
       description="Error Description Error Description Error Description Error Description Error Description Error Description"
       type="error"
-      closable
+      closeIcon
       onClose={onClose}
     />
   </Space>

--- a/components/alert/demo/close-text.md
+++ b/components/alert/demo/close-text.md
@@ -1,7 +1,0 @@
-## zh-CN
-
-可以自定义关闭，自定义的文字会替换原先的关闭 `Icon`。
-
-## en-US
-
-Replace the default icon with customized text.

--- a/components/alert/demo/close-text.tsx
+++ b/components/alert/demo/close-text.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { Alert } from 'antd';
+import React from 'react';
 
-const App: React.FC = () => <Alert message="Info Text" type="info" closeText="Close Now" />;
+const App: React.FC = () => <Alert message="Info Text" type="info" closeIcon="Close Now" />;
 
 export default App;

--- a/components/alert/demo/close-text.tsx
+++ b/components/alert/demo/close-text.tsx
@@ -1,6 +1,0 @@
-import { Alert } from 'antd';
-import React from 'react';
-
-const App: React.FC = () => <Alert message="Info Text" type="info" closeIcon="Close Now" />;
-
-export default App;

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -40,7 +40,7 @@ Alert component for feedback.
 | action | The action of Alert | ReactNode | - | 4.9.0 |
 | afterClose | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closeText | Close text to show, deprecated when >= 5.7.0 | ReactNode | - |  |
+| closeText | Close text to show, deprecated when >= 5.7.0, use `closeIcon` instead. | ReactNode | - |  |
 | closeIcon | Custom close icon | boolean \| ReactNode | `<CloseOutlined />` | 5.7.0: close button will be hidden when setting to null or false |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -25,7 +25,6 @@ Alert component for feedback.
 <code src="./demo/closable.tsx">Closable</code>
 <code src="./demo/description.tsx">Description</code>
 <code src="./demo/icon.tsx">Icon</code>
-<code src="./demo/close-text.tsx">Customized Close Text</code>
 <code src="./demo/banner.tsx" iframe="250">Banner</code>
 <code src="./demo/loop-banner.tsx">Loop Banner</code>
 <code src="./demo/smooth-closed.tsx">Smoothly Unmount</code>

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -40,8 +40,7 @@ Alert component for feedback.
 | action | The action of Alert | ReactNode | - | 4.9.0 |
 | afterClose | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closeText | Close text to show, deprecated when >= 5.7.0, use `closeIcon` instead. | ReactNode | - |  |
-| closeIcon | Custom close icon | boolean \| ReactNode | `<CloseOutlined />` | 5.7.0: close button will be hidden when setting to null or false |
+| closeIcon | Custom close icon, >=5.7.0: close button will be hidden when setting to null or false | boolean \| ReactNode | `<CloseOutlined />` |  |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
 | message | Content of Alert | ReactNode | - |  |

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -40,9 +40,8 @@ Alert component for feedback.
 | action | The action of Alert | ReactNode | - | 4.9.0 |
 | afterClose | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closable | Whether Alert can be closed | boolean | - |  |
-| closeText | Close text to show | ReactNode | - |  |
-| closeIcon | Custom close icon | ReactNode | `<CloseOutlined />` | 4.18.0 |
+| closeText | Close text to show, deprecated when >= 5.7.0 | ReactNode | - |  |
+| closeIcon | Custom close icon | boolean \| ReactNode | `<CloseOutlined />` | 5.7.0: close button will be hidden when setting to null or false |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
 | message | Content of Alert | ReactNode | - |  |

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -39,7 +39,7 @@ Alert component for feedback.
 | action | The action of Alert | ReactNode | - | 4.9.0 |
 | afterClose | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closeIcon | Custom close icon, >=5.7.0: close button will be hidden when setting to null or false | boolean \| ReactNode | `<CloseOutlined />` |  |
+| closeIcon | Custom close icon, >=5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | `<CloseOutlined />` |  |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
 | message | Content of Alert | ReactNode | - |  |

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -219,7 +219,7 @@ const Alert: CompoundedComponent = ({
           <CloseIcon
             isClosable={!!isClosable}
             prefixCls={prefixCls}
-            closeIcon={closeIcon ?? closeText}
+            closeIcon={closeText || closeIcon}
             handleClose={handleClose}
           />
         </div>

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -217,7 +217,7 @@ const Alert: CompoundedComponent = ({
           </div>
           {action ? <div className={`${prefixCls}-action`}>{action}</div> : null}
           <CloseIcon
-            isClosable={!!isClosable}
+            isClosable={isClosable}
             prefixCls={prefixCls}
             closeIcon={closeText || closeIcon}
             handleClose={handleClose}

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -153,7 +153,7 @@ const Alert: CompoundedComponent = ({
     if (typeof closable === 'boolean') {
       return closable;
     }
-    return closeIcon !== null;
+    return closeIcon !== null && closeIcon !== undefined;
   }, [closeText, closeIcon, closable]);
 
   const type = getType();

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -153,7 +153,7 @@ const Alert: CompoundedComponent = ({
     if (typeof closable === 'boolean') {
       return closable;
     }
-    return !!closeIcon;
+    return closeIcon !== null;
   }, [closeText, closeIcon, closable]);
 
   const type = getType();

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -150,8 +150,8 @@ const Alert: CompoundedComponent = ({
     if (closeText) {
       return true;
     }
-    if (closable) {
-      return true;
+    if (typeof closable === 'boolean') {
+      return closable;
     }
     return !!closeIcon;
   }, [closeText, closeIcon, closable]);

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -116,7 +116,7 @@ const Alert: CompoundedComponent = ({
   showIcon,
   closable,
   closeText,
-  closeIcon: oriCloseIcon,
+  closeIcon,
   action,
   ...props
 }) => {
@@ -143,8 +143,6 @@ const Alert: CompoundedComponent = ({
     return banner ? 'warning' : 'info';
   };
 
-  const closeIcon = oriCloseIcon !== null && oriCloseIcon !== false ? oriCloseIcon : null;
-
   // closeable when closeText or closeIcon is assigned
   const isClosable = React.useMemo(() => {
     if (closeText) {
@@ -153,7 +151,8 @@ const Alert: CompoundedComponent = ({
     if (typeof closable === 'boolean') {
       return closable;
     }
-    return closeIcon !== null && closeIcon !== undefined;
+    // should be true when closeIcon is 0 or ''
+    return closeIcon !== false && closeIcon !== null && closeIcon !== undefined;
   }, [closeText, closeIcon, closable]);
 
   const type = getType();

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -121,7 +121,9 @@ const Alert: CompoundedComponent = ({
   ...props
 }) => {
   const [closed, setClosed] = React.useState(false);
-  warning(!closeText, 'Alert', '`closeText` is deprecated. Please use `closeIcon` instead.');
+  if (process.env.NODE_ENV !== 'production') {
+    warning(!closeText, 'Alert', '`closeText` is deprecated. Please use `closeIcon` instead.');
+  }
   const ref = React.useRef<HTMLDivElement>(null);
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('alert', customizePrefixCls);
@@ -144,7 +146,16 @@ const Alert: CompoundedComponent = ({
   const closeIcon = oriCloseIcon !== null && oriCloseIcon !== false ? oriCloseIcon : null;
 
   // closeable when closeText or closeIcon is assigned
-  const isClosable = closeText || closeIcon || closable;
+  const isClosable = React.useMemo(() => {
+    if (closeText) {
+      return true;
+    }
+    if (closable) {
+      return true;
+    }
+    return !!closeIcon;
+  }, [closeText, closeIcon, closable]);
+
   const type = getType();
 
   // banner mode defaults to Icon

--- a/components/alert/index.tsx
+++ b/components/alert/index.tsx
@@ -87,10 +87,12 @@ interface CloseIconProps {
 }
 
 const CloseIcon: React.FC<CloseIconProps> = (props) => {
-  const { isClosable, prefixCls, closeIcon = <CloseOutlined />, handleClose } = props;
+  const { isClosable, prefixCls, closeIcon, handleClose } = props;
+  const mergedCloseIcon =
+    closeIcon === true || closeIcon === undefined ? <CloseOutlined /> : closeIcon;
   return isClosable ? (
     <button type="button" onClick={handleClose} className={`${prefixCls}-close-icon`} tabIndex={0}>
-      {closeIcon === true ? <CloseOutlined /> : closeIcon}
+      {mergedCloseIcon}
     </button>
   ) : null;
 };
@@ -142,7 +144,7 @@ const Alert: CompoundedComponent = ({
   const closeIcon = oriCloseIcon !== null && oriCloseIcon !== false ? oriCloseIcon : null;
 
   // closeable when closeText or closeIcon is assigned
-  const isClosable = closeIcon || closeText || closable;
+  const isClosable = closeText || closeIcon || closable;
   const type = getType();
 
   // banner mode defaults to Icon

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -41,8 +41,7 @@ group:
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
 | afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
-| closeText | 自定义关闭按钮，>= 5.7.0 废弃，请使用 `closeIcon` 代替 | ReactNode | - |  |
-| closeIcon | 自定义关闭 Icon | boolean \| ReactNode | `<CloseOutlined />` | 5.7.0: 设置为 null 或 false 时隐藏关闭按钮 |
+| closeIcon | 自定义关闭 Icon，>=5.7.0: 设置为 null 或 false 时隐藏关闭按钮 | boolean \| ReactNode | `<CloseOutlined />` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
 | icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
 | message | 警告提示内容 | ReactNode | - |  |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -41,9 +41,8 @@ group:
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
 | afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
-| closable | 默认不显示关闭按钮 | boolean | - |  |
-| closeText | 自定义关闭按钮 | ReactNode | - |  |
-| closeIcon | 自定义关闭 Icon | ReactNode | `<CloseOutlined />` | 4.18.0 |
+| closeText | 自定义关闭按钮，>= 5.7.0 废弃，请使用 `closeIcon` 代替 | ReactNode | - |  |
+| closeIcon | 自定义关闭 Icon | boolean \| ReactNode | `<CloseOutlined />` | 5.7.0: 设置为 null 或 false 时隐藏关闭按钮 |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
 | icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
 | message | 警告提示内容 | ReactNode | - |  |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -40,7 +40,7 @@ group:
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
 | afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
-| closeIcon | 自定义关闭 Icon，>=5.7.0: 设置为 null 或 false 时隐藏关闭按钮 | boolean \| ReactNode | `<CloseOutlined />` |  |
+| closeIcon | 自定义关闭 Icon，>=5.7.0: 设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | `<CloseOutlined />` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
 | icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
 | message | 警告提示内容 | ReactNode | - |  |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -26,7 +26,6 @@ group:
 <code src="./demo/closable.tsx">可关闭的警告提示</code>
 <code src="./demo/description.tsx">含有辅助性文字介绍</code>
 <code src="./demo/icon.tsx">图标</code>
-<code src="./demo/close-text.tsx">自定义关闭</code>
 <code src="./demo/banner.tsx" iframe="250">顶部公告</code>
 <code src="./demo/loop-banner.tsx">轮播的公告</code>
 <code src="./demo/smooth-closed.tsx">平滑地卸载</code>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [X] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/discussions/42828

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Alert support hidden close button when closeIcon setting to null or false <br />- deprecated closeText |
| 🇨🇳 Chinese | - 警告组件支持通过设置 closeIcon 为 null 或 false 隐藏关闭按钮 <br/>- 废弃 closeText 属性 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2808e60</samp>

This pull request adds a new `closeIcon` prop to the Alert component, which allows users to customize or hide the close button of the alert. It also deprecates the `closeText` prop, which is replaced by the `closeIcon` prop. It updates the demo files, the test cases, and the API documentation to reflect these changes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2808e60</samp>

*  Add closeIcon prop to Alert component, allowing customization of the close button icon or hiding it by setting it to null or false ([link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L23-R27), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L44-R48), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L87-R93), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L139-R145), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L203-R209), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-a3365a27d5160d6c7c1cf0364ef30876f602733ef443c734003ae750f1a8d104L13-R13), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-a3365a27d5160d6c7c1cf0364ef30876f602733ef443c734003ae750f1a8d104L20-R20), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-3dbaad52bcdfbd35c1528c90de61c60eaae0653da36bbd42dd88b6731e432248L1-R4), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-174ea1bf94f8ca33176522ecbdb934fbd907e6b53ae9307d94f4154fd774f561L43-R44), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-4493184779df5fd085712110fe4651b2cc37c39a689940232ca00af631d8544fL44-R45))
* Deprecate closeText prop in Alert component, logging a warning message when used and recommending to use closeIcon instead ([link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6R12), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L114-R122), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-174ea1bf94f8ca33176522ecbdb934fbd907e6b53ae9307d94f4154fd774f561L43-R44), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-4493184779df5fd085712110fe4651b2cc37c39a689940232ca00af631d8544fL44-R45))
* Remove closeText prop from CloseIcon component, simplifying the props and the logic ([link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L81), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L87-R93), [link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-2aefe53da61f0b93281e271248872af3b04a0a74e56a10006ec813c710632dc6L203-R209))
* Add test cases for Alert component, checking the behavior of the close button when closeIcon is set to null or false, and the warning message when closeText is used ([link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-b3f47a1d74a43149ce487ead616f09aa09447b23a43513b97553f148f7b64474R144-R166))
* Reorder import statements in `closable.tsx` demo file, following the convention of importing React first ([link](https://github.com/ant-design/ant-design/pull/42962/files?diff=unified&w=0#diff-a3365a27d5160d6c7c1cf0364ef30876f602733ef443c734003ae750f1a8d104L1-R2))
