### PR TITLE
feat(Radio): Radio button support for high contract

### DIFF
--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -477,6 +477,48 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
   };
 };
 
+// Styles from ratio in high contract mode
+const getRadioHighContractStyle: GenerateStyle<RadioToken> = (token) => {
+  const { componentCls } = token;
+  const radioInnerPrefixCls = `${componentCls}-inner`;
+
+  return {
+    '@media (forced-colors: active)': {
+      [`${componentCls}-wrapper`]: {
+        [`${componentCls}-inner`]: {
+          '&::after': {
+            transition: 'none',
+          },
+
+          transition: 'none',
+        },
+
+        [`${componentCls}-checked`]: {
+          [radioInnerPrefixCls]: {
+            borderColor: 'Highlight',
+            backgroundColor: 'Highlight',
+
+            '&::after': {
+              transition: 'none',
+            },
+          },
+        },
+
+        [`${componentCls}-disabled`]: {
+          [radioInnerPrefixCls]: {
+            backgroundColor: 'Background',
+            borderColor: 'GrayText',
+
+            '&::after': {
+              backgroundColor: 'GrayText',
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
 const getDotSize = (radioSize: number): number => {
   const dotPadding = 4; // Fixed Value
   return radioSize - dotPadding * 2;
@@ -502,6 +544,7 @@ export default genComponentStyleHook(
       getGroupRadioStyle(radioToken),
       getRadioBasicStyle(radioToken),
       getRadioButtonStyle(radioToken),
+      getRadioHighContractStyle(radioToken),
     ];
   },
   (token) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

add [Radio button support for high contrast #41821](https://github.com/ant-design/ant-design/issues/41821)
close #41821
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Support the normal use of Radio in high contrast mode. At the same time, some CSS transitions have been removed in high contrast mode to achieve a smoother experience.    |
| 🇨🇳 Chinese |   支持Radio在高对比度模式下的正常使用。同时在高对比度模式下移除了部分css transition，以达到更流畅的体验。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53f8af3</samp>

Add high-contrast mode support for radio component. Use `getRadioHighContractStyle` to create styles that adapt to forced-colors mode in `components/radio/style/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53f8af3</samp>

*  Add a new function `getRadioHighContractStyle` to generate CSS styles for the radio component in forced-colors mode ([link](https://github.com/ant-design/ant-design/pull/42986/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afR480-R527))
*  Call `getRadioHighContractStyle` inside `getRadioStyle` and merge the returned styles with the existing ones ([link](https://github.com/ant-design/ant-design/pull/42986/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afR553))
