### PR TITLE
refactor(Drawer): refactor drawer closeIcon

### DIFF
--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -35,7 +35,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     footer,
     extra,
     closeIcon,
-    closable = true,
+    closable,
     onClose,
     headerStyle,
     drawerStyle,
@@ -44,17 +44,23 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     children,
   } = props;
 
+  const mergedClosable = React.useMemo(() => {
+    if (typeof closable === 'boolean') {
+      return closable;
+    }
+
+    return ['string', 'number', 'undefined'].includes(typeof closeIcon) || !!closeIcon;
+  }, [closable, closeIcon]);
+
   const mergedCloseIcon = React.useMemo(() => {
-    if (!closable) {
+    if (!mergedClosable) {
       return null;
     }
     if (closeIcon === undefined || closeIcon === true) {
       return <CloseOutlined />;
     }
-    return closeIcon === null || closeIcon === false ? null : closeIcon;
-  }, [closeIcon, closable]);
-
-  const mergedClosable = mergedCloseIcon || ['string', 'number'].includes(typeof mergedCloseIcon);
+    return closeIcon;
+  }, [closeIcon, mergedClosable]);
 
   const closeIconNode = mergedClosable && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -11,7 +11,7 @@ export interface DrawerPanelProps {
   extra?: React.ReactNode;
 
   closable?: boolean;
-  closeIcon?: React.ReactNode;
+  closeIcon?: boolean | React.ReactNode;
   onClose?: RCDrawerProps['onClose'];
 
   /** Wrapper dom node style of header and body */
@@ -38,7 +38,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     children,
   } = props;
 
-  const closeIconNode = closable && (
+  const closeIconNode = (closeIcon || closable) && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
       {closeIcon}
     </button>

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -49,7 +49,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
       return closable;
     }
 
-    return ['string', 'number', 'undefined'].includes(typeof closeIcon) || !!closeIcon;
+    return closeIcon !== null && closeIcon !== false;
   }, [closable, closeIcon]);
 
   const mergedCloseIcon = React.useMemo(() => {

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -48,22 +48,23 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     return closeIcon === null || closeIcon === false ? null : closeIcon;
   }, [closeIcon, closable]);
 
-  const closeIconNode = (mergedCloseIcon ||
-    ['string', 'number'].includes(typeof mergedCloseIcon)) && (
+  const mergedClosable = mergedCloseIcon || ['string', 'number'].includes(typeof mergedCloseIcon);
+
+  const closeIconNode = mergedClosable && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
       {mergedCloseIcon}
     </button>
   );
 
   const headerNode = React.useMemo<React.ReactNode>(() => {
-    if (!title && !closable) {
+    if (!title && !mergedClosable) {
       return null;
     }
     return (
       <div
         style={headerStyle}
         className={classNames(`${prefixCls}-header`, {
-          [`${prefixCls}-header-close-only`]: closable && !title && !extra,
+          [`${prefixCls}-header-close-only`]: mergedClosable && !title && !extra,
         })}
       >
         <div className={`${prefixCls}-header-title`}>
@@ -73,7 +74,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
         {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
       </div>
     );
-  }, [closable, closeIconNode, extra, headerStyle, prefixCls, title]);
+  }, [mergedClosable, closeIconNode, extra, headerStyle, prefixCls, title]);
 
   const footerNode = React.useMemo<React.ReactNode>(() => {
     if (!footer) {

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -28,8 +28,8 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     title,
     footer,
     extra,
-    closable = true,
-    closeIcon = <CloseOutlined />,
+    closeIcon,
+    closable = closeIcon !== null && closeIcon !== false,
     onClose,
     headerStyle,
     drawerStyle,
@@ -38,9 +38,19 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     children,
   } = props;
 
-  const closeIconNode = (closeIcon || closable) && (
+  const mergedCloseIcon = React.useMemo(() => {
+    if (!closable) {
+      return null;
+    }
+    if (closeIcon === true) {
+      return <CloseOutlined />;
+    }
+    return closeIcon || <CloseOutlined />;
+  }, [closeIcon, closable]);
+
+  const closeIconNode = closable && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
-      {closeIcon}
+      {mergedCloseIcon}
     </button>
   );
 

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -9,7 +9,13 @@ export interface DrawerPanelProps {
   title?: React.ReactNode;
   footer?: React.ReactNode;
   extra?: React.ReactNode;
-
+  /**
+   * advised to use closeIcon instead
+   *
+   * e.g.
+   *
+   * `<Drawer closeIcon={false} />`
+   */
   closable?: boolean;
   closeIcon?: boolean | React.ReactNode;
   onClose?: RCDrawerProps['onClose'];
@@ -28,7 +34,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     title,
     footer,
     extra,
-    closeIcon = <CloseOutlined />,
+    closeIcon,
     closable = true,
     onClose,
     headerStyle,
@@ -42,7 +48,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     if (!closable) {
       return null;
     }
-    if (closeIcon === true) {
+    if (closeIcon === undefined || closeIcon === true) {
       return <CloseOutlined />;
     }
     return closeIcon === null || closeIcon === false ? null : closeIcon;

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -29,7 +29,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     footer,
     extra,
     closeIcon,
-    closable = closeIcon !== null && closeIcon !== false,
+    closable,
     onClose,
     headerStyle,
     drawerStyle,
@@ -38,31 +38,38 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     children,
   } = props;
 
+  const mergedClosable = React.useMemo(() => {
+    if (typeof closable === 'boolean') {
+      return closable;
+    }
+    return closeIcon !== false && closeIcon !== null;
+  }, [closable, closeIcon]);
+
   const mergedCloseIcon = React.useMemo(() => {
-    if (!closable) {
+    if (!mergedClosable) {
       return null;
     }
     if (closeIcon === true) {
       return <CloseOutlined />;
     }
     return closeIcon ?? <CloseOutlined />;
-  }, [closeIcon, closable]);
+  }, [closeIcon, mergedClosable]);
 
-  const closeIconNode = closable && (
+  const closeIconNode = mergedClosable && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
       {mergedCloseIcon}
     </button>
   );
 
   const headerNode = React.useMemo<React.ReactNode>(() => {
-    if (!title && !closable) {
+    if (!title && !mergedClosable) {
       return null;
     }
     return (
       <div
         style={headerStyle}
         className={classNames(`${prefixCls}-header`, {
-          [`${prefixCls}-header-close-only`]: closable && !title && !extra,
+          [`${prefixCls}-header-close-only`]: mergedClosable && !title && !extra,
         })}
       >
         <div className={`${prefixCls}-header-title`}>
@@ -72,7 +79,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
         {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
       </div>
     );
-  }, [closable, closeIconNode, extra, headerStyle, prefixCls, title]);
+  }, [mergedClosable, closeIconNode, extra, headerStyle, prefixCls, title]);
 
   const footerNode = React.useMemo<React.ReactNode>(() => {
     if (!footer) {

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -45,7 +45,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     if (closeIcon === true) {
       return <CloseOutlined />;
     }
-    return closeIcon || <CloseOutlined />;
+    return closeIcon ?? <CloseOutlined />;
   }, [closeIcon, closable]);
 
   const closeIconNode = closable && (

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -28,8 +28,8 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     title,
     footer,
     extra,
-    closeIcon,
-    closable,
+    closeIcon = <CloseOutlined />,
+    closable = true,
     onClose,
     headerStyle,
     drawerStyle,
@@ -38,38 +38,32 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     children,
   } = props;
 
-  const mergedClosable = React.useMemo(() => {
-    if (typeof closable === 'boolean') {
-      return closable;
-    }
-    return closeIcon !== false && closeIcon !== null;
-  }, [closable, closeIcon]);
-
   const mergedCloseIcon = React.useMemo(() => {
-    if (!mergedClosable) {
+    if (!closable) {
       return null;
     }
     if (closeIcon === true) {
       return <CloseOutlined />;
     }
-    return closeIcon ?? <CloseOutlined />;
-  }, [closeIcon, mergedClosable]);
+    return closeIcon === null || closeIcon === false ? null : closeIcon;
+  }, [closeIcon, closable]);
 
-  const closeIconNode = mergedClosable && (
+  const closeIconNode = (mergedCloseIcon ||
+    ['string', 'number'].includes(typeof mergedCloseIcon)) && (
     <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
       {mergedCloseIcon}
     </button>
   );
 
   const headerNode = React.useMemo<React.ReactNode>(() => {
-    if (!title && !mergedClosable) {
+    if (!title && !closable) {
       return null;
     }
     return (
       <div
         style={headerStyle}
         className={classNames(`${prefixCls}-header`, {
-          [`${prefixCls}-header-close-only`]: mergedClosable && !title && !extra,
+          [`${prefixCls}-header-close-only`]: closable && !title && !extra,
         })}
       >
         <div className={`${prefixCls}-header-title`}>
@@ -79,7 +73,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
         {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
       </div>
     );
-  }, [mergedClosable, closeIconNode, extra, headerStyle, prefixCls, title]);
+  }, [closable, closeIconNode, extra, headerStyle, prefixCls, title]);
 
   const footerNode = React.useMemo<React.ReactNode>(() => {
     if (!footer) {

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -280,11 +280,27 @@ describe('Drawer', () => {
       expect(baseElement.querySelector('.custom-close3')).not.toBeNull();
 
       rerender(
-        <Drawer open closeIcon className="custom-drawer">
+        <Drawer open closeIcon={0} className="custom-drawer1">
           Here is content of Drawer
         </Drawer>,
       );
-      expect(baseElement.querySelector('.custom-drawer .anticon-close')).not.toBeNull();
+      expect(baseElement.querySelector('.custom-drawer1 .ant-drawer-close')).not.toBeNull();
+      expect(baseElement.querySelector('.custom-drawer1 .anticon-close')).toBeNull();
+
+      rerender(
+        <Drawer open closeIcon="" className="custom-drawer2">
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-drawer2 .ant-drawer-close')).not.toBeNull();
+      expect(baseElement.querySelector('.custom-drawer2 .anticon-close')).toBeNull();
+
+      rerender(
+        <Drawer open closeIcon className="custom-drawer3">
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-drawer3 .anticon-close')).not.toBeNull();
 
       rerender(
         <Drawer open closable>

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -280,6 +280,13 @@ describe('Drawer', () => {
       expect(baseElement.querySelector('.custom-close3')).not.toBeNull();
 
       rerender(
+        <Drawer open closeIcon className="custom-drawer">
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-drawer .anticon-close')).not.toBeNull();
+
+      rerender(
         <Drawer open closable>
           Here is content of Drawer
         </Drawer>,

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -242,5 +242,49 @@ describe('Drawer', () => {
 
       errorSpy.mockRestore();
     });
+
+    it('should hide close button when closeIcon is null or false', async () => {
+      const { baseElement, rerender } = render(
+        <Drawer open closeIcon={null}>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.ant-drawer-close')).toBeNull();
+
+      rerender(
+        <Drawer open closeIcon={false}>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.ant-drawer-close')).toBeNull();
+
+      rerender(
+        <Drawer open closeIcon={<span className="custom-close">Close</span>}>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-close')).not.toBeNull();
+
+      rerender(
+        <Drawer open closable={false} closeIcon={<span className="custom-close2">Close</span>}>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-close2')).toBeNull();
+
+      rerender(
+        <Drawer open closable closeIcon={<span className="custom-close3">Close</span>}>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.custom-close3')).not.toBeNull();
+
+      rerender(
+        <Drawer open closable>
+          Here is content of Drawer
+        </Drawer>,
+      );
+      expect(baseElement.querySelector('.anticon-close')).not.toBeNull();
+    });
   });
 });

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -46,7 +46,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | afterOpenChange | Callback after the animation ends when switching drawers | function(open) | - |  |
 | bodyStyle | Style of the drawer content part | CSSProperties | - |  |
 | className | Config Drawer Panel className. Use `rootClassName` if want to config top dom style | string | - |  |
-| closeIcon | Custom close icon, 5.7.0: close button will be hidden when setting to null or false | boolean \| ReactNode | &lt;CloseOutlined /> |  |
+| closeIcon | Custom close icon. 5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | contentWrapperStyle | Style of the drawer wrapper of content part | CSSProperties | - |  |
 | destroyOnClose | Whether to unmount child components on closing drawer or not | boolean | false |  |
 | extra | Extra actions area at corner | ReactNode | - | 4.17.0 |

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -46,7 +46,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | afterOpenChange | Callback after the animation ends when switching drawers | function(open) | - |  |
 | bodyStyle | Style of the drawer content part | CSSProperties | - |  |
 | className | Config Drawer Panel className. Use `rootClassName` if want to config top dom style | string | - |  |
-| closeIcon | Custom close icon | boolean \| ReactNode | &lt;CloseOutlined /> | 5.7.0: close button will be hidden when setting to null or false |
+| closeIcon | Custom close icon, 5.7.0: close button will be hidden when setting to null or false | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | contentWrapperStyle | Style of the drawer wrapper of content part | CSSProperties | - |  |
 | destroyOnClose | Whether to unmount child components on closing drawer or not | boolean | false |  |
 | extra | Extra actions area at corner | ReactNode | - | 4.17.0 |

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -46,8 +46,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 | afterOpenChange | Callback after the animation ends when switching drawers | function(open) | - |  |
 | bodyStyle | Style of the drawer content part | CSSProperties | - |  |
 | className | Config Drawer Panel className. Use `rootClassName` if want to config top dom style | string | - |  |
-| closable | Whether a close (x) button is visible on top left of the Drawer dialog or not | boolean | true |  |
-| closeIcon | Custom close icon | ReactNode | &lt;CloseOutlined /> |  |
+| closeIcon | Custom close icon | boolean \| ReactNode | &lt;CloseOutlined /> | 5.7.0: close button will be hidden when setting to null or false |
 | contentWrapperStyle | Style of the drawer wrapper of content part | CSSProperties | - |  |
 | destroyOnClose | Whether to unmount child components on closing drawer or not | boolean | false |  |
 | extra | Extra actions area at corner | ReactNode | - | 4.17.0 |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -45,7 +45,7 @@ demo:
 | afterOpenChange | 切换抽屉时动画结束后的回调 | function(open) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
 | className | Drawer 容器外层 className 设置，如果需要设置最外层，请使用 rootClassName | string | - |  |
-| closeIcon | 自定义关闭图标 | boolean \| ReactNode | &lt;CloseOutlined /> | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
+| closeIcon | 自定义关闭图标，5.7.0：设置为 null 或 false 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | contentWrapperStyle | 可用于设置 Drawer 包裹内容部分的样式 | CSSProperties | - |  |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |  |
 | extra | 抽屉右上角的操作区域 | ReactNode | - | 4.17.0 |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -45,8 +45,7 @@ demo:
 | afterOpenChange | 切换抽屉时动画结束后的回调 | function(open) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
 | className | Drawer 容器外层 className 设置，如果需要设置最外层，请使用 rootClassName | string | - |  |
-| closable | 是否显示左上角的关闭按钮 | boolean | true |  |
-| closeIcon | 自定义关闭图标 | ReactNode | &lt;CloseOutlined /> |  |
+| closeIcon | 自定义关闭图标 | boolean \| ReactNode | &lt;CloseOutlined /> | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
 | contentWrapperStyle | 可用于设置 Drawer 包裹内容部分的样式 | CSSProperties | - |  |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |  |
 | extra | 抽屉右上角的操作区域 | ReactNode | - | 4.17.0 |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -45,7 +45,7 @@ demo:
 | afterOpenChange | 切换抽屉时动画结束后的回调 | function(open) | - |  |
 | bodyStyle | 可用于设置 Drawer 内容部分的样式 | CSSProperties | - |  |
 | className | Drawer 容器外层 className 设置，如果需要设置最外层，请使用 rootClassName | string | - |  |
-| closeIcon | 自定义关闭图标，5.7.0：设置为 null 或 false 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
+| closeIcon | 自定义关闭图标。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | contentWrapperStyle | 可用于设置 Drawer 包裹内容部分的样式 | CSSProperties | - |  |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |  |
 | extra | 抽屉右上角的操作区域 | ReactNode | - | 4.17.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [X] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/discussions/42828

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Drawer support hidden close button when closeIcon setting to null or false |
| 🇨🇳 Chinese | 抽屉组件支持通过设置 closeIcon 为 null 或 false 隐藏关闭按钮 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4432621</samp>

This pull request adds a feature to the `Drawer` component that allows hiding the close button by setting the `closeIcon` prop to `null` or `false`. It also updates the documentation and the test cases accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4432621</samp>

* Allow hiding close button by setting `closeIcon` to `null` or `false` ([link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L14-R14), [link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L31-R32), [link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L41-R53), [link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-7855c9de8eab66dde84ba7237f52b0fb88c917e3c8c78ada5fafa1e98c259721L49-R49), [link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-bb2fbbde54ac7a64e8f607e35d8482d3150594c6466b025b29949ba82b675152L48-R48))
* Memoize close icon value based on `closeIcon` and `closable` props using `React.useMemo` hook ([link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L41-R53))
* Add test case for new `closeIcon` and `closable` props behavior in `Drawer.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/42993/files?diff=unified&w=0#diff-2f59df76b42f52eb16232a5efb82e602e6a1b1cc126238a84971d00efa948df8R245-R288))
