### PR TITLE
site: hide package manager tab which command is empty

### DIFF
--- a/.dumi/theme/builtins/InstallDependencies/index.tsx
+++ b/.dumi/theme/builtins/InstallDependencies/index.tsx
@@ -11,45 +11,37 @@ interface InstallProps {
   pnpm?: string;
 }
 
-const InstallDependencies: React.FC<InstallProps> = (props) => {
-  const { npm, yarn, pnpm } = props;
+const InstallDependencies: React.FC<InstallProps> = ({ npm, yarn, pnpm }) => {
+  const options = [
+    { key: 'npm', value: npm, label: 'npm', icon: <NpmLogo /> },
+    { key: 'yarn', value: yarn, label: 'yarn', icon: <YarnLogo /> },
+    { key: 'pnpm', value: pnpm, label: 'pnpm', icon: <PnpmLogo /> },
+  ];
+
+  const filteredOptions = options.filter((option) => option.value);
+
+  if (filteredOptions.length === 0) return null;
+
+  const renderTabPane = (option) => (
+    <Tabs.TabPane
+      key={option.key}
+      tab={
+        <span className="snippet-label">
+          {option.icon}
+          {option.label}
+        </span>
+      }
+    >
+      <SourceCode lang="bash">{option.value}</SourceCode>
+    </Tabs.TabPane>
+  );
+
+  const tabPanes = filteredOptions.map(renderTabPane);
+
   return (
-    <Tabs
-      className="antd-site-snippet"
-      defaultActiveKey="npm"
-      items={[
-        {
-          key: 'npm',
-          children: <SourceCode lang="bash">{npm}</SourceCode>,
-          label: (
-            <span className="snippet-label">
-              <NpmLogo />
-              npm
-            </span>
-          ),
-        },
-        {
-          key: 'yarn',
-          children: <SourceCode lang="bash">{yarn}</SourceCode>,
-          label: (
-            <span className="snippet-label">
-              <YarnLogo />
-              yarn
-            </span>
-          ),
-        },
-        {
-          key: 'pnpm',
-          children: <SourceCode lang="bash">{pnpm}</SourceCode>,
-          label: (
-            <span className="snippet-label">
-              <PnpmLogo />
-              pnpm
-            </span>
-          ),
-        },
-      ]}
-    />
+    <Tabs className="antd-site-snippet" defaultActiveKey={filteredOptions[0].key}>
+      {tabPanes}
+    </Tabs>
   );
 };
 

--- a/.dumi/theme/builtins/InstallDependencies/index.tsx
+++ b/.dumi/theme/builtins/InstallDependencies/index.tsx
@@ -1,3 +1,4 @@
+import type { TabsProps } from 'antd';
 import { Tabs } from 'antd';
 import SourceCode from 'dumi/theme-default/builtins/SourceCode';
 import React from 'react';

--- a/.dumi/theme/builtins/InstallDependencies/index.tsx
+++ b/.dumi/theme/builtins/InstallDependencies/index.tsx
@@ -11,38 +11,51 @@ interface InstallProps {
   pnpm?: string;
 }
 
-const InstallDependencies: React.FC<InstallProps> = ({ npm, yarn, pnpm }) => {
-  const options = [
-    { key: 'npm', value: npm, label: 'npm', icon: <NpmLogo /> },
-    { key: 'yarn', value: yarn, label: 'yarn', icon: <YarnLogo /> },
-    { key: 'pnpm', value: pnpm, label: 'pnpm', icon: <PnpmLogo /> },
-  ];
+const npmLabel = (
+  <span className="snippet-label">
+    <NpmLogo />
+    npm
+  </span>
+);
 
-  const filteredOptions = options.filter((option) => option.value);
+const pnpmLabel = (
+  <span className="snippet-label">
+    <PnpmLogo />
+    pnpm
+  </span>
+);
 
-  if (filteredOptions.length === 0) return null;
+const yarnLabel = (
+  <span className="snippet-label">
+    <YarnLogo />
+    yarn
+  </span>
+);
 
-  const renderTabPane = (option) => (
-    <Tabs.TabPane
-      key={option.key}
-      tab={
-        <span className="snippet-label">
-          {option.icon}
-          {option.label}
-        </span>
-      }
-    >
-      <SourceCode lang="bash">{option.value}</SourceCode>
-    </Tabs.TabPane>
+const InstallDependencies: React.FC<InstallProps> = (props) => {
+  const { npm, yarn, pnpm } = props;
+  const items = React.useMemo<TabsProps['items']>(
+    () =>
+      [
+        {
+          key: 'npm',
+          children: npm ? <SourceCode lang="bash">{npm}</SourceCode> : null,
+          label: npmLabel,
+        },
+        {
+          key: 'yarn',
+          children: yarn ? <SourceCode lang="bash">{yarn}</SourceCode> : null,
+          label: yarnLabel,
+        },
+        {
+          key: 'pnpm',
+          children: pnpm ? <SourceCode lang="bash">{pnpm}</SourceCode> : null,
+          label: pnpmLabel,
+        },
+      ].filter((item) => item.children),
+    [npm, yarn, pnpm],
   );
-
-  const tabPanes = filteredOptions.map(renderTabPane);
-
-  return (
-    <Tabs className="antd-site-snippet" defaultActiveKey={filteredOptions[0].key}>
-      {tabPanes}
-    </Tabs>
-  );
+  return <Tabs className="antd-site-snippet" defaultActiveKey="npm" items={items} />;
 };
 
 export default InstallDependencies;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Because there are still some problems with the use of pnpm in ant-design projects, sometimes we do not want to show pnpm's commands in recommendation commands, so we need to support  does not render the package manager tab which the incoming command is empty

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  hide package manager tab which command is empty  |
| 🇨🇳 Chinese |  隐藏命令为空的包管理器选项卡  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0754e4c</samp>

Refactor `InstallDependencies` component to use a single array of options and handle empty values. Extract `renderTabPane` function for clarity.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0754e4c</samp>

*  Refactor `InstallDependencies` component to use a single array of options and return null if empty ([link](https://github.com/ant-design/ant-design/pull/43032/files?diff=unified&w=0#diff-aa071af4ca48d5fb545a4c5d2d40d9f28c6899e2fa355550089031c8a7d3d30fL14-R44))
