### PR TITLE
fix: upload event should not trigger the file out of maxCount

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -107,10 +107,13 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   ) => {
     let cloneList = [...changedFileList];
 
+    let exceedMaxCount = false;
+
     // Cut to match count
     if (maxCount === 1) {
       cloneList = cloneList.slice(-1);
     } else if (maxCount) {
+      exceedMaxCount = true;
       cloneList = cloneList.slice(0, maxCount);
     }
 
@@ -129,9 +132,15 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
       changeInfo.event = event;
     }
 
-    flushSync(() => {
-      onChange?.(changeInfo);
-    });
+    if (
+      !exceedMaxCount ||
+      // We should ignore event if current file is exceed `maxCount`
+      cloneList.map((f) => f.uid).includes(file.uid)
+    ) {
+      flushSync(() => {
+        onChange?.(changeInfo);
+      });
+    }
   };
 
   const mergedBeforeUpload = async (file: RcFile, fileListArgs: RcFile[]) => {

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -135,7 +135,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     if (
       !exceedMaxCount ||
       // We should ignore event if current file is exceed `maxCount`
-      cloneList.map((f) => f.uid).includes(file.uid)
+      cloneList.find((f) => f.uid === file.uid)
     ) {
       flushSync(() => {
         onChange?.(changeInfo);

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -135,7 +135,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     if (
       !exceedMaxCount ||
       // We should ignore event if current file is exceed `maxCount`
-      cloneList.find((f) => f.uid === file.uid)
+      cloneList.some((f) => f.uid === file.uid)
     ) {
       flushSync(() => {
         onChange?.(changeInfo);

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -480,7 +480,7 @@ describe('Upload', () => {
     // Delay return true for remove
     await waitFakeTimer();
     await act(async () => {
-      await removePromise(true);
+      removePromise(true);
     });
 
     expect(onChange).toHaveBeenCalled();
@@ -771,6 +771,11 @@ describe('Upload', () => {
           name: 'foo.png',
         }),
       ]);
+
+      // Only trigger for file in `maxCount`
+      onChange.mock.calls.forEach((args) => {
+        expect(args[0].file.name).toBe('foo.png');
+      });
     });
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43031

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Upload trigger extra `onChange` event when upload the file exceeds `maxCount`.   |
| 🇨🇳 Chinese |   修复 Upload 配置 `maxCount` 后，上传超出范围的文件仍然会触发 `onChange` 事件的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7aa1c7</samp>

This pull request enhances the Upload component by adding a `maxCount` prop to limit the number of files and fixing a related bug. It also improves the test case for this feature in `upload.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d7aa1c7</samp>

*  Add logic to limit the `onChange` callback for files that exceed the `maxCount` prop in the Upload component ([link](https://github.com/ant-design/ant-design/pull/43034/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL110-R116), [link](https://github.com/ant-design/ant-design/pull/43034/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL132-R143))
*  Remove unnecessary `await` keyword from the mock `removePromise` call in the test case for the Upload component ([link](https://github.com/ant-design/ant-design/pull/43034/files?diff=unified&w=0#diff-72ea20f11250bb41ad13135c67af7e612d56bd43c8e24ad4db9c782f58306ac7L483-R483))
*  Add assertion to the test case to verify that the `onChange` callback is only called for the file that matches the `maxCount` prop ([link](https://github.com/ant-design/ant-design/pull/43034/files?diff=unified&w=0#diff-72ea20f11250bb41ad13135c67af7e612d56bd43c8e24ad4db9c782f58306ac7R774-R778))
