### PR TITLE
style: fix InputNumber prefix style in Form.Item

### DIFF
--- a/components/input-number/style/affix.less
+++ b/components/input-number/style/affix.less
@@ -45,6 +45,7 @@
     }
 
     &::before {
+      display: inline-block;
       width: 0;
       visibility: hidden;
       content: '\a0';

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5937,90 +5937,8 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
       </span>
     </div>
     <div
-      class="ant-input-number-affix-wrapper"
+      class="ant-input-number ant-input-number-not-a-number"
       style="width:50%"
-    >
-      <span
-        class="ant-input-number-prefix"
-      >
-        @
-      </span>
-      <div
-        class="ant-input-number ant-input-number-not-a-number"
-      >
-        <div
-          class="ant-input-number-handler-wrap"
-        >
-          <span
-            aria-disabled="false"
-            aria-label="Increase Value"
-            class="ant-input-number-handler ant-input-number-handler-up"
-            role="button"
-            unselectable="on"
-          >
-            <span
-              aria-label="up"
-              class="anticon anticon-up ant-input-number-handler-up-inner"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="up"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            aria-disabled="false"
-            aria-label="Decrease Value"
-            class="ant-input-number-handler ant-input-number-handler-down"
-            role="button"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down ant-input-number-handler-down-inner"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-        <div
-          class="ant-input-number-input-wrap"
-        >
-          <input
-            autocomplete="off"
-            class="ant-input-number-input"
-            role="spinbutton"
-            step="1"
-            value="input content"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-input-number"
     >
       <div
         class="ant-input-number-handler-wrap"
@@ -6088,8 +6006,90 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
           class="ant-input-number-input"
           role="spinbutton"
           step="1"
-          value=""
+          value="input content"
         />
+      </div>
+    </div>
+    <div
+      class="ant-input-number-affix-wrapper"
+    >
+      <span
+        class="ant-input-number-prefix"
+      >
+        @
+      </span>
+      <div
+        class="ant-input-number"
+      >
+        <div
+          class="ant-input-number-handler-wrap"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-handler ant-input-number-handler-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up ant-input-number-handler-up-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-handler ant-input-number-handler-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-input-number-handler-down-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-input-number-input-wrap"
+        >
+          <input
+            autocomplete="off"
+            class="ant-input-number-input"
+            role="spinbutton"
+            step="1"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </span>

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5936,80 +5936,12 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
         </span>
       </span>
     </div>
-    <div
-      class="ant-input-number ant-input-number-not-a-number"
+    <input
+      class="ant-input"
       style="width:50%"
-    >
-      <div
-        class="ant-input-number-handler-wrap"
-      >
-        <span
-          aria-disabled="false"
-          aria-label="Increase Value"
-          class="ant-input-number-handler ant-input-number-handler-up"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="up"
-            class="anticon anticon-up ant-input-number-handler-up-inner"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="up"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          aria-disabled="false"
-          aria-label="Decrease Value"
-          class="ant-input-number-handler ant-input-number-handler-down"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="down"
-            class="anticon anticon-down ant-input-number-handler-down-inner"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <div
-        class="ant-input-number-input-wrap"
-      >
-        <input
-          autocomplete="off"
-          class="ant-input-number-input"
-          role="spinbutton"
-          step="1"
-          value="input content"
-        />
-      </div>
-    </div>
+      type="text"
+      value="input content"
+    />
     <div
       class="ant-input-number-affix-wrapper"
     >

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5936,12 +5936,89 @@ exports[`renders ./components/input/demo/group.md extend context correctly 1`] =
         </span>
       </span>
     </div>
-    <input
-      class="ant-input"
+    <div
+      class="ant-input-number-affix-wrapper"
       style="width:50%"
-      type="text"
-      value="input content"
-    />
+    >
+      <span
+        class="ant-input-number-prefix"
+      >
+        @
+      </span>
+      <div
+        class="ant-input-number ant-input-number-not-a-number"
+      >
+        <div
+          class="ant-input-number-handler-wrap"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-handler ant-input-number-handler-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up ant-input-number-handler-up-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-handler ant-input-number-handler-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-input-number-handler-down-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-input-number-input-wrap"
+        >
+          <input
+            autocomplete="off"
+            class="ant-input-number-input"
+            role="spinbutton"
+            step="1"
+            value="input content"
+          />
+        </div>
+      </div>
+    </div>
     <div
       class="ant-input-number"
     >

--- a/components/input/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.ts.snap
@@ -1966,90 +1966,8 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
       </span>
     </div>
     <div
-      class="ant-input-number-affix-wrapper"
+      class="ant-input-number ant-input-number-not-a-number"
       style="width:50%"
-    >
-      <span
-        class="ant-input-number-prefix"
-      >
-        @
-      </span>
-      <div
-        class="ant-input-number ant-input-number-not-a-number"
-      >
-        <div
-          class="ant-input-number-handler-wrap"
-        >
-          <span
-            aria-disabled="false"
-            aria-label="Increase Value"
-            class="ant-input-number-handler ant-input-number-handler-up"
-            role="button"
-            unselectable="on"
-          >
-            <span
-              aria-label="up"
-              class="anticon anticon-up ant-input-number-handler-up-inner"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="up"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            aria-disabled="false"
-            aria-label="Decrease Value"
-            class="ant-input-number-handler ant-input-number-handler-down"
-            role="button"
-            unselectable="on"
-          >
-            <span
-              aria-label="down"
-              class="anticon anticon-down ant-input-number-handler-down-inner"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </span>
-        </div>
-        <div
-          class="ant-input-number-input-wrap"
-        >
-          <input
-            autocomplete="off"
-            class="ant-input-number-input"
-            role="spinbutton"
-            step="1"
-            value="input content"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-input-number"
     >
       <div
         class="ant-input-number-handler-wrap"
@@ -2117,8 +2035,90 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
           class="ant-input-number-input"
           role="spinbutton"
           step="1"
-          value=""
+          value="input content"
         />
+      </div>
+    </div>
+    <div
+      class="ant-input-number-affix-wrapper"
+    >
+      <span
+        class="ant-input-number-prefix"
+      >
+        @
+      </span>
+      <div
+        class="ant-input-number"
+      >
+        <div
+          class="ant-input-number-handler-wrap"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-handler ant-input-number-handler-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up ant-input-number-handler-up-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-handler ant-input-number-handler-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-input-number-handler-down-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-input-number-input-wrap"
+        >
+          <input
+            autocomplete="off"
+            class="ant-input-number-input"
+            role="spinbutton"
+            step="1"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </span>

--- a/components/input/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.ts.snap
@@ -1965,12 +1965,89 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
         </span>
       </span>
     </div>
-    <input
-      class="ant-input"
+    <div
+      class="ant-input-number-affix-wrapper"
       style="width:50%"
-      type="text"
-      value="input content"
-    />
+    >
+      <span
+        class="ant-input-number-prefix"
+      >
+        @
+      </span>
+      <div
+        class="ant-input-number ant-input-number-not-a-number"
+      >
+        <div
+          class="ant-input-number-handler-wrap"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-handler ant-input-number-handler-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up ant-input-number-handler-up-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-handler ant-input-number-handler-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down ant-input-number-handler-down-inner"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="ant-input-number-input-wrap"
+        >
+          <input
+            autocomplete="off"
+            class="ant-input-number-input"
+            role="spinbutton"
+            step="1"
+            value="input content"
+          />
+        </div>
+      </div>
+    </div>
     <div
       class="ant-input-number"
     >

--- a/components/input/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.ts.snap
@@ -1965,80 +1965,12 @@ exports[`renders ./components/input/demo/group.md correctly 1`] = `
         </span>
       </span>
     </div>
-    <div
-      class="ant-input-number ant-input-number-not-a-number"
+    <input
+      class="ant-input"
       style="width:50%"
-    >
-      <div
-        class="ant-input-number-handler-wrap"
-      >
-        <span
-          aria-disabled="false"
-          aria-label="Increase Value"
-          class="ant-input-number-handler ant-input-number-handler-up"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="up"
-            class="anticon anticon-up ant-input-number-handler-up-inner"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="up"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          aria-disabled="false"
-          aria-label="Decrease Value"
-          class="ant-input-number-handler ant-input-number-handler-down"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="down"
-            class="anticon anticon-down ant-input-number-handler-down-inner"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
-      <div
-        class="ant-input-number-input-wrap"
-      >
-        <input
-          autocomplete="off"
-          class="ant-input-number-input"
-          role="spinbutton"
-          step="1"
-          value="input content"
-        />
-      </div>
-    </div>
+      type="text"
+      value="input content"
+    />
     <div
       class="ant-input-number-affix-wrapper"
     >

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -121,7 +121,7 @@ const App: React.FC = () => (
         <Option value="Option1">Option1</Option>
         <Option value="Option2">Option2</Option>
       </Select>
-      <InputNumber style={{ width: '50%' }} defaultValue="input content" />
+      <Input style={{ width: '50%' }} defaultValue="input content" />
       <InputNumber prefix="@" />
     </Input.Group>
     <br />

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -121,8 +121,8 @@ const App: React.FC = () => (
         <Option value="Option1">Option1</Option>
         <Option value="Option2">Option2</Option>
       </Select>
-      <InputNumber prefix="@" style={{ width: '50%' }} defaultValue="input content" />
-      <InputNumber />
+      <InputNumber style={{ width: '50%' }} defaultValue="input content" />
+      <InputNumber prefix="@" />
     </Input.Group>
     <br />
     <Input.Group compact>

--- a/components/input/demo/group.md
+++ b/components/input/demo/group.md
@@ -121,7 +121,7 @@ const App: React.FC = () => (
         <Option value="Option1">Option1</Option>
         <Option value="Option2">Option2</Option>
       </Select>
-      <Input style={{ width: '50%' }} defaultValue="input content" />
+      <InputNumber prefix="@" style={{ width: '50%' }} defaultValue="input content" />
       <InputNumber />
     </Input.Group>
     <br />

--- a/components/input/style/affix.less
+++ b/components/input/style/affix.less
@@ -43,6 +43,7 @@
     }
 
     &::before {
+      display: inline-block;
       width: 0;
       visibility: hidden;
       content: '\a0';

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -330,7 +330,7 @@
     }
 
     & > * {
-      display: inline-block;
+      display: inline-flex;
       float: none;
       vertical-align: top; // https://github.com/ant-design/ant-design-pro/issues/139
       border-radius: 0;

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -331,15 +331,14 @@
 
     & > * {
       display: inline-flex;
+      align-items: center;
       float: none;
       vertical-align: top; // https://github.com/ant-design/ant-design-pro/issues/139
       border-radius: 0;
     }
 
-    & > .@{inputClass}-affix-wrapper {
-      display: inline-flex;
-    }
-
+    & > .@{inputClass}-affix-wrapper,
+    & > .@{inputClass}-number-affix-wrapper,
     & > .@{ant-prefix}-picker-range {
       display: inline-flex;
     }

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -330,8 +330,7 @@
     }
 
     & > * {
-      display: inline-flex;
-      align-items: center;
+      display: inline-block;
       float: none;
       vertical-align: top; // https://github.com/ant-design/ant-design-pro/issues/139
       border-radius: 0;


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #35249

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix InputNumber with `prefix` abnormal height under Form.Item of `hasFeedBack`.      |
| 🇨🇳 Chinese |  修复带 `prefix` InputNumber 在 Form.Item `hasFeedBack` 内高度异常的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b45dae0</samp>

This pull request improves the styling and layout of the `InputNumber` and `Input.Group` components, by adding or modifying the `display` property for their wrapper elements. It also updates the documentation and example code to demonstrate the usage and appearance of these components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b45dae0</samp>

*  Add `display: inline-block` property to `.ant-input-affix-wrapper` and `.ant-input-number` classes to prevent collapsing or expanding of input elements with prefix or suffix icons ([link](https://github.com/ant-design/ant-design/pull/43048/files?diff=unified&w=0#diff-1b69896b627e11b980961d22f84c248986230123b13d63fe837714bc1db819edR48), [link](https://github.com/ant-design/ant-design/pull/43048/files?diff=unified&w=0#diff-d28aae5be4c7d25798c9f56158c2d345e5e7e32abd8fa0fbc6cc82e099c0d400R46))
*  Modify `display: inline-block` property to `display: inline-flex` for the direct children of `.ant-input-group` class to improve responsiveness and compatibility of input group component ([link](https://github.com/ant-design/ant-design/pull/43048/files?diff=unified&w=0#diff-7f1a2bc7425f66cf8c374160bc2e953adc871393b7fc1da7a5eeeb5ad86f8b4cL333-R333))
*  Update `group.md` example code to show how to use prefix icon for `InputNumber` component in input group ([link](https://github.com/ant-design/ant-design/pull/43048/files?diff=unified&w=0#diff-7d6894b2485f9010a924fa9c342dbe2e81e03b4d3e8307430ffe5ec94d44fc7cL124-R124))
