### PR TITLE
feat: ConfigProvider support Tree className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -33,6 +33,7 @@ import Switch from '../../switch';
 import Table from '../../table';
 import Tabs from '../../tabs';
 import Tag from '../../tag';
+import Tree from '../../tree';
 import Typography from '../../typography';
 import Upload from '../../upload';
 
@@ -720,5 +721,49 @@ describe('ConfigProvider support style and className props', () => {
       ?.querySelector<HTMLDivElement>('.ant-notification-notice');
     expect(element).toHaveClass('cp-notification');
     expect(element).toHaveStyle({ color: 'blue' });
+  });
+  
+  it('Should Tree className works', () => {
+    const treeData = [
+      {
+        title: 'test-title',
+        key: '0-0',
+      },
+    ];
+
+    const { container } = render(
+      <ConfigProvider
+        tree={{
+          className: 'test-class',
+        }}
+      >
+        <Tree treeData={treeData} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-tree')).toHaveClass('test-class');
+  });
+
+  it('Should Tree style works', () => {
+    const treeData = [
+      {
+        title: 'test-title',
+        key: '0-0',
+      },
+    ];
+
+    const { container } = render(
+      <ConfigProvider
+        tree={{
+          style: { color: 'red' },
+        }}
+      >
+        <Tree treeData={treeData} style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-tree-list')).toHaveStyle(
+      'color: red; font-size: 16px; position: relative;',
+    );
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -124,6 +124,7 @@ export interface ConfigConsumerProps {
   tabs?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
+  tree?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -134,6 +134,7 @@ const {
 | table | Set Table common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | Set Tag common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | Set Upload common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -168,6 +168,7 @@ export interface ConfigProviderProps {
   tabs?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
+  tree?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -288,6 +289,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tabs,
     upload,
     notification,
+    tree,
   } = props;
 
   // =================================== Warning ===================================
@@ -370,6 +372,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tabs,
     upload,
     notification,
+    tree,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -136,6 +136,7 @@ const {
 | table | 设置 Table 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | 设置 Tabs 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | 设置 Tag 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -156,7 +156,7 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
 }
 
 const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
-  const { getPrefixCls, direction, virtual } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, virtual, tree } = React.useContext(ConfigContext);
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -169,6 +169,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     selectable = true,
     draggable,
     motion: customMotion,
+    style,
   } = props;
 
   const prefixCls = getPrefixCls('tree', customizePrefixCls);
@@ -232,6 +233,8 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       ref={ref}
       virtual={virtual}
       {...newProps}
+      // newProps may contain style so declare style below it
+      style={{ ...tree?.style, ...style }}
       prefixCls={prefixCls}
       className={classNames(
         {
@@ -240,6 +243,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
           [`${prefixCls}-unselectable`]: !selectable,
           [`${prefixCls}-rtl`]: direction === 'rtl',
         },
+        tree?.className,
         className,
         hashId,
       )}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  `ConfigProvider` support `Tree` className and style properties          |
| 🇨🇳 Chinese |  `ConfigProvider` 支持 `Tree` 组件的 className 和 style 属性        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2d71a4</samp>

This pull request adds a new feature to the `ConfigProvider` component that allows customizing the `Tree` component with a `tree` prop. It also updates the `Tree` component, the `ConfigProvider` context and interfaces, and the documentation files to support this feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2d71a4</samp>

*  Add a new `tree` prop to the `ConfigProvider` component, which allows passing common props to the `Tree` component ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R140), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R228), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R278), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R73), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R74))
*  Export the `ComponentStyleConfig` interface from `components/config-provider/index.tsx`, which defines the common props that can be passed to the `Tree` component ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R22))
*  Rename the `componentStyleConfig` interface to `ComponentStyleConfig` and remove redundant properties in `components/config-provider/context.ts` ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaL39-R48))
*  Add the `tree` property to the `ConfigConsumerProps` interface in `components/config-provider/context.ts`, which represents the `tree` prop of the `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR91))
*  Use the `tree` prop from the `ConfigContext` in the `Tree` component, and merge it with the user-provided `style` and `className` props ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6L159-R159), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R172), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R236-R237), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R246))
*  Add two test cases for the `ConfigProvider` component, checking if the `tree` prop can pass a `className` and a `style` to the `Tree` component ([link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R12), [link](https://github.com/ant-design/ant-design/pull/43060/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R202-R245))
