### PR TITLE
feat: config-provider support empty className and style propertie

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -5,6 +5,7 @@ import Breadcrumb from '../../breadcrumb';
 import Checkbox from '../../checkbox';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
+import Empty from '../../empty';
 import Image from '../../image';
 import Pagination from '../../pagination';
 import Result from '../../result';
@@ -270,5 +271,23 @@ describe('ConfigProvider support style and className props', () => {
 
     expect(container.querySelector('.ant-descriptions')).toHaveClass('cp-className');
     expect(container.querySelector('.ant-descriptions')).toHaveStyle({ background: 'red' });
+  });
+
+  it('Should Empty className & style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        empty={{
+          className: 'cp-className',
+          style: {
+            background: 'red',
+          },
+        }}
+      >
+        <Empty />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-empty')).toHaveClass('cp-className');
+    expect(container.querySelector('.ant-empty')).toHaveStyle({ background: 'red' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -97,6 +97,7 @@ export interface ConfigConsumerProps {
   breadcrumb?: ComponentStyleConfig;
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
+  empty?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -106,6 +106,7 @@ const {
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string } | - | 4.2.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -146,6 +146,7 @@ export interface ConfigProviderProps {
   breadcrumb?: ComponentStyleConfig;
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
+  empty?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -245,6 +246,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     slider,
     breadcrumb,
     pagination,
+    empty,
   } = props;
 
   // =================================== Warning ===================================
@@ -308,6 +310,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     slider,
     breadcrumb,
     pagination,
+    empty,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -108,6 +108,7 @@ const {
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -39,9 +39,10 @@ const Empty: CompoundedComponent = ({
   description,
   children,
   imageStyle,
+  style,
   ...restProps
 }) => {
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, empty } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('empty', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
@@ -64,6 +65,7 @@ const Empty: CompoundedComponent = ({
       className={classNames(
         hashId,
         prefixCls,
+        empty?.className,
         {
           [`${prefixCls}-normal`]: image === simpleEmptyImg,
           [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -71,6 +73,7 @@ const Empty: CompoundedComponent = ({
         className,
         rootClassName,
       )}
+      style={{ ...empty?.style, ...style }}
       {...restProps}
     >
       <div className={`${prefixCls}-image`} style={imageStyle}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/discussions/39862


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     `ConfigProvider` support `Empty` className and style properties      |
| 🇨🇳 Chinese |     `ConfigProvider` 支持 `Empty` 组件的 className 和 style 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1443929</samp>

This pull request adds a new feature to the `ConfigProvider` component and its related components and tests. The feature allows customizing the `Empty` component that is rendered when the data source is empty, by passing an `empty` prop to the `ConfigProvider` or using the global configuration context. The documentation and the tests are updated accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1443929</samp>

*  Add a new `empty` prop to the `ConfigProvider` component and the `ConfigConsumerProps` interface to customize the `Empty` component globally ([link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR90-R93), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R139-R142), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R230), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R280))
*  Update the `Empty` component to accept `className` and `style` from the `ConfigProvider` context and apply them to the root div element ([link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L42-R45), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82R68), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82R76))
*  Import the `Empty` component from the `empty` folder in the `index.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R8))
*  Add two test cases to check if the `Empty` component can receive `className` and `style` from the `ConfigProvider` component in the `index.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R202-R231))
*  Update the API documentation for the `ConfigProvider` component in English and Chinese, adding a new row for the `empty` prop and describing its usage and type ([link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R73), [link](https://github.com/ant-design/ant-design/pull/43061/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R74))
