### PR TITLE
feat: config-provider support radio className and style propertie

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -9,6 +9,7 @@ import Divider from '../../divider';
 import Empty from '../../empty';
 import Image from '../../image';
 import Pagination from '../../pagination';
+import Radio from '../../radio';
 import Result from '../../result';
 import Segmented from '../../segmented';
 import Slider from '../../slider';
@@ -197,6 +198,24 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-result');
     expect(element).toHaveClass('cp-result');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should Radio className & style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        radio={{
+          className: 'cp-className',
+          style: {
+            background: 'red',
+          },
+        }}
+      >
+        <Radio>Radio</Radio>
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-radio-wrapper')).toHaveClass('cp-className');
+    expect(container.querySelector('.ant-radio-wrapper')).toHaveStyle({ background: 'red' });
   });
 
   it('Should Slider className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -99,6 +99,7 @@ export interface ConfigConsumerProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
+  radio?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -112,6 +112,7 @@ const {
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string } | - | 4.2.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | Set Result common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | Set Segmented common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | Set Select common props | { showSearch?: boolean } | - |  |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -148,6 +148,7 @@ export interface ConfigProviderProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
+  radio?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -249,6 +250,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     breadcrumb,
     pagination,
     empty,
+    radio,
   } = props;
 
   // =================================== Warning ===================================
@@ -314,6 +316,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     breadcrumb,
     pagination,
     empty,
+    radio,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -114,6 +114,7 @@ const {
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | 设置 Segmented 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | 设置 Select 组件的通用属性 | { showSearch?: boolean } | - |  |

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -3,10 +3,10 @@ import type { CheckboxRef } from 'rc-checkbox';
 import RcCheckbox from 'rc-checkbox';
 import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import { FormItemInputContext } from '../form/context';
-import warning from '../_util/warning';
 import RadioGroupContext, { RadioOptionTypeContext } from './context';
 import type { RadioChangeEvent, RadioProps } from './interface';
 
@@ -16,7 +16,7 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
   const groupContext = React.useContext(RadioGroupContext);
   const radioOptionTypeContext = React.useContext(RadioOptionTypeContext);
 
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, radio } = React.useContext(ConfigContext);
   const innerRef = React.useRef<CheckboxRef>(null);
   const mergedRef = composeRef(ref, innerRef);
   const { isFormItemInput } = React.useContext(FormItemInputContext);
@@ -66,6 +66,7 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
       [`${prefixCls}-wrapper-rtl`]: direction === 'rtl',
       [`${prefixCls}-wrapper-in-form-item`]: isFormItemInput,
     },
+    radio?.className,
     className,
     rootClassName,
     hashId,
@@ -75,7 +76,7 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
     // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label
       className={wrapperClassString}
-      style={style}
+      style={{ ...radio?.style, ...style }}
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
     >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/43051

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     `ConfigProvider` support `Radio` className and style properties      |
| 🇨🇳 Chinese |     `ConfigProvider` 支持 `Radio` 组件的 className 和 style 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da8abf3</samp>

This pull request adds a new `radio` prop to the `ConfigProvider` component, which enables global customization of the radio button style. It also updates the Radio component, the ConfigConsumer component, and the context interfaces to support the new prop. Finally, it adds tests and documentation for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da8abf3</samp>

*  Add `radio` prop to `ConfigProvider` component and its API documentation ([link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R73), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R139-R142), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R230), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R280), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R74))
*  Add `radio` prop to `ConfigConsumerProps` interface in `context.ts` file ([link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR90-R93))
*  Use `radio` prop to set `className` and `style` attributes of the label element in `Radio` component ([link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL19-R19), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cR69), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL78-R79))
*  Reorder import statements in `Radio` component file ([link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL6-R9))
*  Add test cases to check if `ConfigProvider` can pass `radio` prop to `Radio` component ([link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R9), [link](https://github.com/ant-design/ant-design/pull/43067/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R202-R231))
