### PR TITLE
feat(Image): imageRender、toolbarRender、onTransform、items、minScale、max…

### DIFF
--- a/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -298,6 +298,47 @@ exports[`renders components/image/demo/fallback.tsx extend context correctly 1`]
 </div>
 `;
 
+exports[`renders components/image/demo/imageRender.tsx extend context correctly 1`] = `
+<div
+  class="ant-image"
+  style="width: 200px;"
+>
+  <img
+    class="ant-image-img"
+    src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+    width="200"
+  />
+  <div
+    class="ant-image-mask"
+  >
+    <div
+      class="ant-image-mask-info"
+    >
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/image/demo/placeholder.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"
@@ -576,158 +617,44 @@ Array [
 `;
 
 exports[`renders components/image/demo/preview-group-visible.tsx extend context correctly 1`] = `
-Array [
+<div
+  class="ant-image"
+  style="width: 200px;"
+>
+  <img
+    class="ant-image-img"
+    src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
+    width="200"
+  />
   <div
-    class="ant-image"
-    style="width: 200px;"
-  >
-    <img
-      class="ant-image-img"
-      src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
-      width="200"
-    />
-    <div
-      class="ant-image-mask"
-    >
-      <div
-        class="ant-image-mask-info"
-      >
-        <span
-          aria-label="eye"
-          class="anticon anticon-eye"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="eye"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-            />
-          </svg>
-        </span>
-        Preview
-      </div>
-    </div>
-  </div>,
-  <div
-    style="display: none;"
+    class="ant-image-mask"
   >
     <div
-      class="ant-image"
+      class="ant-image-mask-info"
     >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
-      />
-      <div
-        class="ant-image-mask"
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
       >
-        <div
-          class="ant-image-mask-info"
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
     </div>
-    <div
-      class="ant-image"
-    >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/cV16ZqzMjW/photo-1473091540282-9b846e7965e3.webp"
-      />
-      <div
-        class="ant-image-mask"
-      >
-        <div
-          class="ant-image-mask-info"
-        >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-image"
-    >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/x43I27A55%26/photo-1438109491414-7198515b166b.webp"
-      />
-      <div
-        class="ant-image-mask"
-      >
-        <div
-          class="ant-image-mask-info"
-        >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`renders components/image/demo/preview-mask.tsx extend context correctly 1`] = `
@@ -788,6 +715,47 @@ exports[`renders components/image/demo/previewSrc.tsx extend context correctly 1
   <img
     class="ant-image-img"
     src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+    width="200"
+  />
+  <div
+    class="ant-image-mask"
+  >
+    <div
+      class="ant-image-mask-info"
+    >
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/image/demo/toolbarRender.tsx extend context correctly 1`] = `
+<div
+  class="ant-image"
+  style="width: 200px;"
+>
+  <img
+    class="ant-image-img"
+    src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
     width="200"
   />
   <div

--- a/components/image/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo.test.ts.snap
@@ -299,6 +299,47 @@ exports[`renders components/image/demo/fallback.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/image/demo/imageRender.tsx correctly 1`] = `
+<div
+  class="ant-image"
+  style="width:200px"
+>
+  <img
+    class="ant-image-img"
+    src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+    width="200"
+  />
+  <div
+    class="ant-image-mask"
+  >
+    <div
+      class="ant-image-mask-info"
+    >
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/image/demo/placeholder.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"
@@ -577,158 +618,44 @@ Array [
 `;
 
 exports[`renders components/image/demo/preview-group-visible.tsx correctly 1`] = `
-Array [
+<div
+  class="ant-image"
+  style="width:200px"
+>
+  <img
+    class="ant-image-img"
+    src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
+    width="200"
+  />
   <div
-    class="ant-image"
-    style="width:200px"
-  >
-    <img
-      class="ant-image-img"
-      src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
-      width="200"
-    />
-    <div
-      class="ant-image-mask"
-    >
-      <div
-        class="ant-image-mask-info"
-      >
-        <span
-          aria-label="eye"
-          class="anticon anticon-eye"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="eye"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-            />
-          </svg>
-        </span>
-        Preview
-      </div>
-    </div>
-  </div>,
-  <div
-    style="display:none"
+    class="ant-image-mask"
   >
     <div
-      class="ant-image"
+      class="ant-image-mask-info"
     >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
-      />
-      <div
-        class="ant-image-mask"
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
       >
-        <div
-          class="ant-image-mask-info"
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
     </div>
-    <div
-      class="ant-image"
-    >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/cV16ZqzMjW/photo-1473091540282-9b846e7965e3.webp"
-      />
-      <div
-        class="ant-image-mask"
-      >
-        <div
-          class="ant-image-mask-info"
-        >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-image"
-    >
-      <img
-        class="ant-image-img"
-        src="https://gw.alipayobjects.com/zos/antfincdn/x43I27A55%26/photo-1438109491414-7198515b166b.webp"
-      />
-      <div
-        class="ant-image-mask"
-      >
-        <div
-          class="ant-image-mask-info"
-        >
-          <span
-            aria-label="eye"
-            class="anticon anticon-eye"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="eye"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
-              />
-            </svg>
-          </span>
-          Preview
-        </div>
-      </div>
-    </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`renders components/image/demo/preview-mask.tsx correctly 1`] = `
@@ -789,6 +716,47 @@ exports[`renders components/image/demo/previewSrc.tsx correctly 1`] = `
   <img
     class="ant-image-img"
     src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+    width="200"
+  />
+  <div
+    class="ant-image-mask"
+  >
+    <div
+      class="ant-image-mask-info"
+    >
+      <span
+        aria-label="eye"
+        class="anticon anticon-eye"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="eye"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+          />
+        </svg>
+      </span>
+      Preview
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/image/demo/toolbarRender.tsx correctly 1`] = `
+<div
+  class="ant-image"
+  style="width:200px"
+>
+  <img
+    class="ant-image-img"
+    src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
     width="200"
   />
   <div

--- a/components/image/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,39 +52,40 @@ exports[`Image Default Group preview props 1`] = `
         1 / 1
       </li>
       <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-close"
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-flipY"
       >
         <span
-          aria-label="close"
-          class="anticon anticon-close ant-image-preview-operations-icon"
+          aria-label="swap"
+          class="anticon anticon-swap ant-image-preview-operations-icon"
           role="img"
         >
           <svg
             aria-hidden="true"
-            data-icon="close"
+            data-icon="swap"
             fill="currentColor"
             focusable="false"
             height="1em"
+            style="transform: rotate(90deg);"
             viewBox="64 64 896 896"
             width="1em"
           >
             <path
-              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+              d="M847.9 592H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h605.2L612.9 851c-4.1 5.2-.4 13 6.3 13h72.5c4.9 0 9.5-2.2 12.6-6.1l168.8-214.1c16.5-21 1.6-51.8-25.2-51.8zM872 356H266.8l144.3-183c4.1-5.2.4-13-6.3-13h-72.5c-4.9 0-9.5 2.2-12.6 6.1L150.9 380.2c-16.5 21-1.6 51.8 25.1 51.8h696c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
             />
           </svg>
         </span>
       </li>
       <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-zoomIn"
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-flipX"
       >
         <span
-          aria-label="zoom-in"
-          class="anticon anticon-zoom-in ant-image-preview-operations-icon"
+          aria-label="swap"
+          class="anticon anticon-swap ant-image-preview-operations-icon"
           role="img"
         >
           <svg
             aria-hidden="true"
-            data-icon="zoom-in"
+            data-icon="swap"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -92,59 +93,7 @@ exports[`Image Default Group preview props 1`] = `
             width="1em"
           >
             <path
-              d="M637 443H519V309c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v134H325c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h118v134c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V519h118c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm284 424L775 721c122.1-148.9 113.6-369.5-26-509-148-148.1-388.4-148.1-537 0-148.1 148.6-148.1 389 0 537 139.5 139.6 360.1 148.1 509 26l146 146c3.2 2.8 8.3 2.8 11 0l43-43c2.8-2.7 2.8-7.8 0-11zM696 696c-118.8 118.7-311.2 118.7-430 0-118.7-118.8-118.7-311.2 0-430 118.8-118.7 311.2-118.7 430 0 118.7 118.8 118.7 311.2 0 430z"
-            />
-          </svg>
-        </span>
-      </li>
-      <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-zoomOut ant-image-preview-operations-operation-disabled"
-      >
-        <span
-          aria-label="zoom-out"
-          class="anticon anticon-zoom-out ant-image-preview-operations-icon"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="zoom-out"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M637 443H325c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h312c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm284 424L775 721c122.1-148.9 113.6-369.5-26-509-148-148.1-388.4-148.1-537 0-148.1 148.6-148.1 389 0 537 139.5 139.6 360.1 148.1 509 26l146 146c3.2 2.8 8.3 2.8 11 0l43-43c2.8-2.7 2.8-7.8 0-11zM696 696c-118.8 118.7-311.2 118.7-430 0-118.7-118.8-118.7-311.2 0-430 118.8-118.7 311.2-118.7 430 0 118.7 118.8 118.7 311.2 0 430z"
-            />
-          </svg>
-        </span>
-      </li>
-      <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-rotateRight"
-      >
-        <span
-          aria-label="rotate-right"
-          class="anticon anticon-rotate-right ant-image-preview-operations-icon"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="rotate-right"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <defs>
-              <style />
-            </defs>
-            <path
-              d="M480.5 251.2c13-1.6 25.9-2.4 38.8-2.5v63.9c0 6.5 7.5 10.1 12.6 6.1L660 217.6c4-3.2 4-9.2 0-12.3l-128-101c-5.1-4-12.6-.4-12.6 6.1l-.2 64c-118.6.5-235.8 53.4-314.6 154.2A399.75 399.75 0 00123.5 631h74.9c-.9-5.3-1.7-10.7-2.4-16.1-5.1-42.1-2.1-84.1 8.9-124.8 11.4-42.2 31-81.1 58.1-115.8 27.2-34.7 60.3-63.2 98.4-84.3 37-20.6 76.9-33.6 119.1-38.8z"
-            />
-            <path
-              d="M880 418H352c-17.7 0-32 14.3-32 32v414c0 17.7 14.3 32 32 32h528c17.7 0 32-14.3 32-32V450c0-17.7-14.3-32-32-32zm-44 402H396V494h440v326z"
+              d="M847.9 592H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h605.2L612.9 851c-4.1 5.2-.4 13 6.3 13h72.5c4.9 0 9.5-2.2 12.6-6.1l168.8-214.1c16.5-21 1.6-51.8-25.2-51.8zM872 356H266.8l144.3-183c4.1-5.2.4-13-6.3-13h-72.5c-4.9 0-9.5 2.2-12.6 6.1L150.9 380.2c-16.5 21-1.6 51.8 25.1 51.8h696c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
             />
           </svg>
         </span>
@@ -179,48 +128,99 @@ exports[`Image Default Group preview props 1`] = `
         </span>
       </li>
       <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-flipX"
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-rotateRight"
       >
         <span
-          aria-label="swap"
-          class="anticon anticon-swap ant-image-preview-operations-icon"
+          aria-label="rotate-right"
+          class="anticon anticon-rotate-right ant-image-preview-operations-icon"
           role="img"
         >
           <svg
             aria-hidden="true"
-            data-icon="swap"
+            data-icon="rotate-right"
             fill="currentColor"
             focusable="false"
             height="1em"
             viewBox="64 64 896 896"
             width="1em"
           >
+            <defs>
+              <style />
+            </defs>
             <path
-              d="M847.9 592H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h605.2L612.9 851c-4.1 5.2-.4 13 6.3 13h72.5c4.9 0 9.5-2.2 12.6-6.1l168.8-214.1c16.5-21 1.6-51.8-25.2-51.8zM872 356H266.8l144.3-183c4.1-5.2.4-13-6.3-13h-72.5c-4.9 0-9.5 2.2-12.6 6.1L150.9 380.2c-16.5 21-1.6 51.8 25.1 51.8h696c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              d="M480.5 251.2c13-1.6 25.9-2.4 38.8-2.5v63.9c0 6.5 7.5 10.1 12.6 6.1L660 217.6c4-3.2 4-9.2 0-12.3l-128-101c-5.1-4-12.6-.4-12.6 6.1l-.2 64c-118.6.5-235.8 53.4-314.6 154.2A399.75 399.75 0 00123.5 631h74.9c-.9-5.3-1.7-10.7-2.4-16.1-5.1-42.1-2.1-84.1 8.9-124.8 11.4-42.2 31-81.1 58.1-115.8 27.2-34.7 60.3-63.2 98.4-84.3 37-20.6 76.9-33.6 119.1-38.8z"
+            />
+            <path
+              d="M880 418H352c-17.7 0-32 14.3-32 32v414c0 17.7 14.3 32 32 32h528c17.7 0 32-14.3 32-32V450c0-17.7-14.3-32-32-32zm-44 402H396V494h440v326z"
             />
           </svg>
         </span>
       </li>
       <li
-        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-flipY"
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-zoomOut ant-image-preview-operations-operation-disabled"
       >
         <span
-          aria-label="swap"
-          class="anticon anticon-swap ant-image-preview-operations-icon"
+          aria-label="zoom-out"
+          class="anticon anticon-zoom-out ant-image-preview-operations-icon"
           role="img"
         >
           <svg
             aria-hidden="true"
-            data-icon="swap"
+            data-icon="zoom-out"
             fill="currentColor"
             focusable="false"
             height="1em"
-            style="transform: rotate(90deg);"
             viewBox="64 64 896 896"
             width="1em"
           >
             <path
-              d="M847.9 592H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h605.2L612.9 851c-4.1 5.2-.4 13 6.3 13h72.5c4.9 0 9.5-2.2 12.6-6.1l168.8-214.1c16.5-21 1.6-51.8-25.2-51.8zM872 356H266.8l144.3-183c4.1-5.2.4-13-6.3-13h-72.5c-4.9 0-9.5 2.2-12.6 6.1L150.9 380.2c-16.5 21-1.6 51.8 25.1 51.8h696c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              d="M637 443H325c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h312c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm284 424L775 721c122.1-148.9 113.6-369.5-26-509-148-148.1-388.4-148.1-537 0-148.1 148.6-148.1 389 0 537 139.5 139.6 360.1 148.1 509 26l146 146c3.2 2.8 8.3 2.8 11 0l43-43c2.8-2.7 2.8-7.8 0-11zM696 696c-118.8 118.7-311.2 118.7-430 0-118.7-118.8-118.7-311.2 0-430 118.8-118.7 311.2-118.7 430 0 118.7 118.8 118.7 311.2 0 430z"
+            />
+          </svg>
+        </span>
+      </li>
+      <li
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-zoomIn"
+      >
+        <span
+          aria-label="zoom-in"
+          class="anticon anticon-zoom-in ant-image-preview-operations-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="zoom-in"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M637 443H519V309c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v134H325c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h118v134c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V519h118c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8zm284 424L775 721c122.1-148.9 113.6-369.5-26-509-148-148.1-388.4-148.1-537 0-148.1 148.6-148.1 389 0 537 139.5 139.6 360.1 148.1 509 26l146 146c3.2 2.8 8.3 2.8 11 0l43-43c2.8-2.7 2.8-7.8 0-11zM696 696c-118.8 118.7-311.2 118.7-430 0-118.7-118.8-118.7-311.2 0-430 118.8-118.7 311.2-118.7 430 0 118.7 118.8 118.7 311.2 0 430z"
+            />
+          </svg>
+        </span>
+      </li>
+      <li
+        class="ant-image-preview-operations-operation ant-image-preview-operations-operation-close"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close ant-image-preview-operations-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
             />
           </svg>
         </span>

--- a/components/image/demo/imageRender.md
+++ b/components/image/demo/imageRender.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义预览内容。
+
+## en-US
+
+Custom preview render.

--- a/components/image/demo/imageRender.md
+++ b/components/image/demo/imageRender.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-自定义预览内容。
+可以自定义预览内容。
 
 ## en-US
 
-Custom preview render.
+You can customize the preview content.

--- a/components/image/demo/imageRender.tsx
+++ b/components/image/demo/imageRender.tsx
@@ -1,0 +1,24 @@
+import { Image } from 'antd';
+import React from 'react';
+
+const App: React.FC = () => (
+  <Image
+    width={200}
+    preview={{
+      imageRender: () => (
+        <video
+          muted
+          width="100%"
+          controls
+          src="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*uYT7SZwhJnUAAAAAAAAAAAAADgCCAQ"
+        />
+      ),
+      toolbarRender: ({ icons: { closeIcon } }) => (
+        <ul className="ant-image-preview-operations">{closeIcon}</ul>
+      ),
+    }}
+    src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+  />
+);
+
+export default App;

--- a/components/image/demo/imageRender.tsx
+++ b/components/image/demo/imageRender.tsx
@@ -10,11 +10,10 @@ const App: React.FC = () => (
           muted
           width="100%"
           controls
-          style={{ pointerEvents: 'auto' }}
           src="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*uYT7SZwhJnUAAAAAAAAAAAAADgCCAQ"
         />
       ),
-      toolbarRender: ({ icons: { closeIcon } }) => (
+      toolbarRender: (_, { icons: { closeIcon } }) => (
         <ul className="ant-image-preview-operations">{closeIcon}</ul>
       ),
     }}

--- a/components/image/demo/imageRender.tsx
+++ b/components/image/demo/imageRender.tsx
@@ -10,6 +10,7 @@ const App: React.FC = () => (
           muted
           width="100%"
           controls
+          style={{ pointerEvents: 'auto' }}
           src="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*uYT7SZwhJnUAAAAAAAAAAAAADgCCAQ"
         />
       ),

--- a/components/image/demo/preview-group-visible.tsx
+++ b/components/image/demo/preview-group-visible.tsx
@@ -1,26 +1,19 @@
-import React, { useState } from 'react';
 import { Image } from 'antd';
+import React from 'react';
 
-const App: React.FC = () => {
-  const [visible, setVisible] = useState(false);
-
-  return (
-    <>
-      <Image
-        preview={{ visible: false }}
-        width={200}
-        src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
-        onClick={() => setVisible(true)}
-      />
-      <div style={{ display: 'none' }}>
-        <Image.PreviewGroup preview={{ visible, onVisibleChange: (vis) => setVisible(vis) }}>
-          <Image src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp" />
-          <Image src="https://gw.alipayobjects.com/zos/antfincdn/cV16ZqzMjW/photo-1473091540282-9b846e7965e3.webp" />
-          <Image src="https://gw.alipayobjects.com/zos/antfincdn/x43I27A55%26/photo-1438109491414-7198515b166b.webp" />
-        </Image.PreviewGroup>
-      </div>
-    </>
-  );
-};
+const App: React.FC = () => (
+  <Image.PreviewGroup
+    items={[
+      'https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp',
+      'https://gw.alipayobjects.com/zos/antfincdn/cV16ZqzMjW/photo-1473091540282-9b846e7965e3.webp',
+      'https://gw.alipayobjects.com/zos/antfincdn/x43I27A55%26/photo-1438109491414-7198515b166b.webp',
+    ]}
+  >
+    <Image
+      width={200}
+      src="https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp"
+    />
+  </Image.PreviewGroup>
+);
 
 export default App;

--- a/components/image/demo/toolbarRender.md
+++ b/components/image/demo/toolbarRender.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义工具栏。
+
+## en-US
+
+Custom toolbar render.

--- a/components/image/demo/toolbarRender.md
+++ b/components/image/demo/toolbarRender.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-自定义工具栏。
+可以自定义工具栏。
 
 ## en-US
 
-Custom toolbar render.
+You can customize the toolbar.

--- a/components/image/demo/toolbarRender.tsx
+++ b/components/image/demo/toolbarRender.tsx
@@ -1,0 +1,56 @@
+import { DownloadOutlined } from '@ant-design/icons';
+import { Image } from 'antd';
+import React from 'react';
+
+const src = 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
+
+const App: React.FC = () => {
+  const onDownload = () => {
+    fetch(src)
+      .then((response) => response.blob())
+      .then((blob) => {
+        const url = window.URL.createObjectURL(new Blob([blob]));
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'image.jpg';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      });
+  };
+
+  return (
+    <Image
+      width={200}
+      preview={{
+        toolbarRender: ({
+          icons: {
+            flipYIcon,
+            flipXIcon,
+            rotateLeftIcon,
+            rotateRightIcon,
+            zoomOutIcon,
+            zoomInIcon,
+            closeIcon,
+          },
+        }) => (
+          <ul className="ant-image-preview-operations">
+            <li className="ant-image-preview-operations-operation" onClick={onDownload}>
+              <DownloadOutlined className="ant-image-preview-operations-icon" />
+            </li>
+            {flipYIcon}
+            {flipXIcon}
+            {rotateLeftIcon}
+            {rotateRightIcon}
+            {zoomOutIcon}
+            {zoomInIcon}
+            {closeIcon}
+          </ul>
+        ),
+      }}
+      src={src}
+    />
+  );
+};
+
+export default App;

--- a/components/image/demo/toolbarRender.tsx
+++ b/components/image/demo/toolbarRender.tsx
@@ -24,17 +24,20 @@ const App: React.FC = () => {
     <Image
       width={200}
       preview={{
-        toolbarRender: ({
-          icons: {
-            flipYIcon,
-            flipXIcon,
-            rotateLeftIcon,
-            rotateRightIcon,
-            zoomOutIcon,
-            zoomInIcon,
-            closeIcon,
+        toolbarRender: (
+          _,
+          {
+            icons: {
+              flipYIcon,
+              flipXIcon,
+              rotateLeftIcon,
+              rotateRightIcon,
+              zoomOutIcon,
+              zoomInIcon,
+              closeIcon,
+            },
           },
-        }) => (
+        ) => (
           <ul className="ant-image-preview-operations">
             <li className="ant-image-preview-operations-operation" onClick={onDownload}>
               <DownloadOutlined className="ant-image-preview-operations-icon" />

--- a/components/image/demo/toolbarRender.tsx
+++ b/components/image/demo/toolbarRender.tsx
@@ -9,12 +9,13 @@ const App: React.FC = () => {
     fetch(src)
       .then((response) => response.blob())
       .then((blob) => {
-        const url = window.URL.createObjectURL(new Blob([blob]));
+        const url = URL.createObjectURL(new Blob([blob]));
         const link = document.createElement('a');
         link.href = url;
         link.download = 'image.jpg';
         document.body.appendChild(link);
         link.click();
+        URL.revokeObjectURL(url);
         link.remove();
       });
   };

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -58,7 +58,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | mask | Thumbnail mask | ReactNode | - | 4.9.0 |
 | maskClassName | The className of the mask | string | - | 4.11.0 |
 | rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
-| scaleStep | The number to which the scale is increased or decreased | number | 0.5 | - |
+| scaleStep | `1 + scaleStep` is the step to increase or decrease the scale | number | 0.5 | - |
 | minScale | Min scale | number | 1 | 5.7.0 |
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |
@@ -84,7 +84,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | mask | Thumbnail mask | ReactNode | - | 4.9.0 |
 | maskClassName | The className of the mask | string | - | 4.11.0 |
 | rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
-| scaleStep | The number to which the scale is increased or decreased | number | 0.5 | - |
+| scaleStep | `1 + scaleStep` is the step to increase or decrease the scale | number | 0.5 | - |
 | minScale | Min scale | number | 1 | 5.7.0 |
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -62,8 +62,8 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | minScale | Min scale | number | 1 | 5.7.0 |
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |
-| toolbarRender | Custom toolbar render | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
-| imageRender | Custom preview content | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | 5.7.0 |
+| toolbarRender | Custom toolbar render | (originalNode: React.ReactNode, info: Omit<[ToolbarRenderInfoType](#ToolbarRenderInfoType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
+| imageRender | Custom preview content | (originalNode: React.ReactNode, info: { transform: [TransformType](#TransformType) }) => React.ReactNode | - | 5.7.0 |
 | onTransform | Callback when the transform of image changed | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
 | onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean) => void | - | - |
 
@@ -89,8 +89,8 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |
 | countRender | Custom preview count content | (current: number, total: number) => string | - | 4.20.0 |
-| toolbarRender | Custom toolbar render | (params: [ToolbarRenderType](#ToolbarRenderType)) => React.ReactNode | - | 5.7.0 |
-| imageRender | Custom preview content | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | 5.7.0 |
+| toolbarRender | Custom toolbar render | (originalNode: React.ReactNode, info: [ToolbarRenderInfoType](#ToolbarRenderInfoType)) => React.ReactNode | - | 5.7.0 |
+| imageRender | Custom preview content | (originalNode: React.ReactNode, info: { transform: [TransformType](#TransformType), current: number }) => React.ReactNode | - | 5.7.0 |
 | onTransform | Callback when the transform of image changed | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
 | onChange | Callback when switch preview image | (current: number, prevCurrent: number) => void | - | 5.3.0 |
 | onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean, current: number) => void | - | current 参数 5.3.0 |
@@ -129,11 +129,10 @@ type TransformAction =
   | 'dragRebound';
 ```
 
-### ToolbarRenderType
+### ToolbarRenderInfoType
 
 ```typescript
 {
-  originalNode: React.ReactNode;
   icons: {
     flipYIcon: React.ReactNode;
     flipXIcon: React.ReactNode;
@@ -144,13 +143,13 @@ type TransformAction =
     closeIcon: React.ReactNode;
   };
   actions: {
-    flipY: () => void;
-    flipX: () => void;
-    rotateLeft: () => void;
-    rotateRight: () => void;
-    zoomOut: () => void;
-    zoomIn: () => void;
-    close: () => void;
+    onFlipY: () => void;
+    onFlipX: () => void;
+    onRotateLeft: () => void;
+    onRotateRight: () => void;
+    onZoomOut: () => void;
+    onZoomIn: () => void;
+    onClose: () => void;
   };
   transform: TransformType,
   current: number;

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -48,24 +48,6 @@ Previewable image.
 
 Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
 
-### previewType
-
-```typescript
-{
-  visible?: boolean;
-  onVisibleChange?: (visible, prevVisible, current: number) => void; // `current` only support after v5.3.0
-  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0 The mounted node for preview dialog but still display at fullScreen
-  src?: string; // v4.10.0
-  mask?: ReactNode; // v4.9.0
-  maskClassName?: string; // v4.11.0
-  rootClassName?: string; // only support after v5.4.0
-  current?: number; // v4.12.0 Only support PreviewGroup
-  countRender?: (current: number, total: number) => string  // v4.20.0 Only support PreviewGroup
-  scaleStep?: number;
-  onChange?: (current: number, prevCurrent: number) => void; // only support after v5.3.0
-}
-```
-
 ### PreviewType
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
@@ -76,7 +58,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | mask | Thumbnail mask | ReactNode | - | 4.9.0 |
 | maskClassName | The className of the mask | string | - | 4.11.0 |
 | rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
-| scaleStep | The number to which the scale is increased or decreased | number | - | - |
+| scaleStep | The number to which the scale is increased or decreased | number | 0.5 | - |
 | minScale | Min scale | number | 1 | 5.7.0 |
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |
@@ -102,7 +84,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | mask | Thumbnail mask | ReactNode | - | 4.9.0 |
 | maskClassName | The className of the mask | string | - | 4.11.0 |
 | rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
-| scaleStep | The number to which the scale is increased or decreased | number | - | - |
+| scaleStep | The number to which the scale is increased or decreased | number | 0.5 | - |
 | minScale | Min scale | number | 1 | 5.7.0 |
 | maxScale | Max scale | number | 50 | 5.7.0 |
 | forceRender | Force render preview dialog | boolean | - | - |

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -24,11 +24,15 @@ Previewable image.
 <code src="./demo/preview-group-visible.tsx">Preview from one image</code>
 <code src="./demo/previewSrc.tsx">Custom preview image</code>
 <code src="./demo/controlled-preview.tsx">Controlled Preview</code>
+<code src="./demo/toolbarRender.tsx">Custom toolbar render</code>
+<code src="./demo/imageRender.tsx">Custom preview render</code>
 <code src="./demo/preview-mask.tsx" debug>Custom preview mask</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>Top progress customization when previewing multiple images</code>
 <code src="./demo/component-token.tsx" debug>Custom component token</code>
 
 ## API
+
+### Image
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
@@ -36,11 +40,13 @@ Previewable image.
 | fallback | Load failure fault-tolerant src | string | - | 4.6.0 |
 | height | Image height | string \| number | - | 4.6.0 |
 | placeholder | Load placeholder, use default placeholder when set `true` | ReactNode | - | 4.6.0 |
-| preview | preview config, disabled when `false` | boolean \| [previewType](#previewtype) | true | 4.6.0 [previewType](#previewtype):4.7.0 |
+| preview | preview config, disabled when `false` | boolean \| [PreviewType](#PreviewType) | true | 4.6.0 [PreviewType](#PreviewType):4.7.0 |
 | src | Image path | string | - | 4.6.0 |
 | width | Image width | string \| number | - | 4.6.0 |
 | onError | Load failed callback | (event: Event) => void | - | 4.12.0 |
-| rootClassName | add custom className for image root DOM and preview mode root DOM | string | - | 4.20.0 |
+| rootClassName | Add custom className for image root DOM and preview mode root DOM | string | - | 4.20.0 |
+
+Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
 
 ### previewType
 
@@ -60,7 +66,115 @@ Previewable image.
 }
 ```
 
-Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
+### PreviewType
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| visible | Whether the preview dialog is visible or not | boolean | - | - |
+| src | Custom preview src | string | - | 4.10.0 |
+| getContainer | The mounted node for preview dialog but still display at fullScreen | string \| HTMLElement \| (() => HTMLElement) \| false | - | 4.8.0 |
+| mask | Thumbnail mask | ReactNode | - | 4.9.0 |
+| maskClassName | The className of the mask | string | - | 4.11.0 |
+| rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
+| scaleStep | The number to which the scale is increased or decreased | number | - | - |
+| minScale | Min scale | number | 1 | 5.7.0 |
+| maxScale | Max scale | number | 50 | 5.7.0 |
+| forceRender | Force render preview dialog | boolean | - | - |
+| toolbarRender | Custom toolbar render | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
+| imageRender | Custom preview content | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | 5.7.0 |
+| onTransform | Callback when the transform of image changed | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
+| onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean) => void | - | - |
+
+## PreviewGroup
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| preview | Preview config, `disabled` when false | boolean \| [PreviewGroupType](#PreviewGroupType) | true | 4.6.0 [PreviewGroupType](#PreviewGroupType):4.7.0 |
+| items | Preview items | string[] \| { src: string, crossOrigin: string, ... }[] | - | 5.7.0 |
+
+### PreviewGroupType
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| visible | Whether the preview dialog is visible or not | boolean | - | - |
+| getContainer | The mounted node for preview dialog but still display at fullScreen | string \| HTMLElement \| (() => HTMLElement) \| false | - | 4.8.0 |
+| current | The index of the current preview | number | - | 4.12.0 |
+| mask | Thumbnail mask | ReactNode | - | 4.9.0 |
+| maskClassName | The className of the mask | string | - | 4.11.0 |
+| rootClassName | The classname of the preview root DOM | string | - | 5.4.0 |
+| scaleStep | The number to which the scale is increased or decreased | number | - | - |
+| minScale | Min scale | number | 1 | 5.7.0 |
+| maxScale | Max scale | number | 50 | 5.7.0 |
+| forceRender | Force render preview dialog | boolean | - | - |
+| countRender | Custom preview count content | (current: number, total: number) => string | - | 4.20.0 |
+| toolbarRender | Custom toolbar render | (params: [ToolbarRenderType](#ToolbarRenderType)) => React.ReactNode | - | 5.7.0 |
+| imageRender | Custom preview content | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | 5.7.0 |
+| onTransform | Callback when the transform of image changed | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
+| onChange | Callback when switch preview image | (current: number, prevCurrent: number) => void | - | 5.3.0 |
+| onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean, current: number) => void | - | current 参数 5.3.0 |
+
+## Interface
+
+### TransformType
+
+```typescript
+{
+  x: number;
+  y: number;
+  rotate: number;
+  scale: number;
+  flipX: boolean;
+  flipY: boolean;
+}
+```
+
+### TransformAction
+
+```typescript
+type TransformAction =
+  | 'flipY'
+  | 'flipX'
+  | 'rotateLeft'
+  | 'rotateRight'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'close'
+  | 'prev'
+  | 'next'
+  | 'wheel'
+  | 'doubleClick'
+  | 'move'
+  | 'dragRebound';
+```
+
+### ToolbarRenderType
+
+```typescript
+{
+  originalNode: React.ReactNode;
+  icons: {
+    flipYIcon: React.ReactNode;
+    flipXIcon: React.ReactNode;
+    rotateLeftIcon: React.ReactNode;
+    rotateRightIcon: React.ReactNode;
+    zoomOutIcon: React.ReactNode;
+    zoomInIcon: React.ReactNode;
+    closeIcon: React.ReactNode;
+  };
+  actions: {
+    flipY: () => void;
+    flipX: () => void;
+    rotateLeft: () => void;
+    rotateRight: () => void;
+    zoomOut: () => void;
+    zoomIn: () => void;
+    close: () => void;
+  };
+  transform: TransformType,
+  current: number;
+  total: number;
+}
+```
 
 ## Design Token
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -59,7 +59,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | mask | 缩略图遮罩 | ReactNode | - | 4.9.0 |
 | maskClassName | 缩略图遮罩类名 | string | - | 4.11.0 |
 | rootClassName | 预览图的根 DOM 类名 | string | - | 5.4.0 |
-| scaleStep | 缩放放大的每步倍数 | number | 0.5 | - |
+| scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 | - |
 | minScale | 最小缩放倍数 | number | 1 | 5.7.0 |
 | maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
 | forceRender | 强制渲染预览图 | boolean | - | - |
@@ -85,7 +85,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | mask | 缩略图遮罩 | ReactNode | - | 4.9.0 |
 | maskClassName | 缩略图遮罩类名 | string | - | 4.11.0 |
 | rootClassName | 预览图的根 DOM 类名 | string | - | 5.4.0 |
-| scaleStep | 缩放放大的每步倍数 | number | 0.5 | - |
+| scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 | - |
 | minScale | 最小缩放倍数 | number | 1 | 5.7.0 |
 | maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
 | forceRender | 强制渲染预览图 | boolean | - | - |

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -25,11 +25,15 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 <code src="./demo/preview-group-visible.tsx">相册模式</code>
 <code src="./demo/previewSrc.tsx">自定义预览图片</code>
 <code src="./demo/controlled-preview.tsx">受控的预览</code>
+<code src="./demo/toolbarRender.tsx">自定义工具栏</code>
+<code src="./demo/imageRender.tsx">自定义预览内容</code>
 <code src="./demo/preview-mask.tsx" debug>自定义预览文本</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>多图预览时顶部进度自定义</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 Token</code>
 
 ## API
+
+### Image
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
@@ -37,32 +41,123 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | fallback | 加载失败容错地址 | string | - | 4.6.0 |
 | height | 图像高度 | string \| number | - | 4.6.0 |
 | placeholder | 加载占位, 为 `true` 时使用默认占位 | ReactNode | - | 4.6.0 |
-| preview | 预览参数，为 `false` 时禁用 | boolean \| [previewType](#previewtype) | true | 4.6.0 [previewType](#previewtype):4.7.0 |
+| preview | 预览参数，为 `false` 时禁用 | boolean \| [PreviewType](#PreviewType) | true | 4.6.0 [PreviewType](#PreviewType):4.7.0 |
 | src | 图片地址 | string | - | 4.6.0 |
 | width | 图像宽度 | string \| number | - | 4.6.0 |
 | onError | 加载错误回调 | (event: Event) => void | - | 4.12.0 |
 | rootClassName | 为展示图片根 DOM 和预览大图根 DOM 提供自定义 className | string | - | 4.20.0 |
 
-### previewType
+其他属性见 [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
+
+### PreviewType
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| visible | 是否显示 | boolean | - | - |
+| src | 自定义预览 src | string | - | 4.10.0 |
+| getContainer | 指定预览挂载的节点，但依旧为全屏展示，false 为挂载在当前位置 | string \| HTMLElement \| (() => HTMLElement) \| false | - | 4.8.0 |
+| mask | 缩略图遮罩 | ReactNode | - | 4.9.0 |
+| maskClassName | 缩略图遮罩类名 | string | - | 4.11.0 |
+| rootClassName | 预览图的根 DOM 类名 | string | - | 5.4.0 |
+| scaleStep | 缩放放大的每步倍数 | number | 0.5 | - |
+| minScale | 最小缩放倍数 | number | 1 | 5.7.0 |
+| maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
+| forceRender | 强制渲染预览图 | boolean | - | - |
+| toolbarRender | 自定义工具栏 | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
+| imageRender | 自定义预览内容 | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | 5.7.0 |
+| onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
+| onVisibleChange | 当 `visible` 发生改变时的回调 | (visible: boolean, prevVisible: boolean) => void | - | - |
+
+## PreviewGroup
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| preview | 预览参数，为 `false` 时禁用 | boolean \| [PreviewGroupType](#PreviewGroupType) | true | 4.6.0 [PreviewGroupType](#PreviewGroupType):4.7.0 |
+| items | 预览数组 | string[] \| { src: string, crossOrigin: string, ... }[] | - | 5.7.0 |
+
+### PreviewGroupType
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| visible | 是否显示 | boolean | - | - |
+| getContainer | 指定预览挂载的节点，但依旧为全屏展示，false 为挂载在当前位置 | string \| HTMLElement \| (() => HTMLElement) \| false | - | 4.8.0 |
+| current | 当前预览图的 index | number | - | 4.12.0 |
+| mask | 缩略图遮罩 | ReactNode | - | 4.9.0 |
+| maskClassName | 缩略图遮罩类名 | string | - | 4.11.0 |
+| rootClassName | 预览图的根 DOM 类名 | string | - | 5.4.0 |
+| scaleStep | 缩放放大的每步倍数 | number | 0.5 | - |
+| minScale | 最小缩放倍数 | number | 1 | 5.7.0 |
+| maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
+| forceRender | 强制渲染预览图 | boolean | - | - |
+| countRender | 自定义预览计数内容 | (current: number, total: number) => string | - | 4.20.0 |
+| toolbarRender | 自定义工具栏 | (params: [ToolbarRenderType](#ToolbarRenderType)) => React.ReactNode | - | 5.7.0 |
+| imageRender | 自定义预览内容 | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | 5.7.0 |
+| onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
+| onChange | 切换预览图的回调 | (current: number, prevCurrent: number) => void | - | 5.3.0 |
+| onVisibleChange | 当 `visible` 发生改变时的回调 | (visible: boolean, prevVisible: boolean, current: number) => void | - | current 参数 5.3.0 |
+
+## Interface
+
+### TransformType
 
 ```typescript
 {
-  visible?: boolean;
-  onVisibleChange?: (visible, prevVisible, current: number) => void; // current 参数 v5.3.0 后支持
-  getContainer?: string | HTMLElement | (() => HTMLElement); // v4.8.0 指定预览窗口挂载的节点，但依旧为全屏展示
-  src?: string; // v4.10.0
-  mask?: ReactNode; // v4.9.0
-  maskClassName?: string; // v4.11.0
-  rootClassName?: string; // v5.4.0 后支持
-  current?: number; // v4.12.0 仅支持 PreviewGroup
-  countRender?: (current: number, total: number) => string  // v4.20.0 仅支持 PreviewGroup
-  scaleStep?: number;
-  forceRender?: boolean;
-  onChange?: (current: number, prevCurrent: number) => void; // v5.3.0 后支持
+  x: number;
+  y: number;
+  rotate: number;
+  scale: number;
+  flipX: boolean;
+  flipY: boolean;
 }
 ```
 
-其他属性见 [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
+### TransformAction
+
+```typescript
+type TransformAction =
+  | 'flipY'
+  | 'flipX'
+  | 'rotateLeft'
+  | 'rotateRight'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'close'
+  | 'prev'
+  | 'next'
+  | 'wheel'
+  | 'doubleClick'
+  | 'move'
+  | 'dragRebound';
+```
+
+### ToolbarRenderType
+
+```typescript
+{
+  originalNode: React.ReactNode;
+  icons: {
+    flipYIcon: React.ReactNode;
+    flipXIcon: React.ReactNode;
+    rotateLeftIcon: React.ReactNode;
+    rotateRightIcon: React.ReactNode;
+    zoomOutIcon: React.ReactNode;
+    zoomInIcon: React.ReactNode;
+    closeIcon: React.ReactNode;
+  };
+  actions: {
+    flipY: () => void;
+    flipX: () => void;
+    rotateLeft: () => void;
+    rotateRight: () => void;
+    zoomOut: () => void;
+    zoomIn: () => void;
+    close: () => void;
+  };
+  transform: TransformType,
+  current: number;
+  total: number;
+}
+```
 
 ## Design Token
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -63,8 +63,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | minScale | 最小缩放倍数 | number | 1 | 5.7.0 |
 | maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
 | forceRender | 强制渲染预览图 | boolean | - | - |
-| toolbarRender | 自定义工具栏 | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
-| imageRender | 自定义预览内容 | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | 5.7.0 |
+| toolbarRender | 自定义工具栏 | (originalNode: React.ReactNode, info: Omit<[ToolbarRenderInfoType](#ToolbarRenderInfoType), 'current' \| 'total'>) => React.ReactNode | - | 5.7.0 |
+| imageRender | 自定义预览内容 | (originalNode: React.ReactNode, info: { transform: [TransformType](#TransformType) }) => React.ReactNode | - | 5.7.0 |
 | onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
 | onVisibleChange | 当 `visible` 发生改变时的回调 | (visible: boolean, prevVisible: boolean) => void | - | - |
 
@@ -90,8 +90,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | maxScale | 最大放大倍数 | number | 50 | 5.7.0 |
 | forceRender | 强制渲染预览图 | boolean | - | - |
 | countRender | 自定义预览计数内容 | (current: number, total: number) => string | - | 4.20.0 |
-| toolbarRender | 自定义工具栏 | (params: [ToolbarRenderType](#ToolbarRenderType)) => React.ReactNode | - | 5.7.0 |
-| imageRender | 自定义预览内容 | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | 5.7.0 |
+| toolbarRender | 自定义工具栏 | (originalNode: React.ReactNode, info: [ToolbarRenderInfoType](#ToolbarRenderInfoType)) => React.ReactNode | - | 5.7.0 |
+| imageRender | 自定义预览内容 | (originalNode: React.ReactNode, info: { transform: [TransformType](#TransformType), current: number }) => React.ReactNode | - | 5.7.0 |
 | onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | 5.7.0 |
 | onChange | 切换预览图的回调 | (current: number, prevCurrent: number) => void | - | 5.3.0 |
 | onVisibleChange | 当 `visible` 发生改变时的回调 | (visible: boolean, prevVisible: boolean, current: number) => void | - | current 参数 5.3.0 |
@@ -130,11 +130,10 @@ type TransformAction =
   | 'dragRebound';
 ```
 
-### ToolbarRenderType
+### ToolbarRenderInfoType
 
 ```typescript
 {
-  originalNode: React.ReactNode;
   icons: {
     flipYIcon: React.ReactNode;
     flipXIcon: React.ReactNode;
@@ -145,13 +144,13 @@ type TransformAction =
     closeIcon: React.ReactNode;
   };
   actions: {
-    flipY: () => void;
-    flipX: () => void;
-    rotateLeft: () => void;
-    rotateRight: () => void;
-    zoomOut: () => void;
-    zoomIn: () => void;
-    close: () => void;
+    onFlipY: () => void;
+    onFlipX: () => void;
+    onRotateLeft: () => void;
+    onRotateRight: () => void;
+    onZoomOut: () => void;
+    onZoomIn: () => void;
+    onClose: () => void;
   };
   transform: TransformType,
   current: number;

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -182,9 +182,6 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
         [`${previewCls}-body`]: {
           ...genBoxStyle(),
           overflow: 'hidden',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
         },
 
         [`${previewCls}-img`]: {
@@ -195,15 +192,36 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
           cursor: 'grab',
           transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
           userSelect: 'none',
+          pointerEvents: 'auto',
 
           '&-wrapper': {
-            pointerEvents: 'auto',
+            ...genBoxStyle(),
+            transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
+
+            // https://github.com/ant-design/ant-design/issues/39913
+            // TailwindCSS will reset img default style.
+            // Let's set back.
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+
+            '&::before': {
+              display: 'inline-block',
+              width: 1,
+              height: '50%',
+              marginInlineEnd: -1,
+              content: '""',
+            },
           },
         },
 
         [`${previewCls}-moving`]: {
           [`${previewCls}-preview-img`]: {
             cursor: 'grabbing',
+
+            '&-wrapper': {
+              transitionDuration: '0s',
+            },
           },
         },
       },

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -64,7 +64,7 @@ export const genPreviewOperationsStyle = (token: ImageToken): CSSObject => {
     [`${previewCls}-operations`]: {
       ...resetComponent(token),
       display: 'flex',
-      flexDirection: 'row-reverse',
+      justifyContent: 'flex-end',
       alignItems: 'center',
       color: token.previewOperationColor,
       listStyle: 'none',
@@ -87,7 +87,7 @@ export const genPreviewOperationsStyle = (token: ImageToken): CSSObject => {
           pointerEvents: 'none',
         },
 
-        '&:last-of-type': {
+        '&:first-of-type': {
           marginInlineStart: 0,
         },
       },
@@ -182,6 +182,9 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
         [`${previewCls}-body`]: {
           ...genBoxStyle(),
           overflow: 'hidden',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
         },
 
         [`${previewCls}-img`]: {
@@ -192,36 +195,15 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
           cursor: 'grab',
           transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
           userSelect: 'none',
-          pointerEvents: 'auto',
 
           '&-wrapper': {
-            ...genBoxStyle(),
-            transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
-
-            // https://github.com/ant-design/ant-design/issues/39913
-            // TailwindCSS will reset img default style.
-            // Let's set back.
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-
-            '&::before': {
-              display: 'inline-block',
-              width: 1,
-              height: '50%',
-              marginInlineEnd: -1,
-              content: '""',
-            },
+            pointerEvents: 'auto',
           },
         },
 
         [`${previewCls}-moving`]: {
           [`${previewCls}-preview-img`]: {
             cursor: 'grabbing',
-
-            '&-wrapper': {
-              transitionDuration: '0s',
-            },
           },
         },
       },

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -192,7 +192,6 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
           cursor: 'grab',
           transition: `transform ${motionDurationSlow} ${motionEaseOut} 0s`,
           userSelect: 'none',
-          pointerEvents: 'auto',
 
           '&-wrapper': {
             ...genBoxStyle(),
@@ -204,6 +203,10 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
+
+            '& > *': {
+              pointerEvents: 'auto',
+            },
 
             '&::before': {
               display: 'inline-block',

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "rc-drawer": "~6.2.0",
     "rc-dropdown": "~4.1.0",
     "rc-field-form": "~1.32.0",
-    "rc-image": "~5.17.1",
+    "rc-image": "~5.18.1",
     "rc-input": "~1.1.0",
     "rc-input-number": "~8.0.0",
     "rc-mentions": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "rc-drawer": "~6.2.0",
     "rc-dropdown": "~4.1.0",
     "rc-field-form": "~1.32.0",
-    "rc-image": "~5.18.1",
+    "rc-image": "~6.0.0",
     "rc-input": "~1.1.0",
     "rc-input-number": "~8.0.0",
     "rc-mentions": "~2.4.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/42845
https://github.com/ant-design/ant-design/issues/27273
https://github.com/ant-design/ant-design/issues/38418
https://github.com/react-component/image/issues/192
https://github.com/react-component/image/issues/110

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     support imageRender、toolbarRender、onTransform、items、minScale、maxScale. fix img common props are not passed to preview img     |
| 🇨🇳 Chinese |     支持 imageRender、toolbarRender、onTransform、items、minScale、maxScale。修复 img 的原生属性没有传递给预览图的问题     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34cfae4</samp>

This pull request enhances the image component with new features, props, and demos, and updates the documentation and dependency accordingly. It adds the ability to customize the preview and toolbar render, to pass an array of preview sources to the preview group, and to render a video instead of an image in the preview. It also fixes some style and functionality issues of the preview feature, and some typos and inconsistencies in the documentation. It modifies the files `components/image/*`, and `package.json`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34cfae4</samp>

*  Add two new demos of custom toolbar render and custom preview render in the image component, and update the English and Chinese documentation with the links and descriptions of the new demos ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-831179c3c2c6ae10fc9ae3b08afc280a684665418994a76429025b0887aebcd5R1-R7), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-e0f4b6171a2d2ddfa3ab2e746e1fa26aacb7cf8ec6a46cbc3d2250f75507b0e6R1-R24), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-ff24c471c0b5319a02b8f90d81007f652989af18a8555822ca98d324c8b00d73R1-R7), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-94187e7b726a3e17e6c68962179363e372b1b38b03c72eb8d78cc5cf2bff3852R1-R56), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2R27-R28), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281R28-R29))
*  Replace the original demo of preview group visible in the image component with a new one that uses the new `items` prop to pass an array of preview sources to the `Image.PreviewGroup` component ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-9bcd361df3114c2fcb93b12a44d96953f03442fc9206eefba5cf6c53a0972ab8L1-R18))
*  Add a heading for the `Image` component API in the English and Chinese documentation ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2R35-R36), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281R36-R37))
*  Update the type of the `preview` prop in the `Image` component API from `previewType` to `PreviewType` in the English and Chinese documentation, to match the naming convention of the other types ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L39-R50), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281L40-R44))
*  Restructure the `previewType` section in the English and Chinese documentation, and add the detailed descriptions and versions for each prop in the `PreviewType`, `PreviewGroupType`, `TransformType`, `TransformAction`, and `ToolbarRenderType` interfaces ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L63-R178), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281L46-R161))
*  Add the new props `imageRender`, `onTransform`, `minScale`, and `maxScale` to the `PreviewType` and `PreviewGroupType` interfaces, and the new prop `current` to the `imageRender` parameter in the `PreviewType` interface, to support custom preview render and transform events in the image component ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L63-R178), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281L46-R161))
*  Update the style of the preview operations container and icons in the image component, and reverse the order of the icons to align them to the end of the flex container ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-922f1030835ae207735e4fda28ea766dc4a4e35ae7ba47db9d084a4c0b2fec3eL67-R67), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-922f1030835ae207735e4fda28ea766dc4a4e35ae7ba47db9d084a4c0b2fec3eL90-R90))
*  Add the style of the preview content container in the image component, and center the content in the flex container ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-922f1030835ae207735e4fda28ea766dc4a4e35ae7ba47db9d084a4c0b2fec3eR185-R187))
*  Update the style of the preview content wrapper and content in the image component, and remove the `pointerEvents` and `transition` properties from the wrapper, and move the `pointerEvents` property to the content itself, to avoid blocking the mouse events on the custom preview content ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-922f1030835ae207735e4fda28ea766dc4a4e35ae7ba47db9d084a4c0b2fec3eL195-R200), [link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-922f1030835ae207735e4fda28ea766dc4a4e35ae7ba47db9d084a4c0b2fec3eL221-L224))
*  Update the dependency version of the `rc-image` package from `5.17.1` to `5.18.1`, to use the latest features and bug fixes of the image component ([link](https://github.com/ant-design/ant-design/pull/43075/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L132-R132))
