### PR TITLE
docs: color-picker api version

### DIFF
--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -34,36 +34,36 @@ Used when the user needs to customize the color selection.
 > This component is available since `antd@5.5.0`.
 
 <!-- prettier-ignore -->
-| Property | Description | Type | Default |
-| :-- | :-- | :-- | :-- |
-| format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` |
-| value | Value of color | string \| `Color` | - |
-| defaultValue | Default value of color | string \| `Color` | - |
-| allowClear | 	Allow clearing color selected | boolean | false |
-| presets | 	Preset colors | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - |
-| children | Trigger of ColorPicker | React.ReactNode | - |
-| trigger | ColorPicker trigger mode | `hover` \| `click` | `click` |
-| open | Whether to show popup | boolean | - |
-| disabled | Disable ColorPicker | boolean | - |
-| placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` |
-| arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | `true` | - |
-| destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | `false` |
-| onChange | Callback when `value` is changed | `(value: Color, hex: string) => void` | - |
-| onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - |
-| onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - |
-| onClear | Called when clear | `() => void` | - |
+| Property | Description | Type | Default | Version |
+| :-- | :-- | :-- | :-- | :-- |
+| format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | - |
+| value | Value of color | string \| `Color` | - | - |
+| defaultValue | Default value of color | string \| `Color` | - | - |
+| allowClear | 	Allow clearing color selected | boolean | false | - |
+| presets | 	Preset colors | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - | - |
+| children | Trigger of ColorPicker | React.ReactNode | - | - |
+| trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | - |
+| open | Whether to show popup | boolean | - | - |
+| disabled | Disable ColorPicker | boolean | - | - |
+| placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | - |
+| arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | `true` | - | - |
+| destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | `false` | 5.7.0 |
+| onChange | Callback when `value` is changed | `(value: Color, hex: string) => void` | - | - |
+| onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | - |
+| onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | - |
+| onClear | Called when clear | `() => void` | - | 5.6.0 |
 
 ### Color
 
 <!-- prettier-ignore -->
-| Property | Description | Type | Default |
-| :-- | :-- | :-- | :-- |
-| toHex | Convert to `hex` format characters, the return type like: `1677ff` | `() => string` | - |
-| toHexString | Convert to `hex` format color string, the return type like: `#1677ff` | `() => string` | - |
-| toHsb | Convert to `hsb` object  | `() => ({ h: number, s: number, b: number, a number })` | - |
-| toHsbString | Convert to `hsb` format color string, the return type like: `hsb(215, 91%, 100%)` | `() => string` | - |
-| toRgb | Convert to `rgb` object  | `() => ({ r: number, g: number, b: number, a number })` | - |
-| toRgbString | Convert to `rgb` format color string, the return type like: `rgb(22, 119, 255)` | `() => string` | - |
+| Property | Description | Type | Default | Version |
+| :-- | :-- | :-- | :-- | :-- |
+| toHex | Convert to `hex` format characters, the return type like: `1677ff` | `() => string` | - | - |
+| toHexString | Convert to `hex` format color string, the return type like: `#1677ff` | `() => string` | - | - |
+| toHsb | Convert to `hsb` object  | `() => ({ h: number, s: number, b: number, a number })` | - | - |
+| toHsbString | Convert to `hsb` format color string, the return type like: `hsb(215, 91%, 100%)` | `() => string` | - | - |
+| toRgb | Convert to `rgb` object  | `() => ({ r: number, g: number, b: number, a number })` | - | - |
+| toRgbString | Convert to `rgb` format color string, the return type like: `rgb(22, 119, 255)` | `() => string` | - | - |
 
 ## FAQ
 

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -35,36 +35,36 @@ group:
 > 自 `antd@5.5.0` 版本开始提供该组件。
 
 <!-- prettier-ignore -->
-| 参数 | 说明 | 类型 | 默认值 |
-| :-- | :-- | :-- | :-- |
-| format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` |
-| value | 颜色的值 | string \| `Color` | - |
-| defaultValue | 颜色默认的值 | string \| `Color` | - |
-| allowClear | 允许清除选择的颜色 | boolean | false |
-| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - |
-| children | 颜色选择器的触发器 | React.ReactNode | - |
-| trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` |
-| open | 是否显示弹出窗口 | boolean | - |
-| disabled | 禁用颜色选择器 | boolean | - |
-| placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` |
-| arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | `true` | - |
-| destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | `false` |
-| onChange | 颜色变化的回调 | `(value: Color, hex: string) => void` | - |
-| onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - |
-| onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - |
-| onClear | 清除的回调 | `() => void` | - |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| :-- | :-- | :-- | :-- | :-- |
+| format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | - |
+| value | 颜色的值 | string \| `Color` | - | - |
+| defaultValue | 颜色默认的值 | string \| `Color` | - | - |
+| allowClear | 允许清除选择的颜色 | boolean | false | - | 
+| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - | - |
+| children | 颜色选择器的触发器 | React.ReactNode | - | - |
+| trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | - |
+| open | 是否显示弹出窗口 | boolean | - | - |
+| disabled | 禁用颜色选择器 | boolean | - | - |
+| placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | - |
+| arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | `true` | - | - |
+| destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | `false` | 5.7.0 |
+| onChange | 颜色变化的回调 | `(value: Color, hex: string) => void` | - | - |
+| onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | - |
+| onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | - |
+| onClear | 清除的回调 | `() => void` | - | 5.6.0 |
 
 ### Color
 
 <!-- prettier-ignore -->
-| 参数 | 说明 | 类型 | 默认值 |
-| :-- | :-- | :-- | :-- |
-| toHex | 转换成 `hex` 格式字符，返回格式如：`1677ff` | `() => string` | - |
-| toHexString | 转换成 `hex` 格式颜色字符串，返回格式如：`#1677ff` | `() => string` | - |
-| toHsb | 转换成 `hsb` 对象  | `() => ({ h: number, s: number, b: number, a number })` | - |
-| toHsbString | 转换成 `hsb` 格式颜色字符串，返回格式如：`hsb(215, 91%, 100%)` | `() => string` | - |
-| toRgb | 转换成 `rgb` 对象  | `() => ({ r: number, g: number, b: number, a number })` | - |
-| toRgbString | 转换成 `rgb` 格式颜色字符串，返回格式如：`rgb(22, 119, 255)` | `() => string` | - |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| :-- | :-- | :-- | :-- | :-- |
+| toHex | 转换成 `hex` 格式字符，返回格式如：`1677ff` | `() => string` | - | - |
+| toHexString | 转换成 `hex` 格式颜色字符串，返回格式如：`#1677ff` | `() => string` | - | - |
+| toHsb | 转换成 `hsb` 对象  | `() => ({ h: number, s: number, b: number, a number })` | - | - |
+| toHsbString | 转换成 `hsb` 格式颜色字符串，返回格式如：`hsb(215, 91%, 100%)` | `() => string` | - | - |
+| toRgb | 转换成 `rgb` 对象  | `() => ({ r: number, g: number, b: number, a number })` | - | - |
+| toRgbString | 转换成 `rgb` 格式颜色字符串，返回格式如：`rgb(22, 119, 255)` | `() => string` | - | - |
 
 ## FAQ
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bd37a4</samp>

This pull request adds a new column to the API tables of the `ColorPicker` component in both English and Chinese documentation. The column shows the ant-design version for each property. This helps developers to understand the compatibility and history of the component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bd37a4</samp>

* Add a new column to the API table of the `ColorPicker` component in both English and Chinese documentation, indicating the version of ant-design in which a property was introduced or changed ([link](https://github.com/ant-design/ant-design/pull/43090/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560L37-R66), [link](https://github.com/ant-design/ant-design/pull/43090/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249L38-R67))
