### PR TITLE
refactor(breadcrumb): make title null and undefined causes the same b…

### DIFF
--- a/components/breadcrumb/useItemRender.tsx
+++ b/components/breadcrumb/useItemRender.tsx
@@ -11,7 +11,7 @@ type ItemRender = NonNullable<BreadcrumbProps['itemRender']>;
 type InternalItemRenderParams = AddParameters<ItemRender, [href?: string]>;
 
 function getBreadcrumbName(route: InternalRouteType, params: any) {
-  if (route.title === undefined) {
+  if (route.title === undefined || route.title === null) {
     return null;
   }
   const paramsKeys = Object.keys(params).join('|');


### PR DESCRIPTION
When the title of an item is set to undefined, the item is not taken into account. Unfortunately the behaviour is not the same when the title is set to null. I use React 17 and when I don't want to display anything with a component, I return a null element to make it a valid JSX element.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    refactor(breadcrumb): make title null and undefined causes the same behaviour       |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 190decc</samp>

Fixed a bug in `useItemRender` hook that caused an error when `route.title` was null. Updated the condition for returning null from `getBreadcrumbName` in `components/breadcrumb/useItemRender.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 190decc</samp>

* Fix a bug where a null title in a breadcrumb route would cause an error in `useItemRender` ([link](https://github.com/ant-design/ant-design/pull/43099/files?diff=unified&w=0#diff-77a344270cc2afa531ee33d79f3c6d99db0a16a58c9c078a3211bda0846183b8L14-R14))
