### PR TITLE
feat(Radio): support pass name attribute through props (#40703)

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -89,6 +89,15 @@ jobs:
           publish_dir: ./_site
           force_orphan: true
 
+      # Since force_orphan will not trigger Sync to Gitee, we need to force run it here
+      - name: Sync to Gitee
+        uses: wearerequired/git-mirror-action@v1
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        with:
+          source-repo: 'git@github.com:ant-design/ant-design.git'
+          destination-repo: 'git@gitee.com:ant-design/ant-design.git'
+
       - name: Deploy to Surge (with TAG)
         run: |
           export DEPLOY_DOMAIN=ant-design-${{ steps.publish-version.outputs.VERSION }}.surge.sh

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -14,6 +14,7 @@ export interface CheckboxOptionType {
   value: CheckboxValueType;
   style?: React.CSSProperties;
   disabled?: boolean;
+  name?: string;
   title?: string;
   onChange?: (e: CheckboxChangeEvent) => void;
 }
@@ -79,6 +80,7 @@ const InternalCheckboxGroup: React.ForwardRefRenderFunction<HTMLDivElement, Chec
         return {
           label: option,
           value: option,
+          name: option,
         };
       }
       return option;

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -44,6 +44,14 @@ describe('Radio', () => {
     expect(getByRole('radio')).not.toBeDisabled();
   });
 
+  it('should render input element with name attribute if name prop is passed', () => {
+    const nameValue = 'test-radio-name';
+    const { container } = render(<Radio name={nameValue} />);
+    const inputElement = container.querySelector('input');
+
+    expect(inputElement).toHaveAttribute('name', nameValue);
+  });
+
   it('should obtained correctly disabled status', () => {
     const { getByRole } = render(
       <Form disabled>

--- a/components/radio/demo/radiogroup-options.tsx
+++ b/components/radio/demo/radiogroup-options.tsx
@@ -4,14 +4,20 @@ import { Radio } from 'antd';
 
 const plainOptions = ['Apple', 'Pear', 'Orange'];
 const options = [
-  { label: 'Apple', value: 'Apple' },
-  { label: 'Pear', value: 'Pear' },
-  { label: 'Orange', value: 'Orange' },
+  { label: 'Apple', value: 'Apple', name: 'group1' },
+  { label: 'Pear', value: 'Pear', name: 'group1' },
+  { label: 'Orange', value: 'Orange', name: 'group1' },
 ];
 const optionsWithDisabled = [
-  { label: 'Apple', value: 'Apple' },
-  { label: 'Pear', value: 'Pear' },
-  { label: 'Orange', value: 'Orange', disabled: true },
+  { label: 'Apple', value: 'Apple', name: 'group2' },
+  { label: 'Pear', value: 'Pear', name: 'group2' },
+  { label: 'Orange', value: 'Orange', name: 'group2', disabled: true },
+];
+
+const optionsWithDisabledForButtonRadio = [
+  { label: 'Apple', value: 'Apple', name: 'group3' },
+  { label: 'Pear', value: 'Pear', name: 'group3' },
+  { label: 'Orange', value: 'Orange', name: 'group3', disabled: true },
 ];
 
 const App: React.FC = () => {
@@ -51,7 +57,7 @@ const App: React.FC = () => {
       <br />
       <br />
       <Radio.Group
-        options={optionsWithDisabled}
+        options={optionsWithDisabledForButtonRadio}
         onChange={onChange4}
         value={value4}
         optionType="button"

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -63,6 +63,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
             disabled={disabled}
             value={option}
             checked={value === option}
+            name={String(option)}
           >
             {option}
           </Radio>
@@ -78,6 +79,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
           checked={value === option.value}
           title={option.title}
           style={option.style}
+          name={option.name}
         >
           {option.label}
         </Radio>

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -43,18 +43,19 @@ Radio.
 | defaultChecked | Specifies the initial state: whether or not the radio is selected | boolean | false |
 | disabled | Disable radio | boolean | false |
 | value | According to value for comparison, to determine whether the selected | any | - |
+| name | The name attribute of the input element | string | - |
 
 ### RadioGroup
 
 Radio group can wrap a group of `Radio`。
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | buttonStyle | The style type of radio button | `outline` \| `solid` | `outline` |  |
 | defaultValue | Default selected value | any | - |  |
 | disabled | Disable all radio buttons | boolean | false |  |
 | name | The `name` property of all `input[type="radio"]` children | string | - |  |
-| options | Set children optional | string\[] \| number\[] \| Array&lt;{ label: ReactNode; value: string; disabled?: boolean; }> | - |  |
+| options | Set children optional | string\[] \| number\[] \| Array&lt;{ label: ReactNode; value: string; disabled?: boolean; name?: string; }> | - |  |  |
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
 | size | The size of radio button style | `large` \| `middle` \| `small` | - |  |
 | value | Used for setting the currently selected value | any | - |  |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -45,6 +45,7 @@ demo:
 | defaultChecked | 初始是否选中 | boolean | false |
 | disabled | 禁用 Radio | boolean | false |
 | value | 根据 value 进行比较，判断是否选中 | any | - |
+| name | input元素的name属性 | string | - |
 
 ### Radio.Group
 
@@ -57,7 +58,7 @@ demo:
 | defaultValue | 默认选中的值 | any | - |  |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |  |
 | name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性 | string | - |  |  |
-| options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;{ label: ReactNode; value: string; disabled?: boolean; }> | - |  |  |
+| options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;{ label: ReactNode; value: string; disabled?: boolean; name?: string; }> | - |  |  |
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |  |
 | size | 大小，只对按钮样式生效 | `large` \| `middle` \| `small` | - |  |  |
 | value | 用于设置当前选中的值 | any | - |  |  |

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -51,7 +51,7 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
   const disabled = React.useContext(DisabledContext);
 
   if (groupContext) {
-    radioProps.name = groupContext.name;
+    radioProps.name = groupContext.name || radioProps.name;
     radioProps.onChange = onChange;
     radioProps.checked = props.value === groupContext.value;
     radioProps.disabled = radioProps.disabled ?? groupContext.disabled;


### PR DESCRIPTION
feat(Radio): support pass name attribute through props,to support switch focus through tab (#40703)

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
[close#40703](https://github.com/ant-design/ant-design/issues/40703)

### 💡 Background and solution

When switching through the tab key, the focus will be switched to the corresponding input['type=radio'] element of the next different name attribute

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Support passing the name attribute to the input element through props      |
| 🇨🇳 Chinese |     支持通过props传递name属性到input元素      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f3111e</samp>

This pull request adds the `name` property to the `Radio` and `Checkbox` components and their groups, to allow users to specify the name attribute for the input elements. This improves the accessibility and usability of these components, and adds documentation and test cases for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f3111e</samp>

*  Add `name` prop to `CheckboxOptionType` interface and assign it to input element for each checkbox option ([link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63R17), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63R83))
*  Add `name` prop to `RadioGroup` and `RadioButton` components and assign it to input element for each radio option ([link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749R66), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749R82), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL54-R54))
*  Add test cases for `name` prop for `Radio` and `RadioButton` components ([link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-a6b316e6fad7ff1ce27a055149bfabd92c61a26de376a178e67ab0e9104ff27bR47-R54))
*  Update documentation for `name` prop for `Radio` and `RadioButton` components in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-284376d0613bd5179c694e5ba3bd52b7272adba2b80f03c1bf281c57ada16f78R46), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-284376d0613bd5179c694e5ba3bd52b7272adba2b80f03c1bf281c57ada16f78L52-R58), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-a67ba6e2ccf07e742a81b5b32138cf7510a2b5eff68a6498e79aa0487c09bb31R48), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-a67ba6e2ccf07e742a81b5b32138cf7510a2b5eff68a6498e79aa0487c09bb31L60-R61))
*  Update demo for `RadioGroup` component with different options and styles using `name` prop ([link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-036125b84a64cd13e9649179cae1dcdb31690ccdabb33afb64007f2f0ce13ca0L7-R22), [link](https://github.com/ant-design/ant-design/pull/43111/files?diff=unified&w=0#diff-036125b84a64cd13e9649179cae1dcdb31690ccdabb33afb64007f2f0ce13ca0L54-R60))
