### PR TITLE
fix: Transfer with rowKey will be unselectable

### DIFF
--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -496,10 +496,32 @@ describe('Transfer', () => {
     expect(onScroll).toHaveBeenLastCalledWith('right', expect.anything());
   });
 
-  it('should support rowKey is function', () => {
-    expect(() => {
-      render(<Transfer {...listCommonProps} rowKey={(record) => record.key} />);
-    }).not.toThrow();
+  it('support rowKey', () => {
+    const onSelectChange = jest.fn();
+
+    const Demo = () => {
+      const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+      return (
+        <Transfer
+          {...listCommonProps}
+          selectedKeys={selectedKeys}
+          rowKey={(record) => `key_${record.key}`}
+          onSelectChange={(keys) => {
+            onSelectChange(keys);
+            setSelectedKeys(keys);
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.click(container.querySelector('.ant-transfer-list-content input')!);
+    expect(onSelectChange).toHaveBeenCalledWith(['key_a']);
+    expect(
+      container.querySelector<HTMLInputElement>('.ant-transfer-list-content input')!.checked,
+    ).toBeTruthy();
   });
 
   it('should support render value and label in item', () => {

--- a/components/transfer/hooks/useSelection.ts
+++ b/components/transfer/hooks/useSelection.ts
@@ -7,6 +7,10 @@ function filterKeys(keys: string[], dataKeys: Set<string>) {
   return keys.length === filteredKeys.length ? keys : filteredKeys;
 }
 
+function flattenKeys(keys: Set<string>) {
+  return Array.from(keys).join(';');
+}
+
 export default function useSelection<T extends { key: string }>(
   leftDataSource: T[],
   rightDataSource: T[],
@@ -44,7 +48,7 @@ export default function useSelection<T extends { key: string }>(
   React.useEffect(() => {
     setSourceSelectedKeys(filterKeys(sourceSelectedKeys, leftKeys));
     setTargetSelectedKeys(filterKeys(targetSelectedKeys, rightKeys));
-  }, [leftKeys, rightKeys]);
+  }, [flattenKeys(leftKeys), flattenKeys(rightKeys)]);
 
   return [
     // Keys

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -37,6 +37,7 @@ const DEPRECIATED_VERSION = {
     'https://github.com/ant-design/cssinjs/pull/108',
     'https://github.com/ant-design/ant-design/pull/41993',
   ],
+  '5.6.2': ['https://github.com/ant-design/ant-design/issues/43113'],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43113

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Transfer with `rowKey` makes item unselectable.        |
| 🇨🇳 Chinese |     修复 Transfer 配置 `rowKey` 后无法选中的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d16aac2</samp>

This pull request enhances the `Transfer` component by memoizing the selected keys and fixing a bug with the `rowKey` prop. It also updates the test case for the `Transfer` component and adds a warning for the deprecated version `5.6.2` in the `post-script.js` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d16aac2</samp>

* Fix a bug in the `Transfer` component when using a function as `rowKey` ([link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-4c216b8afeb5629f3befe0a7945c5f6f492158195855764e91524049a0462296L499-R524),[link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-284152e219c660a5535c92750bc3dd210907c9ceb08bf60eff240317ec945979R10-R13),[link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-284152e219c660a5535c92750bc3dd210907c9ceb08bf60eff240317ec945979L47-R51))
  - Add a test case in `components/transfer/__tests__/index.test.tsx` to check the selection and checkbox behavior with a custom `rowKey` function ([link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-4c216b8afeb5629f3befe0a7945c5f6f492158195855764e91524049a0462296L499-R524))
  - Add a helper function `flattenKeys` in `components/transfer/hooks/useSelection.ts` to convert a set of keys to a string for memoization ([link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-284152e219c660a5535c92750bc3dd210907c9ceb08bf60eff240317ec945979R10-R13))
  - Use `flattenKeys` to memoize the effect of updating the selected keys in the `useSelection` hook ([link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-284152e219c660a5535c92750bc3dd210907c9ceb08bf60eff240317ec945979L47-R51))
* Add the version `5.6.2` to the deprecated versions list in `scripts/post-script.js` ([link](https://github.com/ant-design/ant-design/pull/43115/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dR40))
