### PR TITLE
feat: ColorPicker implement `size` API

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -7,8 +7,10 @@ import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { CSSProperties } from 'react';
 import React, { useContext, useRef, useState } from 'react';
 import genPurePanel from '../_util/PurePanel';
+import type { SizeType } from '../config-provider/SizeContext';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
+import useSize from '../config-provider/hooks/useSize';
 import type { PopoverProps } from '../popover';
 import Popover from '../popover';
 import theme from '../theme';
@@ -43,6 +45,7 @@ export type ColorPickerProps = Omit<
   arrow?: boolean | { pointAtCenter: boolean };
   showText?: boolean | ((color: Color) => React.ReactNode);
   styles?: { popup?: CSSProperties };
+  size?: SizeType;
   rootClassName?: string;
   onOpenChange?: (open: boolean) => void;
   onFormatChange?: (format: ColorFormat) => void;
@@ -70,6 +73,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     showText,
     style,
     className,
+    size: customizeSize,
     rootClassName,
     styles,
     onFormatChange,
@@ -102,10 +106,20 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   const prefixCls = getPrefixCls('color-picker', customizePrefixCls);
 
+  // ===================== Style =====================
+  const mergedSize = useSize(customizeSize);
   const [wrapSSR, hashId] = useStyle(prefixCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
   const mergeRootCls = classNames(rootClassName, rtlCls);
-  const mergeCls = classNames(mergeRootCls, className, hashId);
+  const mergeCls = classNames(
+    {
+      [`${prefixCls}-sm`]: mergedSize === 'small',
+      [`${prefixCls}-lg`]: mergedSize === 'large',
+    },
+    mergeRootCls,
+    className,
+    hashId,
+  );
   const mergePopupCls = classNames(prefixCls, rtlCls);
 
   const popupAllowCloseRef = useRef(true);

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4363,70 +4363,50 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
     style="margin-right: 8px;"
   >
     <div
-      class="ant-color-picker-trigger ant-color-picker-sm"
+      class="ant-space ant-space-vertical"
     >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom: 8px;"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background: rgb(22, 119, 255);"
-        />
-      </div>
-    </div>
-    <div
-      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      />
-      <div
-        class="ant-popover-content"
-      >
-        <div
-          class="ant-popover-inner"
-          role="tooltip"
+          class="ant-color-picker-trigger ant-color-picker-sm"
         >
           <div
-            class="ant-popover-inner-content"
+            class="ant-color-picker-color-block"
           >
             <div
-              class="ant-color-picker-panel"
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
             >
               <div
-                class="ant-color-picker-inner-panel"
+                class="ant-popover-inner-content"
               >
                 <div
-                  class="ant-color-picker-select"
+                  class="ant-color-picker-panel"
                 >
                   <div
-                    class="ant-color-picker-palette"
-                    style="position: relative;"
+                    class="ant-color-picker-inner-panel"
                   >
                     <div
-                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                    >
-                      <div
-                        class="ant-color-picker-handler"
-                        style="background-color: rgb(22, 119, 255);"
-                      />
-                    </div>
-                    <div
-                      class="ant-color-picker-saturation"
-                      style="background-color: rgb(0, 0, 0);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-slider-container"
-                >
-                  <div
-                    class="ant-color-picker-slider-group"
-                  >
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                      class="ant-color-picker-select"
                     >
                       <div
                         class="ant-color-picker-palette"
@@ -4436,300 +4416,1092 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                           style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
                           <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
-                            style="background-color: rgb(0, 0, 0);"
-                          />
-                        </div>
-                        <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
-                    >
-                      <div
-                        class="ant-color-picker-palette"
-                        style="position: relative;"
-                      >
-                        <div
-                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                        >
-                          <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            class="ant-color-picker-handler"
                             style="background-color: rgb(22, 119, 255);"
                           />
                         </div>
                         <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
                         />
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="ant-color-picker-color-block"
-                  >
                     <div
-                      class="ant-color-picker-color-block-inner"
-                      style="background: rgb(22, 119, 255);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-input-container"
-                >
-                  <div
-                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
-                  >
-                    <div
-                      class="ant-select-selector"
+                      class="ant-color-picker-slider-container"
                     >
-                      <span
-                        class="ant-select-selection-search"
+                      <div
+                        class="ant-color-picker-slider-group"
                       >
-                        <input
-                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-                          aria-autocomplete="list"
-                          aria-controls="rc_select_TEST_OR_SSR_list"
-                          aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="rc_select_TEST_OR_SSR_list"
-                          autocomplete="off"
-                          class="ant-select-selection-search-input"
-                          id="rc_select_TEST_OR_SSR"
-                          readonly=""
-                          role="combobox"
-                          style="opacity: 0;"
-                          type="search"
-                          unselectable="on"
-                          value=""
-                        />
-                      </span>
-                      <span
-                        class="ant-select-selection-item"
-                        title="HEX"
-                      >
-                        HEX
-                      </span>
-                    </div>
-                    <div
-                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
-                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
-                    >
-                      <div>
                         <div
-                          id="rc_select_TEST_OR_SSR_list"
-                          role="listbox"
-                          style="height: 0px; width: 0px; overflow: hidden;"
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
                         >
                           <div
-                            aria-label="HEX"
-                            aria-selected="true"
-                            id="rc_select_TEST_OR_SSR_list_0"
-                            role="option"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            hex
-                          </div>
-                          <div
-                            aria-label="HSB"
-                            aria-selected="false"
-                            id="rc_select_TEST_OR_SSR_list_1"
-                            role="option"
-                          >
-                            hsb
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
                           </div>
                         </div>
                         <div
-                          class="rc-virtual-list"
-                          style="position: relative;"
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
                         >
                           <div
-                            class="rc-virtual-list-holder"
-                            style="max-height: 256px; overflow-y: auto;"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            <div>
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
                               <div
-                                class="rc-virtual-list-holder-inner"
-                                style="display: flex; flex-direction: column;"
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
                               >
-                                <div
-                                  aria-selected="true"
-                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                                  title="HEX"
-                                >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
                                   <div
-                                    class="ant-select-item-option-content"
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
                                   >
-                                    HEX
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
                                   </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="HSB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    HSB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="RGB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    RGB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
                                 </div>
                               </div>
                             </div>
                           </div>
                         </div>
+                        <span
+                          aria-hidden="true"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
+                        >
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                      >
+                        <div
+                          class="ant-input-number-handler-wrap"
+                        >
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
                       </div>
                     </div>
-                    <span
-                      aria-hidden="true"
-                      class="ant-select-arrow"
-                      style="user-select: none;"
-                      unselectable="on"
-                    >
-                      <span
-                        aria-label="down"
-                        class="anticon anticon-down ant-select-suffix"
-                        role="img"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          data-icon="down"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-bottom: 8px;"
+      >
+        <div
+          class="ant-color-picker-trigger"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
+            >
+              <div
+                class="ant-popover-inner-content"
+              >
+                <div
+                  class="ant-color-picker-panel"
+                >
                   <div
-                    class="ant-color-picker-input"
-                  >
-                    <span
-                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
-                    >
-                      <span
-                        class="ant-input-prefix"
-                      >
-                        #
-                      </span>
-                      <input
-                        class="ant-input ant-input-sm"
-                        type="text"
-                        value="1677FF"
-                      />
-                    </span>
-                  </div>
-                  <div
-                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                    class="ant-color-picker-inner-panel"
                   >
                     <div
-                      class="ant-input-number-handler-wrap"
+                      class="ant-color-picker-select"
                     >
-                      <span
-                        aria-disabled="true"
-                        aria-label="Increase Value"
-                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
-                        role="button"
-                        unselectable="on"
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
                       >
-                        <span
-                          aria-label="up"
-                          class="anticon anticon-up ant-input-number-handler-up-inner"
-                          role="img"
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="up"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        aria-disabled="false"
-                        aria-label="Decrease Value"
-                        class="ant-input-number-handler ant-input-number-handler-down"
-                        role="button"
-                        unselectable="on"
-                      >
-                        <span
-                          aria-label="down"
-                          class="anticon anticon-down ant-input-number-handler-down-inner"
-                          role="img"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="down"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
+                          <div
+                            class="ant-color-picker-handler"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
+                        />
+                      </div>
                     </div>
                     <div
-                      class="ant-input-number-input-wrap"
+                      class="ant-color-picker-slider-container"
                     >
-                      <input
-                        aria-valuemax="100"
-                        aria-valuemin="0"
-                        aria-valuenow="100"
-                        autocomplete="off"
-                        class="ant-input-number-input"
-                        role="spinbutton"
-                        step="1"
-                        value="100%"
-                      />
+                      <div
+                        class="ant-color-picker-slider-group"
+                      >
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
+                              >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
+                                  <div
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
+                                  >
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <span
+                          aria-hidden="true"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
+                        >
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                      >
+                        <div
+                          class="ant-input-number-handler-wrap"
+                        >
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-color-picker-trigger ant-color-picker-lg"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
+            >
+              <div
+                class="ant-popover-inner-content"
+              >
+                <div
+                  class="ant-color-picker-panel"
+                >
+                  <div
+                    class="ant-color-picker-inner-panel"
+                  >
+                    <div
+                      class="ant-color-picker-select"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-slider-container"
+                    >
+                      <div
+                        class="ant-color-picker-slider-group"
+                      >
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
+                              >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
+                                  <div
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
+                                  >
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <span
+                          aria-hidden="true"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
+                        >
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                      >
+                        <div
+                          class="ant-input-number-handler-wrap"
+                        >
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -4742,73 +5514,57 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
   </div>
   <div
     class="ant-space-item"
-    style="margin-right: 8px;"
   >
     <div
-      class="ant-color-picker-trigger"
+      class="ant-space ant-space-vertical"
     >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom: 8px;"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background: rgb(22, 119, 255);"
-        />
-      </div>
-    </div>
-    <div
-      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      />
-      <div
-        class="ant-popover-content"
-      >
-        <div
-          class="ant-popover-inner"
-          role="tooltip"
+          class="ant-color-picker-trigger ant-color-picker-sm"
         >
           <div
-            class="ant-popover-inner-content"
+            class="ant-color-picker-color-block"
           >
             <div
-              class="ant-color-picker-panel"
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
             >
               <div
-                class="ant-color-picker-inner-panel"
+                class="ant-popover-inner-content"
               >
                 <div
-                  class="ant-color-picker-select"
+                  class="ant-color-picker-panel"
                 >
                   <div
-                    class="ant-color-picker-palette"
-                    style="position: relative;"
+                    class="ant-color-picker-inner-panel"
                   >
                     <div
-                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                    >
-                      <div
-                        class="ant-color-picker-handler"
-                        style="background-color: rgb(22, 119, 255);"
-                      />
-                    </div>
-                    <div
-                      class="ant-color-picker-saturation"
-                      style="background-color: rgb(0, 0, 0);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-slider-container"
-                >
-                  <div
-                    class="ant-color-picker-slider-group"
-                  >
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                      class="ant-color-picker-select"
                     >
                       <div
                         class="ant-color-picker-palette"
@@ -4818,300 +5574,329 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                           style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
                           <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
-                            style="background-color: rgb(0, 0, 0);"
-                          />
-                        </div>
-                        <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
-                    >
-                      <div
-                        class="ant-color-picker-palette"
-                        style="position: relative;"
-                      >
-                        <div
-                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                        >
-                          <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            class="ant-color-picker-handler"
                             style="background-color: rgb(22, 119, 255);"
                           />
                         </div>
                         <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
                         />
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="ant-color-picker-color-block"
-                  >
                     <div
-                      class="ant-color-picker-color-block-inner"
-                      style="background: rgb(22, 119, 255);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-input-container"
-                >
-                  <div
-                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
-                  >
-                    <div
-                      class="ant-select-selector"
+                      class="ant-color-picker-slider-container"
                     >
-                      <span
-                        class="ant-select-selection-search"
+                      <div
+                        class="ant-color-picker-slider-group"
                       >
-                        <input
-                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-                          aria-autocomplete="list"
-                          aria-controls="rc_select_TEST_OR_SSR_list"
-                          aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="rc_select_TEST_OR_SSR_list"
-                          autocomplete="off"
-                          class="ant-select-selection-search-input"
-                          id="rc_select_TEST_OR_SSR"
-                          readonly=""
-                          role="combobox"
-                          style="opacity: 0;"
-                          type="search"
-                          unselectable="on"
-                          value=""
-                        />
-                      </span>
-                      <span
-                        class="ant-select-selection-item"
-                        title="HEX"
-                      >
-                        HEX
-                      </span>
-                    </div>
-                    <div
-                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
-                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
-                    >
-                      <div>
                         <div
-                          id="rc_select_TEST_OR_SSR_list"
-                          role="listbox"
-                          style="height: 0px; width: 0px; overflow: hidden;"
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
                         >
                           <div
-                            aria-label="HEX"
-                            aria-selected="true"
-                            id="rc_select_TEST_OR_SSR_list_0"
-                            role="option"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            hex
-                          </div>
-                          <div
-                            aria-label="HSB"
-                            aria-selected="false"
-                            id="rc_select_TEST_OR_SSR_list_1"
-                            role="option"
-                          >
-                            hsb
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
                           </div>
                         </div>
                         <div
-                          class="rc-virtual-list"
-                          style="position: relative;"
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
                         >
                           <div
-                            class="rc-virtual-list-holder"
-                            style="max-height: 256px; overflow-y: auto;"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            <div>
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
                               <div
-                                class="rc-virtual-list-holder-inner"
-                                style="display: flex; flex-direction: column;"
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
                               >
-                                <div
-                                  aria-selected="true"
-                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                                  title="HEX"
-                                >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
                                   <div
-                                    class="ant-select-item-option-content"
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
                                   >
-                                    HEX
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
                                   </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="HSB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    HSB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="RGB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    RGB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
                                 </div>
                               </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </div>
-                    <span
-                      aria-hidden="true"
-                      class="ant-select-arrow"
-                      style="user-select: none;"
-                      unselectable="on"
-                    >
-                      <span
-                        aria-label="down"
-                        class="anticon anticon-down ant-select-suffix"
-                        role="img"
-                      >
-                        <svg
+                        <span
                           aria-hidden="true"
-                          data-icon="down"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
                         >
-                          <path
-                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
                           />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="ant-color-picker-input"
-                  >
-                    <span
-                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
-                    >
-                      <span
-                        class="ant-input-prefix"
-                      >
-                        #
-                      </span>
-                      <input
-                        class="ant-input ant-input-sm"
-                        type="text"
-                        value="1677FF"
-                      />
-                    </span>
-                  </div>
-                  <div
-                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
-                  >
-                    <div
-                      class="ant-input-number-handler-wrap"
-                    >
-                      <span
-                        aria-disabled="true"
-                        aria-label="Increase Value"
-                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
-                        role="button"
-                        unselectable="on"
-                      >
-                        <span
-                          aria-label="up"
-                          class="anticon anticon-up ant-input-number-handler-up-inner"
-                          role="img"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="up"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                            />
-                          </svg>
                         </span>
-                      </span>
-                      <span
-                        aria-disabled="false"
-                        aria-label="Decrease Value"
-                        class="ant-input-number-handler ant-input-number-handler-down"
-                        role="button"
-                        unselectable="on"
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
                       >
-                        <span
-                          aria-label="down"
-                          class="anticon anticon-down ant-input-number-handler-down-inner"
-                          role="img"
+                        <div
+                          class="ant-input-number-handler-wrap"
                         >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="down"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
                           >
-                            <path
-                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      class="ant-input-number-input-wrap"
-                    >
-                      <input
-                        aria-valuemax="100"
-                        aria-valuemin="0"
-                        aria-valuenow="100"
-                        autocomplete="off"
-                        class="ant-input-number-input"
-                        role="spinbutton"
-                        step="1"
-                        value="100%"
-                      />
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -5120,76 +5905,53 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
           </div>
         </div>
       </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-color-picker-trigger ant-color-picker-lg"
-    >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom: 8px;"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background: rgb(22, 119, 255);"
-        />
-      </div>
-    </div>
-    <div
-      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      />
-      <div
-        class="ant-popover-content"
-      >
-        <div
-          class="ant-popover-inner"
-          role="tooltip"
+          class="ant-color-picker-trigger"
         >
           <div
-            class="ant-popover-inner-content"
+            class="ant-color-picker-color-block"
           >
             <div
-              class="ant-color-picker-panel"
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
             >
               <div
-                class="ant-color-picker-inner-panel"
+                class="ant-popover-inner-content"
               >
                 <div
-                  class="ant-color-picker-select"
+                  class="ant-color-picker-panel"
                 >
                   <div
-                    class="ant-color-picker-palette"
-                    style="position: relative;"
+                    class="ant-color-picker-inner-panel"
                   >
                     <div
-                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                    >
-                      <div
-                        class="ant-color-picker-handler"
-                        style="background-color: rgb(22, 119, 255);"
-                      />
-                    </div>
-                    <div
-                      class="ant-color-picker-saturation"
-                      style="background-color: rgb(0, 0, 0);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-slider-container"
-                >
-                  <div
-                    class="ant-color-picker-slider-group"
-                  >
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                      class="ant-color-picker-select"
                     >
                       <div
                         class="ant-color-picker-palette"
@@ -5199,300 +5961,715 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                           style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
                           <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
-                            style="background-color: rgb(0, 0, 0);"
-                          />
-                        </div>
-                        <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
-                    >
-                      <div
-                        class="ant-color-picker-palette"
-                        style="position: relative;"
-                      >
-                        <div
-                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
-                        >
-                          <div
-                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            class="ant-color-picker-handler"
                             style="background-color: rgb(22, 119, 255);"
                           />
                         </div>
                         <div
-                          class="ant-color-picker-gradient"
-                          style="position: absolute; inset: 0;"
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
                         />
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="ant-color-picker-color-block"
-                  >
                     <div
-                      class="ant-color-picker-color-block-inner"
-                      style="background: rgb(22, 119, 255);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-input-container"
-                >
-                  <div
-                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
-                  >
-                    <div
-                      class="ant-select-selector"
+                      class="ant-color-picker-slider-container"
                     >
-                      <span
-                        class="ant-select-selection-search"
+                      <div
+                        class="ant-color-picker-slider-group"
                       >
-                        <input
-                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-                          aria-autocomplete="list"
-                          aria-controls="rc_select_TEST_OR_SSR_list"
-                          aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="rc_select_TEST_OR_SSR_list"
-                          autocomplete="off"
-                          class="ant-select-selection-search-input"
-                          id="rc_select_TEST_OR_SSR"
-                          readonly=""
-                          role="combobox"
-                          style="opacity: 0;"
-                          type="search"
-                          unselectable="on"
-                          value=""
-                        />
-                      </span>
-                      <span
-                        class="ant-select-selection-item"
-                        title="HEX"
-                      >
-                        HEX
-                      </span>
-                    </div>
-                    <div
-                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
-                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
-                    >
-                      <div>
                         <div
-                          id="rc_select_TEST_OR_SSR_list"
-                          role="listbox"
-                          style="height: 0px; width: 0px; overflow: hidden;"
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
                         >
                           <div
-                            aria-label="HEX"
-                            aria-selected="true"
-                            id="rc_select_TEST_OR_SSR_list_0"
-                            role="option"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            hex
-                          </div>
-                          <div
-                            aria-label="HSB"
-                            aria-selected="false"
-                            id="rc_select_TEST_OR_SSR_list_1"
-                            role="option"
-                          >
-                            hsb
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
                           </div>
                         </div>
                         <div
-                          class="rc-virtual-list"
-                          style="position: relative;"
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
                         >
                           <div
-                            class="rc-virtual-list-holder"
-                            style="max-height: 256px; overflow-y: auto;"
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
                           >
-                            <div>
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
                               <div
-                                class="rc-virtual-list-holder-inner"
-                                style="display: flex; flex-direction: column;"
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
                               >
-                                <div
-                                  aria-selected="true"
-                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                                  title="HEX"
-                                >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
                                   <div
-                                    class="ant-select-item-option-content"
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
                                   >
-                                    HEX
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
                                   </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="HSB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    HSB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
-                                </div>
-                                <div
-                                  aria-selected="false"
-                                  class="ant-select-item ant-select-item-option"
-                                  title="RGB"
-                                >
-                                  <div
-                                    class="ant-select-item-option-content"
-                                  >
-                                    RGB
-                                  </div>
-                                  <span
-                                    aria-hidden="true"
-                                    class="ant-select-item-option-state"
-                                    style="user-select: none;"
-                                    unselectable="on"
-                                  />
                                 </div>
                               </div>
                             </div>
                           </div>
                         </div>
+                        <span
+                          aria-hidden="true"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
+                        >
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                      >
+                        <div
+                          class="ant-input-number-handler-wrap"
+                        >
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
                       </div>
                     </div>
-                    <span
-                      aria-hidden="true"
-                      class="ant-select-arrow"
-                      style="user-select: none;"
-                      unselectable="on"
-                    >
-                      <span
-                        aria-label="down"
-                        class="anticon anticon-down ant-select-suffix"
-                        role="img"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          data-icon="down"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-color-picker-trigger ant-color-picker-lg"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background: rgb(22, 119, 255);"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
+        <div
+          class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <div
+            class="ant-popover-arrow"
+            style="position: absolute;"
+          />
+          <div
+            class="ant-popover-content"
+          >
+            <div
+              class="ant-popover-inner"
+              role="tooltip"
+            >
+              <div
+                class="ant-popover-inner-content"
+              >
+                <div
+                  class="ant-color-picker-panel"
+                >
                   <div
-                    class="ant-color-picker-input"
-                  >
-                    <span
-                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
-                    >
-                      <span
-                        class="ant-input-prefix"
-                      >
-                        #
-                      </span>
-                      <input
-                        class="ant-input ant-input-sm"
-                        type="text"
-                        value="1677FF"
-                      />
-                    </span>
-                  </div>
-                  <div
-                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                    class="ant-color-picker-inner-panel"
                   >
                     <div
-                      class="ant-input-number-handler-wrap"
+                      class="ant-color-picker-select"
                     >
-                      <span
-                        aria-disabled="true"
-                        aria-label="Increase Value"
-                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
-                        role="button"
-                        unselectable="on"
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
                       >
-                        <span
-                          aria-label="up"
-                          class="anticon anticon-up ant-input-number-handler-up-inner"
-                          role="img"
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
                         >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="up"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        aria-disabled="false"
-                        aria-label="Decrease Value"
-                        class="ant-input-number-handler ant-input-number-handler-down"
-                        role="button"
-                        unselectable="on"
-                      >
-                        <span
-                          aria-label="down"
-                          class="anticon anticon-down ant-input-number-handler-down-inner"
-                          role="img"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            data-icon="down"
-                            fill="currentColor"
-                            focusable="false"
-                            height="1em"
-                            viewBox="64 64 896 896"
-                            width="1em"
-                          >
-                            <path
-                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
+                          <div
+                            class="ant-color-picker-handler"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-saturation"
+                          style="background-color: rgb(0, 0, 0);"
+                        />
+                      </div>
                     </div>
                     <div
-                      class="ant-input-number-input-wrap"
+                      class="ant-color-picker-slider-container"
                     >
-                      <input
-                        aria-valuemax="100"
-                        aria-valuemin="0"
-                        aria-valuenow="100"
-                        autocomplete="off"
-                        class="ant-input-number-input"
-                        role="spinbutton"
-                        step="1"
-                        value="100%"
-                      />
+                      <div
+                        class="ant-color-picker-slider-group"
+                      >
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-hue"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                        >
+                          <div
+                            class="ant-color-picker-palette"
+                            style="position: relative;"
+                          >
+                            <div
+                              style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                            >
+                              <div
+                                class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                style="background-color: rgb(22, 119, 255);"
+                              />
+                            </div>
+                            <div
+                              class="ant-color-picker-gradient"
+                              style="position: absolute; inset: 0;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-color-picker-color-block"
+                      >
+                        <div
+                          class="ant-color-picker-color-block-inner"
+                          style="background: rgb(22, 119, 255);"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-input-container"
+                    >
+                      <div
+                        class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                      >
+                        <div
+                          class="ant-select-selector"
+                        >
+                          <span
+                            class="ant-select-selection-search"
+                          >
+                            <input
+                              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                              aria-autocomplete="list"
+                              aria-controls="rc_select_TEST_OR_SSR_list"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-owns="rc_select_TEST_OR_SSR_list"
+                              autocomplete="off"
+                              class="ant-select-selection-search-input"
+                              id="rc_select_TEST_OR_SSR"
+                              readonly=""
+                              role="combobox"
+                              style="opacity: 0;"
+                              type="search"
+                              unselectable="on"
+                              value=""
+                            />
+                          </span>
+                          <span
+                            class="ant-select-selection-item"
+                            title="HEX"
+                          >
+                            HEX
+                          </span>
+                        </div>
+                        <div
+                          class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                        >
+                          <div>
+                            <div
+                              id="rc_select_TEST_OR_SSR_list"
+                              role="listbox"
+                              style="height: 0px; width: 0px; overflow: hidden;"
+                            >
+                              <div
+                                aria-label="HEX"
+                                aria-selected="true"
+                                id="rc_select_TEST_OR_SSR_list_0"
+                                role="option"
+                              >
+                                hex
+                              </div>
+                              <div
+                                aria-label="HSB"
+                                aria-selected="false"
+                                id="rc_select_TEST_OR_SSR_list_1"
+                                role="option"
+                              >
+                                hsb
+                              </div>
+                            </div>
+                            <div
+                              class="rc-virtual-list"
+                              style="position: relative;"
+                            >
+                              <div
+                                class="rc-virtual-list-holder"
+                                style="max-height: 256px; overflow-y: auto;"
+                              >
+                                <div>
+                                  <div
+                                    class="rc-virtual-list-holder-inner"
+                                    style="display: flex; flex-direction: column;"
+                                  >
+                                    <div
+                                      aria-selected="true"
+                                      class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                      title="HEX"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HEX
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="HSB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        HSB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                    <div
+                                      aria-selected="false"
+                                      class="ant-select-item ant-select-item-option"
+                                      title="RGB"
+                                    >
+                                      <div
+                                        class="ant-select-item-option-content"
+                                      >
+                                        RGB
+                                      </div>
+                                      <span
+                                        aria-hidden="true"
+                                        class="ant-select-item-option-state"
+                                        style="user-select: none;"
+                                        unselectable="on"
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <span
+                          aria-hidden="true"
+                          class="ant-select-arrow"
+                          style="user-select: none;"
+                          unselectable="on"
+                        >
+                          <span
+                            aria-label="down"
+                            class="anticon anticon-down ant-select-suffix"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="ant-color-picker-input"
+                      >
+                        <span
+                          class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                        >
+                          <span
+                            class="ant-input-prefix"
+                          >
+                            #
+                          </span>
+                          <input
+                            class="ant-input ant-input-sm"
+                            type="text"
+                            value="1677FF"
+                          />
+                        </span>
+                      </div>
+                      <div
+                        class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                      >
+                        <div
+                          class="ant-input-number-handler-wrap"
+                        >
+                          <span
+                            aria-disabled="true"
+                            aria-label="Increase Value"
+                            class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="up"
+                              class="anticon anticon-up ant-input-number-handler-up-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="up"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            aria-disabled="false"
+                            aria-label="Decrease Value"
+                            class="ant-input-number-handler ant-input-number-handler-down"
+                            role="button"
+                            unselectable="on"
+                          >
+                            <span
+                              aria-label="down"
+                              class="anticon anticon-down ant-input-number-handler-down-inner"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="down"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="ant-input-number-input-wrap"
+                        >
+                          <input
+                            aria-valuemax="100"
+                            aria-valuemin="0"
+                            aria-valuenow="100"
+                            autocomplete="off"
+                            class="ant-input-number-input"
+                            role="spinbutton"
+                            step="1"
+                            value="100%"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4354,6 +4354,1158 @@ exports[`renders components/color-picker/demo/pure-panel.tsx extend context corr
 </div>
 `;
 
+exports[`renders components/color-picker/demo/size.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right: 8px;"
+  >
+    <div
+      class="ant-color-picker-trigger ant-color-picker-sm"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <div
+              class="ant-color-picker-panel"
+            >
+              <div
+                class="ant-color-picker-inner-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 0, 0);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(0, 0, 0);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
+                        >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
+                              <div
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
+                              >
+                                <div
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-color-picker-input"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677FF"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-right: 8px;"
+  >
+    <div
+      class="ant-color-picker-trigger"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <div
+              class="ant-color-picker-panel"
+            >
+              <div
+                class="ant-color-picker-inner-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 0, 0);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(0, 0, 0);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
+                        >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
+                              <div
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
+                              >
+                                <div
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-color-picker-input"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677FF"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger ant-color-picker-lg"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <div
+              class="ant-color-picker-panel"
+            >
+              <div
+                class="ant-color-picker-inner-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 0, 0);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-hue"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(0, 0, 0);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                    >
+                      <div
+                        class="ant-color-picker-palette"
+                        style="position: relative;"
+                      >
+                        <div
+                          style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                        >
+                          <div
+                            class="ant-color-picker-handler ant-color-picker-handler-sm"
+                            style="background-color: rgb(22, 119, 255);"
+                          />
+                        </div>
+                        <div
+                          class="ant-color-picker-gradient"
+                          style="position: absolute; inset: 0;"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
+                        >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
+                              <div
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
+                              >
+                                <div
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-color-picker-input"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677FF"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/color-picker/demo/text-render.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -258,48 +258,130 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
     style="margin-right:8px"
   >
     <div
-      class="ant-color-picker-trigger ant-color-picker-sm"
+      class="ant-space ant-space-vertical"
     >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom:8px"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background:rgb(22, 119, 255)"
-        />
+          class="ant-color-picker-trigger ant-color-picker-sm"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-bottom:8px"
+      >
+        <div
+          class="ant-color-picker-trigger"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-color-picker-trigger ant-color-picker-lg"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
     class="ant-space-item"
-    style="margin-right:8px"
   >
     <div
-      class="ant-color-picker-trigger"
+      class="ant-space ant-space-vertical"
     >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom:8px"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background:rgb(22, 119, 255)"
-        />
+          class="ant-color-picker-trigger ant-color-picker-sm"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-color-picker-trigger ant-color-picker-lg"
-    >
       <div
-        class="ant-color-picker-color-block"
+        class="ant-space-item"
+        style="margin-bottom:8px"
       >
         <div
-          class="ant-color-picker-color-block-inner"
-          style="background:rgb(22, 119, 255)"
-        />
+          class="ant-color-picker-trigger"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class="ant-color-picker-trigger ant-color-picker-lg"
+        >
+          <div
+            class="ant-color-picker-color-block"
+          >
+            <div
+              class="ant-color-picker-color-block-inner"
+              style="background:rgb(22, 119, 255)"
+            />
+          </div>
+          <div
+            class="ant-color-picker-trigger-text"
+          >
+            #1677FF
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -249,6 +249,63 @@ exports[`renders components/color-picker/demo/pure-panel.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px"
+  >
+    <div
+      class="ant-color-picker-trigger ant-color-picker-sm"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22, 119, 255)"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px"
+  >
+    <div
+      class="ant-color-picker-trigger"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22, 119, 255)"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger ant-color-picker-lg"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22, 119, 255)"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/color-picker/demo/text-render.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -366,4 +366,11 @@ describe('ColorPicker', () => {
     await waitFakeTimer();
     expect(targetEle?.innerHTML).toEqual('#1677FF');
   });
+
+  it('Should size work', async () => {
+    const { container: lg } = render(<ColorPicker size="large" />);
+    expect(lg.querySelector('.ant-color-picker-lg')).toBeTruthy();
+    const { container: sm } = render(<ColorPicker size="small" />);
+    expect(sm.querySelector('.ant-color-picker-sm')).toBeTruthy();
+  });
 });

--- a/components/color-picker/demo/size.md
+++ b/components/color-picker/demo/size.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+触发器有大、中、小三种尺寸，若不设置 size，则尺寸为中。
+
+## en-US
+
+The trigger has three sizes: large, medium and small. If size is not set, the size will be medium.

--- a/components/color-picker/demo/size.tsx
+++ b/components/color-picker/demo/size.tsx
@@ -3,9 +3,16 @@ import React from 'react';
 
 const Demo = () => (
   <Space>
-    <ColorPicker size="small" />
-    <ColorPicker />
-    <ColorPicker size="large" />
+    <Space direction="vertical">
+      <ColorPicker size="small" />
+      <ColorPicker />
+      <ColorPicker size="large" />
+    </Space>
+    <Space direction="vertical">
+      <ColorPicker size="small" showText />
+      <ColorPicker showText />
+      <ColorPicker size="large" showText />
+    </Space>
   </Space>
 );
 

--- a/components/color-picker/demo/size.tsx
+++ b/components/color-picker/demo/size.tsx
@@ -1,0 +1,12 @@
+import { ColorPicker, Space } from 'antd';
+import React from 'react';
+
+const Demo = () => (
+  <Space>
+    <ColorPicker size="small" />
+    <ColorPicker />
+    <ColorPicker size="large" />
+  </Space>
+);
+
+export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -20,6 +20,7 @@ Used when the user needs to customize the color selection.
 
 <!-- prettier-ignore -->
 <code src="./demo/base.tsx">Basic Usage</code>
+<code src="./demo/size.tsx">Trigger size</code>
 <code src="./demo/controlled.tsx">controlled mode</code>
 <code src="./demo/text-render.tsx">Rendering Trigger Text</code>
 <code src="./demo/disabled.tsx">Disable</code>

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -51,6 +51,7 @@ Used when the user needs to customize the color selection.
 | arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | true | |
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | showText | show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
+| size | Setting the trigger size | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | onChange | Callback when `value` is changed | `(value: Color, hex: string) => void` | - | |
 | onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -52,6 +52,7 @@ group:
 | arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | true | |
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
+| size | 设置触发器大小 | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | onChange | 颜色变化的回调 | `(value: Color, hex: string) => void` | - | |
 | onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -21,6 +21,7 @@ group:
 
 <!-- prettier-ignore -->
 <code src="./demo/base.tsx">基本使用</code>
+<code src="./demo/size.tsx">触发器尺寸大小</code>
 <code src="./demo/controlled.tsx">受控模式</code>
 <code src="./demo/text-render.tsx">渲染触发器文本</code>
 <code src="./demo/disabled.tsx">禁用</code>

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -86,7 +86,7 @@ const genSizeStyle = (token: ColorPickerToken): CSSObject => {
   } = token;
   return {
     [`&${componentCls}-lg`]: {
-      width: controlHeightLG,
+      minWidth: controlHeightLG,
       height: controlHeightLG,
       borderRadius: borderRadiusLG,
       [`${componentCls}-color-block`]: {
@@ -96,7 +96,7 @@ const genSizeStyle = (token: ColorPickerToken): CSSObject => {
       },
     },
     [`&${componentCls}-sm`]: {
-      width: controlHeightSM,
+      minWidth: controlHeightSM,
       height: controlHeightSM,
       borderRadius: borderRadiusSM,
       [`${componentCls}-color-block`]: {

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -72,6 +72,42 @@ const genClearStyle = (token: ColorPickerToken, size: number): CSSObject => {
   };
 };
 
+const genSizeStyle = (token: ColorPickerToken): CSSObject => {
+  const {
+    componentCls,
+    controlHeightLG,
+    controlHeightSM,
+    controlHeight,
+    controlHeightXS,
+    borderRadius,
+    borderRadiusSM,
+    borderRadiusXS,
+    borderRadiusLG,
+  } = token;
+  return {
+    [`&${componentCls}-lg`]: {
+      width: controlHeightLG,
+      height: controlHeightLG,
+      borderRadius: borderRadiusLG,
+      [`${componentCls}-color-block`]: {
+        width: controlHeight,
+        height: controlHeight,
+        borderRadius,
+      },
+    },
+    [`&${componentCls}-sm`]: {
+      width: controlHeightSM,
+      height: controlHeightSM,
+      borderRadius: borderRadiusSM,
+      [`${componentCls}-color-block`]: {
+        width: controlHeightXS,
+        height: controlHeightXS,
+        borderRadius: borderRadiusXS,
+      },
+    },
+  };
+};
+
 const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
   const {
     componentCls,
@@ -157,6 +193,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           },
           ...genClearStyle(token, controlHeightSM),
           ...genColorBlockStyle(token, controlHeightSM),
+          ...genSizeStyle(token),
         },
         ...genRtlStyle(token),
       },

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -83,6 +83,7 @@ const genSizeStyle = (token: ColorPickerToken): CSSObject => {
     borderRadiusSM,
     borderRadiusXS,
     borderRadiusLG,
+    fontSizeLG,
   } = token;
   return {
     [`&${componentCls}-lg`]: {
@@ -93,6 +94,9 @@ const genSizeStyle = (token: ColorPickerToken): CSSObject => {
         width: controlHeight,
         height: controlHeight,
         borderRadius,
+      },
+      [`${componentCls}-trigger-text`]: {
+        fontSize: fontSizeLG,
       },
     },
     [`&${componentCls}-sm`]: {
@@ -128,7 +132,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
     lineWidth,
     colorBorder,
     paddingXXS,
-    fontSizeSM,
+    fontSize,
   } = token;
 
   return [
@@ -170,7 +174,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           [`${componentCls}-trigger-text`]: {
             marginInlineStart: marginXS,
             marginInlineEnd: marginXS - (paddingXXS - lineWidth),
-            fontSize: fontSizeSM,
+            fontSize,
             color: colorText,
           },
           '&-active': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/42573

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/21119589/eaedfbea-6640-4fc3-a50c-cca4c6f7a4df)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   ColorPicker implement `size` API         |
| 🇨🇳 Chinese |     颜色选择器实现 `size` API      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c095517</samp>

Added a `size` prop to the `ColorPicker` component to allow users to change the size of the color picker trigger. Updated the style, test, and documentation files to support the new prop. Added a new demo section and code example to showcase the `size` prop.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c095517</samp>

*  Add `size` prop to `ColorPicker` component to allow users to customize the trigger element size ([link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL10-R13), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR48), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR76), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL105-R122))
*  Generate CSS object for `size` prop based on `ColorPickerToken` object and apply it to `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0R75-R110), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0R196))
*  Add test case to check if `size` prop works as expected for `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4R369-R375))
*  Add code examples and demo sections to show the usage of `size` prop for `ColorPicker` component in English and Chinese documentation ([link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-4f1ae2c1aefbbe732cde8bc21539a22d8ed76555f0d63f75987cb81303103ee7R1-R7), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-9857979bb39f8140a694fe3b7f8e87e583bbd4291c0ffe3c14b461b59eaec2adR1-R12), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560R23), [link](https://github.com/ant-design/ant-design/pull/43116/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249R24))
