### PR TITLE
fix: Table filter throw react warning

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -134,6 +134,8 @@ describe('Table.filter', () => {
   });
 
   it('renders empty menu correctly', () => {
+    resetWarned();
+
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const { container } = render(
       createTable({

--- a/components/table/hooks/useFilter/FilterWrapper.tsx
+++ b/components/table/hooks/useFilter/FilterWrapper.tsx
@@ -13,10 +13,21 @@ const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
   }
 };
 
-const FilterDropdownMenuWrapper: React.FC<FilterDropdownMenuWrapperProps> = (props) => (
-  <div className={props.className} onClick={(e) => e.stopPropagation()} onKeyDown={onKeyDown}>
-    {props.children}
-  </div>
+const FilterDropdownMenuWrapper = React.forwardRef<HTMLDivElement, FilterDropdownMenuWrapperProps>(
+  (props, ref) => (
+    <div
+      className={props.className}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={onKeyDown}
+      ref={ref}
+    >
+      {props.children}
+    </div>
+  ),
 );
+
+if (process.env.NODE_ENV !== 'production') {
+  FilterDropdownMenuWrapper.displayName = 'FilterDropdownMenuWrapper';
+}
 
 export default FilterDropdownMenuWrapper;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43138

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Table open filter popup throw react ref warning.       |
| 🇨🇳 Chinese |     修复 Table 打开筛选面板会报 `react ref` 错误警告信息。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fcb146</samp>

This pull request improves the testing and usability of the `Table` component. It clears the warning cache before each test case in `Table.filter.test.tsx` and enables the `getPopupContainer` prop for the filter dropdown menu by using `React.forwardRef` in `FilterWrapper.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2fcb146</samp>

* Forward `ref` to `div` element in `FilterDropdownMenuWrapper` component to support `getPopupContainer` prop of `Table` component ([link](https://github.com/ant-design/ant-design/pull/43139/files?diff=unified&w=0#diff-e7b200015c87575ade5ace58dc69833cc28b4e00c4bcb42a5fd8fce0e22a0b7dL16-R32))
* Add `displayName` to `FilterDropdownMenuWrapper` component in development mode for debugging and testing purposes ([link](https://github.com/ant-design/ant-design/pull/43139/files?diff=unified&w=0#diff-e7b200015c87575ade5ace58dc69833cc28b4e00c4bcb42a5fd8fce0e22a0b7dL16-R32))
* Clear warning cache before each test case in `Table.filter.test.tsx` to avoid duplicate warnings from `rc-util` library ([link](https://github.com/ant-design/ant-design/pull/43139/files?diff=unified&w=0#diff-d86c8b951332164873bf880555e68c0e38dfd36612b14396f4c001b7f2d1187fR137-R138))
