### PR TITLE
chore: Revert includes and replase all includes with indexOf

### DIFF
--- a/components/_util/wave.tsx
+++ b/components/_util/wave.tsx
@@ -87,7 +87,7 @@ class Wave extends React.Component<WaveProps> {
   onClick = (node: HTMLElement, waveColor: string) => {
     const { insertExtraNode, disabled } = this.props;
 
-    if (disabled || !node || isHidden(node) || node.className.includes('-leave')) {
+    if (disabled || !node || isHidden(node) || node.className.indexOf('-leave') >= 0) {
       return;
     }
 
@@ -165,7 +165,7 @@ class Wave extends React.Component<WaveProps> {
       !node ||
       !node.getAttribute ||
       node.getAttribute('disabled') ||
-      node.className.includes('disabled')
+      node.className.indexOf('disabled') >= 0
     ) {
       return;
     }

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -120,7 +120,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
 
   const registerLink = React.useCallback<AntAnchor['registerLink']>(
     link => {
-      if (!links.includes(link)) {
+      if (links.indexOf(link) < 0) {
         setLinks(prev => [...prev, link]);
       }
     },
@@ -129,7 +129,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
 
   const unregisterLink = React.useCallback<AntAnchor['unregisterLink']>(
     link => {
-      if (links.includes(link)) {
+      if (links.indexOf(link) >= 0) {
         setLinks(prev => prev.filter(i => i !== link));
       }
     },

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -108,7 +108,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
   const size = customSize === 'default' ? groupSize : customSize;
 
   const needResponsive = Object.keys(typeof size === 'object' ? size || {} : {}).some(key =>
-    ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].includes(key),
+    ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].indexOf(key) >= 0,
   );
   const screens = useBreakpoint(needResponsive);
   const responsiveSizeStyle: React.CSSProperties = React.useMemo(() => {

--- a/components/badge/utils.tsx
+++ b/components/badge/utils.tsx
@@ -2,5 +2,5 @@ import { PresetColorTypes } from '../_util/colors';
 
 // eslint-disable-next-line import/prefer-default-export
 export function isPresetColor(color?: string): boolean {
-  return (PresetColorTypes as any[]).includes(color);
+  return (PresetColorTypes as any[]).indexOf(color) !== -1;
 }

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -102,7 +102,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<HTMLInputElement, Checkbo
       }
     };
     checkboxProps.name = checkboxGroup.name;
-    checkboxProps.checked = checkboxGroup.value.includes(restProps.value);
+    checkboxProps.checked = checkboxGroup.value.indexOf(restProps.value) !== -1;
   }
   const classString = classNames(
     {

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -101,7 +101,7 @@ const InternalCheckboxGroup: React.ForwardRefRenderFunction<HTMLDivElement, Chec
     const opts = getOptions();
     onChange?.(
       newValue
-        .filter(val => registeredValues.includes(val))
+        .filter(val => registeredValues.indexOf(val) !== -1)
         .sort((a, b) => {
           const indexA = opts.findIndex(opt => opt.value === a);
           const indexB = opts.findIndex(opt => opt.value === b);
@@ -122,7 +122,7 @@ const InternalCheckboxGroup: React.ForwardRefRenderFunction<HTMLDivElement, Chec
         key={option.value.toString()}
         disabled={'disabled' in option ? option.disabled : restProps.disabled}
         value={option.value}
-        checked={value.includes(option.value)}
+        checked={value.indexOf(option.value) !== -1}
         onChange={option.onChange}
         className={`${groupPrefixCls}-item`}
         style={option.style}

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -143,7 +143,7 @@ export const globalConfig = () => ({
     }
 
     // [Legacy] If customize prefixCls provided, we cut it to get the prefixCls
-    if (customizePrefixCls && customizePrefixCls.includes('-')) {
+    if (customizePrefixCls && customizePrefixCls.indexOf('-') >= 0) {
       return customizePrefixCls.replace(/^(.*)-[^-]*$/, '$1');
     }
 

--- a/components/date-picker/generatePicker/index.tsx
+++ b/components/date-picker/generatePicker/index.tsx
@@ -43,17 +43,17 @@ export function getTimeProps<DateType, DisabledTime>(
   const showTimeObj = { ...props };
 
   if (firstFormat && typeof firstFormat === 'string') {
-    if (!firstFormat.includes('s') && showSecond === undefined) {
+    if (firstFormat.indexOf('s') < 0 && showSecond === undefined) {
       showTimeObj.showSecond = false;
     }
-    if (!firstFormat.includes('m') && showMinute === undefined) {
+    if (firstFormat.indexOf('m') < 0 && showMinute === undefined) {
       showTimeObj.showMinute = false;
     }
-    if (!firstFormat.includes('H') && !firstFormat.includes('h') && showHour === undefined) {
+    if (firstFormat.indexOf('H') < 0 && firstFormat.indexOf('h') < 0 && showHour === undefined) {
       showTimeObj.showHour = false;
     }
 
-    if ((firstFormat.includes('a') || firstFormat.includes('A')) && use12Hours === undefined) {
+    if ((firstFormat.indexOf('a') >= 0 || firstFormat.indexOf('A') >= 0) && use12Hours === undefined) {
       showTimeObj.use12Hours = true;
     }
   }

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -119,7 +119,7 @@ const Dropdown: CompoundedComponent = (props) => {
     if (transitionName !== undefined) {
       return transitionName;
     }
-    if (placement.includes('top')) {
+    if (placement.indexOf('top') >= 0) {
       return `${rootPrefixCls}-slide-down`;
     }
     return `${rootPrefixCls}-slide-up`;
@@ -131,10 +131,11 @@ const Dropdown: CompoundedComponent = (props) => {
       return direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
     }
 
-    if (placement.includes('Center')) {
-      const newPlacement = placement.slice(0, placement.indexOf('Center'));
+    const idx = placement.indexOf('Center')
+    if (idx >= 0) {
+      const newPlacement = placement.slice(0, idx);
       warning(
-        !placement.includes('Center'),
+        idx < 0,
         'Dropdown',
         `You are using '${placement}' placement in Dropdown, which is deprecated. Try to use '${newPlacement}' instead.`,
       );
@@ -179,7 +180,7 @@ const Dropdown: CompoundedComponent = (props) => {
 
   const triggerActions = disabled ? [] : trigger;
   let alignPoint: boolean;
-  if (triggerActions && triggerActions.includes('contextMenu')) {
+  if (triggerActions && triggerActions.indexOf('contextMenu') >= 0) {
     alignPoint = true;
   }
 

--- a/components/form/util.ts
+++ b/components/form/util.ts
@@ -22,7 +22,7 @@ export function getFieldId(namePath: InternalNamePath, formName?: string): strin
     return `${formName}_${mergedId}`;
   }
 
-  const isIllegalName = formItemNameBlackList.includes(mergedId);
+  const isIllegalName = formItemNameBlackList.indexOf(mergedId) >= 0;
 
   return isIllegalName ? `${defaultItemNamePrefixCls}_${mergedId}` : mergedId;
 }

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -215,7 +215,7 @@ function List<T>({
   }
 
   const needResponsive = Object.keys(grid || {}).some(key =>
-    ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].includes(key),
+    ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].indexOf(key) >= 0,
   );
   const screens = useBreakpoint(needResponsive);
   const currentBreakpoint = React.useMemo(() => {

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -75,7 +75,7 @@ const Progress: React.FC<ProgressProps> = (props: ProgressProps) => {
 
   function getProgressStatus() {
     const { status } = props;
-    if (!ProgressStatuses.includes(status!) && getPercentNumber() >= 100) {
+    if (ProgressStatuses.indexOf(status!) < 0 && getPercentNumber() >= 100) {
       return 'success';
     }
     return status || 'normal';
@@ -119,7 +119,7 @@ const Progress: React.FC<ProgressProps> = (props: ProgressProps) => {
   const strokeColorNotArray = Array.isArray(strokeColor) ? strokeColor[0] : strokeColor;
   const strokeColorNotGradient =
     typeof strokeColor === 'string' || Array.isArray(strokeColor) ? strokeColor : undefined;
-  let progress: React.ReactNode;
+  let progress;
   // Render progress shape
   if (type === 'line') {
     progress = steps ? (

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -65,7 +65,7 @@ const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
     `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
   );
 
-  if (ExceptionStatus.includes(`${status}`)) {
+  if (ExceptionStatus.indexOf(`${status}`) >= 0) {
     const SVGComponent = ExceptionMap[status as ExceptionStatusType];
     return (
       <div className={`${className} ${prefixCls}-image`}>

--- a/components/statistic/utils.tsx
+++ b/components/statistic/utils.tsx
@@ -41,7 +41,7 @@ export function formatTimeStr(duration: number, format: string) {
   const templateText = format.replace(escapeRegex, '[]');
 
   const replacedText = timeUnits.reduce((current, [name, unit]) => {
-    if (current.includes(name)) {
+    if (current.indexOf(name) !== -1) {
       const value = Math.floor(leftDuration / unit);
       leftDuration -= value * unit;
       return current.replace(new RegExp(`${name}+`, 'g'), (match: string) => {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -482,8 +482,8 @@ function InternalTable<RecordType extends object = any>(
     const defaultPosition = direction === 'rtl' ? 'left' : 'right';
     const { position } = mergedPagination;
     if (position !== null && Array.isArray(position)) {
-      const topPos = position.find(p => p.includes('top'));
-      const bottomPos = position.find(p => p.includes('bottom'));
+      const topPos = position.find(p => p.indexOf('top') !== -1);
+      const bottomPos = position.find(p => p.indexOf('bottom') !== -1);
       const isDisable = position.every(p => `${p}` === 'none');
       if (!topPos && !bottomPos && !isDisable) {
         bottomPaginationNode = renderPagination(defaultPosition);

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -42,7 +42,7 @@ function hasSubMenu(filters: ColumnFilterItem[]) {
 
 function searchValueMatched(searchValue: string, text: React.ReactNode) {
   if (typeof text === 'string' || typeof text === 'number') {
-    return text?.toString().toLowerCase().includes(searchValue.trim().toLowerCase());
+    return text?.toString().toLowerCase().indexOf(searchValue.trim().toLowerCase()) >= 0;
   }
   return false;
 }
@@ -87,7 +87,7 @@ function renderFilterItems({
       key: filter.value !== undefined ? key : index,
       label: (
         <>
-          <Component checked={filteredKeys.includes(key)} />
+          <Component checked={filteredKeys.indexOf(key) >= 0} />
           <span>{filter.text}</span>
         </>
       ),

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -149,7 +149,7 @@ function generateFilterInfo<RecordType>(filterStates: FilterState<RecordType>[])
       currentFilters[key] = filteredKeys || null;
     } else if (Array.isArray(filteredKeys)) {
       const keys = flattenKeys(filters);
-      currentFilters[key] = keys.filter(originKey => filteredKeys.includes(String(originKey)));
+      currentFilters[key] = keys.filter(originKey => filteredKeys.indexOf(String(originKey)) >= 0);
     } else {
       currentFilters[key] = null;
     }

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -355,7 +355,7 @@ export default function useSelection<RecordType>(
       // >>>>>>>>>>> Skip if not exists `rowSelection`
       if (!rowSelection) {
         warning(
-          !columns.includes(SELECTION_COLUMN),
+          columns.indexOf(SELECTION_COLUMN) < 0,
           'Table',
           '`rowSelection` is not config but `SELECTION_COLUMN` exists in the `columns`.',
         );
@@ -636,7 +636,7 @@ export default function useSelection<RecordType>(
       };
 
       // Insert selection column if not exist
-      if (!cloneColumns.includes(SELECTION_COLUMN)) {
+      if (cloneColumns.indexOf(SELECTION_COLUMN) < 0) {
         // Always after expand icon
         if (
           cloneColumns.findIndex(

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -127,7 +127,7 @@ function injectSorter<RecordType>(
       const sorterState = sorterStates.find(({ key }) => key === columnKey);
       const sorterOrder = sorterState ? sorterState.sortOrder : null;
       const nextSortOrder = nextSortDirection(sortDirections, sorterOrder);
-      const upNode: React.ReactNode = sortDirections.includes(ASCEND) && (
+      const upNode: React.ReactNode = sortDirections.indexOf(ASCEND) >= 0 && (
         <CaretUpOutlined
           className={classNames(`${prefixCls}-column-sorter-up`, {
             active: sorterOrder === ASCEND,
@@ -135,7 +135,7 @@ function injectSorter<RecordType>(
           role="presentation"
         />
       );
-      const downNode: React.ReactNode = sortDirections.includes(DESCEND) && (
+      const downNode: React.ReactNode = sortDirections.indexOf(DESCEND) >= 0 && (
         <CaretDownOutlined
           className={classNames(`${prefixCls}-column-sorter-down`, {
             active: sorterOrder === DESCEND,

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -84,7 +84,7 @@ function Tabs({
             className={classNames(
               {
                 [`${prefixCls}-${size}`]: size,
-                [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type as string),
+                [`${prefixCls}-card`]: ['card', 'editable-card'].indexOf(type as string) >= 0,
                 [`${prefixCls}-editable-card`]: type === 'editable-card',
                 [`${prefixCls}-centered`]: centered,
               },

--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -71,7 +71,7 @@ class ListBody<RecordType extends KeyWiseTransferItem> extends React.Component<
 
   onItemSelect = (item: RecordType) => {
     const { onItemSelect, selectedKeys } = this.props;
-    const checked = selectedKeys.includes(item.key);
+    const checked = selectedKeys.indexOf(item.key) >= 0;
     onItemSelect(item.key, !checked);
   };
 
@@ -144,7 +144,7 @@ class ListBody<RecordType extends KeyWiseTransferItem> extends React.Component<
         >
           {this.getItems().map(({ renderedEl, renderedText, item }: RenderedItem<RecordType>) => {
             const { disabled } = item;
-            const checked = selectedKeys.includes(item.key);
+            const checked = selectedKeys.indexOf(item.key) >= 0;
 
             return (
               <ListItem

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -149,8 +149,8 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
     const { selectedKeys = [], targetKeys = [] } = props;
     this.state = {
-      sourceSelectedKeys: selectedKeys.filter(key => !targetKeys.includes(key)),
-      targetSelectedKeys: selectedKeys.filter(key => targetKeys.includes(key)),
+      sourceSelectedKeys: selectedKeys.filter(key => targetKeys.indexOf(key) === -1),
+      targetSelectedKeys: selectedKeys.filter(key => targetKeys.indexOf(key) > -1),
     };
   }
 
@@ -190,7 +190,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     const newTargetKeys =
       direction === 'right'
         ? newMoveKeys.concat(targetKeys)
-        : targetKeys.filter(targetKey => !newMoveKeys.includes(targetKey));
+        : targetKeys.filter(targetKey => newMoveKeys.indexOf(targetKey) === -1);
 
     // empty checked keys
     const oppositeDirection = direction === 'right' ? 'left' : 'right';
@@ -206,13 +206,13 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
 
   onItemSelectAll = (direction: TransferDirection, selectedKeys: string[], checkAll: boolean) => {
     this.setStateKeys(direction, prevKeys => {
-      let mergedCheckedKeys: string[] = [];
+      let mergedCheckedKeys = [];
       if (checkAll) {
         // Merge current keys with origin key
-        mergedCheckedKeys = Array.from(new Set<string>([...prevKeys, ...selectedKeys]));
+        mergedCheckedKeys = Array.from(new Set([...prevKeys, ...selectedKeys]));
       } else {
         // Remove current keys from origin keys
-        mergedCheckedKeys = prevKeys.filter(key => !selectedKeys.includes(key));
+        mergedCheckedKeys = prevKeys.filter((key: string) => selectedKeys.indexOf(key) === -1);
       }
 
       this.handleSelectChange(direction, mergedCheckedKeys);

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -124,9 +124,18 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
   }: TransferProps<T>) {
     if (selectedKeys) {
       const mergedTargetKeys = targetKeys || [];
+      const sourceSelectedKeys: string[] = [];
+      const targetSelectedKeys: string[] = [];
+      selectedKeys.forEach(key => {
+        if (mergedTargetKeys.indexOf(key) >= 0) {
+          targetSelectedKeys.push(key);
+        } else {
+          sourceSelectedKeys.push(key);
+        }
+      });
       return {
-        sourceSelectedKeys: selectedKeys.filter(key => !mergedTargetKeys.includes(key)),
-        targetSelectedKeys: selectedKeys.filter(key => mergedTargetKeys.includes(key)),
+        sourceSelectedKeys,
+        targetSelectedKeys,
       };
     }
 
@@ -275,7 +284,7 @@ class Transfer<RecordType extends TransferItem = TransferItem> extends React.Com
     this.setStateKeys('right', []);
 
     onChange?.(
-      targetKeys.filter(key => !selectedKeys.includes(key)),
+      targetKeys.filter(key => selectedKeys.indexOf(key) < 0),
       'left',
       [...selectedKeys],
     );

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -103,7 +103,7 @@ export default class TransferList<
     if (checkedKeys.length === 0) {
       return 'none';
     }
-    if (filteredItems.every(item => checkedKeys.includes(item.key) || !!item.disabled)) {
+    if (filteredItems.every(item => checkedKeys.indexOf(item.key) >= 0 || !!item.disabled)) {
       return 'all';
     }
     return 'part';
@@ -155,7 +155,7 @@ export default class TransferList<
     if (filterOption) {
       return filterOption(filterValue, item);
     }
-    return text.includes(filterValue);
+    return text.indexOf(filterValue) >= 0;
   };
 
   // =============================== Render ===============================

--- a/components/tree/utils/dictUtil.ts
+++ b/components/tree/utils/dictUtil.ts
@@ -65,7 +65,12 @@ export function calcRangeKeys({
       // Append selection
       keys.push(key);
     }
-    return expandedKeys.includes(key);
+
+    if (expandedKeys.indexOf(key) === -1) {
+      return false;
+    }
+
+    return true;
   });
 
   return keys;

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -349,7 +349,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     tooltipProps = { title: ellipsisConfig.tooltip };
   }
   const topAriaLabel = React.useMemo(() => {
-    const isValid = (val: any): val is string | number => ['string', 'number'].includes(typeof val);
+    const isValid = (val: any): val is string | number => ['string', 'number'].indexOf(typeof val) >= 0;
 
     if (!enableEllipsis || cssEllipsis) {
       return undefined;
@@ -430,7 +430,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     const editTitle = toArray(tooltip)[0] || textLocale.edit;
     const ariaLabel = typeof editTitle === 'string' ? editTitle : '';
 
-    return triggerType.includes('icon') ? (
+    return triggerType.indexOf('icon') ? (
       <Tooltip key="edit" title={tooltip === false ? '' : editTitle}>
         <TransButton
           ref={editIconRef}
@@ -518,7 +518,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             component={component}
             ref={composeRef(resizeRef, typographyRef, ref)}
             direction={direction}
-            onClick={triggerType.includes('text') ? onEditClick : undefined}
+            onClick={triggerType.indexOf('text') ? onEditClick : undefined}
             aria-label={topAriaLabel?.toString()}
             title={title}
             {...textProps}

--- a/components/typography/Title.tsx
+++ b/components/typography/Title.tsx
@@ -19,7 +19,7 @@ const Title = React.forwardRef<HTMLElement, TitleProps>((props, ref) => {
   const { level = 1, ...restProps } = props;
   let component: keyof JSX.IntrinsicElements;
 
-  if (TITLE_ELE_LIST.includes(level)) {
+  if (TITLE_ELE_LIST.indexOf(level) !== -1) {
     component = `h${level}`;
   } else {
     warning(

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -262,14 +262,14 @@ describe('Typography', () => {
             </Paragraph>,
           );
 
-          if (triggerType === undefined || triggerType.indexOf('icon') !== -1) {
+          if (triggerType === undefined || triggerType.includes('icon')) {
             if (icon) {
               expect(wrapper.querySelectorAll('.anticon-highlight').length).toBeGreaterThan(0);
             } else {
               expect(wrapper.querySelectorAll('.anticon-edit').length).toBeGreaterThan(0);
             }
 
-            if (triggerType === undefined || triggerType.indexOf('text') === -1) {
+            if (triggerType === undefined || !triggerType.includes('text')) {
               fireEvent.click(wrapper.firstChild!);
               expect(onStart).not.toHaveBeenCalled();
             }
@@ -295,15 +295,15 @@ describe('Typography', () => {
             fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
 
             expect(onStart).toHaveBeenCalled();
-            if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
+            if (triggerType !== undefined && triggerType.includes('text')) {
               fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
               fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
               expect(onChange).not.toHaveBeenCalled();
             }
           }
 
-          if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
-            if (triggerType.indexOf('icon') === -1) {
+          if (triggerType !== undefined && triggerType.includes('text')) {
+            if (!triggerType.includes('icon')) {
               expect(wrapper.querySelectorAll('.anticon-highlight').length).toBe(0);
               expect(wrapper.querySelectorAll('.anticon-edit').length).toBe(0);
             }

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -262,14 +262,14 @@ describe('Typography', () => {
             </Paragraph>,
           );
 
-          if (triggerType === undefined || triggerType.includes('icon')) {
+          if (triggerType === undefined || triggerType.indexOf('icon') !== -1) {
             if (icon) {
               expect(wrapper.querySelectorAll('.anticon-highlight').length).toBeGreaterThan(0);
             } else {
               expect(wrapper.querySelectorAll('.anticon-edit').length).toBeGreaterThan(0);
             }
 
-            if (triggerType === undefined || !triggerType.includes('text')) {
+            if (triggerType === undefined || triggerType.indexOf('text') === -1) {
               fireEvent.click(wrapper.firstChild!);
               expect(onStart).not.toHaveBeenCalled();
             }
@@ -295,15 +295,15 @@ describe('Typography', () => {
             fireEvent.click(wrapper.querySelectorAll('.ant-typography-edit')[0]);
 
             expect(onStart).toHaveBeenCalled();
-            if (triggerType !== undefined && triggerType.includes('text')) {
+            if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
               fireEvent.keyDown(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
               fireEvent.keyUp(wrapper.querySelector('textarea')!, { keyCode: KeyCode.ESC });
               expect(onChange).not.toHaveBeenCalled();
             }
           }
 
-          if (triggerType !== undefined && triggerType.includes('text')) {
-            if (!triggerType.includes('icon')) {
+          if (triggerType !== undefined && triggerType.indexOf('text') !== -1) {
+            if (triggerType.indexOf('icon') === -1) {
               expect(wrapper.querySelectorAll('.anticon-highlight').length).toBe(0);
               expect(wrapper.querySelectorAll('.anticon-edit').length).toBe(0);
             }

--- a/scripts/generate-authors.js
+++ b/scripts/generate-authors.js
@@ -21,7 +21,7 @@ async function execute() {
   logs = _.remove(logs, ({ author_email: email }) => {
     for (let i = 0; i < excludes.length; i++) {
       const item = excludes[i];
-      if (email.includes(item)) {
+      if (email.indexOf(item) !== -1) {
         return false;
       }
     }

--- a/site/theme/template/Color/Palette.jsx
+++ b/site/theme/template/Color/Palette.jsx
@@ -19,7 +19,7 @@ export default class Palette extends React.Component {
     this.hexColors = {};
     Object.keys(this.colorNodes).forEach(key => {
       const computedColor = getComputedStyle(this.colorNodes[key])['background-color'];
-      if (computedColor.includes('rgba')) {
+      if (computedColor.indexOf('rgba') >= 0) {
         this.hexColors[key] = computedColor;
       } else {
         this.hexColors[key] = rgbToHex(computedColor);

--- a/site/theme/template/Content/index.jsx
+++ b/site/theme/template/Content/index.jsx
@@ -3,7 +3,7 @@ import MainContent from './MainContent';
 import * as utils from '../utils';
 
 function isChangelog(pathname) {
-  return pathname.includes('changelog');
+  return pathname.indexOf('changelog') >= 0;
 }
 
 export default collect(async nextProps => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
Revert 3d33c340103152c7af9157d0023dd1c7db9cab62 in #38139 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

close #31283
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    replase all includes with indexOf        |
| 🇨🇳 Chinese |     去掉所有 includes 用 indexOf  代替以在没有polyfill的情况下支持IE11     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2ed450</samp>

This pull request improves the compatibility and readability of various components in the ant-design library. It mainly replaces the `includes` method with the `indexOf` method for string and array operations, and adds parentheses around single parameters of arrow functions. These changes are applied to files such as `wave.tsx`, `Anchor.tsx`, `avatar.tsx`, `Group.tsx`, `index.tsx`, `dropdown.tsx`, `progress.tsx`, `FilterDropdown.tsx`, `useFilter.tsx`, `useSelection.tsx`, `useSorter.tsx`, `tabs/index.tsx`, `utils.tsx`, `Checkbox.tsx`, `generatePicker/index.tsx`, `util.ts`, `result/index.tsx`, and `Table.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2ed450</samp>

*  Replaced the `includes` method with the `indexOf` method for checking if a string or an array contains a substring or an element, for better browser compatibility and performance ([link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-b4f8b56f8b247697cfea5a706d24f8e32a5aa60d1aee2059473f9a9718327d6dL90-R90), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-b4f8b56f8b247697cfea5a706d24f8e32a5aa60d1aee2059473f9a9718327d6dL168-R168), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL110-R111), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-aefebade557c81a6cdcd040e531cabb442215ba2501b51721e6e15e641962549L5-R5), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L105-R105), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L104-R104), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L125-R125), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L146-R146), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-17a0f2c93d7ac31319015aad11a4a87c2abd9ff3e2b9db737c1736ee1840ae6aL46-R59), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL122-R122), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL134-R137), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-1947c0cad6c52c0417b0ab17c246cc8fffbadf916ebe5e2339c48346cf1e4d3aL25-R25), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L217-R218), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL78-R78), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-2a4cf8cc6b10d688470a1d8c3d8a2253c47e480a42ac182df1dff4a59ce109f4L68-R68), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-94e89fbd68d4e89741607b651692eeb4a5a87c9f1eb34ebd545a84a1b19d7bbeL44-R44), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-9e016ea02fe7dd0ea42d8774d29d45e1a10b8dd108de9c89d50c828c74b993b8L485-R486), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL45-R45), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL90-R90), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-b99a8e21b430359d7018248c40fcff54596fce122c3099e08d4bb404c3a0276fL152-R154), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L358-R363), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L639-R639), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L130-R130), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L138-R138), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL87-R87))
* Added parentheses around the single parameters of arrow functions, for consistent and readable code style ([link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L90-R90), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L122-R124), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L131-R133), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L151-R151), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L203-R203), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L308-R308), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL119-R119), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L155-R155), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L200-R200), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L216-R216), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L273-R273), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L289-R289), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-17a0f2c93d7ac31319015aad11a4a87c2abd9ff3e2b9db737c1736ee1840ae6aL46-R59), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L250-R250), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL248-R248), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL282-R282), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL305-R305), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL383-R383), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL432-R432), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aL494-R494), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-b99a8e21b430359d7018248c40fcff54596fce122c3099e08d4bb404c3a0276fL171-R176), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L62-R62), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L128-R128), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L229-R229), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L235-R235), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L256-R256), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L283-R283), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L332-R332), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L343-R343), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L373-R375), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L381-R386), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L398-R399), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L490-R491), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L526-R526), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L557-R557), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L564-R564), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L575-R576), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L658-R658), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-6c5f2b8a4a1061563259571e5203e5f69eac5c1a68f2f55cf100643d59738d25L704-R704), [link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL75-R75))
* Fixed a logical error in `components/dropdown/dropdown.tsx` by changing the condition from `!placement.includes('Center')` to `placement.indexOf('Center') < 0`, since the former would always be false ([link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL134-R137))
* Removed the unnecessary type annotation of `let progress` in `components/progress/progress.tsx` since it can be inferred from the assignment, for code simplification and optimization ([link](https://github.com/ant-design/ant-design/pull/43150/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL122-R122))
