### PR TITLE
docs: fix prev and next style missing in ssr

### DIFF
--- a/.dumi/theme/common/PrevAndNext.tsx
+++ b/.dumi/theme/common/PrevAndNext.tsx
@@ -1,13 +1,14 @@
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { css } from '@emotion/react';
 import type { MenuProps } from 'antd';
-import { createStyles, css } from 'antd-style';
 import type { MenuItemType } from 'antd/es/menu/hooks/useItems';
-import classNames from 'classnames';
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import useMenu from '../../hooks/useMenu';
+import useSiteToken from '../../hooks/useSiteToken';
 
-const useStyle = createStyles(({ token }) => {
+const useStyle = () => {
+  const { token } = useSiteToken();
   const { colorSplit, iconCls, fontSizeIcon } = token;
 
   return {
@@ -27,6 +28,7 @@ const useStyle = createStyles(({ token }) => {
       text-decoration: none;
 
       ${iconCls} {
+        color: #999;
         font-size: ${fontSizeIcon}px;
         transition: all 0.3s;
       }
@@ -40,7 +42,7 @@ const useStyle = createStyles(({ token }) => {
       display: flex;
       justify-content: flex-start;
       align-items: center;
-      
+
       .footer-nav-icon-after {
         display: none;
       }
@@ -63,7 +65,7 @@ const useStyle = createStyles(({ token }) => {
       display: flex;
       justify-content: flex-end;
       align-items: center;
-      
+
       .footer-nav-icon-before {
         display: none;
       }
@@ -83,7 +85,7 @@ const useStyle = createStyles(({ token }) => {
       }
     `,
   };
-});
+};
 
 const flattenMenu = (menuItems: MenuProps['items']): MenuProps['items'] | null => {
   if (Array.isArray(menuItems)) {
@@ -101,8 +103,7 @@ const flattenMenu = (menuItems: MenuProps['items']): MenuProps['items'] | null =
 };
 
 const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
-  const { styles } = useStyle();
-
+  const styles = useStyle();
   const beforeProps = { className: 'footer-nav-icon-before' };
   const afterProps = { className: 'footer-nav-icon-after' };
 
@@ -129,14 +130,14 @@ const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
   }, [menuItems, selectedKey]);
 
   return (
-    <section className={styles.prevNextNav}>
+    <section css={styles.prevNextNav}>
       {prev &&
         React.cloneElement(prev.label as ReactElement, {
-          className: classNames(styles.pageNav, styles.prevNav),
+          css: [styles.pageNav, styles.prevNav],
         })}
       {next &&
         React.cloneElement(next.label as ReactElement, {
-          className: classNames(styles.pageNav, styles.nextNav),
+          css: [styles.pageNav, styles.nextNav],
         })}
     </section>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
网速慢的情况下，可以明显看到 https://preview-43155-ant-design.surge.sh/docs/react/use-with-create-react-app-cn 注水过程中样式丢失，然后恢复的过程。

![Jun-24-2023 13-20-41](https://github.com/ant-design/ant-design/assets/507615/7e38b0b9-1c00-40eb-80cd-3008837d63e4)

尝试改成 emotion 试试。等预览链接好了试试：https://preview-43158-ant-design.surge.sh/docs/react/use-with-create-react-app-cn 确实好了

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cdc4803</samp>

Update prev and next buttons styling in dumi theme. Use `@emotion/react` for CSS-in-JS and improve code readability.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cdc4803</samp>

*  Update imports and styles for PrevAndNext component ([link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L2-R11), [link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42R31), [link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L104-R106), [link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L132-R140))
* Remove extra whitespace for code style consistency ([link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L43-R45), [link](https://github.com/ant-design/ant-design/pull/43158/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L66-R68))
