### PR TITLE
docs: Table title replaced with caption prop

### DIFF
--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -337,11 +337,6 @@ exports[`renders components/table/demo/bordered.tsx extend context correctly 1`]
         class="ant-table ant-table-bordered"
       >
         <div
-          class="ant-table-title"
-        >
-          Header
-        </div>
-        <div
           class="ant-table-container"
         >
           <div
@@ -350,6 +345,15 @@ exports[`renders components/table/demo/bordered.tsx extend context correctly 1`]
             <table
               style="table-layout: auto;"
             >
+              <caption
+                class="ant-table-caption"
+              >
+                <div
+                  style="text-align: left; padding: 16px;"
+                >
+                  Header
+                </div>
+              </caption>
               <colgroup />
               <thead
                 class="ant-table-thead"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -343,11 +343,6 @@ exports[`renders components/table/demo/bordered.tsx correctly 1`] = `
         class="ant-table ant-table-bordered"
       >
         <div
-          class="ant-table-title"
-        >
-          Header
-        </div>
-        <div
           class="ant-table-container"
         >
           <div
@@ -356,6 +351,15 @@ exports[`renders components/table/demo/bordered.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
+              <caption
+                class="ant-table-caption"
+              >
+                <div
+                  style="text-align:left;padding:16px"
+                >
+                  Header
+                </div>
+              </caption>
               <colgroup />
               <thead
                 class="ant-table-thead"

--- a/components/table/demo/bordered.md
+++ b/components/table/demo/bordered.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Add border, title and footer for table.
+Add border, caption and footer for table.

--- a/components/table/demo/bordered.tsx
+++ b/components/table/demo/bordered.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { Table } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import React from 'react';
 
 interface DataType {
   key: string;
@@ -53,7 +53,7 @@ const App: React.FC = () => (
     columns={columns}
     dataSource={data}
     bordered
-    title={() => 'Header'}
+    caption={<div style={{ textAlign: 'left', padding: 16 }}>Header</div>}
     footer={() => 'Footer'}
   />
 );

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -133,7 +133,7 @@ const columns = [
 | sticky | Set sticky header and scroll bar | boolean \| `{offsetHeader?: number, offsetScroll?: number, getContainer?: () => HTMLElement}` | - | 4.6.0 (getContainer: 4.7.0) |
 | summary | Summary content | (currentData) => ReactNode | - |  |
 | tableLayout | The [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | - \| `auto` \| `fixed` | -<hr />`fixed` when header/columns are fixed, or using `column.ellipsis` |  |
-| caption | Table caption renderer | function(currentPageData) | - |  |
+| caption | Table caption renderer | ReactNode | - |  |
 | onChange | Callback executed when pagination, filters or sorter is changed | function(pagination, filters, sorter, extra: { currentDataSource: \[], action: `paginate` \| `sort` \| `filter` }) | - |  |
 | onHeaderRow | Set props on per header row | function(columns, index) | - |  |
 | onRow | Set props on per row | function(record, index) | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -133,7 +133,7 @@ const columns = [
 | sticky | Set sticky header and scroll bar | boolean \| `{offsetHeader?: number, offsetScroll?: number, getContainer?: () => HTMLElement}` | - | 4.6.0 (getContainer: 4.7.0) |
 | summary | Summary content | (currentData) => ReactNode | - |  |
 | tableLayout | The [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | - \| `auto` \| `fixed` | -<hr />`fixed` when header/columns are fixed, or using `column.ellipsis` |  |
-| caption | Table caption renderer | ReactNode | - |  |
+| caption | Set caption of Table | ReactNode | - |  |
 | onChange | Callback executed when pagination, filters or sorter is changed | function(pagination, filters, sorter, extra: { currentDataSource: \[], action: `paginate` \| `sort` \| `filter` }) | - |  |
 | onHeaderRow | Set props on per header row | function(columns, index) | - |  |
 | onRow | Set props on per row | function(record, index) | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -78,7 +78,7 @@ const columns = [
 <code src="./demo/ajax.tsx">Ajax</code>
 <code src="./demo/size.tsx">size</code>
 <code src="./demo/narrow.tsx" debug>size</code>
-<code src="./demo/bordered.tsx">border, title and footer</code>
+<code src="./demo/bordered.tsx">border, caption and footer</code>
 <code src="./demo/expand.tsx">Expandable Row</code>
 <code src="./demo/order-column.tsx">Order Specific Column</code>
 <code src="./demo/colspan-rowspan.tsx">colSpan and rowSpan</code>
@@ -133,7 +133,7 @@ const columns = [
 | sticky | Set sticky header and scroll bar | boolean \| `{offsetHeader?: number, offsetScroll?: number, getContainer?: () => HTMLElement}` | - | 4.6.0 (getContainer: 4.7.0) |
 | summary | Summary content | (currentData) => ReactNode | - |  |
 | tableLayout | The [table-layout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout) attribute of table element | - \| `auto` \| `fixed` | -<hr />`fixed` when header/columns are fixed, or using `column.ellipsis` |  |
-| title | Table title renderer | function(currentPageData) | - |  |
+| caption | Table caption renderer | function(currentPageData) | - |  |
 | onChange | Callback executed when pagination, filters or sorter is changed | function(pagination, filters, sorter, extra: { currentDataSource: \[], action: `paginate` \| `sort` \| `filter` }) | - |  |
 | onHeaderRow | Set props on per header row | function(columns, index) | - |  |
 | onRow | Set props on per row | function(record, index) | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -134,7 +134,7 @@ const columns = [
 | sticky | 设置粘性头部和滚动条 | boolean \| `{offsetHeader?: number, offsetScroll?: number, getContainer?: () => HTMLElement}` | - | 4.6.0 (getContainer: 4.7.0) |
 | summary | 总结栏 | (currentData) => ReactNode | - |  |
 | tableLayout | 表格元素的 [table-layout](https://developer.mozilla.org/zh-CN/docs/Web/CSS/table-layout) 属性，设为 `fixed` 表示内容不会影响列的布局 | - \| `auto` \| `fixed` | 无<hr />固定表头/列或使用了 `column.ellipsis` 时，默认值为 `fixed` |  |
-| title | 表格标题 | function(currentPageData) | - |  |
+| caption | 表格标题 | ReactNode | - |  |
 | onChange | 分页、排序、筛选变化时触发 | function(pagination, filters, sorter, extra: { currentDataSource: \[], action: `paginate` \| `sort` \| `filter` }) | - |  |
 | onHeaderRow | 设置头部行属性 | function(columns, index) | - |  |
 | onRow | 设置行属性 | function(record, index) | - |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close [#43036]

### 💡 Background and solution

Regarding to rc-table component, title prop is deprecated. I replaced title prop with caption prop. 

<img width="943" alt="Screenshot 2023-06-25 at 2 07 38 am" src="https://github.com/ant-design/ant-design/assets/29937197/8c86e679-6499-4ac7-8b37-ce402d55e9d3">

### 📝 Changelog

Table title prop replaced with caption prop.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23db44f</samp>

Updated the table component and its demos to use the `caption` prop instead of the `title` prop, following the HTML standards and improving accessibility and styling.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23db44f</samp>

*  Replace `title` prop with `caption` prop for table component and update documentation and examples accordingly ([link](https://github.com/ant-design/ant-design/pull/43166/files?diff=unified&w=0#diff-6e1f33c8981440ca04ca723f36c435558a74e0119edd5934edae16ebce591104L7-R7), [link](https://github.com/ant-design/ant-design/pull/43166/files?diff=unified&w=0#diff-5a56dc8f52d7cfd77eccbfc352bd52ac0a23e24ffbcc71ad548b2fe381e7d69eL56-R56), [link](https://github.com/ant-design/ant-design/pull/43166/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9L81-R81), [link](https://github.com/ant-design/ant-design/pull/43166/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9L136-R136))
*  Sort imports by type and source in bordered table demo code according to ESLint rule ([link](https://github.com/ant-design/ant-design/pull/43166/files?diff=unified&w=0#diff-5a56dc8f52d7cfd77eccbfc352bd52ac0a23e24ffbcc71ad548b2fe381e7d69eL1-R3))
