### PR TITLE
fix: Textarea should not have `height: auto` when window resized

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -412,11 +412,11 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
         borderRadius: 0,
       },
 
-      [`
-        & > ${componentCls}-affix-wrapper,
-        & > ${componentCls}-number-affix-wrapper,
-        & > ${antCls}-picker-range
-      `]: {
+      [`& > ${componentCls}-affix-wrapper`]: {
+        display: 'inline-flex',
+      },
+
+      [`& > ${antCls}-picker-range`]: {
         display: 'inline-flex',
       },
 
@@ -620,7 +620,6 @@ const genAffixStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       },
 
       '&::before': {
-        display: 'inline-block',
         width: 0,
         visibility: 'hidden',
         content: '"\\a0"',

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -931,11 +931,10 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
 
       [`&-affix-wrapper${componentCls}-affix-wrapper`]: {
         padding: 0,
+        border: 'none',
 
         [`> textarea${componentCls}`]: {
           fontSize: 'inherit',
-          border: 'none',
-          outline: 'none',
 
           '&:focus': {
             boxShadow: 'none !important',

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -412,11 +412,11 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
         borderRadius: 0,
       },
 
-      [`& > ${componentCls}-affix-wrapper`]: {
-        display: 'inline-flex',
-      },
-
-      [`& > ${antCls}-picker-range`]: {
+      [`
+        & > ${componentCls}-affix-wrapper,
+        & > ${componentCls}-number-affix-wrapper,
+        & > ${antCls}-picker-range
+      `]: {
         display: 'inline-flex',
       },
 
@@ -620,6 +620,7 @@ const genAffixStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       },
 
       '&::before': {
+        display: 'inline-block',
         width: 0,
         visibility: 'hidden',
         content: '"\\a0"',
@@ -931,10 +932,11 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
 
       [`&-affix-wrapper${componentCls}-affix-wrapper`]: {
         padding: 0,
-        border: 'none',
 
         [`> textarea${componentCls}`]: {
           fontSize: 'inherit',
+          border: 'none',
+          outline: 'none',
 
           '&:focus': {
             boxShadow: 'none !important',

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rc-switch": "~4.1.0",
     "rc-table": "~7.32.1",
     "rc-tabs": "~12.8.1",
-    "rc-textarea": "~1.3.0",
+    "rc-textarea": "~1.3.1",
     "rc-tooltip": "~6.0.0",
     "rc-tree": "~5.7.4",
     "rc-tree-select": "~5.9.0",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rc-switch": "~4.1.0",
     "rc-table": "~7.32.1",
     "rc-tabs": "~12.8.1",
-    "rc-textarea": "~1.3.1",
+    "rc-textarea": "~1.3.2",
     "rc-tooltip": "~6.0.0",
     "rc-tree": "~5.7.4",
     "rc-tree-select": "~5.9.0",


### PR DESCRIPTION
- fix: Textarea border should always with textarea element
- fix: Textarea should not resize when window resized

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
Fix https://github.com/ant-design/ant-design/issues/42846
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix TextArea that height lose when window resized.        |
| 🇨🇳 Chinese |  修复 TextArea 组件在屏幕大小变化时设置的高度失效的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e411d83</samp>

Updated `rc-textarea` dependency to fix `autoSize` bug in `TextArea` component. This is part of a pull request to upgrade dependencies and fix issues in the ant-design library.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e411d83</samp>

* Upgrade `rc-textarea` dependency to fix `autoSize` bug in `TextArea` component ([link](https://github.com/ant-design/ant-design/pull/43169/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L151-R151))
