### PR TITLE
site: add juejin column card

### DIFF
--- a/.dumi/theme/slots/Content/ColumnCard.tsx
+++ b/.dumi/theme/slots/Content/ColumnCard.tsx
@@ -4,6 +4,7 @@ import { Button, Card, Divider } from 'antd';
 import React from 'react';
 import useLocale from '../../../hooks/useLocale';
 import useSiteToken from '../../../hooks/useSiteToken';
+import JuejinLogo from './JuejinLogo';
 
 const ANTD_IMG_URL =
   'https://picx.zhimg.com/v2-3b2bca09c2771e7a82a81562e806be4d.jpg?source=d16d100b';
@@ -56,12 +57,17 @@ const useStyle = () => {
       text-overflow: ellipsis;
       white-space: nowrap;
       .logo {
+        width: 24px;
+        height: 24px;
         font-size: 24px;
         &.zhihu-logo {
           color: #056de8;
         }
         &.yuque-logo {
           color: #00b96b;
+        }
+        &.juejin-logo {
+          color: #1e80ff;
         }
       }
       .arrowIcon {
@@ -90,12 +96,14 @@ const locales = {
     bigTitle: '文章被以下专栏收录：',
     zhiHu: '一个 UI 设计体系',
     yuQue: 'Ant Design 官方专栏',
+    junjin: 'Ant Design 开源专栏',
     buttonText: '我有想法，去参与讨论',
   },
   en: {
     bigTitle: 'Articles are included in the column:',
     zhiHu: 'A UI design system',
     yuQue: 'Ant Design official column',
+    junjin: 'Ant Design Open Source Column',
     buttonText: 'Go to discuss',
   },
 };
@@ -103,12 +111,13 @@ const locales = {
 interface Props {
   zhihuLink?: string;
   yuqueLink?: string;
+  juejinLink?: string;
 }
 
-const ColumnCard: React.FC<Props> = ({ zhihuLink, yuqueLink }) => {
+const ColumnCard: React.FC<Props> = ({ zhihuLink, yuqueLink, juejinLink }) => {
   const [locale] = useLocale(locales);
   const { card, bigTitle, cardBody, left, title, subTitle, btn } = useStyle();
-  if (!zhihuLink && !yuqueLink) {
+  if (!zhihuLink && !yuqueLink && !juejinLink) {
     return null;
   }
   return (
@@ -137,7 +146,7 @@ const ColumnCard: React.FC<Props> = ({ zhihuLink, yuqueLink }) => {
           <Button
             type="primary"
             css={btn}
-            icon={<ZhihuOutlined style={{ fontSize: 15 }} />}
+            icon={<ZhihuOutlined style={{ fontSize: 16 }} />}
             ghost
             target="_blank"
             href={zhihuLink}
@@ -171,10 +180,45 @@ const ColumnCard: React.FC<Props> = ({ zhihuLink, yuqueLink }) => {
             <Button
               type="primary"
               css={btn}
-              icon={<YuqueOutlined style={{ fontSize: 15 }} />}
+              icon={<YuqueOutlined style={{ fontSize: 16 }} />}
               ghost
               target="_blank"
               href={yuqueLink}
+            >
+              {locale.buttonText}
+            </Button>
+          </div>
+        </>
+      )}
+      {juejinLink && (
+        <>
+          <Divider />
+          <div css={cardBody}>
+            <div css={left}>
+              <img src={ANTD_IMG_URL} alt="antd" />
+              <div>
+                <p css={title}>Ant Design</p>
+                <div css={subTitle}>
+                  <JuejinLogo className="logo juejin-logo" />
+                  <RightOutlined className="arrowIcon" />
+                  <Button
+                    target="_blank"
+                    href="https://juejin.cn/column/7247354308258054200"
+                    className="zl-btn"
+                    type="link"
+                  >
+                    {locale.junjin}
+                  </Button>
+                </div>
+              </div>
+            </div>
+            <Button
+              type="primary"
+              css={btn}
+              icon={<JuejinLogo style={{ fontSize: 16, width: 16, height: 16 }} />}
+              ghost
+              target="_blank"
+              href={juejinLink}
             >
               {locale.buttonText}
             </Button>

--- a/.dumi/theme/slots/Content/JuejinLogo.tsx
+++ b/.dumi/theme/slots/Content/JuejinLogo.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Props {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const JuejinLogo: React.FC<Props> = (props) => {
+  const { className, style } = props;
+  return (
+    <svg
+      className={className}
+      style={style}
+      xmlns="http://www.w3.org/2000/svg"
+      width="36"
+      height="28"
+      viewBox="0 0 36 28"
+      fill="none"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M17.5875 6.77268L21.8232 3.40505L17.5875 0.00748237L17.5837 0L13.3555 3.39757L17.5837 6.76894L17.5875 6.77268ZM17.5863 17.3955H17.59L28.5161 8.77432L25.5526 6.39453L17.59 12.6808H17.5863L17.5825 12.6845L9.61993 6.40201L6.66016 8.78181L17.5825 17.3992L17.5863 17.3955ZM17.5828 23.2891L17.5865 23.2854L32.2133 11.7456L35.1768 14.1254L28.5238 19.3752L17.5865 28L0.284376 14.3574L0 14.1291L2.95977 11.7531L17.5828 23.2891Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export default JuejinLogo;

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -273,10 +273,13 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
           ) : null}
           {!meta.frontmatter.__autoDescription && meta.frontmatter.description}
           {children}
-          {(meta.frontmatter?.zhihu_url || meta.frontmatter?.yuque_url) && (
+          {(meta.frontmatter?.zhihu_url ||
+            meta.frontmatter?.yuque_url ||
+            meta.frontmatter?.juejin_url) && (
             <ColumnCard
               zhihuLink={meta.frontmatter.zhihu_url}
               yuqueLink={meta.frontmatter.yuque_url}
+              juejinLink={meta.frontmatter.juejin_url}
             />
           )}
           {meta.frontmatter.filename && (

--- a/docs/blog/tree-shaking.en-US.md
+++ b/docs/blog/tree-shaking.en-US.md
@@ -1,7 +1,8 @@
 ---
 title: Bundle Size Optimization
-date: 2023-06-24
+date: 2023-06-25
 author: zombieJ
+juejin_url: https://juejin.cn/post/7248424501813674021
 ---
 
 In modern JS applications, unused module can be automatically removed by modular packaging tools. This process is called [Tree Shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking). However, if you are already very familiar with it, you will find that it is not so perfect in reality. We still need some extra operations to achieve the best size optimization effect. Today, let's talk about a problem that ConfigProvider causes Tree Shaking to fail.

--- a/docs/blog/tree-shaking.zh-CN.md
+++ b/docs/blog/tree-shaking.zh-CN.md
@@ -1,7 +1,8 @@
 ---
 title: 打包体积优化
-date: 2023-06-24
+date: 2023-06-25
 author: zombieJ
+juejin_url: https://juejin.cn/post/7248424501813674021
 ---
 
 在现代 JS 应用中，通过模块化打包工具可以自动将一些未使用的模块代码去除，这个过程叫做 [Tree Shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking)。不过如果你已经对此非常熟悉了，你会发现现实中它并不是那么完美，我们还需要一些额外的操作才能达到最佳的体积优化效果。今天，我们就来讲讲一个 ConfigProvider 导致的 Tree Shaking 失效的问题。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | site: add juejin column card |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e84a54</samp>

Added a new column for the Juejin blog platform to the homepage of the documentation site. Created a custom logo component for the column and updated the blog posts with the Juejin links. Modified the `ColumnCard` and `Content` components to support the new column.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e84a54</samp>

*  Add a new column for Juejin in the blog page ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR7), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR60-R61), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR69-R71), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR99), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR106), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fL106-R120), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR193-R227), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-d35cce55d619dec0ded84589169e1fb012ebaef1b375e4ca711239ce0f1bc450R1-R30), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L276-R282))
  - Import the `JuejinLogo` component from `.dumi/theme/slots/Content/JuejinLogo.tsx` and set its width, height, and color ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR7), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR60-R61), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR69-R71), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-d35cce55d619dec0ded84589169e1fb012ebaef1b375e4ca711239ce0f1bc450R1-R30))
  - Add a new prop for the `juejinLink` and update the condition for rendering the `ColumnCard` component ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fL106-R120), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L276-R282))
  - Add new locale keys for the `juejin` column name in Chinese and English ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR99), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR106))
  - Add a new section for the `juejin` column with a logo, a link button, and a divider ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fR193-R227))
* Increase the font size of the Zhihu and Yuque icons in the blog page ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fL140-R149), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-0245e4304af1087d6465feaa2ed176796371b8a0921af4b8af2b15d2a44f7d5fL174-R183))
* Update the frontmatter and date of the tree-shaking blog posts in Chinese and English ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-24526fd882d78382b0f13a4c2096a238739bb42a7398dc5dec321c86bc074bfaL3-R5), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-508afdecb785c2037c39c0a4d8443de465856c306ebd395caa237b4a3977e638L3-R5))
  - Add the `juejin_url` frontmatter to link to the Juejin platform ([link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-24526fd882d78382b0f13a4c2096a238739bb42a7398dc5dec321c86bc074bfaL3-R5), [link](https://github.com/ant-design/ant-design/pull/43171/files?diff=unified&w=0#diff-508afdecb785c2037c39c0a4d8443de465856c306ebd395caa237b4a3977e638L3-R5))