### PR TITLE
feat: move colorLink to seedToken

### DIFF
--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -10,6 +10,23 @@ import genRadius from '../themes/shared/genRadius';
 const { useToken } = theme;
 
 describe('Theme', () => {
+  const getHookToken = (config?: ThemeConfig) => {
+    let token: any;
+    const Demo = () => {
+      const { token: hookToken } = useToken();
+      token = hookToken;
+      return null;
+    };
+    render(
+      <ConfigProvider theme={config}>
+        <Demo />
+      </ConfigProvider>,
+    );
+    delete token._hashId;
+    delete token._tokenKey;
+    return token;
+  };
+
   it('useTheme', () => {
     const { result } = renderHook(() => useToken());
 
@@ -224,23 +241,6 @@ describe('Theme', () => {
   });
 
   describe('getDesignToken', () => {
-    const getHookToken = (config?: ThemeConfig) => {
-      let token: any;
-      const Demo = () => {
-        const { token: hookToken } = useToken();
-        token = hookToken;
-        return null;
-      };
-      render(
-        <ConfigProvider theme={config}>
-          <Demo />
-        </ConfigProvider>,
-      );
-      delete token._hashId;
-      delete token._tokenKey;
-      return token;
-    };
-
     it('default', () => {
       const token = theme.getDesignToken();
       const hookToken = getHookToken();
@@ -274,6 +274,32 @@ describe('Theme', () => {
       const hookToken = getHookToken(config);
       expect(token).toEqual(hookToken);
       expect(token.colorPrimary).toEqual('#1668dc');
+    });
+  });
+
+  describe('colorLink', () => {
+    it('should follow colorPrimary by default', () => {
+      const token = getHookToken();
+      expect(token.colorLink).toEqual(token.colorPrimary);
+      expect(token.colorLinkHover).toEqual(token.colorPrimaryHover);
+      expect(token.colorLinkActive).toEqual(token.colorPrimaryActive);
+
+      const token2 = getHookToken({ token: { colorPrimary: '#189cff' } });
+      expect(token2.colorLink).toEqual(token2.colorPrimary);
+      expect(token2.colorLinkHover).toEqual(token2.colorPrimaryHover);
+      expect(token2.colorLinkActive).toEqual(token2.colorPrimaryActive);
+
+      const token3 = getHookToken({ algorithm: [theme.darkAlgorithm] });
+      expect(token3.colorLink).toEqual(token3.colorPrimary);
+      expect(token3.colorLinkHover).toEqual(token3.colorPrimaryHover);
+      expect(token3.colorLinkActive).toEqual(token3.colorPrimaryActive);
+    });
+
+    it('should be calculated correctly', () => {
+      const token = getHookToken({ token: { colorLink: '#189cff' } });
+      expect(token.colorLink).toEqual('#189cff');
+      expect(token.colorLinkHover).toEqual('#40b3ff');
+      expect(token.colorLinkActive).toEqual('#0978d9');
     });
   });
 });

--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -280,25 +280,25 @@ describe('Theme', () => {
   describe('colorLink', () => {
     it('should follow colorPrimary by default', () => {
       const token = getHookToken();
-      expect(token.colorLink).toEqual(token.colorPrimary);
-      expect(token.colorLinkHover).toEqual(token.colorPrimaryHover);
-      expect(token.colorLinkActive).toEqual(token.colorPrimaryActive);
+      expect(token.colorLink).toEqual(token.colorInfo);
+      expect(token.colorLinkHover).toEqual(token.colorInfoHover);
+      expect(token.colorLinkActive).toEqual(token.colorInfoActive);
 
       const token2 = getHookToken({ token: { colorPrimary: '#189cff' } });
-      expect(token2.colorLink).toEqual(token2.colorPrimary);
-      expect(token2.colorLinkHover).toEqual(token2.colorPrimaryHover);
-      expect(token2.colorLinkActive).toEqual(token2.colorPrimaryActive);
+      expect(token2.colorLink).toEqual(token2.colorInfo);
+      expect(token2.colorLinkHover).toEqual(token2.colorInfoHover);
+      expect(token2.colorLinkActive).toEqual(token2.colorInfoActive);
 
       const token3 = getHookToken({ algorithm: [theme.darkAlgorithm] });
-      expect(token3.colorLink).toEqual(token3.colorPrimary);
-      expect(token3.colorLinkHover).toEqual(token3.colorPrimaryHover);
-      expect(token3.colorLinkActive).toEqual(token3.colorPrimaryActive);
+      expect(token3.colorLink).toEqual(token3.colorInfo);
+      expect(token3.colorLinkHover).toEqual(token3.colorInfoHover);
+      expect(token3.colorLinkActive).toEqual(token3.colorInfoActive);
     });
 
     it('should be calculated correctly', () => {
       const token = getHookToken({ token: { colorLink: '#189cff' } });
       expect(token.colorLink).toEqual('#189cff');
-      expect(token.colorLinkHover).toEqual('#40b3ff');
+      expect(token.colorLinkHover).toEqual('#69c8ff');
       expect(token.colorLinkActive).toEqual('#0978d9');
     });
   });

--- a/components/theme/interface/alias.ts
+++ b/components/theme/interface/alias.ts
@@ -119,6 +119,7 @@ export interface AliasToken extends MapToken {
    * @descEN Weak action. Such as `allowClear` or Alert close button
    */
   colorIcon: string;
+
   /**  */
   /**
    * @nameZH 弱操作图标悬浮态颜色
@@ -127,28 +128,6 @@ export interface AliasToken extends MapToken {
    * @descEN Weak action hover color. Such as `allowClear` or Alert close button
    */
   colorIconHover: string;
-
-  /**
-   * @nameZH 超链接颜色
-   * @nameEN Hyperlink color
-   * @desc 控制超链接的颜色。
-   * @descEN Control the color of hyperlink.
-   */
-  colorLink: string;
-  /**
-   * @nameZH 超链接悬浮颜色
-   * @nameEN Hyperlink hover color
-   * @desc 控制超链接悬浮时的颜色。
-   * @descEN Control the color of hyperlink when hovering.
-   */
-  colorLinkHover: string;
-  /**
-   * @nameZH 超链接激活颜色
-   * @nameEN Hyperlink active color
-   * @desc 控制超链接被点击时的颜色。
-   * @descEN Control the color of hyperlink when clicked.
-   */
-  colorLinkActive: string;
 
   /**
    * @nameZH 高亮颜色

--- a/components/theme/interface/maps/colors.ts
+++ b/components/theme/interface/maps/colors.ts
@@ -531,13 +531,38 @@ interface ColorErrorMapToken {
   colorErrorTextActive: string; // 10
 }
 
+export interface ColorLinkMapToken {
+  /**
+   * @nameZH 超链接颜色
+   * @nameEN Hyperlink color
+   * @desc 控制超链接的颜色。
+   * @descEN Control the color of hyperlink.
+   */
+  colorLink: string;
+  /**
+   * @nameZH 超链接悬浮颜色
+   * @nameEN Hyperlink hover color
+   * @desc 控制超链接悬浮时的颜色。
+   * @descEN Control the color of hyperlink when hovering.
+   */
+  colorLinkHover: string;
+  /**
+   * @nameZH 超链接激活颜色
+   * @nameEN Hyperlink active color
+   * @desc 控制超链接被点击时的颜色。
+   * @descEN Control the color of hyperlink when clicked.
+   */
+  colorLinkActive: string;
+}
+
 export interface ColorMapToken
   extends ColorNeutralMapToken,
     ColorPrimaryMapToken,
     ColorSuccessMapToken,
     ColorWarningMapToken,
     ColorErrorMapToken,
-    ColorInfoMapToken {
+    ColorInfoMapToken,
+    ColorLinkMapToken {
   /**
    * @nameZH 纯白色
    * @desc 不随主题变化的纯白色

--- a/components/theme/interface/seeds.ts
+++ b/components/theme/interface/seeds.ts
@@ -63,6 +63,14 @@ export interface SeedToken extends PresetColorType {
    */
   colorBgBase: string;
 
+  /**
+   * @nameZH 超链接颜色
+   * @nameEN Hyperlink color
+   * @desc 控制超链接的颜色。
+   * @descEN Control the color of hyperlink.
+   */
+  colorLink: string;
+
   //  ----------   Font   ---------- //
 
   /**

--- a/components/theme/themes/seed.ts
+++ b/components/theme/themes/seed.ts
@@ -26,6 +26,7 @@ const seedToken: SeedToken = {
   colorWarning: '#faad14',
   colorError: '#ff4d4f',
   colorInfo: '#1677ff',
+  colorLink: '',
   colorTextBase: '',
 
   colorBgBase: '',

--- a/components/theme/themes/shared/genColorMapToken.ts
+++ b/components/theme/themes/shared/genColorMapToken.ts
@@ -28,6 +28,10 @@ export default function genColorMapToken(
   const infoColors = generateColorPalettes(colorInfoBase);
   const neutralColors = generateNeutralColorPalettes(colorBgBase, colorTextBase);
 
+  // Color Link
+  const colorLink = seed.colorLink || seed.colorPrimary;
+  const linkColors = generateColorPalettes(colorLink);
+
   return {
     ...neutralColors,
 
@@ -85,6 +89,10 @@ export default function genColorMapToken(
     colorInfoTextHover: infoColors[8],
     colorInfoText: infoColors[9],
     colorInfoTextActive: infoColors[10],
+
+    colorLinkHover: linkColors[5],
+    colorLink: linkColors[6],
+    colorLinkActive: linkColors[7],
 
     colorBgMask: new TinyColor('#000').setAlpha(0.45).toRgbString(),
     colorWhite: '#fff',

--- a/components/theme/themes/shared/genColorMapToken.ts
+++ b/components/theme/themes/shared/genColorMapToken.ts
@@ -29,7 +29,7 @@ export default function genColorMapToken(
   const neutralColors = generateNeutralColorPalettes(colorBgBase, colorTextBase);
 
   // Color Link
-  const colorLink = seed.colorLink || seed.colorPrimary;
+  const colorLink = seed.colorLink || seed.colorInfo;
   const linkColors = generateColorPalettes(colorLink);
 
   return {
@@ -90,7 +90,7 @@ export default function genColorMapToken(
     colorInfoText: infoColors[9],
     colorInfoTextActive: infoColors[10],
 
-    colorLinkHover: linkColors[5],
+    colorLinkHover: linkColors[4],
     colorLink: linkColors[6],
     colorLinkActive: linkColors[7],
 

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -43,10 +43,6 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
   const aliasToken: AliasToken = {
     ...mergedToken,
 
-    colorLink: mergedToken.colorInfoText,
-    colorLinkHover: mergedToken.colorInfoHover,
-    colorLinkActive: mergedToken.colorInfoActive,
-
     // ============== Background ============== //
     colorFillContent: mergedToken.colorFillSecondary,
     colorFillContentHover: mergedToken.colorFill,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Move `colorLink` to seed token, `colorLinkHover` and `colorLinkActive` will be calculated with `colorLink`.        |
| 🇨🇳 Chinese |    将 `colorLink` 添加至 seed token 中, `colorLinkHover` 和 `colorLinkActive` 将会由 `colorLink` 计算得出。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 387f9fe</samp>

This pull request adds support for hyperlink colors in the theme system. It introduces a new `colorLink` token and its related interfaces and functions. It also removes unused and redundant properties from the alias token and updates the token tests.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 387f9fe</samp>

*  Add `ColorLinkMapToken` interface to define hyperlink colors ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-ab724fab615e4a65d687b76c6460750b4f30ad47cb3c33988328f0c9971fd41fR534-R557),[link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-ab724fab615e4a65d687b76c6460750b4f30ad47cb3c33988328f0c9971fd41fL540-R565))
*  Extend `ColorMapToken` interface with `ColorLinkMapToken` interface ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-ab724fab615e4a65d687b76c6460750b4f30ad47cb3c33988328f0c9971fd41fL540-R565))
*  Remove `colorLink`, `colorLinkHover`, and `colorLinkActive` properties from `AliasToken` interface ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-f6ab6e133f17bf8cfb1e390e3e6fc000340af4360bd20a8ca08175cdaacc06ccL132-L153))
*  Remove `colorLink`, `colorLinkHover`, and `colorLinkActive` properties from alias token object ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-f3ab017a082c77a7f16d580585fe689bfc5be5f003cf3bfd91aa4913c8f020fbL46-L49))
*  Add `colorLink` property to `SeedToken` interface with default value of `colorPrimary` ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-1c052f1a5a3be349f7851e5359b5fbf107db46bca91e43e5ac38a797ec50a3a5R66-R73))
*  Add `colorLink` property to `seedToken` value with empty string ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-1b8c17af4cb07d6d93d8230835a094e25be953f60de69837a0bcafa2e4e4ad14R29))
*  Generate `colorLink` token based on `colorLink` or `colorPrimary` seed value ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-ac8b65d5ca7360b4d78a9b17c96be11585c61e01a5757a5e40486610c740c203R31-R34))
*  Add `colorLinkHover`, `colorLink`, and `colorLinkActive` properties to color map token object ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-ac8b65d5ca7360b4d78a9b17c96be11585c61e01a5757a5e40486610c740c203R93-R96))
*  Add test suite for `colorLink` token in `token.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-37ce89d0868e7510a9c83f58a4d4a2cba035535684d5585549df8962f6a7e421R279-R304))
*  Move `getHookToken` helper function to the top of `token.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-37ce89d0868e7510a9c83f58a4d4a2cba035535684d5585549df8962f6a7e421R13-R29),[link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-37ce89d0868e7510a9c83f58a4d4a2cba035535684d5585549df8962f6a7e421L227-L243))
*  Add blank line to `alias.ts` for formatting ([link](https://github.com/ant-design/ant-design/pull/43183/files?diff=unified&w=0#diff-f6ab6e133f17bf8cfb1e390e3e6fc000340af4360bd20a8ca08175cdaacc06ccR122))
