### PR TITLE
fix: Upload with maxCount not trigger onChange

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -113,7 +113,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     if (maxCount === 1) {
       cloneList = cloneList.slice(-1);
     } else if (maxCount) {
-      exceedMaxCount = true;
+      exceedMaxCount = cloneList.length > maxCount;
       cloneList = cloneList.slice(0, maxCount);
     }
 

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -779,7 +779,7 @@ describe('Upload', () => {
     });
 
     // https://github.com/ant-design/ant-design/issues/43190
-    it('should trigger onChange when remove', () => {
+    it('should trigger onChange when remove', async () => {
       const onChange = jest.fn();
 
       const { container } = render(
@@ -805,7 +805,14 @@ describe('Upload', () => {
       // Click delete
       fireEvent.click(container.querySelector('.ant-upload-list-item-action')!);
 
-      expect(onChange).toHaveBeenCalledWith({});
+      await waitFakeTimer();
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // Have 1 file
+          fileList: [expect.anything()],
+        }),
+      );
     });
   });
 

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -777,6 +777,36 @@ describe('Upload', () => {
         expect(args[0].file.name).toBe('foo.png');
       });
     });
+
+    // https://github.com/ant-design/ant-design/issues/43190
+    it('should trigger onChange when remove', () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <Upload
+          onChange={onChange}
+          maxCount={2}
+          defaultFileList={[
+            {
+              uid: 'bamboo',
+              name: 'bamboo.png',
+            },
+            {
+              uid: 'little',
+              name: 'little.png',
+            },
+          ]}
+          showUploadList
+        >
+          <button type="button">upload</button>
+        </Upload>,
+      );
+
+      // Click delete
+      fireEvent.click(container.querySelector('.ant-upload-list-item-action')!);
+
+      expect(onChange).toHaveBeenCalledWith({});
+    });
   });
 
   it('auto fill file uid', () => {

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -38,6 +38,7 @@ const DEPRECIATED_VERSION = {
     'https://github.com/ant-design/ant-design/pull/41993',
   ],
   '5.6.2': ['https://github.com/ant-design/ant-design/issues/43113'],
+  '5.6.3': ['https://github.com/ant-design/ant-design/issues/43190'],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43190

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Upload with `maxCount` will skip `onChange` when remove file.     |
| 🇨🇳 Chinese |     修复 Upload 配置 `maxCount` 后删除文件不会触发 `onChange` 的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d80fe27</samp>

This pull request fixes a bug in the `Upload` component that prevented the `onChange` event from firing when the file list reached the `maxCount` limit. It also adds a test case for the bug and a link to the issue in the deprecated version warning.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d80fe27</samp>

* Fix bug in Upload component that prevented `onChange` event from firing when file list exceeded `maxCount` prop ([link](https://github.com/ant-design/ant-design/pull/43193/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL116-R116))
* Add test case to verify bug fix and ensure correct behavior of Upload component with `maxCount` prop ([link](https://github.com/ant-design/ant-design/pull/43193/files?diff=unified&w=0#diff-72ea20f11250bb41ad13135c67af7e612d56bd43c8e24ad4db9c782f58306ac7R780-R816))
* Add link to issue #28394 to `DEPRECIATED_VERSION` object in `scripts/post-script.js` to inform users of deprecated versions about the bug and the fix ([link](https://github.com/ant-design/ant-design/pull/43193/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dR41))
