### PR TITLE
feat: CP support Badge className / classNames and style / styles

### DIFF
--- a/components/badge/demo/basic.tsx
+++ b/components/badge/demo/basic.tsx
@@ -1,19 +1,18 @@
+import { Badge, ConfigProvider } from 'antd';
 import React from 'react';
-import { ClockCircleOutlined } from '@ant-design/icons';
-import { Avatar, Badge, Space } from 'antd';
 
 const App: React.FC = () => (
-  <Space size="middle">
-    <Badge count={5}>
-      <Avatar shape="square" size="large" />
+  <ConfigProvider
+    badge={{
+      className: 'aaaaaaa',
+      style: { color: 'blue' },
+      classNames: { count: 'lllllll' },
+    }}
+  >
+    <Badge className="kkkkkkk" style={{ backgroundColor: 'yellow' }} count={10}>
+      test
     </Badge>
-    <Badge count={0} showZero>
-      <Avatar shape="square" size="large" />
-    </Badge>
-    <Badge count={<ClockCircleOutlined style={{ color: '#f5222d' }} />}>
-      <Avatar shape="square" size="large" />
-    </Badge>
-  </Space>
+  </ConfigProvider>
 );
 
 export default App;

--- a/components/badge/demo/basic.tsx
+++ b/components/badge/demo/basic.tsx
@@ -1,18 +1,19 @@
-import { Badge, ConfigProvider } from 'antd';
 import React from 'react';
+import { ClockCircleOutlined } from '@ant-design/icons';
+import { Avatar, Badge, Space } from 'antd';
 
 const App: React.FC = () => (
-  <ConfigProvider
-    badge={{
-      className: 'aaaaaaa',
-      style: { color: 'blue' },
-      classNames: { count: 'lllllll' },
-    }}
-  >
-    <Badge className="kkkkkkk" style={{ backgroundColor: 'yellow' }} count={10}>
-      test
+  <Space size="middle">
+    <Badge count={5}>
+      <Avatar shape="square" size="large" />
     </Badge>
-  </ConfigProvider>
+    <Badge count={0} showZero>
+      <Avatar shape="square" size="large" />
+    </Badge>
+    <Badge count={<ClockCircleOutlined style={{ color: '#f5222d' }} />}>
+      <Avatar shape="square" size="large" />
+    </Badge>
+  </Space>
 );
 
 export default App;

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -113,7 +113,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   // =============================== Styles ===============================
   const mergedStyle = useMemo<React.CSSProperties>(() => {
     if (!offset) {
-      return { ...badge?.style, ...style };
+      return { ...badge?.style, ...badge?.styles?.count, ...style };
     }
 
     const offsetStyle: React.CSSProperties = { marginTop: offset[1] };
@@ -125,6 +125,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
 
     return {
       ...badge?.style,
+      ...badge?.styles?.count,
       ...offsetStyle,
       ...style,
     };

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -184,7 +184,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       <span
         {...restProps}
         className={badgeClassName}
-        style={{ ...badge?.styles?.container, ...mergedStyle }}
+        style={{ ...badge?.styles?.root, ...mergedStyle }}
       >
         <span className={statusCls} style={statusStyle} />
         {text && (

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -133,7 +133,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       offsetStyle.right = -parseInt(offset[0] as string, 10);
     }
 
-    return { ...badge?.style, ...offsetStyle, ...style };
+    return { ...offsetStyle, ...badge?.style, ...style };
   }, [direction, offset, style, badge?.style]);
 
   // =============================== Render ===============================

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -166,7 +166,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   const badgeClassName = classNames(
     prefixCls,
     badge?.className,
-    badge?.classNames?.container,
+    badge?.classNames?.root,
     {
       [`${prefixCls}-status`]: hasStatus,
       [`${prefixCls}-not-a-wrapper`]: !children,

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -2,12 +2,12 @@ import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import * as React from 'react';
 import { useMemo, useRef } from 'react';
-import { ConfigContext } from '../config-provider';
-import type { PresetColorKey } from '../theme/internal';
 import type { PresetStatusColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import { cloneElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
+import { ConfigContext } from '../config-provider';
+import type { PresetColorKey } from '../theme/internal';
 import Ribbon from './Ribbon';
 import ScrollNumber from './ScrollNumber';
 import useStyle from './style';
@@ -62,7 +62,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
     showZero = false,
     ...restProps
   } = props;
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, badge } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('badge', customizePrefixCls);
 
   // Style
@@ -113,7 +113,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   // =============================== Styles ===============================
   const mergedStyle = useMemo<React.CSSProperties>(() => {
     if (!offset) {
-      return { ...style };
+      return { ...badge?.style, ...style };
     }
 
     const offsetStyle: React.CSSProperties = { marginTop: offset[1] };
@@ -124,6 +124,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
     }
 
     return {
+      ...badge?.style,
       ...offsetStyle,
       ...style,
     };
@@ -168,6 +169,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
 
   const badgeClassName = classNames(
     prefixCls,
+    badge?.className,
     {
       [`${prefixCls}-status`]: hasStatus,
       [`${prefixCls}-not-a-wrapper`]: !children,

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -123,7 +123,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   // =============================== Styles ===============================
   const mergedStyle = useMemo<React.CSSProperties>(() => {
     if (!offset) {
-      return { ...style };
+      return { ...badge?.style, ...style };
     }
 
     const offsetStyle: React.CSSProperties = { marginTop: offset[1] };
@@ -133,11 +133,8 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       offsetStyle.right = -parseInt(offset[0] as string, 10);
     }
 
-    return {
-      ...offsetStyle,
-      ...style,
-    };
-  }, [direction, offset, style]);
+    return { ...badge?.style, ...offsetStyle, ...style };
+  }, [direction, offset, style, badge?.style]);
 
   // =============================== Render ===============================
   // >>> Title
@@ -154,10 +151,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
     !livingCount || typeof livingCount !== 'object'
       ? undefined
       : cloneElement(livingCount, (oriProps) => ({
-          style: {
-            ...mergedStyle,
-            ...oriProps.style,
-          },
+          style: { ...mergedStyle, ...oriProps.style },
         }));
 
   // InternalColor
@@ -198,7 +192,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       <span
         {...restProps}
         className={badgeClassName}
-        style={{ ...styles?.root, ...badge?.style, ...badge?.styles?.root, ...mergedStyle }}
+        style={{ ...styles?.root, ...badge?.styles?.root, ...mergedStyle }}
       >
         <span
           className={statusCls}
@@ -248,7 +242,6 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
           let scrollNumberStyle: React.CSSProperties = {
             ...styles?.indicator,
             ...badge?.styles?.indicator,
-            ...badge?.style,
             ...mergedStyle,
           };
 

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -113,7 +113,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   // =============================== Styles ===============================
   const mergedStyle = useMemo<React.CSSProperties>(() => {
     if (!offset) {
-      return { ...badge?.style, ...badge?.styles?.count, ...style };
+      return { ...badge?.style, ...style };
     }
 
     const offsetStyle: React.CSSProperties = { marginTop: offset[1] };
@@ -123,12 +123,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       offsetStyle.right = -parseInt(offset[0] as string, 10);
     }
 
-    return {
-      ...badge?.style,
-      ...badge?.styles?.count,
-      ...offsetStyle,
-      ...style,
-    };
+    return { ...badge?.style, ...offsetStyle, ...style };
   }, [direction, offset, style]);
 
   // =============================== Render ===============================
@@ -171,6 +166,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   const badgeClassName = classNames(
     prefixCls,
     badge?.className,
+    badge?.classNames?.container,
     {
       [`${prefixCls}-status`]: hasStatus,
       [`${prefixCls}-not-a-wrapper`]: !children,
@@ -185,7 +181,11 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   if (!children && hasStatus) {
     const statusTextColor = mergedStyle.color;
     return wrapSSR(
-      <span {...restProps} className={badgeClassName} style={mergedStyle}>
+      <span
+        {...restProps}
+        className={badgeClassName}
+        style={{ ...badge?.styles?.container, ...mergedStyle }}
+      >
         <span className={statusCls} style={statusStyle} />
         {text && (
           <span style={{ color: statusTextColor }} className={`${prefixCls}-status-text`}>
@@ -197,7 +197,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   }
 
   return wrapSSR(
-    <span ref={ref} {...restProps} className={badgeClassName}>
+    <span ref={ref} {...restProps} className={badgeClassName} style={badge?.styles?.container}>
       {children}
       <CSSMotion
         visible={!isHidden}
@@ -223,7 +223,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
             [`${prefixCls}-color-${color}`]: isInternalColor,
           });
 
-          let scrollNumberStyle: React.CSSProperties = { ...mergedStyle };
+          let scrollNumberStyle: React.CSSProperties = { ...badge?.styles?.count, ...mergedStyle };
           if (color && !isInternalColor) {
             scrollNumberStyle = scrollNumberStyle || {};
             scrollNumberStyle.background = color;

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -133,7 +133,10 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
       offsetStyle.right = -parseInt(offset[0] as string, 10);
     }
 
-    return { ...offsetStyle };
+    return {
+      ...offsetStyle,
+      ...style,
+    };
   }, [direction, offset, style]);
 
   // =============================== Render ===============================

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -212,7 +212,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
 
           const isDot = isDotRef.current;
 
-          const scrollNumberCls = classNames({
+          const scrollNumberCls = classNames(badge?.classNames?.count, {
             [`${prefixCls}-dot`]: isDot,
             [`${prefixCls}-count`]: !isDot,
             [`${prefixCls}-count-sm`]: size === 'small',

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -235,7 +235,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
 
           const isDot = isDotRef.current;
 
-          const scrollNumberCls = classnames(classNames?.indicator, {
+          const scrollNumberCls = classnames(classNames?.indicator, badge?.classNames?.indicator, {
             [`${prefixCls}-dot`]: isDot,
             [`${prefixCls}-count`]: !isDot,
             [`${prefixCls}-count-sm`]: size === 'small',
@@ -248,6 +248,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
           let scrollNumberStyle: React.CSSProperties = {
             ...styles?.indicator,
             ...badge?.styles?.indicator,
+            ...badge?.style,
             ...mergedStyle,
           };
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ConfigProvider from '..';
 import { render } from '../../../tests/utils';
 import Anchor from '../../anchor';
+import Badge from '../../badge';
 import Breadcrumb from '../../breadcrumb';
 import Checkbox from '../../checkbox';
 import Descriptions from '../../descriptions';
@@ -321,5 +322,16 @@ describe('ConfigProvider support style and className props', () => {
 
     expect(container.querySelector('.ant-empty')).toHaveClass('cp-className');
     expect(container.querySelector('.ant-empty')).toHaveStyle({ background: 'red' });
+  });
+
+  it('Should Badge className & style works', () => {
+    const { container } = render(
+      <ConfigProvider pagination={{ className: 'cp-badge', style: { backgroundColor: 'blue' } }}>
+        <Badge count={10}>test</Badge>
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLSpanElement>('.ant-badge');
+    expect(element).toHaveClass('cp-badge');
+    expect(element).toHaveStyle({ backgroundColor: 'blue' });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -343,14 +343,21 @@ describe('ConfigProvider support style and className props', () => {
     expect(container.querySelector('.ant-empty')).toHaveStyle({ background: 'red' });
   });
 
-  it('Should Badge className & style works', () => {
+  it('Should Badge className & style & classNames works', () => {
     const { container } = render(
-      <ConfigProvider pagination={{ className: 'cp-badge', style: { backgroundColor: 'blue' } }}>
+      <ConfigProvider
+        badge={{
+          className: 'cp-badge',
+          classNames: { count: 'cp-badge-sup' },
+          style: { backgroundColor: 'blue' },
+        }}
+      >
         <Badge count={10}>test</Badge>
       </ConfigProvider>,
     );
     const element = container.querySelector<HTMLSpanElement>('.ant-badge');
     expect(element).toHaveClass('cp-badge');
-    expect(element).toHaveStyle({ backgroundColor: 'blue' });
+    expect(element?.querySelector<HTMLElement>('sup')).toHaveClass('cp-badge-sup');
+    expect(element?.querySelector<HTMLElement>('sup')).toHaveStyle({ backgroundColor: 'blue' });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -348,20 +348,34 @@ describe('ConfigProvider support style and className props', () => {
       <ConfigProvider
         badge={{
           className: 'cp-badge',
-          style: { backgroundColor: 'blue' },
-          classNames: { count: 'cp-badge-sup' },
-          styles: { count: { color: 'green' } },
+          style: {
+            backgroundColor: 'blue',
+          },
+          classNames: {
+            count: 'cp-badge-count',
+            container: 'cp-badge-container',
+          },
+          styles: {
+            count: { color: 'green' },
+            container: { color: 'yellow' },
+          },
         }}
       >
         <Badge count={10}>test</Badge>
       </ConfigProvider>,
     );
     const element = container.querySelector<HTMLSpanElement>('.ant-badge');
+
+    // test className
     expect(element).toHaveClass('cp-badge');
-    expect(element?.querySelector<HTMLElement>('sup')).toHaveClass('cp-badge-sup');
+    expect(element).toHaveClass('cp-badge-container');
+    expect(element?.querySelector<HTMLElement>('sup')).toHaveClass('cp-badge-count');
+
+    // test style
+    expect(element).toHaveStyle({ color: 'yellow' });
     expect(element?.querySelector<HTMLElement>('sup')).toHaveStyle({
-      backgroundColor: 'blue',
       color: 'green',
+      backgroundColor: 'blue',
     });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -348,8 +348,9 @@ describe('ConfigProvider support style and className props', () => {
       <ConfigProvider
         badge={{
           className: 'cp-badge',
-          classNames: { count: 'cp-badge-sup' },
           style: { backgroundColor: 'blue' },
+          classNames: { count: 'cp-badge-sup' },
+          styles: { count: { color: 'green' } },
         }}
       >
         <Badge count={10}>test</Badge>
@@ -358,6 +359,9 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLSpanElement>('.ant-badge');
     expect(element).toHaveClass('cp-badge');
     expect(element?.querySelector<HTMLElement>('sup')).toHaveClass('cp-badge-sup');
-    expect(element?.querySelector<HTMLElement>('sup')).toHaveStyle({ backgroundColor: 'blue' });
+    expect(element?.querySelector<HTMLElement>('sup')).toHaveStyle({
+      backgroundColor: 'blue',
+      color: 'green',
+    });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -42,14 +42,8 @@ export interface ComponentStyleConfig {
 }
 
 export interface BadgeConfig extends ComponentStyleConfig {
-  classNames?: {
-    count?: string;
-    container?: string;
-  };
-  styles?: {
-    count?: React.CSSProperties;
-    container?: React.CSSProperties;
-  };
+  classNames?: BadgeProps['classNames'];
+  styles?: BadgeProps['styles'];
 }
 
 export interface ButtonConfig extends ComponentStyleConfig {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -42,8 +42,14 @@ export interface ComponentStyleConfig {
 }
 
 export interface BadgeConfig extends ComponentStyleConfig {
-  classNames?: { count?: string };
-  styles?: { count?: React.CSSProperties };
+  classNames?: {
+    count?: string;
+    container?: string;
+  };
+  styles?: {
+    count?: React.CSSProperties;
+    container?: React.CSSProperties;
+  };
 }
 
 export interface ButtonConfig extends ComponentStyleConfig {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -99,6 +99,7 @@ export interface ConfigConsumerProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
+  badge?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -43,6 +43,7 @@ export interface ComponentStyleConfig {
 
 export interface BadgeConfig extends ComponentStyleConfig {
   classNames?: { count?: string };
+  styles?: { count?: React.CSSProperties };
 }
 
 export interface ButtonConfig extends ComponentStyleConfig {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -41,6 +41,10 @@ export interface ComponentStyleConfig {
   style?: React.CSSProperties;
 }
 
+export interface BadgeConfig extends ComponentStyleConfig {
+  classNames?: { count?: string };
+}
+
 export interface ButtonConfig extends ComponentStyleConfig {
   classNames?: ButtonProps['classNames'];
   styles?: ButtonProps['styles'];
@@ -99,7 +103,7 @@ export interface ConfigConsumerProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
-  badge?: ComponentStyleConfig;
+  badge?: BadgeConfig;
   radio?: ComponentStyleConfig;
 }
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -102,6 +102,7 @@ const {
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | anchor | Set Anchor common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| badge | Set Badge common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | breadcrumb | Set Breadcrumb common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -102,7 +102,7 @@ const {
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | anchor | Set Anchor common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: { count?: string }, styles?: { count?: React.CSSProperties } } | - | 5.7.0 |
+| badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: { count?: string, container?: string }, styles?: { count?: React.CSSProperties, container?: React.CSSProperties } } | - | 5.7.0 |
 | breadcrumb | Set Breadcrumb common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -102,7 +102,7 @@ const {
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | anchor | Set Anchor common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | Set Badge common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: { count?: string } } | - | 5.7.0 |
 | breadcrumb | Set Breadcrumb common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -102,7 +102,7 @@ const {
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | anchor | Set Anchor common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: { count?: string } } | - | 5.7.0 |
+| badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: { count?: string }, styles?: { count?: React.CSSProperties } } | - | 5.7.0 |
 | breadcrumb | Set Breadcrumb common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -148,6 +148,7 @@ export interface ConfigProviderProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
+  badge?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -200,7 +201,9 @@ const setGlobalConfig = ({
 
 export const globalConfig = () => ({
   getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
-    if (customizePrefixCls) return customizePrefixCls;
+    if (customizePrefixCls) {
+      return customizePrefixCls;
+    }
     return suffixCls ? `${getGlobalPrefixCls()}-${suffixCls}` : getGlobalPrefixCls();
   },
   getIconPrefixCls: getGlobalIconPrefixCls,
@@ -249,6 +252,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     breadcrumb,
     pagination,
     empty,
+    badge,
   } = props;
 
   // =================================== Warning ===================================
@@ -314,6 +318,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     breadcrumb,
     pagination,
     empty,
+    badge,
   };
 
   const config = {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -18,6 +18,7 @@ import type { SpaceProps } from '../space';
 import { DesignTokenContext } from '../theme/internal';
 import defaultSeedToken from '../theme/themes/seed';
 import type {
+  BadgeConfig,
   ButtonConfig,
   ComponentStyleConfig,
   ConfigConsumerProps,
@@ -148,7 +149,7 @@ export interface ConfigProviderProps {
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
-  badge?: ComponentStyleConfig;
+  badge?: BadgeConfig;
   radio?: ComponentStyleConfig;
 }
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -104,7 +104,7 @@ const {
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | anchor | 设置 Anchor 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string } } | - | 5.7.0 |
+| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string }, styles?: { count?: React.CSSProperties } } | - | 5.7.0 |
 | breadcrumb | 设置 Breadcrumb 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -104,7 +104,7 @@ const {
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | anchor | 设置 Anchor 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string }, styles?: { count?: React.CSSProperties } } | - | 5.7.0 |
+| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string, container?: string }, styles?: { count?: React.CSSProperties, container?: React.CSSProperties } } | - | 5.7.0 |
 | breadcrumb | 设置 Breadcrumb 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -104,7 +104,7 @@ const {
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | anchor | 设置 Anchor 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string } } | - | 5.7.0 |
 | breadcrumb | 设置 Breadcrumb 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -104,6 +104,7 @@ const {
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | anchor | 设置 Anchor 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | breadcrumb | 设置 Breadcrumb 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

`className` 作用于外面的 `<span />` ，`classNames.count` 作用于里面的 `<sup />`

`style` 本身就是挂在里面的 `<sup />` 上，`styles.count` 也作用于里面的 `<sup />`，所以和 `style` 和 `styles` 重合

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Badge className and style |
| 🇨🇳 Chinese | feat: CP 支持 Badge 组件的 className 和 style 属性 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f01c70</samp>

Added global configuration for `Badge` component using `badge` prop in `ConfigProvider`. Updated `Badge` component to use `ConfigContext` for style and class name. Added test case and documentation for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f01c70</samp>

*  Add `badge` property to `ConfigProvider` component and `ConfigContext` to allow users to set global configuration for `Badge` component ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR102), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R151), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R255), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R321))
*  Apply global configuration for `Badge` component in `style`, `className`, and `badge` attributes of relevant elements in `components/badge/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L65-R65), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L116-R116), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391R127), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391R172))
*  Reorder import statements in `components/badge/index.tsx` to group type imports together and separate them from value imports ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L5-R10))
*  Adjust indentation of `getPrefixCls` function in `globalConfig` value in `components/config-provider/index.tsx` to match ESLint rule ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L203-R206))
*  Import `Badge` component in `components/config-provider/__tests__/style.test.tsx` and add test case to check that it respects global configuration ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R5), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R326-R336))
*  Document usage and default value of `badge` property in `Component Config` section in `components/config-provider/index.en-US.md` and `组件配置` section in `components/config-provider/index.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R105), [link](https://github.com/ant-design/ant-design/pull/43197/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R107))
