### PR TITLE
fix: error reported when the name of Form.List is 0

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -1,8 +1,8 @@
 import { List } from 'rc-field-form';
 import type { StoreValue, ValidatorRule } from 'rc-field-form/lib/interface';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
 import warning from '../_util/warning';
+import { ConfigContext } from '../config-provider';
 import { FormItemPrefixContext } from './context';
 
 export interface FormListFieldData {
@@ -35,7 +35,12 @@ const FormList: React.FC<FormListProps> = ({
   children,
   ...props
 }) => {
-  warning(!!props.name, 'Form.List', 'Miss `name` prop.');
+  warning(
+    typeof props.name === 'number' ||
+      (Array.isArray(props.name) ? !!props.name.length : !!props.name),
+    'Form.List',
+    'Miss `name` prop.',
+  );
 
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('form', customizePrefixCls);

--- a/components/form/__tests__/list.test.tsx
+++ b/components/form/__tests__/list.test.tsx
@@ -262,4 +262,48 @@ describe('Form.List', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('no warning when name is 0', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Form>
+        <Form.List name={0}>
+          {(fields) =>
+            fields.map((field) => (
+              <Form.Item {...field} key={field.key}>
+                <Input />
+              </Form.Item>
+            ))
+          }
+        </Form.List>
+      </Form>,
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('warning when name is empty array', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Form>
+        <Form.List name={[]}>
+          {(fields) =>
+            fields.map((field) => (
+              <Form.Item {...field} key={field.key}>
+                <Input />
+              </Form.Item>
+            ))
+          }
+        </Form.List>
+      </Form>,
+    );
+
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
 });

--- a/components/form/__tests__/list.test.tsx
+++ b/components/form/__tests__/list.test.tsx
@@ -306,4 +306,26 @@ describe('Form.List', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('warning when name is null', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Form>
+        <Form.List name={null!!}>
+          {(fields) =>
+            fields.map((field) => (
+              <Form.Item {...field} key={field.key}>
+                <Input />
+              </Form.Item>
+            ))
+          }
+        </Form.List>
+      </Form>,
+    );
+
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/43195
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed an error when `Form.list` name was 0         |
| 🇨🇳 Chinese |  修复 `Form.list` 的 name 为 0 时报错  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12c6fff</samp>

Fixed a bug in `Form.List` that prevented using `0` as a name prop, and added a test case to ensure the fix works. This improves the usability and reliability of the `Form.List` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12c6fff</samp>

* Allow `0` as a valid value for the `name` prop of `Form.List` to fix a bug with array indexes ([link](https://github.com/ant-design/ant-design/pull/43199/files?diff=unified&w=0#diff-691085a7670f5a2b2ce8f80fba164377389d91d7e42de16b355a652d7538b8daL38-R38), [link](https://github.com/ant-design/ant-design/pull/43199/files?diff=unified&w=0#diff-dca63426af6a59cf27ec1ecc043a02033bfc075e0c552d46c3106bfc523c0333R265-R286))
* Adjust the import order of modules in `FormList.tsx` to follow the convention of external before internal ([link](https://github.com/ant-design/ant-design/pull/43199/files?diff=unified&w=0#diff-691085a7670f5a2b2ce8f80fba164377389d91d7e42de16b355a652d7538b8daL4-R5))
