### PR TITLE
docs: changelog 4.24.11

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -31,6 +31,7 @@ timeline: true
 - 🐞 Fix Form `onFieldsChange` missing `validating` status change. [#42263](https://github.com/ant-design/ant-design/pull/42263)
 - 🐞 Fix Popover that display empty `div` when `title` and `content` is null. [19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
 - 🐞 Fix Upload `disabled` logic. [#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
+- 🐞 Fix RangePicker wrong panel position under some circumstances. [#43179](https://github.com/ant-design/ant-design/pull/43179) [@cooljser](https://github.com/cooljser)
 - 💄 Optimize Spin style to keep height of container the same as child element. [#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
 
 ## 4.24.10

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -32,6 +32,7 @@ timeline: true
 - 🐞 Fix Popover that display empty `div` when `title` and `content` is null. [19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
 - 🐞 Fix Upload `disabled` logic. [#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
 - 🐞 Fix RangePicker wrong panel position under some circumstances. [#43179](https://github.com/ant-design/ant-design/pull/43179) [@cooljser](https://github.com/cooljser)
+- 🐞 Fix ConfigProvider makes Form component in the bundle even not use it. [#43207](https://github.com/ant-design/ant-design/pull/43207) [@yoyo837](https://github.com/yoyo837)
 - 💄 Optimize Spin style to keep height of container the same as child element. [#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
 
 ## 4.24.10

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,24 @@ timeline: true
 
 ---
 
+## 4.24.11
+
+`2023-06-27`
+
+- 🆕 Drawer panel support event listener. [#42712](https://github.com/ant-design/ant-design/pull/42712) [@kiner-tang](https://github.com/kiner-tang)
+- 🐞 Fix Upload `onChange` sometime not sync when in React 18. [#43200](https://github.com/ant-design/ant-design/pull/43200)
+- 🐞 Fix Notification cannot hide close icon by `closeIcon={null}`. [#42791](https://github.com/ant-design/ant-design/pull/42791)
+- 🐞 Fix Drawer `id` was passed in incorrectly, and now is always added to the popup panel. [#43124](https://github.com/ant-design/ant-design/pull/43124) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 Fix InputNumber with `prefix` abnormal height under Form.Item of `hasFeedBack`. [#43048](https://github.com/ant-design/ant-design/pull/43048)
+- 🐞 Fix Popover with `getPopupContainer` sometime makes width too narrow. [#42697](https://github.com/ant-design/ant-design/pull/42697)
+- 🐞 Fix Select will display the letter A under some circumstances. [#42654](https://github.com/ant-design/ant-design/pull/42654) [@tchen-l](https://github.com/tchen-l)
+- 🐞 Fix ConfigProvider that import useless modules from `rc-field-form` when importing `FormProvider` . [#42502](https://github.com/ant-design/ant-design/pull/42502) [@BanShan-Alec](https://github.com/BanShan-Alec)
+- 🐞 Fix Popconfirm trigger `onVisibleChange` twice. [#42351](https://github.com/ant-design/ant-design/pull/42351)
+- 🐞 Fix Form `onFieldsChange` missing `validating` status change. [#42263](https://github.com/ant-design/ant-design/pull/42263)
+- 🐞 Fix Popover that display empty `div` when `title` and `content` is null. [19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
+- 🐞 Fix Upload `disabled` logic. [#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
+- 💄 Optimize Spin style to keep height of container the same as child element. [#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
+
 ## 4.24.10
 
 `2023-05-04`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -32,6 +32,7 @@ timeline: true
 - 🐞 修复 Popover 组件当 `title` 和 `content` 都为空时展示空气泡的问题[19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
 - 🐞 修复 Upload 禁用状态逻辑。[#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
 - 🐞 修复 RangePicker 在某些情况下面板打开未知不正确的问题。[#43179](https://github.com/ant-design/ant-design/pull/43179) [@cooljser](https://github.com/cooljser)
+- 🐞 修复使用 ConfigProvider 会导致未使用的 Form 组件也被打包的问题。[#43207](https://github.com/ant-design/ant-design/pull/43207) [@yoyo837](https://github.com/yoyo837)
 - 💄 优化 Spin 样式，保持容器与子元素图标高度一致。[#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
 
 ## 4.24.10

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -31,6 +31,7 @@ timeline: true
 - 🐞 修复 Form `onFieldsChange` 丢失一次 `validating` 状态变更的更新事件。[#42263](https://github.com/ant-design/ant-design/pull/42263)
 - 🐞 修复 Popover 组件当 `title` 和 `content` 都为空时展示空气泡的问题[19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
 - 🐞 修复 Upload 禁用状态逻辑。[#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
+- 🐞 修复 RangePicker 在某些情况下面板打开未知不正确的问题。[#43179](https://github.com/ant-design/ant-design/pull/43179) [@cooljser](https://github.com/cooljser)
 - 💄 优化 Spin 样式，保持容器与子元素图标高度一致。[#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
 
 ## 4.24.10

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,24 @@ timeline: true
 
 ---
 
+## 4.24.11
+
+`2023-06-27`
+
+- 🆕 Drawer 组件面板支持事件监听。[#42712](https://github.com/ant-design/ant-design/pull/42712) [@kiner-tang](https://github.com/kiner-tang)
+- 🐞 修复 Upload 在 React 18 下 `onChange` 有时数据不正确的问题。[#43200](https://github.com/ant-design/ant-design/pull/43200)
+- 🐞 修复 Notification 设置 `closeIcon={null}` 时关闭图标没有消失的问题。[#42791](https://github.com/ant-design/ant-design/pull/42791)
+- 🐞 修复 Drawer `id` 传入位置不正确的问题，现在始终会添加至弹出面板上。[#43124](https://github.com/ant-design/ant-design/pull/43124) [@MuxinFeng](https://github.com/MuxinFeng)
+- 🐞 修复 InputNumber 带有 `prefix` 时在 Form.Item `hasFeedBack` 内高度异常的问题。[#43048](https://github.com/ant-design/ant-design/pull/43048)
+- 🐞 修复 Popover 设置 `getPopupContainer` 后，某些时候宽度会过窄的问题。[#42697](https://github.com/ant-design/ant-design/pull/42697)
+- 🐞 修复 Select 在某些情况下会显示字母 A 的问题。[#42654](https://github.com/ant-design/ant-design/pull/42654) [@tchen-l](https://github.com/tchen-l)
+- 🐞 修复 ConfigProvider 引入 `FormProvider` 时，错误引入 'rc-field-form' 其他的无关依赖的问题。[#42502](https://github.com/ant-design/ant-design/pull/42502) [@BanShan-Alec](https://github.com/BanShan-Alec)
+- 🐞 修复 Popconfirm 的 `onVisibleChange` 会重复触发的问题。[#42351](https://github.com/ant-design/ant-design/pull/42351)
+- 🐞 修复 Form `onFieldsChange` 丢失一次 `validating` 状态变更的更新事件。[#42263](https://github.com/ant-design/ant-design/pull/42263)
+- 🐞 修复 Popover 组件当 `title` 和 `content` 都为空时展示空气泡的问题[19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
+- 🐞 修复 Upload 禁用状态逻辑。[#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
+- 💄 优化 Spin 样式，保持容器与子元素图标高度一致。[#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)
+
 ## 4.24.10
 
 `2023-05-04`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.24.10",
+  "version": "4.24.11",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
- 🆕 Drawer panel support event listener. [#42712](https://github.com/ant-design/ant-design/pull/42712) [@kiner-tang](https://github.com/kiner-tang)
- 🐞 Fix Upload `onChange` sometime not sync when in React 18. [#43200](https://github.com/ant-design/ant-design/pull/43200)
- 🐞 Fix Notification cannot hide close icon by `closeIcon={null}`. [#42791](https://github.com/ant-design/ant-design/pull/42791)
- 🐞 Fix Drawer `id` was passed in incorrectly, and now is always added to the popup panel. [#43124](https://github.com/ant-design/ant-design/pull/43124) [@MuxinFeng](https://github.com/MuxinFeng)
- 🐞 Fix InputNumber with `prefix` abnormal height under Form.Item of `hasFeedBack`. [#43048](https://github.com/ant-design/ant-design/pull/43048)
- 🐞 Fix Popover with `getPopupContainer` sometime makes width too narrow. [#42697](https://github.com/ant-design/ant-design/pull/42697)
- 🐞 Fix Select will display the letter A under some circumstances. [#42654](https://github.com/ant-design/ant-design/pull/42654) [@tchen-l](https://github.com/tchen-l)
- 🐞 Fix ConfigProvider that import useless modules from `rc-field-form` when importing `FormProvider` . [#42502](https://github.com/ant-design/ant-design/pull/42502) [@BanShan-Alec](https://github.com/BanShan-Alec)
- 🐞 Fix Popconfirm trigger `onVisibleChange` twice. [#42351](https://github.com/ant-design/ant-design/pull/42351)
- 🐞 Fix Form `onFieldsChange` missing `validating` status change. [#42263](https://github.com/ant-design/ant-design/pull/42263)
- 🐞 Fix Popover that display empty `div` when `title` and `content` is null. [19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
- 🐞 Fix Upload `disabled` logic. [#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
- 💄 Optimize Spin style to keep height of container the same as child element. [#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)

---

- 🆕 Drawer 组件面板支持事件监听。[#42712](https://github.com/ant-design/ant-design/pull/42712) [@kiner-tang](https://github.com/kiner-tang)
- 🐞 修复 Upload 在 React 18 下 `onChange` 有时数据不正确的问题。[#43200](https://github.com/ant-design/ant-design/pull/43200)
- 🐞 修复 Notification 设置 `closeIcon={null}` 时关闭图标没有消失的问题。[#42791](https://github.com/ant-design/ant-design/pull/42791)
- 🐞 修复 Drawer `id` 传入位置不正确的问题，现在始终会添加至弹出面板上。[#43124](https://github.com/ant-design/ant-design/pull/43124) [@MuxinFeng](https://github.com/MuxinFeng)
- 🐞 修复 InputNumber 带有 `prefix` 时在 Form.Item `hasFeedBack` 内高度异常的问题。[#43048](https://github.com/ant-design/ant-design/pull/43048)
- 🐞 修复 Popover 设置 `getPopupContainer` 后，某些时候宽度会过窄的问题。[#42697](https://github.com/ant-design/ant-design/pull/42697)
- 🐞 修复 Select 在某些情况下会显示字母 A 的问题。[#42654](https://github.com/ant-design/ant-design/pull/42654) [@tchen-l](https://github.com/tchen-l)
- 🐞 修复 ConfigProvider 引入 `FormProvider` 时，错误引入 'rc-field-form' 其他的无关依赖的问题。[#42502](https://github.com/ant-design/ant-design/pull/42502) [@BanShan-Alec](https://github.com/BanShan-Alec)
- 🐞 修复 Popconfirm 的 `onVisibleChange` 会重复触发的问题。[#42351](https://github.com/ant-design/ant-design/pull/42351)
- 🐞 修复 Form `onFieldsChange` 丢失一次 `validating` 状态变更的更新事件。[#42263](https://github.com/ant-design/ant-design/pull/42263)
- 🐞 修复 Popover 组件当 `title` 和 `content` 都为空时展示空气泡的问题[19f8505](https://github.com/ant-design/ant-design/commit/19f8505) [@MaHui](https://github.com/MaHui)
- 🐞 修复 Upload 禁用状态逻辑。[#42143](https://github.com/ant-design/ant-design/pull/42143) [@Wxh16144](https://github.com/Wxh16144)
- 💄 优化 Spin 样式，保持容器与子元素图标高度一致。[#42163](https://github.com/ant-design/ant-design/pull/42163) [@cheapCoder](https://github.com/cheapCoder)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03e1969</samp>

This pull request updates the `package.json` and the `CHANGELOG.en-US.md` and `CHANGELOG.zh-CN.md` files to prepare for the release of antd version 4.24.11. The changelog files document the new features, bug fixes and style improvements of the latest version.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03e1969</samp>

*  Bump version to 4.24.11 and update changelogs ([link](https://github.com/ant-design/ant-design/pull/43206/files?diff=unified&w=0#diff-e961ad288c43a2feb2d56b696e10c0b670d652dbb17c76c9aa0452d45157977cR18-R35), [link](https://github.com/ant-design/ant-design/pull/43206/files?diff=unified&w=0#diff-1224d5ca5233fdeba67ba2e2dc6fa3e615905253f35dc132c4b4b86f51f9eab4R18-R35), [link](https://github.com/ant-design/ant-design/pull/43206/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))
