### PR TITLE
refactor: ConfigProvider form dependency inversion for v4

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -1,9 +1,9 @@
 import IconContext from '@ant-design/icons/lib/components/Context';
-import { FormProvider as RcFormProvider } from 'rc-field-form/lib/FormContext';
 import type { ValidateMessages } from 'rc-field-form/lib/interface';
 import useMemo from 'rc-util/lib/hooks/useMemo';
 import * as React from 'react';
 import type { RequiredMark } from '../form/Form';
+import ValidateMessagesContext from '../form/validateMessagesContext';
 import type { Locale } from '../locale-provider';
 import LocaleProvider, { ANT_MARK } from '../locale-provider';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
@@ -152,7 +152,7 @@ export const globalConfig = () => ({
   },
 });
 
-const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
+const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   const {
     children,
     csp,
@@ -197,7 +197,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
 
   // Pass the props used by `useContext` directly with child component.
   // These props should merged into `config`.
-  PASSED_PROPS.forEach(propName => {
+  PASSED_PROPS.forEach((propName) => {
     const propValue = props[propName];
     if (propValue) {
       (config as any)[propName] = propValue;
@@ -213,7 +213,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
       const currentKeys = Object.keys(currentConfig) as Array<keyof typeof config>;
       return (
         prevKeys.length !== currentKeys.length ||
-        prevKeys.some(key => prevConfig[key] !== currentConfig[key])
+        prevKeys.some((key) => prevConfig[key] !== currentConfig[key])
       );
     },
   );
@@ -236,7 +236,11 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   }
 
   if (Object.keys(validateMessages).length > 0) {
-    childNode = <RcFormProvider validateMessages={validateMessages}>{children}</RcFormProvider>;
+    childNode = (
+      <ValidateMessagesContext.Provider value={validateMessages}>
+        {children}
+      </ValidateMessagesContext.Provider>
+    );
   }
 
   if (locale) {
@@ -270,7 +274,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
   ConfigContext: typeof ConfigContext;
   SizeContext: typeof SizeContext;
   config: typeof setGlobalConfig;
-} = props => {
+} = (props) => {
   React.useEffect(() => {
     if (props.direction) {
       message.config({
@@ -286,7 +290,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
     <LocaleReceiver>
       {(_, __, legacyLocale) => (
         <ConfigConsumer>
-          {context => (
+          {(context) => (
             <ProviderChildren parentContext={context} legacyLocale={legacyLocale} {...props} />
           )}
         </ConfigConsumer>

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -152,7 +152,7 @@ export const globalConfig = () => ({
   },
 });
 
-const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
+const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   const {
     children,
     csp,
@@ -197,7 +197,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 
   // Pass the props used by `useContext` directly with child component.
   // These props should merged into `config`.
-  PASSED_PROPS.forEach((propName) => {
+  PASSED_PROPS.forEach(propName => {
     const propValue = props[propName];
     if (propValue) {
       (config as any)[propName] = propValue;
@@ -213,7 +213,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
       const currentKeys = Object.keys(currentConfig) as Array<keyof typeof config>;
       return (
         prevKeys.length !== currentKeys.length ||
-        prevKeys.some((key) => prevConfig[key] !== currentConfig[key])
+        prevKeys.some(key => prevConfig[key] !== currentConfig[key])
       );
     },
   );
@@ -274,7 +274,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
   ConfigContext: typeof ConfigContext;
   SizeContext: typeof SizeContext;
   config: typeof setGlobalConfig;
-} = (props) => {
+} = props => {
   React.useEffect(() => {
     if (props.direction) {
       message.config({
@@ -290,7 +290,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> & {
     <LocaleReceiver>
       {(_, __, legacyLocale) => (
         <ConfigConsumer>
-          {(context) => (
+          {context => (
             <ProviderChildren parentContext={context} legacyLocale={legacyLocale} {...props} />
           )}
         </ConfigConsumer>

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -11,7 +11,8 @@ import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext, { SizeContextProvider } from '../config-provider/SizeContext';
 import type { ColProps } from '../grid/col';
 import type { FormContextProps } from './context';
-import { FormContext } from './context';
+import { FormContext, FormProvider } from './context';
+import ValidateMessagesContext from './validateMessagesContext';
 import useForm, { FormInstance } from './hooks/useForm';
 import type { FormLabelAlign } from './interface';
 
@@ -60,6 +61,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
     name,
     ...restFormProps
   } = props;
+
+  const contextValidateMessages = React.useContext(ValidateMessagesContext);
 
   const mergedRequiredMark = useMemo(() => {
     if (requiredMark !== undefined) {
@@ -130,16 +133,23 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   return (
     <DisabledContextProvider disabled={disabled}>
       <SizeContextProvider size={size}>
-        <FormContext.Provider value={formContextValue}>
-          <FieldForm
-            id={name}
-            {...restFormProps}
-            name={name}
-            onFinishFailed={onInternalFinishFailed}
-            form={wrapForm}
-            className={formClassName}
-          />
-        </FormContext.Provider>
+        <FormProvider
+          {...{
+            // This is not list in API, we pass with spread
+            validateMessages: contextValidateMessages,
+          }}
+        >
+          <FormContext.Provider value={formContextValue}>
+            <FieldForm
+              id={name}
+              {...restFormProps}
+              name={name}
+              onFinishFailed={onInternalFinishFailed}
+              form={wrapForm}
+              className={formClassName}
+            />
+          </FormContext.Provider>
+        </FormProvider>
       </SizeContextProvider>
     </DisabledContextProvider>
   );

--- a/components/form/validateMessagesContext.tsx
+++ b/components/form/validateMessagesContext.tsx
@@ -1,0 +1,7 @@
+import type { ValidateMessages } from 'rc-field-form/lib/interface';
+import { createContext } from 'react';
+
+// ZombieJ: We export single file here since
+// ConfigProvider use this which will make loop deps
+// to import whole `rc-field-form`
+export default createContext<ValidateMessages | undefined>(undefined);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
same as #42604 #43023
close #42499
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ConfigProvider makes Form component in the bundle even not use it.      |
| 🇨🇳 Chinese |     修复使用 ConfigProvider 会导致未使用的 Form 组件也被打包的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 479bd28</samp>

Refactored the form component and the config provider component to use a new `ValidateMessagesContext` to handle the `validateMessages` prop. This improves the code quality and the consistency of the validation messages. Created a new file `validateMessagesContext.tsx` to export the context.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 479bd28</samp>

*  Refactor the form components to use the new `ValidateMessagesContext` instead of the `RcFormProvider` to pass the `validateMessages` prop from the `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L2-R6), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L239-R243), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL14-R15), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eR65-R66), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL133-R152), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-7af7ca3495e222d3b2dfd30ce1b5c466a53c3c812da5703c4c92e03a3c32d2f3R1-R7))
* Create the `validateMessagesContext.tsx` file to export the `ValidateMessagesContext` as a React context ([link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-7af7ca3495e222d3b2dfd30ce1b5c466a53c3c812da5703c4c92e03a3c32d2f3R1-R7))
* Add the `FormProvider` component to wrap the `FormContext.Provider` component and pass the `validateMessages` prop to the form components ([link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL14-R15), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL133-R152))
* Add parentheses around the parameters of arrow functions and render prop functions to follow the ESLint rule `arrow-parens` ([link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L155-R155), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L200-R200), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L216-R216), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L273-R277), [link](https://github.com/ant-design/ant-design/pull/43207/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L289-R293))
