### PR TITLE
feat: config-provider support Input className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -9,6 +9,7 @@ import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Empty from '../../empty';
 import Image from '../../image';
+import Input from '../../input';
 import Mentions from '../../mentions';
 import Modal from '../../modal';
 import Pagination from '../../pagination';
@@ -253,6 +254,18 @@ describe('ConfigProvider support style and className props', () => {
       ?.querySelector<HTMLDivElement>('.ant-image')
       ?.querySelector<HTMLImageElement>('img');
     expect(element).toHaveClass('config-provider-image');
+    expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should Input className & style works', () => {
+    const { container } = render(
+      <ConfigProvider input={{ className: 'cp-input', style: { backgroundColor: 'red' } }}>
+        <Input placeholder="Basic usage" />
+      </ConfigProvider>,
+    );
+
+    const element = container.querySelector<HTMLDivElement>('.ant-input');
+    expect(element).toHaveClass('cp-input');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -257,15 +257,30 @@ describe('ConfigProvider support style and className props', () => {
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 
-  it('Should Input className & style works', () => {
+  it('Should Input className & style & classNames & styles works', () => {
     const { container } = render(
-      <ConfigProvider input={{ className: 'cp-input', style: { backgroundColor: 'red' } }}>
+      <ConfigProvider
+        input={{
+          className: 'cp-input',
+          style: { backgroundColor: 'red' },
+          classNames: {
+            input: 'cp-classNames-input',
+          },
+          styles: {
+            input: {
+              color: 'blue',
+            },
+          },
+        }}
+      >
         <Input placeholder="Basic usage" />
       </ConfigProvider>,
     );
 
     const element = container.querySelector<HTMLDivElement>('.ant-input');
     expect(element).toHaveClass('cp-input');
+    expect(element).toHaveClass('cp-classNames-input');
+    expect(element).toHaveStyle({ color: 'blue' });
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -8,7 +8,6 @@ import Checkbox from '../../checkbox';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Empty from '../../empty';
-import Form from '../../form';
 import Image from '../../image';
 import Input from '../../input';
 import Mentions from '../../mentions';
@@ -240,22 +239,6 @@ describe('ConfigProvider support style and className props', () => {
     );
     const element = container.querySelector<HTMLDivElement>('.ant-steps');
     expect(element).toHaveClass('config-provider-steps');
-    expect(element).toHaveStyle({ backgroundColor: 'red' });
-  });
-
-  it('Should Form className & style works', () => {
-    const { container } = render(
-      <ConfigProvider form={{ className: 'cp-form', style: { backgroundColor: 'red' } }}>
-        <Form name="basic">
-          <Form.Item label="Username" name="username">
-            <Input />
-          </Form.Item>
-        </Form>
-      </ConfigProvider>,
-    );
-
-    const element = container.querySelector<HTMLDivElement>('.ant-form');
-    expect(element).toHaveClass('cp-form');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -8,6 +8,7 @@ import Checkbox from '../../checkbox';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Empty from '../../empty';
+import Form from '../../form';
 import Image from '../../image';
 import Input from '../../input';
 import Mentions from '../../mentions';
@@ -239,6 +240,22 @@ describe('ConfigProvider support style and className props', () => {
     );
     const element = container.querySelector<HTMLDivElement>('.ant-steps');
     expect(element).toHaveClass('config-provider-steps');
+    expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should Form className & style works', () => {
+    const { container } = render(
+      <ConfigProvider form={{ className: 'cp-form', style: { backgroundColor: 'red' } }}>
+        <Form name="basic">
+          <Form.Item label="Username" name="username">
+            <Input />
+          </Form.Item>
+        </Form>
+      </ConfigProvider>,
+    );
+
+    const element = container.querySelector<HTMLDivElement>('.ant-form');
+    expect(element).toHaveClass('cp-form');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -265,23 +265,33 @@ describe('ConfigProvider support style and className props', () => {
           style: { backgroundColor: 'red' },
           classNames: {
             input: 'cp-classNames-input',
+            prefix: 'cp-classNames-prefix',
           },
           styles: {
             input: {
               color: 'blue',
             },
+            prefix: {
+              color: 'black',
+            },
           },
         }}
       >
-        <Input placeholder="Basic usage" />
+        <Input placeholder="Basic usage" prefix="￥" />
       </ConfigProvider>,
     );
 
-    const element = container.querySelector<HTMLDivElement>('.ant-input');
-    expect(element).toHaveClass('cp-input');
-    expect(element).toHaveClass('cp-classNames-input');
-    expect(element).toHaveStyle({ color: 'blue' });
-    expect(element).toHaveStyle({ backgroundColor: 'red' });
+    const wrapperElement = container.querySelector<HTMLDivElement>('.ant-input-affix-wrapper');
+    expect(wrapperElement).toHaveClass('cp-input');
+    expect(wrapperElement).toHaveStyle({ backgroundColor: 'red' });
+
+    const prefixElement = container.querySelector<HTMLDivElement>('.ant-input-prefix');
+    expect(prefixElement).toHaveClass('cp-classNames-prefix');
+    expect(prefixElement).toHaveStyle({ color: 'black' });
+
+    const inputElement = container.querySelector<HTMLDivElement>('.ant-input');
+    expect(inputElement).toHaveClass('cp-classNames-input');
+    expect(inputElement).toHaveStyle({ color: 'blue' });
   });
 
   it('Should Mentions className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -76,7 +76,7 @@ export interface ConfigConsumerProps {
   virtual?: boolean;
   popupMatchSelectWidth?: boolean;
   popupOverflow?: PopupOverflow;
-  form?: ComponentStyleConfig & {
+  form?: {
     requiredMark?: RequiredMark;
     colon?: boolean;
     scrollToFirstError?: Options | boolean;

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -76,7 +76,7 @@ export interface ConfigConsumerProps {
   virtual?: boolean;
   popupMatchSelectWidth?: boolean;
   popupOverflow?: PopupOverflow;
-  form?: {
+  form?: ComponentStyleConfig & {
     requiredMark?: RequiredMark;
     colon?: boolean;
     scrollToFirstError?: Options | boolean;

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
 import type { ButtonProps } from '../button';
 import type { RequiredMark } from '../form/Form';
+import type { InputProps } from '../input';
 import type { Locale } from '../locale';
 import type { SpaceProps } from '../space';
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from '../theme/interface';
@@ -59,6 +60,8 @@ export interface ConfigConsumerProps {
   autoInsertSpaceInButton?: boolean;
   input?: ComponentStyleConfig & {
     autoComplete?: string;
+    classNames?: InputProps['classNames'];
+    styles?: InputProps['styles'];
   };
   pagination?: ComponentStyleConfig & { showSizeChanger?: boolean };
   locale?: Locale;

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -57,7 +57,7 @@ export interface ConfigConsumerProps {
   renderEmpty?: RenderEmptyHandler;
   csp?: CSPConfig;
   autoInsertSpaceInButton?: boolean;
-  input?: {
+  input?: ComponentStyleConfig & {
     autoComplete?: string;
   };
   pagination?: ComponentStyleConfig & { showSizeChanger?: boolean };

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -111,14 +111,14 @@ const {
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| input | Set Input common props | { autoComplete?: string } | - | 4.2.0 |
+| input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | Set Result common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | Set Segmented common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| select | Set Select common props | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - |  |
+| select | Set Select common props | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |
 | slider | Set Slider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,7 +109,7 @@ const {
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
+| form | Set Form common props | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,7 +109,7 @@ const {
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| form | Set Form common props | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |
+| form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -101,7 +101,7 @@ export interface ConfigProviderProps {
   renderEmpty?: RenderEmptyHandler;
   csp?: CSPConfig;
   autoInsertSpaceInButton?: boolean;
-  form?: ComponentStyleConfig & {
+  form?: {
     validateMessages?: ValidateMessages;
     requiredMark?: RequiredMark;
     colon?: boolean;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -101,7 +101,7 @@ export interface ConfigProviderProps {
   renderEmpty?: RenderEmptyHandler;
   csp?: CSPConfig;
   autoInsertSpaceInButton?: boolean;
-  form?: {
+  form?: ComponentStyleConfig & {
     validateMessages?: ValidateMessages;
     requiredMark?: RequiredMark;
     colon?: boolean;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -9,6 +9,7 @@ import type { Options } from 'scroll-into-view-if-needed';
 import warning from '../_util/warning';
 import type { RequiredMark } from '../form/Form';
 import ValidateMessagesContext from '../form/validateMessagesContext';
+import type { InputProps } from '../input';
 import type { Locale } from '../locale';
 import LocaleProvider, { ANT_MARK } from '../locale';
 import type { LocaleContextProps } from '../locale/context';
@@ -108,6 +109,8 @@ export interface ConfigProviderProps {
     scrollToFirstError?: Options | boolean;
   };
   input?: ComponentStyleConfig & {
+    classNames?: InputProps['classNames'];
+    styles?: InputProps['styles'];
     autoComplete?: string;
   };
   select?: ComponentStyleConfig & {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -107,7 +107,7 @@ export interface ConfigProviderProps {
     colon?: boolean;
     scrollToFirstError?: Options | boolean;
   };
-  input?: {
+  input?: ComponentStyleConfig & {
     autoComplete?: string;
   };
   select?: ComponentStyleConfig & {
@@ -255,6 +255,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     slider,
     breadcrumb,
     pagination,
+    input,
     empty,
     radio,
   } = props;
@@ -318,6 +319,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     divider,
     steps,
     image,
+    input,
     mentions,
     modal,
     result,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -113,14 +113,14 @@ const {
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| input | 设置 Input 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | 设置 Segmented 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| select | 设置 Select 组件的通用属性 | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - |  |
+| select | 设置 Select 组件的通用属性 | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |
 | slider | 设置 Slider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | 设置 Space 的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | 设置 Spin 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,7 +111,7 @@ const {
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
+| form | 设置 Form 组件的通用属性 | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,7 +111,7 @@ const {
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| form | 设置 Form 组件的通用属性 | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |
+| form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -63,6 +63,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
     requiredMark,
     onFinishFailed,
     name,
+    style,
     ...restFormProps
   } = props;
 
@@ -107,6 +108,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
       [`${prefixCls}-${mergedSize}`]: mergedSize,
     },
     hashId,
+    contextForm?.className,
     className,
     rootClassName,
   );
@@ -174,6 +176,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
               name={name}
               onFinishFailed={onInternalFinishFailed}
               form={wrapForm}
+              style={{ ...contextForm?.style, ...style }}
               className={formClassName}
             />
           </FormContext.Provider>

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -63,7 +63,6 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
     requiredMark,
     onFinishFailed,
     name,
-    style,
     ...restFormProps
   } = props;
 
@@ -108,7 +107,6 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
       [`${prefixCls}-${mergedSize}`]: mergedSize,
     },
     hashId,
-    contextForm?.className,
     className,
     rootClassName,
   );
@@ -176,7 +174,6 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
               name={name}
               onFinishFailed={onInternalFinishFailed}
               form={wrapForm}
-              style={{ ...contextForm?.style, ...style }}
               className={formClassName}
             />
           </FormContext.Provider>

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -81,6 +81,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     addonBefore,
     className,
     style,
+    styles,
     rootClassName,
     onChange,
     classNames: classes,
@@ -165,6 +166,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       onBlur={handleBlur}
       onFocus={handleFocus}
       style={{ ...input?.style, ...style }}
+      styles={{ ...input?.styles, ...styles }}
       suffix={suffixNode}
       allowClear={mergedAllowClear}
       className={classNames(className, rootClassName, compactItemClassnames, input?.className)}
@@ -189,6 +191,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       }
       classNames={{
         ...classes,
+        ...input?.classNames,
         input: classNames(
           {
             [`${prefixCls}-sm`]: mergedSize === 'small',
@@ -198,6 +201,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
           },
           !inputHasPrefixSuffix && getStatusClassNames(prefixCls, mergedStatus),
           classes?.input,
+          input?.classNames?.input,
           hashId,
         ),
       }}

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -80,6 +80,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     addonAfter,
     addonBefore,
     className,
+    style,
     rootClassName,
     onChange,
     classNames: classes,
@@ -163,9 +164,10 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       disabled={mergedDisabled}
       onBlur={handleBlur}
       onFocus={handleFocus}
+      style={{ ...input?.style, ...style }}
       suffix={suffixNode}
       allowClear={mergedAllowClear}
-      className={classNames(className, rootClassName, compactItemClassnames)}
+      className={classNames(className, rootClassName, compactItemClassnames, input?.className)}
       onChange={handleChange}
       addonAfter={
         addonAfter && (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ConfigProvider support `Input` className and style properties      |
| 🇨🇳 Chinese |     ConfigProvider 支持 `Input`  组件的 className 和 style 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46cd51e</samp>

This pull request adds a new feature to the `ConfigProvider` component, which allows it to customize the `Input` component's style and className props. It also updates the documentation, tests, and types for this feature, and fixes a bug in the `Input` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46cd51e</samp>

*  Add className and style props for the Input component to the ConfigProvider component ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaL60-R60), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L110-R110), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R258), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R322), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaR83), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL166-R170))
  - Extend the input field of the ConfigProviderProps interface with the ComponentStyleConfig type in `context.ts` and `index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaL60-R60), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L110-R110))
  - Pass the input field to the config object of the ConfigContext.Provider and the legacyLocaleProvider.Provider in `index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R258), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R322))
  - Destructure the style prop and merge it with the input.style prop from the config object in the Input component in `Input.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaR83), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL166-R170))
  - Add the input.className prop from the config object to the className prop of the Input component in `Input.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL166-R170))
* Update the documentation of the ConfigProvider component to include the new props for the Input component and the version number for the Select component in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L114-R114), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L121-R121), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L116-R116), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L123-R123))
  - Add the input field with the className and style props to the component config table in `index.en-US.md` and `index.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L114-R114), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L116-R116))
  - Add the version number 5.7.0 for the Select component in the component config table in `index.en-US.md` and `index.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L121-R121), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L123-R123))
* Add a test case to check if the Input component can receive the className and style props from the ConfigProvider component in `style.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R12), [link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R260-R271))
  - Import the Input component from the input folder in `style.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R12))
  - Render the Input component inside the ConfigProvider component with the input field set to a custom className and style in `style.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R260-R271))
  - Expect the input element to have the custom className and style in `style.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43227/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R260-R271))
