### PR TITLE
docs: Fix typo in App Component english version

### DIFF
--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -13,7 +13,7 @@ Application wrapper for some global usages.
 ## When To Use
 
 - Provide reset styles based on `.ant-app` element.
-- You could use static methods of `message/notification/Modal` form `useApp` without put `contextHolder` mannully.
+- You could use static methods of `message/notification/Modal` form `useApp` without writing `contextHolder` manually.
 
 ## Examples
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link



### 💡 Background and solution
Noticed a typo in the App component documentation English version. The word manually and put were misspelled, and this PR provides a fix for that.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---


### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae2c926</samp>

Fix typos in `useApp` hook documentation. The change corrects two misspelled words in `components/app/index.en-US.md` to enhance clarity and quality.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae2c926</samp>

* Fix typos in `useApp` hook documentation ([link](https://github.com/ant-design/ant-design/pull/43235/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cL16-R16))
