### PR TITLE
feat: config-provider support Layout className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -10,6 +10,7 @@ import Divider from '../../divider';
 import Empty from '../../empty';
 import Image from '../../image';
 import Input from '../../input';
+import Layout from '../../layout';
 import Mentions from '../../mentions';
 import Modal from '../../modal';
 import Pagination from '../../pagination';
@@ -292,6 +293,29 @@ describe('ConfigProvider support style and className props', () => {
     const inputElement = container.querySelector<HTMLDivElement>('.ant-input');
     expect(inputElement).toHaveClass('cp-classNames-input');
     expect(inputElement).toHaveStyle({ color: 'blue' });
+  });
+
+  it('Should Layout className & style works', () => {
+    const { baseElement } = render(
+      <ConfigProvider
+        layout={{
+          className: 'cp-layout',
+          style: {
+            background: 'red',
+          },
+        }}
+      >
+        <Layout>
+          <Layout.Header>Header</Layout.Header>
+          <Layout.Content>Content</Layout.Content>
+          <Layout.Footer>Footer</Layout.Footer>
+        </Layout>
+      </ConfigProvider>,
+    );
+
+    const element = baseElement.querySelector<HTMLDivElement>('.ant-layout');
+    expect(element).toHaveClass('cp-layout');
+    expect(element).toHaveStyle({ background: 'red' });
   });
 
   it('Should Mentions className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -97,6 +97,7 @@ export interface ConfigConsumerProps {
   segmented?: ComponentStyleConfig;
   steps?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
+  layout?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
   result?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -112,6 +112,7 @@ const {
 | form | Set Form common props | { validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
+| layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -146,6 +146,7 @@ export interface ConfigProviderProps {
   segmented?: ComponentStyleConfig;
   steps?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
+  layout?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
   result?: ComponentStyleConfig;
@@ -252,6 +253,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     divider,
     steps,
     image,
+    layout,
     mentions,
     modal,
     result,
@@ -323,6 +325,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     steps,
     image,
     input,
+    layout,
     mentions,
     modal,
     result,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -114,6 +114,7 @@ const {
 | form | 设置 Form 组件的通用属性 | { validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0 |
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| layout | 设置 Layout 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -82,12 +82,13 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
     children,
     hasSider,
     tagName: Tag,
+    style,
     ...others
   } = props;
 
   const passedProps = omit(others, ['suffixCls']);
 
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const { getPrefixCls, layout } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('layout', customizePrefixCls);
 
   const [wrapSSR, hashId] = useStyle(prefixCls as string);
@@ -97,6 +98,7 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
       [`${prefixCls}-has-sider`]: typeof hasSider === 'boolean' ? hasSider : siders.length > 0,
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
+    layout?.className,
     className,
     rootClassName,
     hashId,
@@ -118,7 +120,12 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
 
   return wrapSSR(
     <LayoutContext.Provider value={contextValue}>
-      <Tag ref={ref} className={classString} {...passedProps}>
+      <Tag
+        ref={ref}
+        className={classString}
+        style={{ ...layout?.style, ...style }}
+        {...passedProps}
+      >
         {children}
       </Tag>
     </LayoutContext.Provider>,
@@ -148,6 +155,6 @@ const Content = generator({
   displayName: 'Content',
 })(Basic);
 
-export { Header, Footer, Content };
+export { Content, Footer, Header };
 
 export default Layout;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      ConfigProvider support `Layout` className and style properties     |
| 🇨🇳 Chinese |     ConfigProvider 支持 `Layout` 组件的 className 和 style 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7371b70</samp>

This pull request adds a new feature to the `ConfigProvider` component, which allows customizing the appearance of the `Layout` component and its subcomponents. It also adds test cases and documentation for the new feature, and refactors some code in the layout module.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7371b70</samp>

*  Add a new layout prop to the `ConfigProvider` component that can set the common props of the `Layout` component, such as className and style ([link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR100), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R149), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R256), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R328), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R115), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R117))
*  Use the layout value from the context provided by the `ConfigProvider` component to apply the className and style props to the `Tag` component that renders the HTML element for the `Layout`, `Header`, `Footer`, and `Content` components in the `layout` module ([link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658R85), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658L90-R91), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658R101), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658L121-R128))
*  Add a test case in `components/config-provider/__tests__/style.test.tsx` that renders a `Layout` component inside a `ConfigProvider` component with a custom layout prop and asserts that the `Layout` component has the expected class and style attributes ([link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R13), [link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R298-R320))
*  Reorder the export statements of the `Content`, `Footer`, `Header`, and `Layout` components in the `layout` module for consistency and readability ([link](https://github.com/ant-design/ant-design/pull/43241/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658L151-R158))
