### PR TITLE
fix: correct type & remove useless type

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -76,8 +76,6 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
   __ANT_BUTTON: boolean;
 };
 
-type Loading = number | boolean;
-
 type LoadingConfigType = {
   loading: boolean;
   delay: number;
@@ -137,7 +135,7 @@ const InternalButton: React.ForwardRefRenderFunction<
 
   const loadingOrDelay = useMemo<LoadingConfigType>(() => getLoadingConfig(loading), [loading]);
 
-  const [innerLoading, setLoading] = useState<Loading>(loadingOrDelay.loading);
+  const [innerLoading, setLoading] = useState<boolean>(loadingOrDelay.loading);
 
   const [hasTwoCNChar, setHasTwoCNChar] = useState<boolean>(false);
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] TypeScript 定义更新


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. innerLoading 很明显是boolean，是loadingOrDelay的loading，通过getLoadingConfig返回的loading是boolean。
<img width="899" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/c2b153a5-3971-4ffa-ab60-6566a6180555">
2. loadingOrDelay 现在已经有了LoadingConfigType来标记delay类型number了，那个 ｜number已经有些多余了
<img width="509" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/1a3ed01a-7a74-4fe9-b781-a9354f98b893">
<img width="898" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/b73a5d5e-8ec0-4974-bf0f-0e17e19a7aa2">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  fix: correct type & remove useless type     |
| 🇨🇳 中文 |       修正loading type 的使用   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
