### PR TITLE
feat: CP support Switch className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -25,6 +25,7 @@ import Slider from '../../slider';
 import Space from '../../space';
 import Spin from '../../spin';
 import Steps from '../../steps';
+import Switch from '../../switch';
 import Typography from '../../typography';
 
 describe('ConfigProvider support style and className props', () => {
@@ -591,6 +592,17 @@ describe('ConfigProvider support style and className props', () => {
     );
     const element = container.querySelector<HTMLUListElement>('.ant-rate');
     expect(element).toHaveClass('cp-rate');
+    expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Switch className & style works', () => {
+    const { container } = render(
+      <ConfigProvider switch={{ className: 'cp-switch', style: { backgroundColor: 'blue' } }}>
+        <Switch />
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLButtonElement>('.ant-switch');
+    expect(element).toHaveClass('cp-switch');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -115,6 +115,7 @@ export interface ConfigConsumerProps {
   badge?: BadgeConfig;
   radio?: ComponentStyleConfig;
   rate?: ComponentStyleConfig;
+  switch?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -123,6 +123,7 @@ const {
 | segmented | Set Segmented common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | Set Select common props | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |
 | slider | Set Slider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| switch | Set Switch common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | Set Steps common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -159,6 +159,7 @@ export interface ConfigProviderProps {
   badge?: BadgeConfig;
   radio?: ComponentStyleConfig;
   rate?: ComponentStyleConfig;
+  switch?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -270,6 +271,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     badge,
     radio,
     rate,
+    switch: SWITCH,
   } = props;
 
   // =================================== Warning ===================================
@@ -343,6 +345,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     badge,
     radio,
     rate,
+    switch: SWITCH,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -125,6 +125,7 @@ const {
 | segmented | 设置 Segmented 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | 设置 Select 组件的通用属性 | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |
 | slider | 设置 Slider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| switch | 设置 Switch 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | 设置 Space 的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | 设置 Spin 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | 设置 Steps 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -43,70 +43,74 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
   __ANT_SWITCH: boolean;
 };
 
-const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  (
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    size: customizeSize,
+    disabled: customDisabled,
+    loading,
+    className,
+    rootClassName,
+    style,
+    ...restProps
+  } = props;
+
+  warning(
+    'checked' in props || !('value' in props),
+    'Switch',
+    '`value` is not a valid prop, do you mean `checked`?',
+  );
+
+  const { getPrefixCls, direction, switch: SWITCH } = React.useContext(ConfigContext);
+
+  // ===================== Disabled =====================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = (customDisabled ?? disabled) || loading;
+
+  const prefixCls = getPrefixCls('switch', customizePrefixCls);
+
+  const loadingIcon = (
+    <div className={`${prefixCls}-handle`}>
+      {loading && <LoadingOutlined className={`${prefixCls}-loading-icon`} />}
+    </div>
+  );
+
+  // Style
+  const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const mergedSize = useSize(customizeSize);
+
+  const classes = classNames(
+    SWITCH?.className,
     {
-      prefixCls: customizePrefixCls,
-      size: customizeSize,
-      disabled: customDisabled,
-      loading,
-      className,
-      rootClassName,
-      ...props
+      [`${prefixCls}-small`]: mergedSize === 'small',
+      [`${prefixCls}-loading`]: loading,
+      [`${prefixCls}-rtl`]: direction === 'rtl',
     },
-    ref,
-  ) => {
-    warning(
-      'checked' in props || !('value' in props),
-      'Switch',
-      '`value` is not a valid prop, do you mean `checked`?',
-    );
+    className,
+    rootClassName,
+    hashId,
+  );
 
-    const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const mergedStyle: React.CSSProperties = { ...SWITCH?.style, ...style };
 
-    // ===================== Disabled =====================
-    const disabled = React.useContext(DisabledContext);
-    const mergedDisabled = (customDisabled ?? disabled) || loading;
-
-    const prefixCls = getPrefixCls('switch', customizePrefixCls);
-    const loadingIcon = (
-      <div className={`${prefixCls}-handle`}>
-        {loading && <LoadingOutlined className={`${prefixCls}-loading-icon`} />}
-      </div>
-    );
-
-    // Style
-    const [wrapSSR, hashId] = useStyle(prefixCls);
-
-    const mergedSize = useSize(customizeSize);
-
-    const classes = classNames(
-      {
-        [`${prefixCls}-small`]: mergedSize === 'small',
-        [`${prefixCls}-loading`]: loading,
-        [`${prefixCls}-rtl`]: direction === 'rtl',
-      },
-      className,
-      rootClassName,
-      hashId,
-    );
-
-    return wrapSSR(
-      <Wave>
-        <RcSwitch
-          {...props}
-          prefixCls={prefixCls}
-          className={classes}
-          disabled={mergedDisabled}
-          ref={ref}
-          loadingIcon={loadingIcon}
-        />
-      </Wave>,
-    );
-  },
-) as CompoundedComponent;
+  return wrapSSR(
+    <Wave>
+      <RcSwitch
+        {...restProps}
+        prefixCls={prefixCls}
+        className={classes}
+        style={mergedStyle}
+        disabled={mergedDisabled}
+        ref={ref}
+        loadingIcon={loadingIcon}
+      />
+    </Wave>,
+  );
+}) as CompoundedComponent;
 
 Switch.__ANT_SWITCH = true;
+
 if (process.env.NODE_ENV !== 'production') {
   Switch.displayName = 'Switch';
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Switch className and style |
| 🇨🇳 Chinese | - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54174fa</samp>

This pull request adds a new feature to the config-provider component that allows users to customize the switch component. It updates the `switch` prop in the `components/config-provider/index.tsx`, `components/config-provider/context.ts`, and `components/switch/index.tsx` files, and adds test cases and documentation for the feature in the `components/config-provider/__tests__/style.test.tsx`, `components/config-provider/index.en-US.md`, and `components/config-provider/index.zh-CN.md` files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54174fa</samp>

*  Add a switch prop to the config-provider component and context to allow customizing the switch component with className and style ([link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR118), [link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R162), [link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R274), [link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R348))
*  Modify the switch component to accept and apply the switch prop from the config-provider context ([link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L46-R113))
*  Add a test case to verify that the switch component can receive the className and style props from the config-provider component ([link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R28), [link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R597-R607))
*  Update the config-provider documentation in English and Chinese to document the usage and effect of the switch prop ([link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R126), [link](https://github.com/ant-design/ant-design/pull/43283/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R128))