### PR TITLE
docs: 4.24.12 changelog

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,13 @@ timeline: true
 
 ---
 
+## 4.24.12
+
+`2023-06-30`
+
+- 🐞 Fix Form submit trigger wrong `onFieldsChange` event even all the fields do not config `rules`. [#43292](https://github.com/ant-design/ant-design/pull/43292)
+- 🐞 Fix Form.List nested Form event bubble not correct. [#43292](https://github.com/ant-design/ant-design/pull/43292)
+
 ## 4.24.11
 
 `2023-06-27`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,13 @@ timeline: true
 
 ---
 
+## 4.24.12
+
+`2023-06-30`
+
+- 🐞 修复 Form 在提交时，字段没有配置 `rules` 时仍会错误触发 `onFieldsChange` 事件的问题。[#43292](https://github.com/ant-design/ant-design/pull/43292)
+- 🐞 修复 Form 嵌套 Form.List 嵌套 Form 的场景下，事件触发不正确的问题。[#43292](https://github.com/ant-design/ant-design/pull/43292)
+
 ## 4.24.11
 
 `2023-06-27`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.24.11",
+  "version": "4.24.12",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

- 🐞 修复 Form 在提交时，字段没有配置 `rules` 时仍会错误触发 `onFieldsChange` 事件的问题。[#43292](https://github.com/ant-design/ant-design/pull/43292)
- 🐞 修复 Form 嵌套 Form.List 嵌套 Form 的场景下，事件触发不正确的问题。[#43292](https://github.com/ant-design/ant-design/pull/43292)
- 🐞 Fix Form submit trigger wrong `onFieldsChange` event even all the fields do not config `rules`. [#43292](https://github.com/ant-design/ant-design/pull/43292)
- 🐞 Fix Form.List nested Form event bubble not correct. [#43292](https://github.com/ant-design/ant-design/pull/43292)
