### PR TITLE
feat: CP support Tag className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -26,6 +26,7 @@ import Space from '../../space';
 import Spin from '../../spin';
 import Steps from '../../steps';
 import Switch from '../../switch';
+import Tag from '../../tag';
 import Typography from '../../typography';
 
 describe('ConfigProvider support style and className props', () => {
@@ -603,6 +604,17 @@ describe('ConfigProvider support style and className props', () => {
     );
     const element = container.querySelector<HTMLButtonElement>('.ant-switch');
     expect(element).toHaveClass('cp-switch');
+    expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Tag className & style works', () => {
+    const { container } = render(
+      <ConfigProvider tag={{ className: 'cp-tag', style: { backgroundColor: 'blue' } }}>
+        <Tag>Test</Tag>
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLSpanElement>('.ant-tag');
+    expect(element).toHaveClass('cp-tag');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -116,6 +116,7 @@ export interface ConfigConsumerProps {
   radio?: ComponentStyleConfig;
   rate?: ComponentStyleConfig;
   switch?: ComponentStyleConfig;
+  tag?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -127,6 +127,7 @@ const {
 | space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | Set Steps common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tag | Set Tag common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 
 ## FAQ

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -160,6 +160,7 @@ export interface ConfigProviderProps {
   radio?: ComponentStyleConfig;
   rate?: ComponentStyleConfig;
   switch?: ComponentStyleConfig;
+  tag?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -272,6 +273,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     radio,
     rate,
     switch: SWITCH,
+    tag,
   } = props;
 
   // =================================== Warning ===================================
@@ -346,6 +348,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     radio,
     rate,
     switch: SWITCH,
+    tag,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -129,6 +129,7 @@ const {
 | space | 设置 Space 的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | 设置 Spin 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | 设置 Steps 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tag | 设置 Tag 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 
 ## FAQ

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -49,7 +49,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     bordered = true,
     ...props
   } = tagProps;
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, tag } = React.useContext(ConfigContext);
   const [visible, setVisible] = React.useState(true);
 
   // Warning for deprecated usage
@@ -71,6 +71,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
 
   const tagStyle: React.CSSProperties = {
     backgroundColor: color && !isInternalColor ? color : undefined,
+    ...tag?.style,
     ...style,
   };
 
@@ -80,6 +81,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
 
   const tagClassName = classNames(
     prefixCls,
+    tag?.className,
     {
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Tag className and style |
| 🇨🇳 Chinese | - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e5fc05</samp>

This pull request adds a new `tag` prop to the `ConfigProvider` component, which allows users to customize the style and className of the HTML tag that wraps the `ConfigProvider` and the `Tag` components. It also updates the tests and the documentation files for the `ConfigProvider` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e5fc05</samp>

*  Add a new `tag` prop to the `ConfigProvider` component and the `ConfigContext` to allow customizing the `Tag` component's className and style ([link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR119), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R163), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R276), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R351), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L52-R52), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R74), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R84))
*  Import the `Tag` component in the `config-provider` tests file and add a test case to verify the `tag` prop functionality ([link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R29), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R609-R619))
*  Update the `config-provider` documentation files in English and Chinese to document the `tag` prop, its type, default value, and version ([link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R130), [link](https://github.com/ant-design/ant-design/pull/43294/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R132))