### PR TITLE
feat: fix Select clear icon position wrong with FormItem has hasFeedback

### DIFF
--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -235,7 +235,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
     // ========================= Feedback ==========================
     [`${componentCls}-has-feedback`]: {
       [`${componentCls}-clear`]: {
-        insetInlineEnd: inputPaddingHorizontalBase + token.fontSize + token.paddingXXS,
+        insetInlineEnd: inputPaddingHorizontalBase + token.fontSize + token.paddingXS,
       },
     },
   };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution


1. FormItem 的 hasFeedback 和 select 的 allowClear 属性同时存在，select在鼠标hover触发时，clear图标位置偏移超多 arrow图标 
2.clear的css属性insetInlineEnd计算时，用paddingXs代替paddingXXS  



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix select with allowClear and FormItem with hasFeedback will make clear icon position wrong    |
| 🇨🇳 Chinese |      修复 Select 组件的clear图标在 FormItem 设置hasFeedback时的位置问题     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2dae43</samp>

Refactored select component styles to use CSS variables and tokens, and adjusted clear icon padding.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2dae43</samp>

* Increase the padding of the clear icon in the select component to match the design spec and improve the visual alignment ([link](https://github.com/ant-design/ant-design/pull/43302/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L238-R238))
