### PR TITLE
feat: CP support Tabs className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -29,6 +29,7 @@ import Spin from '../../spin';
 import Steps from '../../steps';
 import Switch from '../../switch';
 import Table from '../../table';
+import Tabs from '../../tabs';
 import Tag from '../../tag';
 import Typography from '../../typography';
 
@@ -652,5 +653,16 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-card');
     expect(element).toHaveClass('cp-card');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Tabs className & style works', () => {
+    const { container } = render(
+      <ConfigProvider tabs={{ className: 'cp-tabs', style: { backgroundColor: 'red' } }}>
+        <Tabs />
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLDivElement>('.ant-tabs');
+    expect(element).toHaveClass('cp-tabs');
+    expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -120,6 +120,7 @@ export interface ConfigConsumerProps {
   tag?: ComponentStyleConfig;
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;
+  tabs?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -130,6 +130,7 @@ const {
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | Set Steps common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | table | Set Table common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | Set Tag common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -164,6 +164,7 @@ export interface ConfigProviderProps {
   tag?: ComponentStyleConfig;
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;
+  tabs?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -280,6 +281,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tag,
     table,
     card,
+    tabs,
   } = props;
 
   // =================================== Warning ===================================
@@ -358,6 +360,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tag,
     table,
     card,
+    tabs,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -132,6 +132,7 @@ const {
 | spin | 设置 Spin 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | 设置 Steps 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | table | 设置 Table 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tabs | 设置 Tabs 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | 设置 Tag 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -31,23 +31,25 @@ export interface TabsProps extends Omit<RcTabsProps, 'editable'> {
   children?: React.ReactNode;
 }
 
-function Tabs({
-  type,
-  className,
-  rootClassName,
-  size: customSize,
-  onEdit,
-  hideAdd,
-  centered,
-  addIcon,
-  popupClassName,
-  children,
-  items,
-  animated,
-  ...props
-}: TabsProps) {
-  const { prefixCls: customizePrefixCls, moreIcon = <EllipsisOutlined /> } = props;
-  const { direction, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
+const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
+  const {
+    type,
+    className,
+    rootClassName,
+    size: customSize,
+    onEdit,
+    hideAdd,
+    centered,
+    addIcon,
+    popupClassName,
+    children,
+    items,
+    animated,
+    style,
+    ...otherProps
+  } = props;
+  const { prefixCls: customizePrefixCls, moreIcon = <EllipsisOutlined /> } = otherProps;
+  const { direction, tabs, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -76,32 +78,36 @@ function Tabs({
 
   const size = useSize(customSize);
 
+  const mergedStyle: React.CSSProperties = { ...tabs?.style, ...style };
+
   return wrapSSR(
     <RcTabs
       direction={direction}
       getPopupContainer={getPopupContainer}
       moreTransitionName={`${rootPrefixCls}-slide-up`}
-      {...props}
+      {...otherProps}
       items={mergedItems}
       className={classNames(
         {
           [`${prefixCls}-${size}`]: size,
-          [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type as string),
+          [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type!),
           [`${prefixCls}-editable-card`]: type === 'editable-card',
           [`${prefixCls}-centered`]: centered,
         },
+        tabs?.className,
         className,
         rootClassName,
         hashId,
       )}
       popupClassName={classNames(popupClassName, hashId)}
+      style={mergedStyle}
       editable={editable}
       moreIcon={moreIcon}
       prefixCls={prefixCls}
       animated={mergedAnimated}
     />,
   );
-}
+};
 
 Tabs.TabPane = TabPane;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Tabs className and style |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06aca5c</samp>

This pull request adds a new feature to the `ConfigProvider` component, which allows it to pass custom style and className to the `Tabs` component. It also updates the style test, the TypeScript definitions, and the documentation for both components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06aca5c</samp>

*  Add a new property `tabs` to the `ConfigProvider` component and the `ConfigContext`, which allows customizing the `Tabs` component with `className` and `style` props ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR123), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R167), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R284), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R363), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL34-R52))
*  Modify the `Tabs` component to merge the `style` prop and the `tabs.style` property from the `ConfigContext`, and pass it to the `RcTabs` component ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adR81-R82), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adR103))
*  Modify the `Tabs` component to include the `tabs.className` property from the `ConfigContext` in the `className` prop that is passed to the `RcTabs` component ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL84-R97))
*  Change the `Tabs` component from a function declaration to a function expression, and assign the `TabPane` component as a static property of the `Tabs` component, to avoid a TypeScript error ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL104-R110))
*  Add a new test case to check if the `Tabs` component can receive `className` and `style` props from the `ConfigProvider` component in the `style.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R32), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R657-R667))
*  Update the English and Chinese documentation for the `ConfigProvider` component to explain the `tabs` property and its type and default value in the `index.en-US.md` and `index.zh-CN.md` files ([link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R133), [link](https://github.com/ant-design/ant-design/pull/43319/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R135))