### PR TITLE
feat: CP support Notification className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -693,7 +693,9 @@ describe('ConfigProvider support style and className props', () => {
     };
     const { container } = render(<Demo />);
     fireEvent.click(container.querySelector<HTMLButtonElement>('button')!);
-    const element = document?.querySelector<HTMLDivElement>('.ant-notification');
+    const element = document
+      ?.querySelector<HTMLDivElement>('.ant-notification')
+      ?.querySelector<HTMLDivElement>('.ant-notification-notice');
     expect(element).toHaveClass('cp-notification');
     expect(element).toHaveStyle({ color: 'blue' });
   });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ConfigProvider from '..';
-import { render } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import Anchor from '../../anchor';
 import Avatar from '../../avatar';
 import Badge from '../../badge';
@@ -17,6 +17,7 @@ import Input from '../../input';
 import Layout from '../../layout';
 import Mentions from '../../mentions';
 import Modal from '../../modal';
+import notification from '../../notification';
 import Pagination from '../../pagination';
 import Radio from '../../radio';
 import Rate from '../../rate';
@@ -676,5 +677,24 @@ describe('ConfigProvider support style and className props', () => {
     const element = container?.querySelector<HTMLSpanElement>('.ant-upload-wrapper');
     expect(element).toHaveClass('cp-upload');
     expect(element?.querySelector<HTMLDivElement>('.ant-upload')).toHaveStyle({ color: 'blue' });
+  });
+
+  it('Should notification className & style works', () => {
+    const Demo: React.FC = () => {
+      const [api, holder] = notification.useNotification();
+      return (
+        <ConfigProvider notification={{ className: 'cp-notification', style: { color: 'blue' } }}>
+          <button type="button" onClick={() => api.open({ message: 'test', duration: 0 })}>
+            test
+          </button>
+          {holder}
+        </ConfigProvider>
+      );
+    };
+    const { container } = render(<Demo />);
+    fireEvent.click(container.querySelector<HTMLButtonElement>('button')!);
+    const element = document?.querySelector<HTMLDivElement>('.ant-notification');
+    expect(element).toHaveClass('cp-notification');
+    expect(element).toHaveStyle({ color: 'blue' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -122,6 +122,7 @@ export interface ConfigConsumerProps {
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
+  notification?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -118,7 +118,7 @@ const {
 | layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| modal | Set Notification common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| notification | Set Notification common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | Set Rate common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -118,6 +118,7 @@ const {
 | layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| modal | Set Notification common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | Set Rate common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -166,6 +166,7 @@ export interface ConfigProviderProps {
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
+  notification?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -284,6 +285,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     card,
     tabs,
     upload,
+    notification,
   } = props;
 
   // =================================== Warning ===================================
@@ -364,6 +366,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     card,
     tabs,
     upload,
+    notification,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -120,6 +120,7 @@ const {
 | layout | 设置 Layout 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| notification | 设置 Notification 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | 设置 Rate 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -48,15 +48,8 @@ const typeToIcon = {
   warning: ExclamationCircleFilled,
 };
 
-export function PureContent({
-  prefixCls,
-  icon,
-  type,
-  message,
-  description,
-  btn,
-  role = 'alert',
-}: PureContentProps) {
+export const PureContent: React.FC<PureContentProps> = (props) => {
+  const { prefixCls, icon, type, message, description, btn, role = 'alert' } = props;
   let iconNode: React.ReactNode = null;
   if (icon) {
     iconNode = <span className={`${prefixCls}-icon`}>{icon}</span>;
@@ -65,21 +58,15 @@ export function PureContent({
       className: classNames(`${prefixCls}-icon`, `${prefixCls}-icon-${type}`),
     });
   }
-
   return (
-    <div
-      className={classNames({
-        [`${prefixCls}-with-icon`]: iconNode,
-      })}
-      role={role}
-    >
+    <div className={classNames({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
       <div className={`${prefixCls}-message`}>{message}</div>
       <div className={`${prefixCls}-description`}>{description}</div>
       {btn && <div className={`${prefixCls}-btn`}>{btn}</div>}
     </div>
   );
-}
+};
 
 export interface PurePanelProps
   extends Omit<NoticeProps, 'prefixCls' | 'eventKey'>,
@@ -88,7 +75,7 @@ export interface PurePanelProps
 }
 
 /** @internal Internal Component. Do not use in your production. */
-export default function PurePanel(props: PurePanelProps) {
+const PurePanel: React.FC<PurePanelProps> = (props) => {
   const {
     prefixCls: staticPrefixCls,
     className,
@@ -129,4 +116,10 @@ export default function PurePanel(props: PurePanelProps) {
       }
     />
   );
+};
+
+if (process.env.NODE_ENV !== 'production') {
+  PurePanel.displayName = 'InternalPurePanel';
 }
+
+export default PurePanel;

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -118,8 +118,4 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   );
 };
 
-if (process.env.NODE_ENV !== 'production') {
-  PurePanel.displayName = 'InternalPurePanel';
-}
-
 export default PurePanel;

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -45,8 +45,8 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
 
   // =============================== Style ===============================
   const getStyle = (placement: NotificationPlacement): React.CSSProperties => ({
-    ...notification?.style,
     ...getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET),
+    ...notification?.style,
   });
 
   // Style

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -39,18 +39,21 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     rtl,
     onAllRemoved,
   } = props;
-  const { getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
+  const { getPrefixCls, getPopupContainer, notification } = React.useContext(ConfigContext);
 
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
   // =============================== Style ===============================
-  const getStyle = (placement: NotificationPlacement) =>
-    getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
+  const getStyle = (placement: NotificationPlacement): React.CSSProperties => ({
+    ...notification?.style,
+    ...getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET),
+  });
 
   // Style
   const [, hashId] = useStyle(prefixCls);
 
-  const getClassName = () => classNames(hashId, { [`${prefixCls}-rtl`]: rtl });
+  const getClassName = () =>
+    classNames(hashId, notification?.className, { [`${prefixCls}-rtl`]: rtl });
 
   // ============================== Motion ===============================
   const getNotificationMotion = () => getMotion(prefixCls);

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -4,6 +4,7 @@ import type { NotificationAPI } from 'rc-notification/lib';
 import * as React from 'react';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
+import type { ComponentStyleConfig } from '../config-provider/context';
 import { PureContent, getCloseIcon } from './PurePanel';
 import type {
   ArgsProps,
@@ -27,6 +28,7 @@ type HolderProps = NotificationConfig & {
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
   hashId: string;
+  notification?: ComponentStyleConfig;
 }
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
@@ -44,16 +46,13 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
   // =============================== Style ===============================
-  const getStyle = (placement: NotificationPlacement): React.CSSProperties => ({
-    ...getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET),
-    ...notification?.style,
-  });
+  const getStyle = (placement: NotificationPlacement): React.CSSProperties =>
+    getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
 
   // Style
   const [, hashId] = useStyle(prefixCls);
 
-  const getClassName = () =>
-    classNames(hashId, notification?.className, { [`${prefixCls}-rtl`]: rtl });
+  const getClassName = () => classNames(hashId, { [`${prefixCls}-rtl`]: rtl });
 
   // ============================== Motion ===============================
   const getNotificationMotion = () => getMotion(prefixCls);
@@ -77,6 +76,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     ...api,
     prefixCls,
     hashId,
+    notification,
   }));
 
   return holder;
@@ -105,7 +105,8 @@ export function useInternalNotification(
         return;
       }
 
-      const { open: originOpen, prefixCls, hashId } = holderRef.current;
+      const { open: originOpen, prefixCls, hashId, notification } = holderRef.current;
+
       const noticePrefixCls = `${prefixCls}-notice`;
 
       const {
@@ -115,6 +116,7 @@ export function useInternalNotification(
         type,
         btn,
         className,
+        style,
         role = 'alert',
         closeIcon,
         ...restConfig
@@ -136,7 +138,13 @@ export function useInternalNotification(
             role={role}
           />
         ),
-        className: classNames(type && `${noticePrefixCls}-${type}`, hashId, className),
+        className: classNames(
+          type && `${noticePrefixCls}-${type}`,
+          hashId,
+          className,
+          notification?.className,
+        ),
+        style: { ...notification?.style, ...style },
         closeIcon: realCloseIcon,
         closable: !!realCloseIcon,
       });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Notification className and style |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 192df0f</samp>

This pull request adds a new feature to the `ConfigProvider` component to allow customizing the style of the `notification` component. It updates the TypeScript interfaces, the documentation, and the test cases to reflect this change. It also refactors some of the `notification` component code to improve consistency and readability.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 192df0f</samp>

*  Add `notification` prop to `ConfigProvider` component to allow customizing the `style` and `className` of the `notification` component ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR125), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R169), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R288), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R369), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL42-R56))
* Update documentation of `ConfigProvider` component to include the `notification` prop and its usage in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R121), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R123))
* Add test case to check if `ConfigProvider` component can pass the `notification` prop to the `notification` component and affect its appearance ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L3-R3), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R20), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R681-R699))
* Convert `PureContent` and `PurePanel` components from function declarations to function expressions and assign them to `React.FC` types ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL51-R52), [link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL91-R78))
* Move `role` prop from `div` element to `PureContent` component's props ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL68-R62))
* Add semicolon after `PureContent` component's definition ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL82-R69))
* Add conditional statement to set `displayName` of `PurePanel` component to `InternalPurePanel` in development environment and export it as default ([link](https://github.com/ant-design/ant-design/pull/43328/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL132-R125))
