### PR TITLE
feat: CP support Message className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ConfigProvider from '..';
-import { render } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import Anchor from '../../anchor';
 import Avatar from '../../avatar';
 import Badge from '../../badge';
@@ -16,6 +16,7 @@ import Image from '../../image';
 import Input from '../../input';
 import Layout from '../../layout';
 import Mentions from '../../mentions';
+import message from '../../message';
 import Modal from '../../modal';
 import Pagination from '../../pagination';
 import Radio from '../../radio';
@@ -665,6 +666,25 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-tabs');
     expect(element).toHaveClass('cp-tabs');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should message className & style works', () => {
+    const Demo: React.FC = () => {
+      const [messageApi, contextHolder] = message.useMessage();
+      return (
+        <ConfigProvider message={{ className: 'cp-message', style: { color: 'blue' } }}>
+          {contextHolder}
+          <button type="button" onClick={() => messageApi.success('success')}>
+            test
+          </button>
+        </ConfigProvider>
+      );
+    };
+    const { container } = render(<Demo />);
+    fireEvent.click(container.querySelector<HTMLButtonElement>('button')!);
+    const element = document?.querySelector<HTMLDivElement>('.ant-message');
+    expect(element).toHaveClass('cp-message');
+    expect(element).toHaveStyle({ color: 'blue' });
   });
 
   it('Should Upload className & style works', () => {

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -682,7 +682,9 @@ describe('ConfigProvider support style and className props', () => {
     };
     const { container } = render(<Demo />);
     fireEvent.click(container.querySelector<HTMLButtonElement>('button')!);
-    const element = document?.querySelector<HTMLDivElement>('.ant-message');
+    const element = document
+      ?.querySelector<HTMLDivElement>('.ant-message')
+      ?.querySelector<HTMLDivElement>('.ant-message-notice');
     expect(element).toHaveClass('cp-message');
     expect(element).toHaveStyle({ color: 'blue' });
   });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -117,6 +117,7 @@ export interface ConfigConsumerProps {
   rate?: ComponentStyleConfig;
   switch?: ComponentStyleConfig;
   avatar?: ComponentStyleConfig;
+  message?: ComponentStyleConfig;
   tag?: ComponentStyleConfig;
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -117,6 +117,7 @@ const {
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| message | Set Message common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -161,6 +161,7 @@ export interface ConfigProviderProps {
   rate?: ComponentStyleConfig;
   switch?: ComponentStyleConfig;
   avatar?: ComponentStyleConfig;
+  message?: ComponentStyleConfig;
   tag?: ComponentStyleConfig;
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;
@@ -279,6 +280,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     rate,
     switch: SWITCH,
     avatar,
+    message,
     tag,
     table,
     card,
@@ -359,6 +361,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     rate,
     switch: SWITCH,
     avatar,
+    message,
     tag,
     table,
     card,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -119,6 +119,7 @@ const {
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | layout | 设置 Layout 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
-import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
-import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
-import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
+import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
+import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
-import { Notice } from 'rc-notification';
+import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
+import { Notice } from 'rc-notification';
 import type { NoticeProps } from 'rc-notification/lib/Notice';
-import useStyle from './style';
+import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { NoticeType } from './interface';
+import useStyle from './style';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,
@@ -26,14 +26,12 @@ export interface PureContentProps {
   children: React.ReactNode;
 }
 
-export function PureContent({ prefixCls, type, icon, children }: PureContentProps) {
-  return (
-    <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
-      {icon || TypeIcon[type!]}
-      <span>{children}</span>
-    </div>
-  );
-}
+export const PureContent: React.FC<PureContentProps> = ({ prefixCls, type, icon, children }) => (
+  <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
+    {icon || TypeIcon[type!]}
+    <span>{children}</span>
+  </div>
+);
 
 export interface PurePanelProps
   extends Omit<NoticeProps, 'prefixCls' | 'eventKey'>,
@@ -42,7 +40,7 @@ export interface PurePanelProps
 }
 
 /** @private Internal Component. Do not use in your production. */
-export default function PurePanel(props: PurePanelProps) {
+const PurePanel: React.FC<PurePanelProps> = (props) => {
   const { prefixCls: staticPrefixCls, className, type, icon, content, ...restProps } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
 
@@ -64,4 +62,6 @@ export default function PurePanel(props: PurePanelProps) {
       }
     />
   );
-}
+};
+
+export default PurePanel;

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import classNames from 'classnames';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-import classNames from 'classnames';
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
+import * as React from 'react';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
-import useStyle from './style';
+import { PureContent } from './PurePanel';
 import type {
-  MessageInstance,
   ArgsProps,
-  MessageType,
   ConfigOptions,
+  MessageInstance,
+  MessageType,
   NoticeType,
   TypeOpen,
 } from './interface';
+import useStyle from './style';
 import { getMotion, wrapPromiseFn } from './util';
-import warning from '../_util/warning';
-import { PureContent } from './PurePanel';
 
 const DEFAULT_OFFSET = 8;
 const DEFAULT_DURATION = 3;
@@ -43,17 +43,18 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     transitionName,
     onAllRemoved,
   } = props;
-  const { getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
+  const { getPrefixCls, getPopupContainer, message } = React.useContext(ConfigContext);
 
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
   const [, hashId] = useStyle(prefixCls);
 
   // =============================== Style ===============================
-  const getStyle = () => ({
+  const getStyle = (): React.CSSProperties => ({
     left: '50%',
     transform: 'translateX(-50%)',
     top: top ?? DEFAULT_OFFSET,
+    ...message?.style,
   });
 
   const getClassName = () => classNames(hashId, rtl ? `${prefixCls}-rtl` : '');

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -5,6 +5,7 @@ import type { NotificationAPI } from 'rc-notification/lib';
 import * as React from 'react';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
+import type { ComponentStyleConfig } from '../config-provider/context';
 import { PureContent } from './PurePanel';
 import type {
   ArgsProps,
@@ -30,6 +31,7 @@ type HolderProps = ConfigOptions & {
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
   hashId: string;
+  message?: ComponentStyleConfig;
 }
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
@@ -54,10 +56,9 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     left: '50%',
     transform: 'translateX(-50%)',
     top: top ?? DEFAULT_OFFSET,
-    ...message?.style,
   });
 
-  const getClassName = () => classNames(hashId, rtl ? `${prefixCls}-rtl` : '');
+  const getClassName = () => classNames(hashId, { [`${prefixCls}-rtl`]: rtl });
 
   // ============================== Motion ===============================
   const getNotificationMotion = () => getMotion(prefixCls, transitionName);
@@ -88,6 +89,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     ...api,
     prefixCls,
     hashId,
+    message,
   }));
 
   return holder;
@@ -126,10 +128,10 @@ export function useInternalMessage(
         return fakeResult;
       }
 
-      const { open: originOpen, prefixCls, hashId } = holderRef.current;
+      const { open: originOpen, prefixCls, hashId, message } = holderRef.current;
       const noticePrefixCls = `${prefixCls}-notice`;
 
-      const { content, icon, type, key, className, onClose, ...restConfig } = config;
+      const { content, icon, type, key, className, style, onClose, ...restConfig } = config;
 
       let mergedKey: React.Key = key!;
       if (mergedKey === undefined || mergedKey === null) {
@@ -147,7 +149,13 @@ export function useInternalMessage(
             </PureContent>
           ),
           placement: 'top',
-          className: classNames(type && `${noticePrefixCls}-${type}`, hashId, className),
+          className: classNames(
+            type && `${noticePrefixCls}-${type}`,
+            hashId,
+            className,
+            message?.className,
+          ),
+          style: { ...message?.style, ...style },
           onClose: () => {
             onClose?.();
             resolve();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Message className and style  |
| 🇨🇳 Chinese | - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 528f79a</samp>

Added a new feature to customize the message component style with the config provider component. Added a `message` prop to the `ConfigProvider` component and its context, and used it in the `useMessage` hook and the `PurePanel` function. Added test cases and documentation for the new feature in both English and Chinese. Refactored some code in `components/message` to improve readability and consistency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 528f79a</samp>

*  Add `message` property to `ConfigProviderProps` and `ConfigConsumerProps` interfaces to support message component style config ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR120), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R164), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R283))
*  Provide `message` property to `ConfigContext.Provider` value to pass message component style config to config context ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R364))
*  Access `message` property from config context in `Holder` function and pass it to `useRcNotification` hook and `originOpen` function in `useInternalMessage` function to apply message component style config to message notice ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R34), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L46-R48), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R92), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L128-R134), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L149-R158))
*  Refactor `PureContent` and `PurePanel` functions in `PurePanel.tsx` to use arrow function syntax and explicit return types for consistency and readability ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL29-R34), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL45-R43))
*  Export `PurePanel` function as default export at the end of `PurePanel.tsx` to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL67-R67))
*  Simplify `getClassName` function in `Holder` function to use object syntax of `classNames` function to avoid unnecessary string concatenation ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L59-R61))
*  Annotate `getStyle` function in `Holder` function with `React.CSSProperties` type to specify return type of style object ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L53-R55))
*  Sort imports in `PurePanel.tsx` and `useMessage.tsx` alphabetically to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL1-R12), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L1-R19))
*  Document usage of message component style config in config provider component in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R120), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R122))
*  Add test case to check if message component can receive className and style props from config provider component ([link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L3-R3), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R19), [link](https://github.com/ant-design/ant-design/pull/43333/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R671-R691))