### PR TITLE
feat: CP support ColorPicker className and style

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -90,7 +90,8 @@ const ColorPicker: CompoundedComponent = (props) => {
     destroyTooltipOnHide,
   } = props;
 
-  const { getPrefixCls, direction } = useContext<ConfigConsumerProps>(ConfigContext);
+  const { getPrefixCls, direction, colorPicker } = useContext<ConfigConsumerProps>(ConfigContext);
+
   const { token } = theme.useToken();
 
   const [colorValue, setColorValue] = useColorState(token.colorPrimary, {
@@ -121,6 +122,7 @@ const ColorPicker: CompoundedComponent = (props) => {
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-lg`]: mergedSize === 'large',
     },
+    colorPicker?.className,
     mergeRootCls,
     className,
     hashId,
@@ -182,10 +184,18 @@ const ColorPicker: CompoundedComponent = (props) => {
     onFormatChange: setFormatValue,
   };
 
+  const mergedStyle: React.CSSProperties = { ...colorPicker?.style, ...style };
+
   return wrapSSR(
     <Popover
-      style={styles?.popup}
-      overlayInnerStyle={styles?.popupOverlayInner}
+      style={{
+        ...colorPicker?.styles?.popup,
+        ...styles?.popup,
+      }}
+      overlayInnerStyle={{
+        ...colorPicker?.styles?.popupOverlayInner,
+        ...styles?.popupOverlayInner,
+      }}
       onOpenChange={(visible) => {
         if (popupAllowCloseRef.current) {
           setPopupOpen(visible);
@@ -206,7 +216,7 @@ const ColorPicker: CompoundedComponent = (props) => {
         <ColorTrigger
           open={popupOpen}
           className={mergeCls}
-          style={style}
+          style={mergedStyle}
           color={colorValue}
           prefixCls={prefixCls}
           disabled={disabled}

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -188,14 +188,8 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   return wrapSSR(
     <Popover
-      style={{
-        ...colorPicker?.styles?.popup,
-        ...styles?.popup,
-      }}
-      overlayInnerStyle={{
-        ...colorPicker?.styles?.popupOverlayInner,
-        ...styles?.popupOverlayInner,
-      }}
+      style={styles?.popup}
+      overlayInnerStyle={styles?.popupOverlayInner}
       onOpenChange={(visible) => {
         if (popupAllowCloseRef.current) {
           setPopupOpen(visible);

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ConfigProvider from '..';
-import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import Anchor from '../../anchor';
 import Avatar from '../../avatar';
 import Badge from '../../badge';
@@ -768,19 +768,10 @@ describe('ConfigProvider support style and className props', () => {
     );
   });
 
-  it('Should ColorPicker className & style works', async () => {
+  it('Should ColorPicker className & style works', () => {
     const { container } = render(
       <ConfigProvider
-        colorPicker={{
-          className: 'cp-colorPicker',
-          style: {
-            backgroundColor: 'red',
-          },
-          styles: {
-            popup: { backgroundColor: 'blue' },
-            popupOverlayInner: { backgroundColor: 'yellow' },
-          },
-        }}
+        colorPicker={{ className: 'cp-colorPicker', style: { backgroundColor: 'red' } }}
       >
         <ColorPicker />
       </ConfigProvider>,
@@ -788,10 +779,5 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-color-picker-trigger');
     expect(element).toHaveClass('cp-colorPicker');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
-    fireEvent.click(element!);
-    await waitFakeTimer();
-    expect(
-      container?.querySelector<HTMLDivElement>('.ant-color-picker .ant-popover-inner'),
-    ).toHaveStyle({ backgroundColor: 'yellow' });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ConfigProvider from '..';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Anchor from '../../anchor';
 import Avatar from '../../avatar';
 import Badge from '../../badge';
@@ -8,6 +8,7 @@ import Breadcrumb from '../../breadcrumb';
 import Card from '../../card';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
+import ColorPicker from '../../color-picker';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Empty from '../../empty';
@@ -722,7 +723,7 @@ describe('ConfigProvider support style and className props', () => {
     expect(element).toHaveClass('cp-notification');
     expect(element).toHaveStyle({ color: 'blue' });
   });
-  
+
   it('Should Tree className works', () => {
     const treeData = [
       {
@@ -765,5 +766,34 @@ describe('ConfigProvider support style and className props', () => {
     expect(container.querySelector('.ant-tree-list')).toHaveStyle(
       'color: red; font-size: 16px; position: relative;',
     );
+  });
+
+  it('Should ColorPicker className & style works', async () => {
+    const { container } = render(
+      <ConfigProvider
+        colorPicker={{
+          className: 'cp-colorPicker',
+          style: {
+            backgroundColor: 'red',
+          },
+          styles: {
+            popup: { backgroundColor: 'blue' },
+            popupOverlayInner: { backgroundColor: 'yellow' },
+          },
+        }}
+      >
+        <ColorPicker />
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLDivElement>('.ant-color-picker-trigger');
+    expect(element).toHaveClass('cp-colorPicker');
+    expect(element).toHaveStyle({ backgroundColor: 'red' });
+    fireEvent.click(element!);
+    await waitFakeTimer();
+    expect(
+      element
+        ?.querySelector<HTMLDivElement>('.ant-color-picker')
+        ?.querySelector<HTMLDivElement>('.ant-popover-inner'),
+    ).toHaveStyle({ backgroundColor: 'yellow' });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -791,9 +791,7 @@ describe('ConfigProvider support style and className props', () => {
     fireEvent.click(element!);
     await waitFakeTimer();
     expect(
-      element
-        ?.querySelector<HTMLDivElement>('.ant-color-picker')
-        ?.querySelector<HTMLDivElement>('.ant-popover-inner'),
+      container?.querySelector<HTMLDivElement>('.ant-color-picker .ant-popover-inner'),
     ).toHaveStyle({ backgroundColor: 'yellow' });
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -3,7 +3,6 @@ import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
 import type { BadgeProps } from '../badge';
 import type { ButtonProps } from '../button';
-import type { ColorPickerProps } from '../color-picker';
 import type { RequiredMark } from '../form/Form';
 import type { InputProps } from '../input';
 import type { Locale } from '../locale';
@@ -52,10 +51,6 @@ export interface BadgeConfig extends ComponentStyleConfig {
 export interface ButtonConfig extends ComponentStyleConfig {
   classNames?: ButtonProps['classNames'];
   styles?: ButtonProps['styles'];
-}
-
-export interface ColorPickerConfig extends ComponentStyleConfig {
-  styles?: ColorPickerProps['styles'];
 }
 
 export type PopupOverflow = 'viewport' | 'scroll';
@@ -130,7 +125,7 @@ export interface ConfigConsumerProps {
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
-  colorPicker?: ColorPickerConfig;
+  colorPicker?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { Options } from 'scroll-into-view-if-needed';
 import type { BadgeProps } from '../badge';
 import type { ButtonProps } from '../button';
+import type { ColorPickerProps } from '../color-picker';
 import type { RequiredMark } from '../form/Form';
 import type { InputProps } from '../input';
 import type { Locale } from '../locale';
@@ -51,6 +52,10 @@ export interface BadgeConfig extends ComponentStyleConfig {
 export interface ButtonConfig extends ComponentStyleConfig {
   classNames?: ButtonProps['classNames'];
   styles?: ButtonProps['styles'];
+}
+
+export interface ColorPickerConfig extends ComponentStyleConfig {
+  styles?: ColorPickerProps['styles'];
 }
 
 export type PopupOverflow = 'viewport' | 'scroll';
@@ -125,6 +130,7 @@ export interface ConfigConsumerProps {
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
+  colorPicker?: ColorPickerConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,6 +109,7 @@ const {
 | card | Set Card common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | Set Cascader common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| colorPicker | Set ColorPicker common props | { className?: string, style?: React.CSSProperties, styles?: { popup?: React.CSSProperties, popupOverlayInner: React.CSSProperties } } | - | 5.7.0 |
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,7 +109,7 @@ const {
 | card | Set Card common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | Set Cascader common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| colorPicker | Set ColorPicker common props | { className?: string, style?: React.CSSProperties, styles?: { popup?: React.CSSProperties, popupOverlayInner: React.CSSProperties } } | - | 5.7.0 |
+| colorPicker | Set ColorPicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -21,7 +21,6 @@ import defaultSeedToken from '../theme/themes/seed';
 import type {
   BadgeConfig,
   ButtonConfig,
-  ColorPickerConfig,
   ComponentStyleConfig,
   ConfigConsumerProps,
   CSPConfig,
@@ -170,7 +169,7 @@ export interface ConfigProviderProps {
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
-  colorPicker?: ColorPickerConfig;
+  colorPicker?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -21,6 +21,7 @@ import defaultSeedToken from '../theme/themes/seed';
 import type {
   BadgeConfig,
   ButtonConfig,
+  ColorPickerConfig,
   ComponentStyleConfig,
   ConfigConsumerProps,
   CSPConfig,
@@ -169,6 +170,7 @@ export interface ConfigProviderProps {
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
+  colorPicker?: ColorPickerConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -290,6 +292,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     upload,
     notification,
     tree,
+    colorPicker,
   } = props;
 
   // =================================== Warning ===================================
@@ -373,6 +376,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     upload,
     notification,
     tree,
+    colorPicker,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,6 +111,7 @@ const {
 | card | 设置 Card 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | 设置 Cascader 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| colorPicker | 设置 ColorPicker 组件的通用属性 | { className?: string, style?: React.CSSProperties, styles?: { popup?: React.CSSProperties, popupOverlayInner: React.CSSProperties } } | - | 5.7.0 |
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,7 +111,7 @@ const {
 | card | 设置 Card 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | 设置 Cascader 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| colorPicker | 设置 ColorPicker 组件的通用属性 | { className?: string, style?: React.CSSProperties, styles?: { popup?: React.CSSProperties, popupOverlayInner: React.CSSProperties } } | - | 5.7.0 |
+| colorPicker | 设置 ColorPicker 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support ColorPicker className and style |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67d1aa1</samp>

This pull request adds a new feature to the `ConfigProvider` component that allows customizing the `ColorPicker` component globally. It introduces a new `colorPicker` prop to the `ConfigProvider` component and passes it to the `ColorPicker` component through the `ConfigContext`. It also updates the `ColorPicker` component to support custom class names and styles, and adds a test case and documentation for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67d1aa1</samp>

*  Add `colorPicker` prop to `ConfigProvider` component to allow setting common props for `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR57-R60), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R173), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R295), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R379), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R112), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R114))
*  Add `colorPicker` property to `ConfigConsumerProps` interface to allow `ColorPicker` component to access common props from `ConfigContext` ([link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR133))
*  Destructure `colorPicker` from `ConfigConsumerProps` and apply custom class name and styles to `Popover` and `ColorPickerPanel` components inside `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL93-R94), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR125), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL185-R198), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL209-R219))
*  Add test case to verify `colorPicker` prop of `ConfigProvider` component using `ColorPicker` component and `waitFakeTimer` function ([link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L3-R3), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R11), [link](https://github.com/ant-design/ant-design/pull/43339/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R770-R798))