### PR TITLE
feat: ConfigProvider support Progress className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -21,6 +21,7 @@ import message from '../../message';
 import Modal from '../../modal';
 import notification from '../../notification';
 import Pagination from '../../pagination';
+import Progress from '../../progress';
 import Radio from '../../radio';
 import Rate from '../../rate';
 import Result from '../../result';
@@ -518,6 +519,34 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLUListElement>('.ant-pagination');
     expect(element).toHaveClass('cp-pagination');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Progress className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        progress={{
+          className: 'test-class',
+        }}
+      >
+        <Progress />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-progress')).toHaveClass('test-class');
+  });
+
+  it('Should Progress style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        progress={{
+          style: { color: 'red' },
+        }}
+      >
+        <Progress style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-progress')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Descriptions className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -106,6 +106,7 @@ export interface ConfigConsumerProps {
   layout?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
+  progress?: ComponentStyleConfig;
   result?: ComponentStyleConfig;
   slider?: ComponentStyleConfig;
   breadcrumb?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -122,6 +122,7 @@ const {
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | notification | Set Notification common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| progress | Set Progress common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | Set Rate common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | Set Result common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -150,6 +150,7 @@ export interface ConfigProviderProps {
   layout?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
+  progress?: ComponentStyleConfig;
   result?: ComponentStyleConfig;
   slider?: ComponentStyleConfig;
   breadcrumb?: ComponentStyleConfig;
@@ -272,6 +273,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     layout,
     mentions,
     modal,
+    progress,
     result,
     slider,
     breadcrumb,
@@ -357,6 +359,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     layout,
     mentions,
     modal,
+    progress,
     result,
     slider,
     breadcrumb,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -124,6 +124,7 @@ const {
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | notification | 设置 Notification 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| progress | 设置 Progress 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | 设置 Rate 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -70,6 +70,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     type = 'line',
     status,
     format,
+    style,
     ...restProps
   } = props;
 
@@ -88,7 +89,11 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     return status || 'normal';
   }, [status, percentNumber]);
 
-  const { getPrefixCls, direction } = React.useContext<ConfigConsumerProps>(ConfigContext);
+  const {
+    getPrefixCls,
+    direction,
+    progress: progressStyle,
+  } = React.useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('progress', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -167,6 +172,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
       [`${prefixCls}-${size}`]: typeof size === 'string',
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
+    progressStyle?.className,
     className,
     rootClassName,
     hashId,
@@ -175,6 +181,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
   return wrapSSR(
     <div
       ref={ref}
+      style={{ ...progressStyle?.style, ...style }}
       className={classString}
       role="progressbar"
       aria-valuenow={percentNumber}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  ConfigProvider support Progress className and style properties          |
| 🇨🇳 Chinese | ConfigProvider 支持 Progress 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4fdae4</samp>

This pull request adds support for configuring common props of the `Progress` component via the `ConfigProvider` component. It also fixes a bug with the `style` prop of the `Progress` component and updates the tests and documentation accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4fdae4</samp>

*  Add `progress` prop to `ConfigProvider` component to allow setting common props for `Progress` component ([link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR109), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R153), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R275), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R360), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R124), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R126))
*  Use `progressStyle` from `ConfigContext` in `Progress` component to apply common `className` and `style` props from `ConfigProvider` component, and merge them with `style` prop from `Progress` component ([link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddR73), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL91-R96), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddR175), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddR184))
*  Add test cases to check if `Progress` component can receive `className` and `style` props from `ConfigProvider` component, and if they are applied correctly to the rendered element ([link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R23), [link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R523-R550))
*  Add a blank line between two test cases for readability and consistency ([link](https://github.com/ant-design/ant-design/pull/43340/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L725-R754))
