### PR TITLE
docs: Example titles begin with uppercase

### DIFF
--- a/components/tour/demo/mask.md
+++ b/components/tour/demo/mask.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-custom mask style.
+Custom mask style.

--- a/components/tour/index.en-US.md
+++ b/components/tour/index.en-US.md
@@ -20,8 +20,8 @@ Use when you want to guide users through a product.
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/non-modal.tsx">Non-modal</code>
 <code src="./demo/placement.tsx">Placement</code>
-<code src="./demo/mask.tsx">custom mask style</code>
-<code src="./demo/indicator.tsx">custom indicator</code>
+<code src="./demo/mask.tsx">Custom mask style</code>
+<code src="./demo/indicator.tsx">Custom indicator</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Site / documentation update


### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

观察发现文档其他处标题和描述开头都是大写字母开头的 感觉这边可以优化一下
![Pasted Graphic](https://github.com/ant-design/ant-design/assets/117748716/b1f79d35-ef62-4cc6-856a-c60c0d31b9b1)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Example titles begin with uppercase     |
| 🇨🇳 Chinese |      示例标题开头大写     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


