### PR TITLE
type: add React.ReactNode

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -20,7 +20,7 @@ export const TypeIcon = {
   loading: <LoadingOutlined />,
 };
 
-export function getCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) {
+export function getCloseIcon(prefixCls: string, closeIcon?: React.ReactNode): React.ReactNode {
   return (
     closeIcon || (
       <span className={`${prefixCls}-close-x`}>


### PR DESCRIPTION

### 🤔 This is a ...


- [x] TypeScript definition update




### 💡 Background and solution
返回的类型可以用React.ReactNode来表示
![image](https://github.com/ant-design/ant-design/assets/117748716/de4ef8ac-4884-4481-899e-3e5d40553ff7)


- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
