### PR TITLE
feat: ColorPicker implement `disabledAlpha` API

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -148,9 +148,6 @@ const ColorPicker: CompoundedComponent = (props) => {
     if (disabledAlpha && getAlphaColor(color) < 100) {
       color = genAlphaColor(color);
     }
-    if (!value) {
-      setColorValue(color);
-    }
     // Only for drag-and-drop color picking
     if (pickColor) {
       popupAllowCloseRef.current = false;

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -30,7 +30,7 @@ import { customizePrefixCls, generateColor } from './util';
 
 export type ColorPickerProps = Omit<
   RcColorPickerProps,
-  'onChange' | 'value' | 'defaultValue' | 'panelRender' | 'onChangeComplete'
+  'onChange' | 'value' | 'defaultValue' | 'panelRender' | 'disabledAlpha' | 'onChangeComplete'
 > & {
   value?: Color | string;
   defaultValue?: Color | string;
@@ -51,6 +51,7 @@ export type ColorPickerProps = Omit<
   size?: SizeType;
   styles?: { popup?: CSSProperties; popupOverlayInner?: CSSProperties };
   rootClassName?: string;
+  disabledAlpha?: boolean;
   onOpenChange?: (open: boolean) => void;
   onFormatChange?: (format: ColorFormat) => void;
   onChange?: (value: Color, hex: string) => void;
@@ -82,6 +83,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     size: customizeSize,
     rootClassName,
     styles,
+    disabledAlpha,
     onFormatChange,
     onChange,
     onClear,
@@ -180,6 +182,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     allowClear,
     colorCleared,
     disabled,
+    disabledAlpha,
     presets,
     panelRender,
     format: formatValue,

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -26,7 +26,7 @@ import type {
   TriggerType,
 } from './interface';
 import useStyle from './style/index';
-import { customizePrefixCls, generateColor } from './util';
+import { customizePrefixCls, genAlphaColor, generateColor, getAlphaColor } from './util';
 
 export type ColorPickerProps = Omit<
   RcColorPickerProps,
@@ -139,12 +139,17 @@ const ColorPicker: CompoundedComponent = (props) => {
     let color: Color = generateColor(data);
     if (colorCleared) {
       setColorCleared(false);
-      const hsba = color.toHsb();
       // ignore alpha slider
-      if (colorValue.toHsb().a === 0 && type !== 'alpha') {
-        hsba.a = 1;
-        color = generateColor(hsba);
+      if (getAlphaColor(colorValue) === 0 && type !== 'alpha') {
+        color = genAlphaColor(color);
       }
+    }
+    // ignore alpha color
+    if (disabledAlpha && getAlphaColor(color) < 100) {
+      color = genAlphaColor(color);
+    }
+    if (!value) {
+      setColorValue(color);
     }
     // Only for drag-and-drop color picking
     if (pickColor) {
@@ -162,7 +167,12 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   const handleChangeComplete: ColorPickerProps['onChangeComplete'] = (color) => {
     popupAllowCloseRef.current = true;
-    onChangeComplete?.(generateColor(color));
+    let changeColor = generateColor(color);
+    // ignore alpha color
+    if (disabledAlpha && getAlphaColor(color) < 100) {
+      changeColor = genAlphaColor(color);
+    }
+    onChangeComplete?.(changeColor);
   };
 
   const popoverProps: PopoverProps = {

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1920,6 +1920,291 @@ Array [
 ]
 `;
 
+exports[`renders components/color-picker/demo/disabled-alpha.tsx extend context correctly 1`] = `
+Array [
+  <div
+    class="ant-color-picker-trigger"
+  >
+    <div
+      class="ant-color-picker-color-block"
+    >
+      <div
+        class="ant-color-picker-color-block-inner"
+        style="background: rgb(22, 119, 255);"
+      />
+    </div>
+  </div>,
+  <div
+    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div
+      class="ant-popover-arrow"
+      style="position: absolute;"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <div
+            class="ant-color-picker-inner-content"
+          >
+            <div
+              class="ant-color-picker-panel"
+            >
+              <div
+                class="ant-color-picker-select"
+              >
+                <div
+                  class="ant-color-picker-palette"
+                  style="position: relative;"
+                >
+                  <div
+                    style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                  >
+                    <div
+                      class="ant-color-picker-handler"
+                      style="background-color: rgb(22, 119, 255);"
+                    />
+                  </div>
+                  <div
+                    class="ant-color-picker-saturation"
+                    style="background-color: rgb(0, 0, 0);"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-slider-container"
+              >
+                <div
+                  class="ant-color-picker-slider-group ant-color-picker-slider-group-disabled-alpha"
+                >
+                  <div
+                    class="ant-color-picker-slider ant-color-picker-slider-hue"
+                  >
+                    <div
+                      class="ant-color-picker-palette"
+                      style="position: relative;"
+                    >
+                      <div
+                        style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                      >
+                        <div
+                          class="ant-color-picker-handler ant-color-picker-handler-sm"
+                          style="background-color: rgb(0, 0, 0);"
+                        />
+                      </div>
+                      <div
+                        class="ant-color-picker-gradient"
+                        style="position: absolute; inset: 0;"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-color-block"
+                >
+                  <div
+                    class="ant-color-picker-color-block-inner"
+                    style="background: rgb(22, 119, 255);"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="ant-color-picker-input-container"
+            >
+              <div
+                class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+              >
+                <div
+                  class="ant-select-selector"
+                >
+                  <span
+                    class="ant-select-selection-search"
+                  >
+                    <input
+                      aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+                      aria-autocomplete="list"
+                      aria-controls="rc_select_TEST_OR_SSR_list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-owns="rc_select_TEST_OR_SSR_list"
+                      autocomplete="off"
+                      class="ant-select-selection-search-input"
+                      id="rc_select_TEST_OR_SSR"
+                      readonly=""
+                      role="combobox"
+                      style="opacity: 0;"
+                      type="search"
+                      unselectable="on"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="ant-select-selection-item"
+                    title="HEX"
+                  >
+                    HEX
+                  </span>
+                </div>
+                <div
+                  class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; width: 68px;"
+                >
+                  <div>
+                    <div
+                      id="rc_select_TEST_OR_SSR_list"
+                      role="listbox"
+                      style="height: 0px; width: 0px; overflow: hidden;"
+                    >
+                      <div
+                        aria-label="HEX"
+                        aria-selected="true"
+                        id="rc_select_TEST_OR_SSR_list_0"
+                        role="option"
+                      >
+                        hex
+                      </div>
+                      <div
+                        aria-label="HSB"
+                        aria-selected="false"
+                        id="rc_select_TEST_OR_SSR_list_1"
+                        role="option"
+                      >
+                        hsb
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position: relative;"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height: 256px; overflow-y: auto;"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display: flex; flex-direction: column;"
+                          >
+                            <div
+                              aria-selected="true"
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="HEX"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HEX
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="HSB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HSB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              aria-selected="false"
+                              class="ant-select-item ant-select-item-option"
+                              title="RGB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                RGB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-arrow"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down ant-select-suffix"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-color-picker-input"
+              >
+                <span
+                  class="ant-input-affix-wrapper ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                >
+                  <span
+                    class="ant-input-prefix"
+                  >
+                    #
+                  </span>
+                  <input
+                    class="ant-input ant-input-sm"
+                    type="text"
+                    value="1677FF"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/color-picker/demo/format.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -84,6 +84,21 @@ exports[`renders components/color-picker/demo/disabled.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/color-picker/demo/disabled-alpha.tsx correctly 1`] = `
+<div
+  class="ant-color-picker-trigger"
+>
+  <div
+    class="ant-color-picker-color-block"
+  >
+    <div
+      class="ant-color-picker-color-block-inner"
+      style="background:rgb(22, 119, 255)"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders components/color-picker/demo/format.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-vertical"

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -412,4 +412,11 @@ describe('ColorPicker', () => {
     doMouseMove(container, 0, 999);
     expect(handleChangeComplete).toHaveBeenCalledTimes(1);
   });
+
+  it('Should disabledAlpha work', async () => {
+    const { container } = render(<ColorPicker open disabledAlpha />);
+    expect(container.querySelector('.ant-color-picker-slider-group-disabled-alpha')).toBeTruthy();
+    expect(container.querySelector('.ant-color-picker-slider-alpha')).toBeFalsy();
+    expect(container.querySelector('.ant-color-picker-alpha-input')).toBeFalsy();
+  });
 });

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -462,10 +462,7 @@ describe('ColorPicker', () => {
   });
 
   it('Should warning work when set disabledAlpha true and color is alpha color', () => {
-    render(<ColorPicker disabledAlpha value="#1677ff86" />);
-    expect(errorSpy).toHaveBeenCalled();
-    resetWarned();
     render(<ColorPicker disabledAlpha value="#1677ff" />);
-    expect(errorSpy).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import theme from '../../theme';
+import type { ColorPickerProps } from '../ColorPicker';
 import ColorPicker from '../ColorPicker';
 import type { Color } from '../color';
 
@@ -418,5 +419,24 @@ describe('ColorPicker', () => {
     expect(container.querySelector('.ant-color-picker-slider-group-disabled-alpha')).toBeTruthy();
     expect(container.querySelector('.ant-color-picker-slider-alpha')).toBeFalsy();
     expect(container.querySelector('.ant-color-picker-alpha-input')).toBeFalsy();
+  });
+
+  it('Should disabledAlpha work with value', async () => {
+    const Demo = () => {
+      const [value, setValue] = useState<ColorPickerProps['value']>('#1677ff86');
+      return (
+        <ColorPicker open disabledAlpha value={value} onChange={setValue}>
+          <div className="color-value">
+            {typeof value === 'string' ? value : value?.toHexString()}
+          </div>
+        </ColorPicker>
+      );
+    };
+    const { container } = render(<Demo />);
+    expect(container.querySelector('.color-value')?.innerHTML).toEqual('#1677ff86');
+    fireEvent.change(container.querySelector('.ant-color-picker-hex-input input')!, {
+      target: { value: '1677ff86' },
+    });
+    expect(container.querySelector('.color-value')?.innerHTML).toEqual('#1677ff');
   });
 });

--- a/components/color-picker/components/ColorInput.tsx
+++ b/components/color-picker/components/ColorInput.tsx
@@ -11,7 +11,7 @@ import ColorHsbInput from './ColorHsbInput';
 import ColorRgbInput from './ColorRgbInput';
 
 interface ColorInputProps
-  extends Pick<ColorPickerBaseProps, 'prefixCls' | 'format' | 'onFormatChange'> {
+  extends Pick<ColorPickerBaseProps, 'prefixCls' | 'format' | 'onFormatChange' | 'disabledAlpha'> {
   value?: Color;
   onChange?: (value: Color) => void;
 }
@@ -22,7 +22,7 @@ const selectOptions = [ColorFormat.hex, ColorFormat.hsb, ColorFormat.rgb].map((f
 }));
 
 const ColorInput: FC<ColorInputProps> = (props) => {
-  const { prefixCls, format, value, onFormatChange, onChange } = props;
+  const { prefixCls, format, value, disabledAlpha, onFormatChange, onChange } = props;
   const [colorFormat, setColorFormat] = useMergedState(ColorFormat.hex, {
     value: format,
     onChange: onFormatChange,
@@ -61,7 +61,9 @@ const ColorInput: FC<ColorInputProps> = (props) => {
         options={selectOptions}
       />
       <div className={colorInputPrefixCls}>{steppersNode}</div>
-      <ColorAlphaInput prefixCls={prefixCls} value={value} onChange={onChange} />
+      {!disabledAlpha && (
+        <ColorAlphaInput prefixCls={prefixCls} value={value} onChange={onChange} />
+      )}
     </div>
   );
 };

--- a/components/color-picker/components/PanelPicker.tsx
+++ b/components/color-picker/components/PanelPicker.tsx
@@ -11,7 +11,7 @@ import ColorInput from './ColorInput';
 export interface PanelPickerProps
   extends Pick<
     ColorPickerBaseProps,
-    'prefixCls' | 'colorCleared' | 'allowClear' | 'onChangeComplete'
+    'prefixCls' | 'colorCleared' | 'allowClear' | 'disabledAlpha' | 'onChangeComplete'
   > {
   value?: Color;
   onChange?: (value?: Color, type?: HsbaColorType, pickColor?: boolean) => void;
@@ -24,6 +24,7 @@ const PanelPicker: FC = () => {
     colorCleared,
     allowClear,
     value,
+    disabledAlpha,
     onChange,
     onClear,
     onChangeComplete,
@@ -46,10 +47,17 @@ const PanelPicker: FC = () => {
       <RcColorPicker
         prefixCls={prefixCls}
         value={value?.toHsb()}
+        disabledAlpha={disabledAlpha}
         onChange={(colorValue, type) => onChange?.(colorValue, type, true)}
         onChangeComplete={onChangeComplete}
       />
-      <ColorInput value={value} onChange={onChange} prefixCls={prefixCls} {...injectProps} />
+      <ColorInput
+        value={value}
+        onChange={onChange}
+        prefixCls={prefixCls}
+        disabledAlpha={disabledAlpha}
+        {...injectProps}
+      />
     </>
   );
 };

--- a/components/color-picker/demo/disabled-alpha.md
+++ b/components/color-picker/demo/disabled-alpha.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+禁用颜色透明度。
+
+## en-US
+
+Disabled color alpha.

--- a/components/color-picker/demo/disabled-alpha.tsx
+++ b/components/color-picker/demo/disabled-alpha.tsx
@@ -1,0 +1,6 @@
+import { ColorPicker } from 'antd';
+import React from 'react';
+
+const Demo = () => <ColorPicker disabledAlpha />;
+
+export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -25,6 +25,7 @@ Used when the user needs to customize the color selection.
 <code src="./demo/change-completed.tsx">Color change completed</code>
 <code src="./demo/text-render.tsx">Rendering Trigger Text</code>
 <code src="./demo/disabled.tsx">Disable</code>
+<code src="./demo/disabled-alpha.tsx">Disabled Alpha</code>
 <code src="./demo/allowClear.tsx">Clear Color</code>
 <code src="./demo/trigger.tsx">Custom Trigger</code>
 <code src="./demo/trigger-event.tsx">Custom Trigger Event</code>
@@ -45,6 +46,7 @@ Used when the user needs to customize the color selection.
 | children | Trigger of ColorPicker | React.ReactNode | - | |
 | defaultValue | Default value of color | string \| `Color` | - | |
 | disabled | Disable ColorPicker | boolean | - | |
+| disabledAlpha | Disable Alpha | boolean | - | 5.7.0 |
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -46,7 +46,7 @@ Used when the user needs to customize the color selection.
 | children | Trigger of ColorPicker | React.ReactNode | - | |
 | defaultValue | Default value of color | string \| `Color` | - | |
 | disabled | Disable ColorPicker | boolean | - | |
-| disabledAlpha | Disable Alpha | boolean | - | 5.7.0 |
+| disabledAlpha | Disable Alpha | boolean | - | 5.8.0 |
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -26,6 +26,7 @@ group:
 <code src="./demo/change-completed.tsx">颜色完成选择</code>
 <code src="./demo/text-render.tsx">渲染触发器文本</code>
 <code src="./demo/disabled.tsx">禁用</code>
+<code src="./demo/disabled-alpha.tsx">禁用透明度</code>
 <code src="./demo/allowClear.tsx">清除颜色</code>
 <code src="./demo/trigger.tsx">自定义触发器</code>
 <code src="./demo/trigger-event.tsx">自定义触发事件</code>
@@ -46,6 +47,7 @@ group:
 | children | 颜色选择器的触发器 | React.ReactNode | - | |
 | defaultValue | 颜色默认的值 | string \| `Color` | - | |
 | disabled | 禁用颜色选择器 | boolean | - | |
+| disabledAlpha | 禁用透明度 | boolean | - | 5.7.0 |
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -47,7 +47,7 @@ group:
 | children | 颜色选择器的触发器 | React.ReactNode | - | |
 | defaultValue | 颜色默认的值 | string \| `Color` | - | |
 | disabled | 禁用颜色选择器 | boolean | - | |
-| disabledAlpha | 禁用透明度 | boolean | - | 5.7.0 |
+| disabledAlpha | 禁用透明度 | boolean | - | 5.8.0 |
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -28,6 +28,7 @@ export interface ColorPickerBaseProps {
   allowClear?: boolean;
   colorCleared?: boolean;
   disabled?: boolean;
+  disabledAlpha?: boolean;
   presets?: PresetsItem[];
   panelRender?: ColorPickerProps['panelRender'];
   onFormatChange?: ColorPickerProps['onFormatChange'];

--- a/components/color-picker/style/picker.ts
+++ b/components/color-picker/style/picker.ts
@@ -58,14 +58,23 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         boxShadow: colorPickerInsetShadow,
       },
       '&-alpha': getTransBg(`${colorPickerSliderHeight}px`, token.colorFillSecondary),
-      marginBottom: marginSM,
+      '&-hue': { marginBottom: marginSM },
     },
 
     [`${componentCls}-slider-container`]: {
       display: 'flex',
       gap: marginSM,
+      marginBottom: marginSM,
       [`${componentCls}-slider-group`]: {
         flex: 1,
+        '&-disabled-alpha': {
+          display: 'flex',
+          alignItems: 'center',
+          [`${componentCls}-slider`]: {
+            flex: 1,
+            marginBottom: 0,
+          },
+        },
       },
     },
   };

--- a/components/color-picker/util.ts
+++ b/components/color-picker/util.ts
@@ -14,3 +14,9 @@ export const generateColor = (color: ColorGenInput<Color>): Color => {
 export const getRoundNumber = (value: number) => Math.round(Number(value || 0));
 
 export const getAlphaColor = (color: Color) => getRoundNumber(color.toHsb().a * 100);
+
+export const genAlphaColor = (color: Color, alpha?: number) => {
+  const hsba = color.toHsb();
+  hsba.a = alpha || 1;
+  return generateColor(hsba);
+};

--- a/components/upload/style/motion.ts
+++ b/components/upload/style/motion.ts
@@ -1,7 +1,7 @@
 import { Keyframes } from '@ant-design/cssinjs';
 import type { UploadToken } from '.';
-import { initFadeMotion } from '../../style/motion';
 import type { GenerateStyle } from '../../theme/internal';
+import { initFadeMotion } from '../../style/motion';
 
 const uploadAnimateInlineIn = new Keyframes('uploadAnimateInlineIn', {
   from: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- close #43253
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/21119589/9feac35d-c1c2-4858-9058-91af3de4994b)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   ColorPicker implement `disabledAlpha` API      |
| 🇨🇳 Chinese |    颜色选择器实现 `disabledAlpha` API       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f80144</samp>

Added a new feature to the `ColorPicker` component to allow disabling the alpha channel of the color picker. This feature is controlled by a new prop `disabledAlpha` that is passed to the `ColorPicker` and its subcomponents. Updated the documentation, demo, styles, and tests to reflect this change.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f80144</samp>

*  Add `disabledAlpha` prop to `ColorPicker` component and its subcomponents to allow users to disable the alpha channel of the color picker ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL33-R33), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR54), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L14-R14), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-a04e15c33ec6c3cfe7d1f5772c30cd22e640b5f00500f1404d652d83f825e8c9L12-R15), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-83dba3026e7dc41ad64d3a2f4d484eeb085f0c3798dc2316fbb90d23520fca6eR31))
*  Pass `disabledAlpha` prop to `RcColorPickerPanel` and `ColorInput` components in `PanelPicker` component to disable the alpha slider and input in the panel and the input box ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-a04e15c33ec6c3cfe7d1f5772c30cd22e640b5f00500f1404d652d83f825e8c9R28), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-a04e15c33ec6c3cfe7d1f5772c30cd22e640b5f00500f1404d652d83f825e8c9L47-R61))
*  Destructure `disabledAlpha` prop from the `props` object in `ColorPicker`, `PanelPicker`, and `ColorInput` components to use it later ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR85), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L25-R25), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-a04e15c33ec6c3cfe7d1f5772c30cd22e640b5f00500f1404d652d83f825e8c9R28))
*  Add conditional rendering to `ColorInput` component to hide the `ColorAlphaInput` component if the `disabledAlpha` prop is true ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-92ce74ec7f4cf4bb67a1fe8516714a57233367553933dd62c59ae8806fe43146L64-R66))
*  Add margin bottom styles to the hue slider and the slider group in the `genPickerStyle` function to avoid overlapping and create some space between the sliders and the input box ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L61-R61), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L67-R77))
*  Add a new style rule to the slider group with the `disabledAlpha` modifier to adjust the layout of the sliders when the alpha slider is disabled ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L67-R77))
*  Add a new test case to check if the `disabledAlpha` prop works as expected in the `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4R400-R406))
*  Add a new example link and a new API entry to the `ColorPicker` documentation in Chinese and English to describe the `disabledAlpha` prop ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560R27), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560R48), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249R28), [link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249R49))
*  Omit the `disabledAlpha` prop from the `ColorPickerProps` type to avoid passing it to the underlying `RcColorPicker` component, which does not support it ([link](https://github.com/ant-design/ant-design/pull/43355/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL33-R33))
