### PR TITLE
fix: some browser may not repaint when remove nodes

### DIFF
--- a/components/_util/styleChecker.ts
+++ b/components/_util/styleChecker.ts
@@ -25,10 +25,17 @@ export const detectFlexGapSupported = () => {
   flex.appendChild(document.createElement('div'));
   flex.appendChild(document.createElement('div'));
 
+  // some browser may not repaint when remove nodes, so we need create a new layer to detect.
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.zIndex = '-9999';
+  container.appendChild(flex);
+
+
   // append to the DOM (needed to obtain scrollHeight)
-  document.body.appendChild(flex);
+  document.body.appendChild(container);
   flexGapSupported = flex.scrollHeight === 1; // flex container should be 1px high from the row-gap
-  document.body.removeChild(flex);
+  document.body.removeChild(container);
 
   return flexGapSupported;
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here. https://g5hqdw.csb.app
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
some browser may not repaint when remove nodes.
![2023-07-04 19 58 54](https://github.com/ant-design/ant-design/assets/35845083/2b4c33a1-0c91-4fd0-b75f-05b8ac3a2e4e)

so we need create a new layer to detect.
一些浏览器因为元素正好占满整个高度后，stylechecker添加了一个节点后再移除，浏览器会出现滚动条（拖拽修改浏览器窗口宽高可以触发重绘，滚动条消失）。比如safari 14.1.2 (16611.3.10.1.3)，虽然是浏览器的bug。但是建议做stylecheck的时候用元素脱离文档流的方式处理更好一点。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   create a new layer to fix some browser do not repaint when remove node        |
| 🇨🇳 Chinese |    修复一些浏览器因为未重绘导致出现滚动条的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8100e35</samp>

Fix flex gap support detection by appending a container element to the body instead of the flex element. Modify `components/_util/styleChecker.ts` to implement this workaround.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8100e35</samp>

* Fix flex gap support detection for style checker utility ([link](https://github.com/ant-design/ant-design/pull/43358/files?diff=unified&w=0#diff-fe8f24d3deab77dc6673d14a10012f8b5fcc44e939c75da39a45cccfc5a32937L28-R38),                             
