### PR TITLE
fix: use the same camelCase

### DIFF
--- a/.dumi/theme/common/Color/ColorPalettes.tsx
+++ b/.dumi/theme/common/Color/ColorPalettes.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import Palette from './Palette';
 
@@ -80,7 +80,7 @@ const colors = [
 const ColorPalettes: React.FC<{ dark?: boolean }> = (props) => {
   const { dark } = props;
   return (
-    <div className={classnames('color-palettes', { 'color-palettes-dark': dark })}>
+    <div className={classNames('color-palettes', { 'color-palettes-dark': dark })}>
       {colors.map((color) => (
         <Palette key={color.name} color={color} dark={dark} showTitle />
       ))}


### PR DESCRIPTION


- [x] Code style optimization


### 💡 Background and solution
项目中仅有这一处命名非驼峰规范的，感觉可以统一一下
![image](https://github.com/ant-design/ant-design/assets/117748716/837121ae-7eac-4dd8-a00b-6ec010af3cf4)
![image](https://github.com/ant-design/ant-design/assets/117748716/66401cc0-04b8-4821-8af4-5f4c47cd665d)


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad702b4</samp>

Fixed a minor typo in a theme file. Renamed a variable from `classnames` to `classNames` in `.dumi/theme/common/Color/ColorPalettes.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad702b4</samp>

*  Rename `classnames` import and usage to `classNames` for consistency and clarity ([link](https://github.com/ant-design/ant-design/pull/43371/files?diff=unified&w=0#diff-87b3284e96e0896fd69642bf8d5665a0cc1d8d58b172428e241211c2d0aa9f11L1-R1), [link](https://github.com/ant-design/ant-design/pull/43371/files?diff=unified&w=0#diff-87b3284e96e0896fd69642bf8d5665a0cc1d8d58b172428e241211c2d0aa9f11L83-R83))
