### PR TITLE
feat: ConfigProvider support Menu className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -17,6 +17,7 @@ import Image from '../../image';
 import Input from '../../input';
 import Layout from '../../layout';
 import Mentions from '../../mentions';
+import Menu from '../../menu';
 import message from '../../message';
 import Modal from '../../modal';
 import notification from '../../notification';
@@ -24,9 +25,9 @@ import Pagination from '../../pagination';
 import Radio from '../../radio';
 import Rate from '../../rate';
 import Result from '../../result';
-import Skeleton from '../../skeleton';
 import Segmented from '../../segmented';
 import Select from '../../select';
+import Skeleton from '../../skeleton';
 import Slider from '../../slider';
 import Space from '../../space';
 import Spin from '../../spin';
@@ -375,6 +376,46 @@ describe('ConfigProvider support style and className props', () => {
     const element = baseElement.querySelector<HTMLDivElement>('.ant-layout');
     expect(element).toHaveClass('cp-layout');
     expect(element).toHaveStyle({ background: 'red' });
+  });
+
+  it('Should Menu className works', () => {
+    const menuItems = [
+      {
+        label: 'Test Label',
+        key: 'test',
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider
+        menu={{
+          className: 'test-class',
+        }}
+      >
+        <Menu items={menuItems} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-menu')).toHaveClass('test-class');
+  });
+
+  it('Should Menu style works', () => {
+    const menuItems = [
+      {
+        label: 'Test Label',
+        key: 'test',
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider
+        menu={{
+          style: { color: 'red' },
+        }}
+      >
+        <Menu items={menuItems} style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-menu')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Mentions className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -110,6 +110,7 @@ export interface ConfigConsumerProps {
   result?: ComponentStyleConfig;
   slider?: ComponentStyleConfig;
   breadcrumb?: ComponentStyleConfig;
+  menu?: ComponentStyleConfig;
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -117,6 +117,7 @@ const {
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| menu | Set Menu common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | Set Message common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -154,6 +154,7 @@ export interface ConfigProviderProps {
   result?: ComponentStyleConfig;
   slider?: ComponentStyleConfig;
   breadcrumb?: ComponentStyleConfig;
+  menu?: ComponentStyleConfig;
   checkbox?: ComponentStyleConfig;
   descriptions?: ComponentStyleConfig;
   empty?: ComponentStyleConfig;
@@ -277,6 +278,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     result,
     slider,
     breadcrumb,
+    menu,
     pagination,
     input,
     empty,
@@ -363,6 +365,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     result,
     slider,
     breadcrumb,
+    menu,
     pagination,
     empty,
     badge,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -119,6 +119,7 @@ const {
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | layout | 设置 Layout 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| menu | 设置 Menu 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -41,13 +41,14 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   const override = React.useContext(OverrideContext);
   const overrideObj = override || {};
 
-  const { getPrefixCls, getPopupContainer, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, getPopupContainer, direction, menu } = React.useContext(ConfigContext);
 
   const rootPrefixCls = getPrefixCls();
 
   const {
     prefixCls: customizePrefixCls,
     className,
+    style,
     theme = 'light',
     expandIcon,
     _internalDisableMenuItemTitleTooltip,
@@ -119,7 +120,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('menu', customizePrefixCls || overrideObj.prefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls, !override);
-  const menuClassName = classNames(`${prefixCls}-${theme}`, className);
+  const menuClassName = classNames(`${prefixCls}-${theme}`, menu?.className, className);
 
   // ====================== Expand Icon ========================
   let mergedExpandIcon: MenuProps[`expandIcon`];
@@ -163,6 +164,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           onClick={onItemClick}
           {...passedProps}
           inlineCollapsed={mergedInlineCollapsed}
+          style={{ ...menu?.style, ...style }}
           className={menuClassName}
           prefixCls={prefixCls}
           direction={direction}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  ConfigProvider support Skeleton className and style properties         |
| 🇨🇳 Chinese |  ConfigProvider 支持 Skeleton 组件的 className 和 style 属性         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6cea2d3</samp>

This pull request adds a new feature to the `ConfigProvider` component, which allows users to set common props for the `Menu` component via a `menu` prop. It also adds tests and documentation for this feature, and fixes some style prop issues in the `Menu` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6cea2d3</samp>

*  Add a new `menu` prop to the `ConfigProvider` component and the `ConfigConsumerProps` interface, which allows setting common props for the menu component ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR113), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R157))
*  Pass the `menu` prop to the `ConfigContext.Provider` value in the `ConfigProvider` component, so that it can be accessed by the menu component via the `useContext` hook ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R281), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R368))
*  Destructure the `menu` prop from the `ConfigContext` in the `InternalMenu` component, and merge it with the `style` and `className` props from the menu component ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L44-R44), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43R51), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43L122-R123), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-bcc9a016f0b5e2844ec9d0aa399d06a86134f535931eeced33c3d08c3462ce43R167))
*  Update the documentation for the `ConfigProvider` component in English and Chinese, adding a new row for the `menu` prop and its details ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R120), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R122))
*  Add two new test cases for the `menu` component in `components/config-provider/__tests__/style.test.tsx`, verifying that the `style` and `className` props from the `ConfigProvider` are applied to the menu element ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R20), [link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R381-R420))
*  Reorder the imports in `components/config-provider/__tests__/style.test.tsx` alphabetically, following the code style convention ([link](https://github.com/ant-design/ant-design/pull/43382/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L27-R30))
