### PR TITLE
feat: ConfigProvider support Calendar className and style properties

### DIFF
--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -115,7 +115,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
       onPanelChange,
       onSelect,
     } = props;
-    const { getPrefixCls, direction } = React.useContext(ConfigContext);
+    const { getPrefixCls, direction, calendar } = React.useContext(ConfigContext);
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
     const calendarPrefixCls = `${prefixCls}-calendar`;
 
@@ -304,11 +304,12 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
             [`${calendarPrefixCls}-mini`]: !fullscreen,
             [`${calendarPrefixCls}-rtl`]: direction === 'rtl',
           },
+          calendar?.className,
           className,
           rootClassName,
           hashId,
         )}
-        style={style}
+        style={{ ...calendar?.style, ...style }}
       >
         {headerRender ? (
           headerRender({

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -5,6 +5,7 @@ import Anchor from '../../anchor';
 import Avatar from '../../avatar';
 import Badge from '../../badge';
 import Breadcrumb from '../../breadcrumb';
+import Calendar from '../../calendar';
 import Card from '../../card';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
@@ -25,9 +26,9 @@ import Progress from '../../progress';
 import Radio from '../../radio';
 import Rate from '../../rate';
 import Result from '../../result';
-import Skeleton from '../../skeleton';
 import Segmented from '../../segmented';
 import Select from '../../select';
+import Skeleton from '../../skeleton';
 import Slider from '../../slider';
 import Space from '../../space';
 import Spin from '../../spin';
@@ -705,6 +706,36 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-table-wrapper');
     expect(element).toHaveClass('cp-table');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Calendar className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        calendar={{
+          className: 'test-class',
+        }}
+      >
+        <Calendar />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker-calendar')).toHaveClass('test-class');
+  });
+
+  it('Should Calendar style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        calendar={{
+          style: { color: 'red' },
+        }}
+      >
+        <Calendar style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker-calendar')).toHaveStyle(
+      'color: red; font-size: 16px;',
+    );
   });
 
   it('Should Card className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -97,6 +97,7 @@ export interface ConfigConsumerProps {
   anchor?: ComponentStyleConfig;
   button?: ButtonConfig;
   divider?: ComponentStyleConfig;
+  calendar?: ComponentStyleConfig;
   cascader?: ComponentStyleConfig;
   typography?: ComponentStyleConfig;
   skeleton?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -107,6 +107,7 @@ const {
 | breadcrumb | Set Breadcrumb common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | card | Set Card common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| calendar | Set Calendar common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | Set Cascader common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | colorPicker | Set ColorPicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -140,6 +140,7 @@ export interface ConfigProviderProps {
   theme?: ThemeConfig;
   anchor?: ComponentStyleConfig;
   button?: ButtonConfig;
+  calendar?: ComponentStyleConfig;
   cascader?: ComponentStyleConfig;
   divider?: ComponentStyleConfig;
   typography?: ComponentStyleConfig;
@@ -264,6 +265,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     componentDisabled,
     segmented,
     spin,
+    calendar,
     cascader,
     typography,
     checkbox,
@@ -350,6 +352,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     theme: mergedTheme,
     segmented,
     spin,
+    calendar,
     cascader,
     typography,
     checkbox,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -108,6 +108,7 @@ const {
 | badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { count?: string, indicator?: string }, styles?: { count?: React.CSSProperties, indicator?: React.CSSProperties } } | - | 5.7.0 |
 | breadcrumb | 设置 Breadcrumb 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
+| calendar | 设置 Calendar 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | card | 设置 Card 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | 设置 Cascader 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ConfigProvider support Calendar className and style properties          |
| 🇨🇳 Chinese | ConfigProvider 支持 Calendar 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b1ec4b</samp>

This pull request adds a new `calendar` prop to the `ConfigProvider` component, which allows users to customize the style and common props of the `Calendar` component. It also updates the `generateCalendar` function, the `ConfigProvider` context and documentation, and the relevant tests.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b1ec4b</samp>

*  Add `calendar` prop to `ConfigProvider` component and context to allow setting common props for calendar component ([link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR100), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R143), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R268), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R355), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R110), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R111))
*  Pass `calendar` prop from `ConfigContext` to `generateCalendar` function and apply it to the root element of calendar component ([link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L118-R118), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L307-R312))
*  Import `Calendar` component to `style.test.tsx` file and add test cases for `className` and `style` props of calendar component ([link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R8), [link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R711-R740))
*  Add missing import of `Skeleton` component to `style.test.tsx` file for consistency ([link](https://github.com/ant-design/ant-design/pull/43385/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149L28-R31))
