### PR TITLE
feat: ConfigProvider support List className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -16,6 +16,7 @@ import Form from '../../form';
 import Image from '../../image';
 import Input from '../../input';
 import Layout from '../../layout';
+import List from '../../list';
 import Mentions from '../../mentions';
 import Menu from '../../menu';
 import message from '../../message';
@@ -377,6 +378,44 @@ describe('ConfigProvider support style and className props', () => {
     const element = baseElement.querySelector<HTMLDivElement>('.ant-layout');
     expect(element).toHaveClass('cp-layout');
     expect(element).toHaveStyle({ background: 'red' });
+  });
+
+  it('Should List className works', () => {
+    const listData = [
+      {
+        title: 'Test Title',
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider
+        list={{
+          className: 'test-class',
+        }}
+      >
+        <List dataSource={listData} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-list')).toHaveClass('test-class');
+  });
+
+  it('Should List style works', () => {
+    const listData = [
+      {
+        title: 'Test Title',
+      },
+    ];
+    const { container } = render(
+      <ConfigProvider
+        list={{
+          style: { color: 'red' },
+        }}
+      >
+        <List style={{ fontSize: '16px' }} dataSource={listData} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-list')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Menu className works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -105,6 +105,7 @@ export interface ConfigConsumerProps {
   steps?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
   layout?: ComponentStyleConfig;
+  list?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
   progress?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -117,6 +117,7 @@ const {
 | image | Set Image common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | Set Input common props | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 4.2.0 |
 | layout | Set Layout common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| list | Set List common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | menu | Set Menu common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | Set Message common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -149,6 +149,7 @@ export interface ConfigProviderProps {
   steps?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
   layout?: ComponentStyleConfig;
+  list?: ComponentStyleConfig;
   mentions?: ComponentStyleConfig;
   modal?: ComponentStyleConfig;
   progress?: ComponentStyleConfig;
@@ -274,6 +275,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     steps,
     image,
     layout,
+    list,
     mentions,
     modal,
     progress,
@@ -362,6 +364,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     image,
     input,
     layout,
+    list,
     mentions,
     modal,
     progress,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -119,6 +119,7 @@ const {
 | image | 设置 Image 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | input | 设置 Input 组件的通用属性 | { autoComplete?: string, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | layout | 设置 Layout 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| list | 设置 List 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | menu | 设置 Menu 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -75,6 +75,7 @@ function List<T>({
   split = true,
   className,
   rootClassName,
+  style,
   children,
   itemLayout,
   loadMore,
@@ -96,7 +97,7 @@ function List<T>({
   );
   const [paginationSize, setPaginationSize] = React.useState(paginationObj.defaultPageSize || 10);
 
-  const { getPrefixCls, renderEmpty, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, renderEmpty, direction, list } = React.useContext(ConfigContext);
 
   const defaultPaginationProps = {
     current: 1,
@@ -176,6 +177,7 @@ function List<T>({
       [`${prefixCls}-something-after-last-item`]: isSomethingAfterLastItem(),
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
+    list?.className,
     className,
     rootClassName,
     hashId,
@@ -280,7 +282,7 @@ function List<T>({
 
   return wrapSSR(
     <ListContext.Provider value={contextValue}>
-      <div className={classString} {...rest}>
+      <div style={{ ...list?.style, ...style }} className={classString} {...rest}>
         {(paginationPosition === 'top' || paginationPosition === 'both') && paginationContent}
         {header && <div className={`${prefixCls}-header`}>{header}</div>}
         <Spin {...loadingProp}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ConfigProvider support List className and style properties          |
| 🇨🇳 Chinese | ConfigProvider 支持 List 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2c6af3</samp>

This pull request adds a new `list` prop to the `ConfigProvider` component, which allows customizing the style and className of the `List` component globally or locally. It updates the relevant files in the `components/config-provider` and `components/list` directories, as well as the documentation files in English and Chinese.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2c6af3</samp>

*  Add a new optional `list` prop to the `ConfigProvider` component and the `ConfigConsumerProps` interface, which allows setting the `style` and `className` props for the `List` component globally. ([link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR108), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R152), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R278), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R367))
*  Document the `list` prop and its type, default value, and version in the `index.en-US.md` and `index.zh-CN.md` files. ([link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R120), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R122))
*  Import the `List` component in the `style.test.tsx` file and add two test cases to verify that the `list` prop can be set through the `ConfigProvider` component and is applied to the `List` component. ([link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R19), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R383-R420))
*  Destructure the `style` prop and the `list` prop from the `ConfigContext` value in the `List` component and use them to apply the `style` and `className` props to the `List` element. ([link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R78), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L99-R100), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R180), [link](https://github.com/ant-design/ant-design/pull/43387/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L283-R285))
