### PR TITLE
feat: ConfigProvider support Timeline className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -41,6 +41,7 @@ import Switch from '../../switch';
 import Table from '../../table';
 import Tabs from '../../tabs';
 import Tag from '../../tag';
+import Timeline from '../../timeline';
 import Transfer from '../../transfer';
 import Tree from '../../tree';
 import Typography from '../../typography';
@@ -964,6 +965,46 @@ describe('ConfigProvider support style and className props', () => {
       ?.querySelector<HTMLDivElement>('.ant-notification-notice');
     expect(element).toHaveClass('cp-notification');
     expect(element).toHaveStyle({ color: 'blue' });
+  });
+
+  it('Should Timeline className works', () => {
+    const items = [
+      {
+        children: 'test item',
+      },
+    ];
+
+    const { container } = render(
+      <ConfigProvider
+        timeline={{
+          className: 'test-class',
+        }}
+      >
+        <Timeline items={items} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-timeline')).toHaveClass('test-class');
+  });
+
+  it('Should Timeline style works', () => {
+    const items = [
+      {
+        children: 'test item',
+      },
+    ];
+
+    const { container } = render(
+      <ConfigProvider
+        timeline={{
+          style: { color: 'red' },
+        }}
+      >
+        <Timeline items={items} style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-timeline')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Transfer className works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -130,6 +130,7 @@ export interface ConfigConsumerProps {
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
+  timeline?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -142,6 +142,7 @@ const {
 | table | Set Table common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | Set Tag common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| timeline | Set Timeline common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | transfer | Set Transfer common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -174,6 +174,7 @@ export interface ConfigProviderProps {
   table?: ComponentStyleConfig;
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
+  timeline?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
@@ -304,6 +305,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     table,
     card,
     tabs,
+    timeline,
     upload,
     notification,
     tree,
@@ -396,6 +398,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     table,
     card,
     tabs,
+    timeline,
     upload,
     notification,
     tree,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -144,8 +144,9 @@ const {
 | table | 设置 Table 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | 设置 Tabs 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | 设置 Tag 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| timeline | 设置 Timeline 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | transfer | 设置 Transfer 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -1,9 +1,10 @@
+import classNames from 'classnames';
 import * as React from 'react';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { TimelineItemProps } from './TimelineItem';
-import TimelineItemList from './TimelineItemList';
 import TimelineItem from './TimelineItem';
-import warning from '../_util/warning';
+import TimelineItemList from './TimelineItemList';
 import useItems from './useItems';
 
 // CSSINJS
@@ -28,8 +29,8 @@ type CompoundedComponent = React.FC<TimelineProps> & {
 };
 
 const Timeline: CompoundedComponent = (props) => {
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
-  const { prefixCls: customizePrefixCls, children, items, ...restProps } = props;
+  const { getPrefixCls, direction, timeline } = React.useContext(ConfigContext);
+  const { prefixCls: customizePrefixCls, children, items, className, style, ...restProps } = props;
   const prefixCls = getPrefixCls('timeline', customizePrefixCls);
 
   // =================== Warning =====================
@@ -45,6 +46,8 @@ const Timeline: CompoundedComponent = (props) => {
   return wrapSSR(
     <TimelineItemList
       {...restProps}
+      className={classNames(timeline?.className, className)}
+      style={{ ...timeline?.style, ...style }}
       prefixCls={prefixCls}
       direction={direction}
       items={mergedItems}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ConfigProvider support Timeline className and style properties         |
| 🇨🇳 Chinese | ConfigProvider 支持 Timeline 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef8f320</samp>

This pull request adds the ability to pass common props for the `Timeline` component through the `ConfigProvider` component, such as className and style. It updates the Timeline component, the ConfigProvider component, the context.ts file, and the documentation files in both English and Chinese to support this feature. It also adds style tests for the Timeline component in the ConfigProvider context.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef8f320</samp>

*  Add `timeline` prop to `ConfigProvider` component and `ConfigContext` to allow passing common props to `Timeline` component ([link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR128), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R172), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R298), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R386))
*  Document `timeline` prop usage and default value in English and Chinese markdown files ([link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R141), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R143))
*  Import `Timeline` component and `classNames` function in `style.test.tsx` and `Timeline.tsx` files ([link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R1), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dL1-R7))
*  Receive and merge `className` and `style` props from `ConfigProvider` component and `Timeline` component in `Timeline.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dL31-R33), [link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dR49-R50))
*  Add test cases to check `className` and `style` props of `Timeline` component in `style.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43392/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R827-R866))
