### PR TITLE
docs: fix desc text

### DIFF
--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -22,12 +22,12 @@ export interface ComponentToken {
    */
   itemPaddingBottom: number;
   /**
-   * @desc 分号右间距
+   * @desc 冒号右间距
    * @descEN Right margin of colon
    */
   colonMarginRight: number;
   /**
-   * @desc 分号左间距
+   * @desc 冒号左间距
    * @descEN Left margin of colon
    */
   colonMarginLeft: number;


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Site / documentation update




### 💡 Background and solution
看了一下colon主要影响的范围是descriptions组件是否显示冒号，似乎这边表示的是冒号而不是分号
<img width="752" alt="Pasted Graphic" src="https://github.com/ant-design/ant-design/assets/117748716/ed64523b-51df-4296-af30-664b3df6ec01">

<img width="1070" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/0eb9af68-7595-41d4-a1e2-3bf517a1c873">
<img width="959" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/4f058de1-81a7-46df-8101-6564b6599d52">





### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de0d238</samp>

Fixed a typo in the Chinese comment for `colonMarginRight` and `colonMarginLeft` in `components/descriptions/style/index.ts`. This change corrects the documentation of the description component's style.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de0d238</samp>

* Fix Chinese comment for colon margin variables ([link](https://github.com/ant-design/ant-design/pull/43393/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L25-R30))
