### PR TITLE
type: use React.ReactElement<any> replace any

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -101,7 +101,10 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     ) as React.ReactNode;
 
     return cloneElement(icon, () => ({
-      className: classNames((icon as any).props.className, `${prefixCls}-arrow`),
+      className: classNames(
+        (icon as React.ReactElement<any>).props.className,
+        `${prefixCls}-arrow`,
+      ),
     }));
   };
 


### PR DESCRIPTION

### 🤔 This is a ...

- [x] TypeScript definition update



### 💡 Background and solution
看到项目中其他地方关于这种元素的类型定义用的是React.ReactElement<any> 不知道是否会比any来的更好
![image](https://github.com/ant-design/ant-design/assets/117748716/0b99c453-4c19-407f-a6db-c3e642e1af83)


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9228ebc</samp>

Fix TypeScript errors in `Collapse.tsx` by adding type assertion to `icon` prop. Ensure `icon` is a cloneable React element with a custom class name.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9228ebc</samp>

* Assert `icon` prop as `React.ReactElement` to avoid TypeScript error ([link](https://github.com/ant-design/ant-design/pull/43397/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L104-R107))
