### PR TITLE
feat: ConfigProvider support Statistic className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -37,6 +37,7 @@ import Skeleton from '../../skeleton';
 import Slider from '../../slider';
 import Space from '../../space';
 import Spin from '../../spin';
+import Statistic from '../../statistic';
 import Steps from '../../steps';
 import Switch from '../../switch';
 import Table from '../../table';
@@ -323,6 +324,34 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-spin');
     expect(element).toHaveClass('config-provider-spin');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should Statistic className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        statistic={{
+          className: 'test-class',
+        }}
+      >
+        <Statistic title="Test Title" value={100} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-statistic')).toHaveClass('test-class');
+  });
+
+  it('Should Statistic style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        statistic={{
+          style: { color: 'red' },
+        }}
+      >
+        <Statistic style={{ fontSize: '16px' }} title="Test Title" value={100} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-statistic')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Segmented className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -107,6 +107,7 @@ export interface ConfigConsumerProps {
   spin?: ComponentStyleConfig;
   segmented?: ComponentStyleConfig;
   steps?: ComponentStyleConfig;
+  statistic?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
   layout?: ComponentStyleConfig;
   list?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -139,6 +139,7 @@ const {
 | switch | Set Switch common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| statistic | Set Statistic common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | Set Steps common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | table | Set Table common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -150,6 +150,7 @@ export interface ConfigProviderProps {
   skeleton?: ComponentStyleConfig;
   spin?: ComponentStyleConfig;
   segmented?: ComponentStyleConfig;
+  statistic?: ComponentStyleConfig;
   steps?: ComponentStyleConfig;
   image?: ComponentStyleConfig;
   layout?: ComponentStyleConfig;
@@ -272,6 +273,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     theme,
     componentDisabled,
     segmented,
+    statistic,
     spin,
     calendar,
     cascader,
@@ -366,6 +368,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     iconPrefixCls,
     theme: mergedTheme,
     segmented,
+    statistic,
     spin,
     calendar,
     cascader,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -141,6 +141,7 @@ const {
 | switch | 设置 Switch 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | space | 设置 Space 的通用属性，参考 [Space](/components/space-cn) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: { item: string }, styles?: { item: React.CSSProperties } } | - | 5.6.0 |
 | spin | 设置 Spin 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| statistic | 设置 Statistic 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | steps | 设置 Steps 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | table | 设置 Table 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tabs | 设置 Tabs 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -42,7 +42,8 @@ const Statistic: React.FC<StatisticProps> = (props) => {
     groupSeparator = ',',
   } = props;
 
-  const { getPrefixCls, direction } = React.useContext<ConfigConsumerProps>(ConfigContext);
+  const { getPrefixCls, direction, statistic } =
+    React.useContext<ConfigConsumerProps>(ConfigContext);
 
   const prefixCls = getPrefixCls('statistic', customizePrefixCls);
 
@@ -63,13 +64,19 @@ const Statistic: React.FC<StatisticProps> = (props) => {
     {
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
+    statistic?.className,
     className,
     rootClassName,
     hashId,
   );
 
   return wrapSSR(
-    <div className={cls} style={style} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+    <div
+      className={cls}
+      style={{ ...statistic?.style, ...style }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       {title && <div className={`${prefixCls}-title`}>{title}</div>}
       <Skeleton paragraph={false} loading={loading} className={`${prefixCls}-skeleton`}>
         <div style={valueStyle} className={`${prefixCls}-content`}>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ConfigProvider support Statistic className and style properties          |
| 🇨🇳 Chinese | ConfigProvider 支持 Statistic 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2394ae</samp>

This pull request adds a new `statistic` prop to the `ConfigProvider` component, which allows setting the common className and style props of the `Statistic` component globally. It also updates the `Statistic` component to support this prop, and adds tests and documentation for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2394ae</samp>

*  Add the `statistic` prop to the `ConfigProvider` component and the `ConfigContext`, which allows setting the common `className` and `style` props of the `Statistic` component ([link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR110), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R153), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R276), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R371))
*  Pass the `statistic` prop from the `ConfigProvider` component to the `Statistic` component through the `ConfigContext` and use it to set the `className` and `style` of the root div element of the `Statistic` component, merging them with the `Statistic` component's own props if any ([link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-645dcf4b7e21e273f0bf17d2243a3c84d0fb975fb5c6915a84f4fd91b32b4a53L45-R46), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-645dcf4b7e21e273f0bf17d2243a3c84d0fb975fb5c6915a84f4fd91b32b4a53R67), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-645dcf4b7e21e273f0bf17d2243a3c84d0fb975fb5c6915a84f4fd91b32b4a53L72-R79))
*  Import the `Statistic` component in the `style.test.tsx` file and add two test cases to check if the `ConfigProvider` component can pass and merge the `statistic` prop to the `Statistic` component ([link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R40), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R329-R356))
*  Document the `statistic` prop in the `index.en-US.md` and `index.zh-CN.md` files, providing its type, default value, and description in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R142), [link](https://github.com/ant-design/ant-design/pull/43408/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R144))
