### PR TITLE
feat: ConfigProvider support Carousel className and style properties

### DIFF
--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -39,11 +39,13 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
       dotPosition = 'bottom',
       vertical = dotPosition === 'left' || dotPosition === 'right',
       rootClassName,
+      className: customClassName,
+      style,
       ...props
     },
     ref,
   ) => {
-    const { getPrefixCls, direction } = React.useContext(ConfigContext);
+    const { getPrefixCls, direction, carousel } = React.useContext(ConfigContext);
     const slickRef = React.useRef<any>();
 
     const goTo = (slide: number, dontAnimate = false) => {
@@ -73,6 +75,8 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>(
 
     const newProps = {
       vertical,
+      className: classNames(customClassName, carousel?.className),
+      style: { ...carousel?.style, ...style },
       ...props,
     };
 

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -8,6 +8,7 @@ import Badge from '../../badge';
 import Breadcrumb from '../../breadcrumb';
 import Calendar from '../../calendar';
 import Card from '../../card';
+import Carousel from '../../carousel';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
 import Collapse from '../../collapse';
@@ -180,6 +181,41 @@ describe('ConfigProvider support style and className props', () => {
     expect(document.querySelector('.ant-drawer-content')).toHaveStyle(
       'color: red; font-size: 16px;',
     );
+  });
+
+  it('Should Carousel className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        carousel={{
+          className: 'test-class',
+        }}
+      >
+        <Carousel>
+          <div>
+            <h3>test item</h3>
+          </div>
+        </Carousel>
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.slick-slider')).toHaveClass('test-class');
+  });
+
+  it('Should Carousel style works', () => {
+    const { container } = render(
+      <ConfigProvider carousel={{ style: { color: 'red' } }}>
+        <Carousel style={{ fontSize: '16px' }}>
+          <div>
+            <h3>test item 1</h3>
+          </div>
+          <div>
+            <h3>test item 2</h3>
+          </div>
+        </Carousel>
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.slick-slider')).toHaveStyle('color: red; font-size: 16px;');
   });
 
   it('Should Cascader className & style works', () => {

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -100,6 +100,7 @@ export interface ConfigConsumerProps {
   divider?: ComponentStyleConfig;
   drawer?: ComponentStyleConfig;
   calendar?: ComponentStyleConfig;
+  carousel?: ComponentStyleConfig;
   cascader?: ComponentStyleConfig;
   collapse?: ComponentStyleConfig;
   typography?: ComponentStyleConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,6 +109,7 @@ const {
 | button | Set Button common props | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | card | Set Card common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | calendar | Set Calendar common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| carousel | Set Carousel common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | Set Cascader common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | collapse | Set Collapse common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -142,6 +142,7 @@ export interface ConfigProviderProps {
   anchor?: ComponentStyleConfig;
   button?: ButtonConfig;
   calendar?: ComponentStyleConfig;
+  carousel?: ComponentStyleConfig;
   cascader?: ComponentStyleConfig;
   collapse?: ComponentStyleConfig;
   divider?: ComponentStyleConfig;
@@ -274,6 +275,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     segmented,
     spin,
     calendar,
+    carousel,
     cascader,
     collapse,
     typography,
@@ -368,6 +370,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     segmented,
     spin,
     calendar,
+    carousel,
     cascader,
     collapse,
     typography,

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,6 +111,7 @@ const {
 | button | 设置 Button 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: { icon: string }, styles?: { icon: React.CSSProperties } } | - | 5.6.0 |
 | calendar | 设置 Calendar 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | card | 设置 Card 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| carousel | 设置 Carousel 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | cascader | 设置 Cascader 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | collapse | 设置 Collapse 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  ConfigProvider support Carousel className and style properties         |
| 🇨🇳 Chinese | ConfigProvider 支持 Carousel 组件的 className 和 style 属性          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8648316</samp>

The pull request adds a new feature to the `Carousel` component, which allows customizing its container style via `className` and `style` props or the `ConfigProvider` context. It also updates the tests, types, and documentation for the `ConfigProvider` and `Carousel` components accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8648316</samp>

*  Add `className` and `style` props to `Carousel` component to allow customizing the carousel container ([link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbL42-R48), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR78-R79))
*  Apply `className` and `style` props from `ConfigProvider` context to `Carousel` component, enabling global carousel settings ([link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR78-R79), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR103), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R145), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R278), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R373))
*  Document the new `carousel` prop for `ConfigProvider` component in English and Chinese ([link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R112), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R114))
*  Test the style-related features of `Carousel` component in `style.test.tsx` file, using fake timers and `ConfigProvider` context ([link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R11), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R53-R64), [link](https://github.com/ant-design/ant-design/pull/43412/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R198-R232))
