### PR TITLE
type(select): supplementary mode type

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -43,7 +43,7 @@ export interface InternalSelectProps<
   suffixIcon?: React.ReactNode;
   size?: SizeType;
   disabled?: boolean;
-  mode?: 'multiple' | 'tags' | 'SECRET_COMBOBOX_MODE_DO_NOT_USE';
+  mode?: 'multiple' | 'tags' | 'SECRET_COMBOBOX_MODE_DO_NOT_USE' | 'combobox';
   bordered?: boolean;
 }
 
@@ -118,7 +118,7 @@ const InternalSelect = <
   const mode = React.useMemo(() => {
     const { mode: m } = props as InternalSelectProps<OptionType>;
 
-    if ((m as any) === 'combobox') {
+    if (m === 'combobox') {
       return undefined;
     }
 


### PR DESCRIPTION

### 🤔 This is a ...


- [x] TypeScript definition update


### 💡 Background and solution
下面的代码将使用对象解构将 props.mode 的值分配给变量 m, 其实可以补充一下 `combobox` ,感觉比用any好
![image](https://github.com/ant-design/ant-design/assets/117748716/4f135b49-f961-4264-8fe1-e4431d896650)
![image](https://github.com/ant-design/ant-design/assets/117748716/73b91070-5883-4369-a6e4-cf661d7a0e56)

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a12b172</samp>

Enhanced `Select` component to support `'combobox'` mode and improved code quality in `components/select/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a12b172</samp>

* Add a combobox mode to the `Select` component, which combines a single-select and an input box ([link](https://github.com/ant-design/ant-design/pull/43413/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L46-R46), [link](https://github.com/ant-design/ant-design/pull/43413/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L121-R121),                                         F1L243
