### PR TITLE
feat: ConfigProvider support DatePicker & TimePicker className and style properties

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -13,6 +13,7 @@ import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
 import Collapse from '../../collapse';
 import ColorPicker from '../../color-picker';
+import DatePicker from '../../date-picker';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Drawer from '../../drawer';
@@ -44,6 +45,7 @@ import Switch from '../../switch';
 import Table from '../../table';
 import Tabs from '../../tabs';
 import Tag from '../../tag';
+import TimePicker from '../../time-picker';
 import Timeline from '../../timeline';
 import Transfer from '../../transfer';
 import Tree from '../../tree';
@@ -1010,6 +1012,34 @@ describe('ConfigProvider support style and className props', () => {
     expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 
+  it('Should TimePicker className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        timePicker={{
+          className: 'test-class',
+        }}
+      >
+        <TimePicker />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker')).toHaveClass('test-class');
+  });
+
+  it('Should TimePicker style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        timePicker={{
+          style: { color: 'red' },
+        }}
+      >
+        <TimePicker style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker')).toHaveStyle('color: red; font-size: 16px;');
+  });
+
   it('Should message className & style works', () => {
     const Demo: React.FC = () => {
       const [messageApi, contextHolder] = message.useMessage();
@@ -1204,5 +1234,33 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-color-picker-trigger');
     expect(element).toHaveClass('cp-colorPicker');
     expect(element).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  it('Should DatePicker className works', () => {
+    const { container } = render(
+      <ConfigProvider
+        datePicker={{
+          className: 'test-class',
+        }}
+      >
+        <DatePicker />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker')).toHaveClass('test-class');
+  });
+
+  it('Should DatePicker style works', () => {
+    const { container } = render(
+      <ConfigProvider
+        datePicker={{
+          style: { color: 'red' },
+        }}
+      >
+        <DatePicker style={{ fontSize: '16px' }} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker')).toHaveStyle('color: red; font-size: 16px;');
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -136,10 +136,12 @@ export interface ConfigConsumerProps {
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
   timeline?: ComponentStyleConfig;
+  timePicker?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
   colorPicker?: ComponentStyleConfig;
+  datePicker?: ComponentStyleConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -114,6 +114,7 @@ const {
 | checkbox | Set Checkbox common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | collapse | Set Collapse common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | colorPicker | Set ColorPicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| datePicker | Set datePicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | drawer | Set Drawer common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
@@ -146,6 +147,7 @@ const {
 | tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | Set Tag common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | timeline | Set Timeline common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| timePicker | Set TimePicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | transfer | Set Transfer common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -178,10 +178,12 @@ export interface ConfigProviderProps {
   card?: ComponentStyleConfig;
   tabs?: ComponentStyleConfig;
   timeline?: ComponentStyleConfig;
+  timePicker?: ComponentStyleConfig;
   upload?: ComponentStyleConfig;
   notification?: ComponentStyleConfig;
   tree?: ComponentStyleConfig;
   colorPicker?: ComponentStyleConfig;
+  datePicker?: ComponentStyleConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -312,10 +314,12 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     card,
     tabs,
     timeline,
+    timePicker,
     upload,
     notification,
     tree,
     colorPicker,
+    datePicker,
   } = props;
 
   // =================================== Warning ===================================
@@ -408,10 +412,12 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     card,
     tabs,
     timeline,
+    timePicker,
     upload,
     notification,
     tree,
     colorPicker,
+    datePicker,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -116,6 +116,7 @@ const {
 | checkbox | 设置 Checkbox 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | collapse | 设置 Collapse 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | colorPicker | 设置 ColorPicker 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| datePicker | 设置 DatePicker 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | drawer | 设置 Drawer 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
@@ -148,6 +149,7 @@ const {
 | tabs | 设置 Tabs 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tag | 设置 Tag 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | timeline | 设置 Timeline 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| timePicker | 设置 TimePicker 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | transfer | 设置 Transfer 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -37,11 +37,13 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
     picker?: PickerMode,
     displayName?: string,
   ) {
+    const consumerName = displayName === 'TimePicker' ? 'timePicker' : 'datePicker';
     const Picker = forwardRef<DatePickRef<DateType> | CommonPickerMethods, InnerPickerProps>(
       (props, ref) => {
         const {
           prefixCls: customizePrefixCls,
           getPopupContainer: customizeGetPopupContainer,
+          style,
           className,
           rootClassName,
           size: customizeSize,
@@ -55,7 +57,14 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           ...restProps
         } = props;
 
-        const { getPrefixCls, direction, getPopupContainer } = useContext(ConfigContext);
+        const {
+          getPrefixCls,
+          direction,
+          getPopupContainer,
+          // Consume different styles according to different names
+          [consumerName]: consumerStyle,
+        } = useContext(ConfigContext);
+
         const prefixCls = getPrefixCls('picker', customizePrefixCls);
         const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
         const innerRef = React.useRef<RCPicker<DateType>>(null);
@@ -153,9 +162,11 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               ),
               hashId,
               compactItemClassnames,
+              consumerStyle?.className,
               className,
               rootClassName,
             )}
+            style={{ ...consumerStyle?.style, ...style }}
             prefixCls={prefixCls}
             getPopupContainer={customizeGetPopupContainer || getPopupContainer}
             generateConfig={generateConfig}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
- close #43051
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ConfigProvider support DatePicker & TimePicker className and style properties          |
| 🇨🇳 Chinese |  ConfigProvider 支持 DatePicker 和 TimePicker 组件的 className 和 style 属性         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e523eb7</samp>

This pull request adds two new props, `timePicker` and `datePicker`, to the `ConfigProvider` component, which allow users to customize the style and className of the `TimePicker` and `DatePicker` components globally. It updates the documentation, the demo files, and the internal logic of the `generatePicker` functions to support these new props.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e523eb7</samp>

*  Add `timePicker` and `datePicker` props to `ConfigProvider` component to allow setting common style and className props for `TimePicker` and `DatePicker` components ([link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaL135-R140), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L179-R184), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L311-R318), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L405-R414))
*  Update `ConfigProvider` documentation in English and Chinese to describe the new props and their usage ([link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R116), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R148), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R118), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R150))
*  Modify `generateSinglePicker` and `generateRangePicker` functions to consume the style and className props from `ConfigProvider` and apply them to the `Picker` and `RCRangePicker` components ([link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bR26-R27), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL39-R43), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bR49), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL58-R71), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL156-R173), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL186-R201), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34R44), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L56-R57), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L136-R140))
*  Add `ConfigProvider` component to `TimePicker` and `DatePicker` demo files and pass some style and className props to them ([link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-4ab01e142168d67b52a674b8de11e721f5a69f69c11b299eb26c775848ff0b99L2-R2), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-4ab01e142168d67b52a674b8de11e721f5a69f69c11b299eb26c775848ff0b99L10-R14), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-5d7175667bac480675976be1ec06b3e8c89c4919e69bdcc607e08ee591cd51bcL1-R5), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-5d7175667bac480675976be1ec06b3e8c89c4919e69bdcc607e08ee591cd51bcL14-R16))
*  Add test cases to verify that `TimePicker` and `DatePicker` components can receive the style and className props from `ConfigProvider` and that they are applied correctly to the DOM elements ([link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R15), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R47), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R950-R977), [link](https://github.com/ant-design/ant-design/pull/43418/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R1173-R1200))
