### PR TITLE
chore: optimization type & props

### DIFF
--- a/.dumi/theme/builtins/Previewer/index.tsx
+++ b/.dumi/theme/builtins/Previewer/index.tsx
@@ -1,7 +1,6 @@
-import type { FC } from 'react';
-import React from 'react';
 import type { IPreviewerProps } from 'dumi';
 import { useTabMeta } from 'dumi';
+import React from 'react';
 import CodePreviewer from './CodePreviewer';
 import DesignPreviewer from './DesignPreviewer';
 
@@ -9,7 +8,7 @@ export interface AntdPreviewerProps extends IPreviewerProps {
   originDebug?: IPreviewerProps['debug'];
 }
 
-const Previewer: FC<AntdPreviewerProps> = ({ ...props }) => {
+const Previewer: React.FC<AntdPreviewerProps> = (props) => {
   const tab = useTabMeta();
 
   if (tab?.frontmatter.title === 'Design') {

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -14,7 +14,7 @@ export type ThemeSwitchProps = {
   onChange: (value: ThemeName[]) => void;
 };
 
-const ThemeSwitch: React.FC<ThemeSwitchProps> = (props: ThemeSwitchProps) => {
+const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
   const { value = ['light'], onChange } = props;
   const { token } = useSiteToken();
   const { pathname, search } = useLocation();


### PR DESCRIPTION

### 🤔 This is a ...


- [x] Code style optimization



### 💡 Background and solution
1. 并没有对props重新赋值，可以简写
2.  引入 React 但是没用，可以用起来
![image](https://github.com/ant-design/ant-design/assets/117748716/24217f57-5e75-4c58-9a1f-a0ff1cbc226d)


<!--
1. Describe the problem and the scenario.
3. GIF or snapshot should be provided if includes UI/interactive modification.
4. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a82b63</samp>

Improved code style and quality of `Previewer` component in `.dumi/theme/builtins/Previewer/index.tsx` by reordering imports and updating type annotation.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a82b63</samp>

*  Adjust import order to follow ESLint rule `import/order` ([link](https://github.com/ant-design/ant-design/pull/43433/files?diff=unified&w=0#diff-d4c2b096e898ee55c192cd1d13952ec5c5be4c1ff563d0ccaba74d8555e19adaL1-R3))
*  Change type annotation of `Previewer` component from `FC` to `React.FC` and remove unnecessary spread operator on `props` parameter ([link](https://github.com/ant-design/ant-design/pull/43433/files?diff=unified&w=0#diff-d4c2b096e898ee55c192cd1d13952ec5c5be4c1ff563d0ccaba74d8555e19adaL12-R11))
