### PR TITLE
type(Button): remove unnecessary code

### DIFF
--- a/components/button/button-group.tsx
+++ b/components/button/button-group.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { SizeType } from '../config-provider/SizeContext';
 import { useToken } from '../theme/internal';
-import warning from '../_util/warning';
 
 export interface ButtonGroupProps {
   size?: SizeType;
@@ -13,7 +13,7 @@ export interface ButtonGroupProps {
   children?: React.ReactNode;
 }
 
-export const GroupSizeContext = React.createContext<SizeType | undefined>(undefined);
+export const GroupSizeContext = React.createContext<SizeType>(undefined);
 
 const ButtonGroup: React.FC<ButtonGroupProps> = (props) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);


### PR DESCRIPTION

### 🤔 This is a ...

- [x] TypeScript definition update

### 💡 Background and solution
export  SizeType 已经包含了undefined 类型

![image](https://github.com/ant-design/ant-design/assets/117748716/fd3c6ed1-e4ec-4720-84bd-6b230828fd7d)

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e81baf5</samp>

Improve code quality of `button-group.tsx` component. Fix import order and simplify group size context type.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e81baf5</samp>

*  Simplify the type of `GroupSizeContext` to `SizeType` ([link](https://github.com/ant-design/ant-design/pull/43439/files?diff=unified&w=0#diff-10c9160b1ddfa140f8c94f9e1019d992e883eeede7c5babb41a44a92f7fa9650L16-R16)) in `button-group.tsx`
* Adjust the import order of modules in `button-group.tsx` to follow the ESLint rule `import/order` ([link](https://github.com/ant-design/ant-design/pull/43439/files?diff=unified&w=0#diff-10c9160b1ddfa140f8c94f9e1019d992e883eeede7c5babb41a44a92f7fa9650L3-R6))
