### PR TITLE
fix(Descriptions): nested Descriptions are affected by the external border style

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -269,7 +269,7 @@ describe('Descriptions', () => {
     expect(container).toHaveAttribute('aria-describedby', 'some-label');
   });
 
-  it('Descriptions should inherit the size from ConfigProvider if the componentSize is set ', () => {
+  it('Descriptions should inherit the size from ConfigProvider if the componentSize is set', () => {
     const { container } = render(
       <ConfigProvider componentSize="small">
         <Descriptions bordered>
@@ -305,5 +305,19 @@ describe('Descriptions', () => {
     expect(container.querySelector('.ant-descriptions-item')).toBeTruthy();
     expect(container.querySelectorAll('.ant-descriptions-item')).toHaveLength(3);
     expect(container).toMatchSnapshot();
+  });
+
+  it('Descriptions nested within an Item are unaffected by the external borderless style', () => {
+    const { container } = render(
+      <Descriptions bordered>
+        <Descriptions.Item>
+          <Descriptions bordered={false} />
+        </Descriptions.Item>
+      </Descriptions>,
+    );
+
+    const nestDesc = container.querySelectorAll('.ant-descriptions')?.[1];
+    const view = nestDesc.querySelector('.ant-descriptions-view');
+    expect(getComputedStyle(view!).border).toBeFalsy();
   });
 });

--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -44,41 +44,45 @@ const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
   const { componentCls, labelBg } = token;
   return {
     [`&${componentCls}-bordered`]: {
-      [`${componentCls}-view`]: {
+      [`> ${componentCls}-view`]: {
         border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
         '> table': {
           tableLayout: 'auto',
           borderCollapse: 'collapse',
         },
-      },
-      [`${componentCls}-item-label, ${componentCls}-item-content`]: {
-        padding: `${token.padding}px ${token.paddingLG}px`,
-        borderInlineEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
-        '&:last-child': {
-          borderInlineEnd: 'none',
-        },
-      },
-      [`${componentCls}-item-label`]: {
-        color: token.colorTextSecondary,
-        backgroundColor: labelBg,
-        '&::after': {
-          display: 'none',
-        },
-      },
-      [`${componentCls}-row`]: {
-        borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
-        '&:last-child': {
-          borderBottom: 'none',
+        [`${componentCls}-row`]: {
+          borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+          '&:last-child': {
+            borderBottom: 'none',
+          },
+          [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
+            padding: `${token.padding}px ${token.paddingLG}px`,
+            borderInlineEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+            '&:last-child': {
+              borderInlineEnd: 'none',
+            },
+          },
+          [`> ${componentCls}-item-label`]: {
+            color: token.colorTextSecondary,
+            backgroundColor: labelBg,
+            '&::after': {
+              display: 'none',
+            },
+          },
         },
       },
       [`&${componentCls}-middle`]: {
-        [`${componentCls}-item-label, ${componentCls}-item-content`]: {
-          padding: `${token.paddingSM}px ${token.paddingLG}px`,
+        [`${componentCls}-row`]: {
+          [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
+            padding: `${token.paddingSM}px ${token.paddingLG}px`,
+          },
         },
       },
       [`&${componentCls}-small`]: {
-        [`${componentCls}-item-label, ${componentCls}-item-content`]: {
-          padding: `${token.paddingXS}px ${token.padding}px`,
+        [`${componentCls}-row`]: {
+          [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
+            padding: `${token.paddingXS}px ${token.padding}px`,
+          },
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/43446
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix ` Descriptions` nested` Descriptions` are affected by the external border style           |
| 🇨🇳 Chinese | 修复 `Descriptions` 组件嵌套的 `Descriptions` 组件会受到外部边框样式影响          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4611a0</samp>

This pull request adds a new feature to the `Descriptions` component that allows it to have a rimless appearance. It also improves the CSS styling of the bordered and rimless layouts and updates the test file accordingly. The changes affect the files `components/descriptions/index.tsx`, `components/descriptions/style/index.ts`, and `components/descriptions/__tests__/index.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4611a0</samp>

*  Add support for rimless descriptions with `bordered` prop ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR173), [link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L47-R47), [link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L53-R93))
  - Use new class name `${prefixCls}-rimless` to apply different styles to the `Descriptions` component based on the `bordered` prop ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR173))
  - Modify CSS selector for bordered descriptions to target direct child of `${componentCls}-view` and avoid conflicts with rimless descriptions ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L47-R47))
  - Restructure CSS rules for bordered descriptions to nest them under `${componentCls}-row` and add rules for rimless descriptions to unset padding for middle and small sizes ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L53-R93))
* Add test case for nested `Descriptions` components with `bordered` prop ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R282-R295))
  - Check that the `bordered` prop of the parent `Descriptions` component does not affect the nested `Descriptions` components within an `Item` ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R282-R295))
  - Use `components/descriptions/__tests__/index.test.tsx` file to add the test case ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R282-R295))
* Remove extra space at the end of test description for consistency and readability ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0L272-R272))
  - Use `components/descriptions/__tests__/index.test.tsx` file to remove the space ([link](https://github.com/ant-design/ant-design/pull/43454/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0L272-R272))
