### PR TITLE
chore: merge master into feature

### DIFF
--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
 import type { PresetColorType } from '../_util/colors';
-import type { LiteralUnion } from '../_util/type';
-import useStyle from './style';
 import { isPresetColor } from '../_util/colors';
+import type { LiteralUnion } from '../_util/type';
+import { ConfigContext } from '../config-provider';
+import useStyle from './style';
 
 type RibbonPlacement = 'start' | 'end';
 
@@ -18,15 +18,16 @@ export interface RibbonProps {
   placement?: RibbonPlacement;
 }
 
-const Ribbon: React.FC<RibbonProps> = ({
-  className,
-  prefixCls: customizePrefixCls,
-  style,
-  color,
-  children,
-  text,
-  placement = 'end',
-}) => {
+const Ribbon: React.FC<RibbonProps> = (props) => {
+  const {
+    className,
+    prefixCls: customizePrefixCls,
+    style,
+    color,
+    children,
+    text,
+    placement = 'end',
+  } = props;
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('ribbon', customizePrefixCls);
   const colorInPreset = isPresetColor(color, false);

--- a/components/badge/ScrollNumber.tsx
+++ b/components/badge/ScrollNumber.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
 import { cloneElement } from '../_util/reactNode';
+import { ConfigContext } from '../config-provider';
 import SingleNumber from './SingleNumber';
 
 export interface ScrollNumberProps {
@@ -21,75 +21,67 @@ export interface ScrollNumberState {
   count?: string | number | null;
 }
 
-const ScrollNumber = React.forwardRef<HTMLElement, ScrollNumberProps>(
-  (
-    {
-      prefixCls: customizePrefixCls,
-      count,
-      className,
-      motionClassName,
-      style,
-      title,
-      show,
-      component: Component = 'sup',
-      children,
-      ...restProps
-    },
-    ref,
-  ) => {
-    const { getPrefixCls } = React.useContext(ConfigContext);
-    const prefixCls = getPrefixCls('scroll-number', customizePrefixCls);
+const ScrollNumber = React.forwardRef<HTMLElement, ScrollNumberProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    count,
+    className,
+    motionClassName,
+    style,
+    title,
+    show,
+    component: Component = 'sup',
+    children,
+    ...restProps
+  } = props;
+  const { getPrefixCls } = React.useContext(ConfigContext);
+  const prefixCls = getPrefixCls('scroll-number', customizePrefixCls);
 
-    // ============================ Render ============================
-    const newProps = {
-      ...restProps,
-      'data-show': show,
-      style,
-      className: classNames(prefixCls, className, motionClassName),
-      title: title as string,
+  // ============================ Render ============================
+  const newProps = {
+    ...restProps,
+    'data-show': show,
+    style,
+    className: classNames(prefixCls, className, motionClassName),
+    title: title as string,
+  };
+
+  // Only integer need motion
+  let numberNodes: React.ReactNode = count;
+  if (count && Number(count) % 1 === 0) {
+    const numberList = String(count).split('');
+
+    numberNodes = numberList.map((num, i) => (
+      <SingleNumber
+        prefixCls={prefixCls}
+        count={Number(count)}
+        value={num}
+        // eslint-disable-next-line react/no-array-index-key
+        key={numberList.length - i}
+      />
+    ));
+  }
+
+  // allow specify the border
+  // mock border-color by box-shadow for compatible with old usage:
+  // <Badge count={4} style={{ backgroundColor: '#fff', color: '#999', borderColor: '#d9d9d9' }} />
+  if (style && style.borderColor) {
+    newProps.style = {
+      ...style,
+      boxShadow: `0 0 0 1px ${style.borderColor} inset`,
     };
+  }
+  if (children) {
+    return cloneElement(children, (oriProps) => ({
+      className: classNames(`${prefixCls}-custom-component`, oriProps?.className, motionClassName),
+    }));
+  }
 
-    // Only integer need motion
-    let numberNodes: React.ReactNode = count;
-    if (count && Number(count) % 1 === 0) {
-      const numberList = String(count).split('');
-
-      numberNodes = numberList.map((num, i) => (
-        <SingleNumber
-          prefixCls={prefixCls}
-          count={Number(count)}
-          value={num}
-          // eslint-disable-next-line react/no-array-index-key
-          key={numberList.length - i}
-        />
-      ));
-    }
-
-    // allow specify the border
-    // mock border-color by box-shadow for compatible with old usage:
-    // <Badge count={4} style={{ backgroundColor: '#fff', color: '#999', borderColor: '#d9d9d9' }} />
-    if (style && style.borderColor) {
-      newProps.style = {
-        ...style,
-        boxShadow: `0 0 0 1px ${style.borderColor} inset`,
-      };
-    }
-    if (children) {
-      return cloneElement(children, (oriProps) => ({
-        className: classNames(
-          `${prefixCls}-custom-component`,
-          oriProps?.className,
-          motionClassName,
-        ),
-      }));
-    }
-
-    return (
-      <Component {...newProps} ref={ref}>
-        {numberNodes}
-      </Component>
-    );
-  },
-);
+  return (
+    <Component {...newProps} ref={ref}>
+      {numberNodes}
+    </Component>
+  );
+});
 
 export default ScrollNumber;

--- a/components/button/LoadingIcon.tsx
+++ b/components/button/LoadingIcon.tsx
@@ -1,7 +1,7 @@
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
+import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import React, { forwardRef } from 'react';
-import classNames from 'classnames';
 import IconWrapper from './IconWrapper';
 
 type InnerLoadingIconProps = {
@@ -43,13 +43,8 @@ const getRealWidth = (node: HTMLElement): React.CSSProperties => ({
   transform: 'scale(1)',
 });
 
-const LoadingIcon: React.FC<LoadingIconProps> = ({
-  prefixCls,
-  loading,
-  existIcon,
-  className,
-  style,
-}) => {
+const LoadingIcon: React.FC<LoadingIconProps> = (props) => {
+  const { prefixCls, loading, existIcon, className, style } = props;
   const visible = !!loading;
 
   if (existIcon) {

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@rc-component/trigger', () => {
   const h: typeof React = jest.requireActual('react');
 
   return {
-    default: h.forwardRef<unknown, TriggerProps>((props, ref) => {
+    default: h.forwardRef<HTMLElement, TriggerProps>((props, ref) => {
       triggerProps = props;
       return h.createElement(Trigger, { ref, ...props });
     }),

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -19,19 +19,20 @@ export interface CellProps {
   colon?: boolean;
 }
 
-const Cell: React.FC<CellProps> = ({
-  itemPrefixCls,
-  component,
-  span,
-  className,
-  style,
-  labelStyle,
-  contentStyle,
-  bordered,
-  label,
-  content,
-  colon,
-}) => {
+const Cell: React.FC<CellProps> = (props) => {
+  const {
+    itemPrefixCls,
+    component,
+    span,
+    className,
+    style,
+    labelStyle,
+    contentStyle,
+    bordered,
+    label,
+    content,
+    colon,
+  } = props;
   const Component = component as any;
 
   if (bordered) {

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -115,23 +115,28 @@ export interface DescriptionsProps {
   contentStyle?: React.CSSProperties;
 }
 
-function Descriptions({
-  prefixCls: customizePrefixCls,
-  title,
-  extra,
-  column = DEFAULT_COLUMN_MAP,
-  colon = true,
-  bordered,
-  layout,
-  children,
-  className,
-  rootClassName,
-  style,
-  size: customizeSize,
-  labelStyle,
-  contentStyle,
-  ...restProps
-}: DescriptionsProps) {
+type CompoundedComponent = React.FC<DescriptionsProps> & {
+  Item: typeof DescriptionsItem;
+};
+
+const Descriptions: CompoundedComponent = (props) => {
+  const {
+    prefixCls: customizePrefixCls,
+    title,
+    extra,
+    column = DEFAULT_COLUMN_MAP,
+    colon = true,
+    bordered,
+    layout,
+    children,
+    className,
+    rootClassName,
+    style,
+    size: customizeSize,
+    labelStyle,
+    contentStyle,
+    ...restProps
+  } = props;
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('descriptions', customizePrefixCls);
   const [screens, setScreens] = React.useState<ScreenMap>({});
@@ -207,7 +212,7 @@ function Descriptions({
       </div>
     </DescriptionsContext.Provider>,
   );
-}
+};
 
 if (process.env.NODE_ENV !== 'production') {
   Descriptions.displayName = 'Descriptions';

--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@rc-component/trigger', () => {
   const h: typeof React = jest.requireActual('react');
 
   return {
-    default: h.forwardRef<unknown, TriggerProps>((props, ref) => {
+    default: h.forwardRef<HTMLElement, TriggerProps>((props, ref) => {
       triggerProps = props;
       return h.createElement(Trigger, { ref, ...props });
     }),

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -29,103 +29,97 @@ export interface TextAreaRef {
   resizableTextArea?: RcTextAreaRef['resizableTextArea'];
 }
 
-const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
-  (
-    {
-      prefixCls: customizePrefixCls,
-      bordered = true,
-      size: customizeSize,
-      disabled: customDisabled,
-      status: customStatus,
-      allowClear,
-      showCount,
-      classNames: classes,
-      ...rest
+const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    bordered = true,
+    size: customizeSize,
+    disabled: customDisabled,
+    status: customStatus,
+    allowClear,
+    showCount,
+    classNames: classes,
+    ...rest
+  } = props;
+  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+
+  // ===================== Size =====================
+  const mergedSize = useSize(customizeSize);
+
+  // ===================== Disabled =====================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? disabled;
+
+  // ===================== Status =====================
+  const {
+    status: contextStatus,
+    hasFeedback,
+    feedbackIcon,
+  } = React.useContext(FormItemInputContext);
+  const mergedStatus = getMergedStatus(contextStatus, customStatus);
+
+  // ===================== Ref =====================
+  const innerRef = React.useRef<RcTextAreaRef>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    resizableTextArea: innerRef.current?.resizableTextArea,
+    focus: (option?: InputFocusOptions) => {
+      triggerFocus(innerRef.current?.resizableTextArea?.textArea, option);
     },
-    ref,
-  ) => {
-    const { getPrefixCls, direction } = React.useContext(ConfigContext);
+    blur: () => innerRef.current?.blur(),
+  }));
 
-    // ===================== Size =====================
-    const mergedSize = useSize(customizeSize);
+  const prefixCls = getPrefixCls('input', customizePrefixCls);
 
-    // ===================== Disabled =====================
-    const disabled = React.useContext(DisabledContext);
-    const mergedDisabled = customDisabled ?? disabled;
+  // Allow clear
+  let mergedAllowClear: BaseInputProps['allowClear'];
+  if (typeof allowClear === 'object' && allowClear?.clearIcon) {
+    mergedAllowClear = allowClear;
+  } else if (allowClear) {
+    mergedAllowClear = { clearIcon: <CloseCircleFilled /> };
+  }
 
-    // ===================== Status =====================
-    const {
-      status: contextStatus,
-      hasFeedback,
-      feedbackIcon,
-    } = React.useContext(FormItemInputContext);
-    const mergedStatus = getMergedStatus(contextStatus, customStatus);
+  // ===================== Style =====================
+  const [wrapSSR, hashId] = useStyle(prefixCls);
 
-    // ===================== Ref =====================
-    const innerRef = React.useRef<RcTextAreaRef>(null);
-
-    React.useImperativeHandle(ref, () => ({
-      resizableTextArea: innerRef.current?.resizableTextArea,
-      focus: (option?: InputFocusOptions) => {
-        triggerFocus(innerRef.current?.resizableTextArea?.textArea, option);
-      },
-      blur: () => innerRef.current?.blur(),
-    }));
-
-    const prefixCls = getPrefixCls('input', customizePrefixCls);
-
-    // Allow clear
-    let mergedAllowClear: BaseInputProps['allowClear'];
-    if (typeof allowClear === 'object' && allowClear?.clearIcon) {
-      mergedAllowClear = allowClear;
-    } else if (allowClear) {
-      mergedAllowClear = { clearIcon: <CloseCircleFilled /> };
-    }
-
-    // ===================== Style =====================
-    const [wrapSSR, hashId] = useStyle(prefixCls);
-
-    return wrapSSR(
-      <RcTextArea
-        {...rest}
-        disabled={mergedDisabled}
-        allowClear={mergedAllowClear}
-        classes={{
-          affixWrapper: classNames(
-            `${prefixCls}-textarea-affix-wrapper`,
-            {
-              [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
-              [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
-              [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
-              [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
-              [`${prefixCls}-textarea-show-count`]: showCount,
-            },
-            getStatusClassNames(`${prefixCls}-affix-wrapper`, mergedStatus),
-            hashId,
-          ),
-        }}
-        classNames={{
-          ...classes,
-          textarea: classNames(
-            {
-              [`${prefixCls}-borderless`]: !bordered,
-              [`${prefixCls}-sm`]: mergedSize === 'small',
-              [`${prefixCls}-lg`]: mergedSize === 'large',
-            },
-            getStatusClassNames(prefixCls, mergedStatus),
-            hashId,
-            classes?.textarea,
-          ),
-        }}
-        prefixCls={prefixCls}
-        suffix={
-          hasFeedback && <span className={`${prefixCls}-textarea-suffix`}>{feedbackIcon}</span>
-        }
-        showCount={showCount}
-        ref={innerRef}
-      />,
-    );
-  },
-);
+  return wrapSSR(
+    <RcTextArea
+      {...rest}
+      disabled={mergedDisabled}
+      allowClear={mergedAllowClear}
+      classes={{
+        affixWrapper: classNames(
+          `${prefixCls}-textarea-affix-wrapper`,
+          {
+            [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
+            [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
+            [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
+            [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
+            [`${prefixCls}-textarea-show-count`]: showCount,
+          },
+          getStatusClassNames(`${prefixCls}-affix-wrapper`, mergedStatus),
+          hashId,
+        ),
+      }}
+      classNames={{
+        ...classes,
+        textarea: classNames(
+          {
+            [`${prefixCls}-borderless`]: !bordered,
+            [`${prefixCls}-sm`]: mergedSize === 'small',
+            [`${prefixCls}-lg`]: mergedSize === 'large',
+          },
+          getStatusClassNames(prefixCls, mergedStatus),
+          hashId,
+          classes?.textarea,
+        ),
+      }}
+      prefixCls={prefixCls}
+      suffix={hasFeedback && <span className={`${prefixCls}-textarea-suffix`}>{feedbackIcon}</span>}
+      showCount={showCount}
+      ref={innerRef}
+    />,
+  );
+});
 
 export default TextArea;

--- a/components/modal/demo/modal-render.tsx
+++ b/components/modal/demo/modal-render.tsx
@@ -71,6 +71,7 @@ const App: React.FC = () => {
           <Draggable
             disabled={disabled}
             bounds={bounds}
+            nodeRef={draggleRef}
             onStart={(event, uiData) => onStart(event, uiData)}
           >
             <div ref={draggleRef}>{modal}</div>

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -9,7 +9,7 @@ import { cloneElement } from '../_util/reactNode';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
 import { ConfigContext } from '../config-provider';
 import Popover from '../popover';
-import type { AbstractTooltipProps } from '../tooltip';
+import type { AbstractTooltipProps, TooltipRef } from '../tooltip';
 import PurePanel, { Overlay } from './PurePanel';
 import usePopconfirmStyle from './style';
 
@@ -37,7 +37,7 @@ export interface PopconfirmState {
   open?: boolean;
 }
 
-const Popconfirm = React.forwardRef<unknown, PopconfirmProps>((props, ref) => {
+const Popconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     placement = 'top',

--- a/components/popover/PurePanel.tsx
+++ b/components/popover/PurePanel.tsx
@@ -25,7 +25,11 @@ export interface PurePanelProps extends Omit<PopoverProps, 'children'> {
   children?: React.ReactNode;
 }
 
-export function RawPurePanel(props: any) {
+interface RawPurePanelProps extends PopoverProps {
+  hashId: string;
+}
+
+export const RawPurePanel: React.FC<RawPurePanelProps> = (props) => {
   const {
     hashId,
     prefixCls,
@@ -50,13 +54,13 @@ export function RawPurePanel(props: any) {
     >
       <div className={`${prefixCls}-arrow`} />
       <Popup {...props} className={hashId} prefixCls={prefixCls}>
-        {children || getOverlay(prefixCls, title, content)}
+        {children || getOverlay(prefixCls!, title, content)}
       </Popup>
     </div>
   );
-}
+};
 
-export default function PurePanel(props: any) {
+const PurePanel: React.FC<PurePanelProps> = (props) => {
   const { prefixCls: customizePrefixCls, ...restProps } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
 
@@ -64,4 +68,6 @@ export default function PurePanel(props: any) {
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   return wrapSSR(<RawPurePanel {...restProps} prefixCls={prefixCls} hashId={hashId} />);
-}
+};
+
+export default PurePanel;

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -4,7 +4,7 @@ import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
 import { ConfigContext } from '../config-provider';
-import type { AbstractTooltipProps } from '../tooltip';
+import type { AbstractTooltipProps, TooltipRef } from '../tooltip';
 import Tooltip from '../tooltip';
 import PurePanel from './PurePanel';
 // CSSINJS
@@ -28,7 +28,7 @@ const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => (
   </>
 );
 
-const Popover = React.forwardRef<unknown, PopoverProps>((props, ref) => {
+const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     title,

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -10,6 +10,7 @@ import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { CSSProperties } from 'react';
 import * as React from 'react';
 import type { PresetColorType } from '../_util/colors';
+import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
 import type { AdjustOverflow, PlacementsConfig } from '../_util/placements';
 import getPlacements from '../_util/placements';
@@ -109,8 +110,6 @@ export interface AbstractTooltipProps extends LegacyTooltipProps {
   children?: React.ReactNode;
   destroyTooltipOnHide?: boolean | { keepParent?: boolean };
 }
-
-export type RenderFunction = () => React.ReactNode;
 
 export interface TooltipPropsWithOverlay extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
+import warning from '../_util/warning';
 import type { DirectionType } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import warning from '../_util/warning';
 import useStyle from './style';
 
 export interface TypographyProps<C extends keyof JSX.IntrinsicElements>
@@ -29,53 +29,49 @@ interface InternalTypographyProps<C extends keyof JSX.IntrinsicElements>
 const Typography = React.forwardRef<
   HTMLElement,
   InternalTypographyProps<keyof JSX.IntrinsicElements>
->(
-  (
+>((props, ref) => {
+  const {
+    prefixCls: customizePrefixCls,
+    component: Component = 'article',
+    className,
+    rootClassName,
+    setContentRef,
+    children,
+    direction: typographyDirection,
+    ...restProps
+  } = props;
+  const { getPrefixCls, direction: contextDirection } = React.useContext(ConfigContext);
+
+  const direction = typographyDirection ?? contextDirection;
+
+  let mergedRef = ref;
+  if (setContentRef) {
+    warning(false, 'Typography', '`setContentRef` is deprecated. Please use `ref` instead.');
+    mergedRef = composeRef(ref, setContentRef);
+  }
+
+  const prefixCls = getPrefixCls('typography', customizePrefixCls);
+
+  // Style
+  const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const componentClassName = classNames(
+    prefixCls,
     {
-      prefixCls: customizePrefixCls,
-      component: Component = 'article',
-      className,
-      rootClassName,
-      setContentRef,
-      children,
-      direction: typographyDirection,
-      ...restProps
+      [`${prefixCls}-rtl`]: direction === 'rtl',
     },
-    ref,
-  ) => {
-    const { getPrefixCls, direction: contextDirection } = React.useContext(ConfigContext);
+    className,
+    rootClassName,
+    hashId,
+  );
 
-    const direction = typographyDirection ?? contextDirection;
-
-    let mergedRef = ref;
-    if (setContentRef) {
-      warning(false, 'Typography', '`setContentRef` is deprecated. Please use `ref` instead.');
-      mergedRef = composeRef(ref, setContentRef);
-    }
-
-    const prefixCls = getPrefixCls('typography', customizePrefixCls);
-
-    // Style
-    const [wrapSSR, hashId] = useStyle(prefixCls);
-
-    const componentClassName = classNames(
-      prefixCls,
-      {
-        [`${prefixCls}-rtl`]: direction === 'rtl',
-      },
-      className,
-      rootClassName,
-      hashId,
-    );
-
-    return wrapSSR(
-      // @ts-expect-error: Expression produces a union type that is too complex to represent.
-      <Component className={componentClassName} ref={mergedRef} {...restProps}>
-        {children}
-      </Component>,
-    );
-  },
-);
+  return wrapSSR(
+    // @ts-expect-error: Expression produces a union type that is too complex to represent.
+    <Component className={componentClassName} ref={mergedRef} {...restProps}>
+      {children}
+    </Component>,
+  );
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Typography.displayName = 'Typography';

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "stylelint": "^15.1.0",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^34.0.0",
-    "stylelint-prettier": "^3.0.0",
+    "stylelint-prettier": "^4.0.0",
     "sylvanas": "^0.6.1",
     "terser": "^5.16.1",
     "ts-node": "^10.8.2",

--- a/tests/__mocks__/@rc-component/trigger.tsx
+++ b/tests/__mocks__/@rc-component/trigger.tsx
@@ -1,4 +1,4 @@
-import type { TriggerProps } from '@rc-component/trigger';
+import type { TriggerProps, TriggerRef } from '@rc-component/trigger';
 import MockTrigger from '@rc-component/trigger/lib/mock';
 import * as React from 'react';
 import { TriggerMockContext } from '../../shared/demoTestContext';
@@ -6,22 +6,21 @@ import { TriggerMockContext } from '../../shared/demoTestContext';
 let OriginTrigger = jest.requireActual('@rc-component/trigger');
 OriginTrigger = OriginTrigger.default ?? OriginTrigger;
 
-const ForwardTrigger = React.forwardRef<any, TriggerProps>((props, ref) => {
+const ForwardTrigger = React.forwardRef<TriggerRef, TriggerProps>((props, ref) => {
   const context = React.useContext(TriggerMockContext);
 
   const mergedPopupVisible = context?.popupVisible ?? props.popupVisible;
   (global as any).triggerProps = props;
 
-  const mergedProps = {
+  const mergedProps: TriggerProps = {
     ...props,
-    ref,
-    popupVisible: mergedPopupVisible as boolean,
+    popupVisible: mergedPopupVisible,
   };
 
   if (context?.mock === false) {
-    return <OriginTrigger {...mergedProps} />;
+    return <OriginTrigger ref={ref} {...mergedProps} />;
   }
-  return <MockTrigger {...mergedProps} />;
+  return <MockTrigger ref={ref} {...mergedProps} />;
 });
 
 export default ForwardTrigger;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: merge master into feature |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e47a76</samp>

This pull request refactors several components in the `badge`, `button`, `descriptions`, `modal`, `popconfirm`, `popover`, `tooltip`, `date-picker`, `dropdown`, and `input` modules to improve code style, readability, and type safety. It also updates the `stylelint-prettier` dependency and fixes some React warnings and type errors in the tests and demos.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e47a76</samp>

*  Sort import statements alphabetically in several files to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-14f85870e2c911caa9b080f35767efa029c02b5ecf4118b487c75145b7554f09L3-R7), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-f21667e40fab95c6faf03e2fa7cda583c6793be192eeea8c5855515d3d3cff21L3-R4), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-2107ebf32abbf181377ff77c8318c01ab12c098f9276fa74c6d8ea4956f3c33dL2-R4), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-809373ca4d89e35286dbd5d0aa3b26e07e7211e45de8dd0dc171d31b9f778730L1-R2))
*  Destructure props in a separate line in several components to improve readability and consistency ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-14f85870e2c911caa9b080f35767efa029c02b5ecf4118b487c75145b7554f09L21-R30), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-f21667e40fab95c6faf03e2fa7cda583c6793be192eeea8c5855515d3d3cff21L24-R85), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-2107ebf32abbf181377ff77c8318c01ab12c098f9276fa74c6d8ea4956f3c33dL46-R47), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-a5d44f830f82f98732efaf0941e3f256349080a2ff3d86b944f8d185810c48afL22-R35), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L32-R123))
*  Change the type of the `ref` parameter in the `forwardRef` function from `unknown` to a specific type in several files to match the type of the `ref` prop in the corresponding component ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-7fdce5d71fac3793bf16cbc035559eeb8d5565c0db96d0b9399b5265a8c471b4L24-R24), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-a5e933ff15a7392fe4b00b0eb3b62fc823173b3ec9c87dda164f0e03488cf738L18-R18), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L12-R12), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-36878e30875e0d3ac3e1c9a9d6bebbcb023b8197cddd259fb7bc00976d795285L40-R40), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L7-R7), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L31-R31), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-1ee49fb90f67d3f2711176bd471e7171ddac4985b89bc5bd952576e1b8542b83L1-R1), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-1ee49fb90f67d3f2711176bd471e7171ddac4985b89bc5bd952576e1b8542b83L9-R9))
*  Add the `CompoundedComponent` interface to `components/descriptions/index.tsx` to declare the type of the `Descriptions` component that has a static `Item` property ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR95-R98))
*  Change the `Descriptions` component from a function declaration to a function expression with the `CompoundedComponent` type and assign it to a constant in `components/descriptions/index.tsx` to avoid hoisting issues and to explicitly assign the type of the component ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL112-R133))
*  Add a semicolon to the end of the `Descriptions` function expression in `components/descriptions/index.tsx` to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL205-R210))
*  Add the `nodeRef` prop to the `Draggable` component in `components/modal/demo/modal-render.tsx` to pass the ref of the drag handle element and fix a warning from React about using `findDOMNode` on a function component ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-809373ca4d89e35286dbd5d0aa3b26e07e7211e45de8dd0dc171d31b9f778730R74))
*  Add the `RawPurePanelProps` interface to `components/popover/PurePanel.tsx` to declare the type of the props of the `RawPurePanel` component ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L28-R32))
*  Change the `RawPurePanel` and `PurePanel` components from function declarations to function expressions with the corresponding prop types and assign them to constants in `components/popover/PurePanel.tsx` to avoid hoisting issues and to explicitly assign the types of the components and their props ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L28-R32), [link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L53-R63))
*  Add a non-null assertion operator to the `prefixCls` prop in the `getOverlay` function call in `components/popover/PurePanel.tsx` to avoid a TypeScript error ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L53-R63))
*  Add semicolons to the end of the `RawPurePanel` and `PurePanel` function expressions in `components/popover/PurePanel.tsx` to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L67-R73))
*  Export the `PurePanel` component as the default export at the end of `components/popover/PurePanel.tsx` to follow code style convention ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-886f99db030d39d3800e518bae5901505e8b61e0949c76246b64130e991a5416L67-R73))
*  Import the `RenderFunction` type from `components/_util/getRenderPropValue` in `components/tooltip/index.tsx` to use it as the type of the `title` and `overlay` props in the `AbstractTooltipProps` interface ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966R13))
*  Remove the redundant `RenderFunction` type declaration from `components/tooltip/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966L113-L114))
*  Update the version of the `stylelint-prettier` dependency from `3.0.0` to `4.0.0` in `package.json` to use the latest version with bug fixes and improvements ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L294-R294))
*  Cast the `popupVisible` prop to a boolean in the `mergedProps` object in `tests/__mocks__/@rc-component/trigger.tsx` to avoid a TypeScript error ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-1ee49fb90f67d3f2711176bd471e7171ddac4985b89bc5bd952576e1b8542b83L15-R23))
*  Add the `ref` prop to the `OriginTrigger` and `MockTrigger` components in `tests/__mocks__/@rc-component/trigger.tsx` to pass the ref from the `forwardRef` function ([link](https://github.com/ant-design/ant-design/pull/43459/files?diff=unified&w=0#diff-1ee49fb90f67d3f2711176bd471e7171ddac4985b89bc5bd952576e1b8542b83L15-R23))
