### PR TITLE
chore: code style optimization

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -51,7 +51,10 @@ export interface CheckboxProps extends AbstractCheckboxProps<CheckboxChangeEvent
 }
 
 const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProps> = (
-  {
+  props,
+  ref,
+) => {
+  const {
     prefixCls: customizePrefixCls,
     className,
     rootClassName,
@@ -63,9 +66,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     skipGroup = false,
     disabled,
     ...restProps
-  },
-  ref,
-) => {
+  } = props;
   const { getPrefixCls, direction, checkbox } = React.useContext(ConfigContext);
   const checkboxGroup = React.useContext(GroupContext);
   const { isFormItemInput } = React.useContext(FormItemInputContext);

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -13,14 +13,15 @@ export interface CompositionImage<P> extends React.FC<P> {
   PreviewGroup: typeof PreviewGroup;
 }
 
-const Image: CompositionImage<ImageProps> = ({
-  prefixCls: customizePrefixCls,
-  preview,
-  className,
-  rootClassName,
-  style,
-  ...otherProps
-}) => {
+const Image: CompositionImage<ImageProps> = (props) => {
+  const {
+    prefixCls: customizePrefixCls,
+    preview,
+    className,
+    rootClassName,
+    style,
+    ...otherProps
+  } = props;
   const {
     getPrefixCls,
     locale: contextLocale = defaultLocale,

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -64,7 +64,10 @@ type CompoundedComponent = React.ForwardRefExoticComponent<
 };
 
 const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps> = (
-  {
+  props,
+  ref,
+) => {
+  const {
     prefixCls: customizePrefixCls,
     className,
     rootClassName,
@@ -78,9 +81,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
     popupClassName,
     style,
     ...restProps
-  },
-  ref,
-) => {
+  } = props;
   const [focused, setFocused] = React.useState(false);
   const innerRef = React.useRef<MentionsRef>(null);
   const mergedRef = composeRef(ref, innerRef);

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -34,19 +34,20 @@ export interface PaginationConfig extends Omit<PaginationProps, 'rootClassName'>
 
 export type { PaginationLocale };
 
-const Pagination: React.FC<PaginationProps> = ({
-  prefixCls: customizePrefixCls,
-  selectPrefixCls: customizeSelectPrefixCls,
-  className,
-  rootClassName,
-  style,
-  size: customizeSize,
-  locale: customLocale,
-  selectComponentClass,
-  responsive,
-  showSizeChanger,
-  ...restProps
-}) => {
+const Pagination: React.FC<PaginationProps> = (props) => {
+  const {
+    prefixCls: customizePrefixCls,
+    selectPrefixCls: customizeSelectPrefixCls,
+    className,
+    rootClassName,
+    style,
+    size: customizeSize,
+    locale: customLocale,
+    selectComponentClass,
+    responsive,
+    showSizeChanger,
+    ...restProps
+  } = props;
   const { xs } = useBreakpoint(responsive);
 
   const { getPrefixCls, direction, pagination = {} } = React.useContext(ConfigContext);

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -3,10 +3,10 @@ import classNames from 'classnames';
 import type { AutoSizeType } from 'rc-textarea';
 import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
-import type { DirectionType } from '../config-provider';
-import TextArea from '../input/TextArea';
-import type { TextAreaRef } from '../input/TextArea';
 import { cloneElement } from '../_util/reactNode';
+import type { DirectionType } from '../config-provider';
+import type { TextAreaRef } from '../input/TextArea';
+import TextArea from '../input/TextArea';
 import useStyle from './style';
 
 interface EditableProps {
@@ -25,21 +25,22 @@ interface EditableProps {
   component?: string;
 }
 
-const Editable: React.FC<EditableProps> = ({
-  prefixCls,
-  'aria-label': ariaLabel,
-  className,
-  style,
-  direction,
-  maxLength,
-  autoSize = true,
-  value,
-  onSave,
-  onCancel,
-  onEnd,
-  component,
-  enterIcon = <EnterOutlined />,
-}) => {
+const Editable: React.FC<EditableProps> = (props) => {
+  const {
+    prefixCls,
+    'aria-label': ariaLabel,
+    className,
+    style,
+    direction,
+    maxLength,
+    autoSize = true,
+    value,
+    onSave,
+    onCancel,
+    onEnd,
+    component,
+    enterIcon = <EnterOutlined />,
+  } = props;
   const ref = React.useRef<TextAreaRef>(null);
 
   const inComposition = React.useRef(false);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       code style optimization    |
| 🇨🇳 Chinese |       代码风格优化    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e8b1a7</samp>

This pull request refactors several components to use a single `props` parameter instead of destructuring the props in the function signature. This improves code consistency and avoids ref conflicts. The affected components are `Checkbox`, `CheckboxGroup`, `Mentions`, `Editable`, `Image`, and `Pagination`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e8b1a7</samp>

*  Use a single `props` parameter for component interfaces to avoid conflicts with `ref` and improve consistency ([link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L54-R57), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L40-R43), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-6755d2dc445a769167d64d5ff481db516522d39820a68d34bd5476f2b8cc5e05L16-R25), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L67-R70), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352L37-R50), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7L28-R43))
*  Destructure the `props` parameter inside the component function bodies to access the relevant props ([link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L66-R69), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L50-R53), [link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-70d5a1401a2836d63ffd091fbcd5e9f43de05c2f404265a51a366862e1e157b6L81-R84))
*  Reorder the imports of `Editable.tsx` to follow the convention of types, components, and hooks ([link](https://github.com/ant-design/ant-design/pull/43475/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7L6-R9))
