### PR TITLE
feat(range-picker): preset value support callback function

### DIFF
--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -32580,6 +32580,13 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
             >
               <ul>
                 <li>
+                  <span
+                    aria-label="Current Time to End of Day"
+                  >
+                    Now ~ EOD
+                  </span>
+                </li>
+                <li>
                   Last 7 Days
                 </li>
                 <li>

--- a/components/date-picker/__tests__/__snapshots__/other.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/other.test.tsx.snap
@@ -436,7 +436,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                 </thead>
                 <tbody>
                   <tr
-                    class="ant-picker-week-panel-row ant-picker-week-panel-row-selected"
+                    class="ant-picker-week-panel-row"
                   >
                     <td
                       class="ant-picker-cell ant-picker-cell-week"

--- a/components/date-picker/demo/preset-ranges.md
+++ b/components/date-picker/demo/preset-ranges.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-可以预设常用的日期范围以提高用户体验。
+可以预设常用的日期范围以提高用户体验。自 `5.7.0` 开始，value 支持回调函数返回值方式。
 
 ## en-US
 
-We can set preset ranges to RangePicker to improve user experience.
+We can set preset ranges to RangePicker to improve user experience. Since `5.7.0`, the `value` prop supports callback function.

--- a/components/date-picker/demo/preset-ranges.md
+++ b/components/date-picker/demo/preset-ranges.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-可以预设常用的日期范围以提高用户体验。自 `5.7.0` 开始，value 支持回调函数返回值方式。
+可以预设常用的日期范围以提高用户体验。自 `5.7.0` 开始，preset value 支持回调函数返回值方式。
 
 ## en-US
 
-We can set preset ranges to RangePicker to improve user experience. Since `5.7.0`, the `value` prop supports callback function.
+We can set preset ranges to RangePicker to improve user experience. Since `5.7.0`, preset value supports callback function.

--- a/components/date-picker/demo/preset-ranges.md
+++ b/components/date-picker/demo/preset-ranges.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-可以预设常用的日期范围以提高用户体验。自 `5.7.0` 开始，preset value 支持回调函数返回值方式。
+可以预设常用的日期范围以提高用户体验。自 `5.8.0` 开始，preset value 支持回调函数返回值方式。
 
 ## en-US
 
-We can set preset ranges to RangePicker to improve user experience. Since `5.7.0`, preset value supports callback function.
+We can set preset ranges to RangePicker to improve user experience. Since `5.8.0`, preset value supports callback function.

--- a/components/date-picker/demo/preset-ranges.tsx
+++ b/components/date-picker/demo/preset-ranges.tsx
@@ -44,7 +44,7 @@ const App: React.FC = () => (
       presets={[
         {
           label: <span aria-label="Current Time to End of Day">Now ~ EOD</span>,
-          value: () => [dayjs(), dayjs().endOf('day')], // 5.7.0+ support function
+          value: () => [dayjs(), dayjs().endOf('day')], // 5.8.0+ support function
         },
         ...rangePresets,
       ]}

--- a/components/date-picker/demo/preset-ranges.tsx
+++ b/components/date-picker/demo/preset-ranges.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DatePicker, Space } from 'antd';
 import dayjs from 'dayjs';
+import type { TimeRangePickerProps } from 'antd';
 import type { Dayjs } from 'dayjs';
 
 const { RangePicker } = DatePicker;
@@ -21,10 +22,7 @@ const onRangeChange = (dates: null | (Dayjs | null)[], dateStrings: string[]) =>
   }
 };
 
-const rangePresets: {
-  label: string;
-  value: [Dayjs, Dayjs];
-}[] = [
+const rangePresets: TimeRangePickerProps['presets'] = [
   { label: 'Last 7 Days', value: [dayjs().add(-7, 'd'), dayjs()] },
   { label: 'Last 14 Days', value: [dayjs().add(-14, 'd'), dayjs()] },
   { label: 'Last 30 Days', value: [dayjs().add(-30, 'd'), dayjs()] },
@@ -43,7 +41,13 @@ const App: React.FC = () => (
     />
     <RangePicker presets={rangePresets} onChange={onRangeChange} />
     <RangePicker
-      presets={rangePresets}
+      presets={[
+        {
+          label: <span aria-label="Current Time to End of Day">Now ~ EOD</span>,
+          value: () => [dayjs(), dayjs().endOf('day')], // 5.7.0+ support function
+        },
+        ...rangePresets,
+      ]}
       showTime
       format="YYYY/MM/DD HH:mm:ss"
       onChange={onRangeChange}

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -99,7 +99,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | placeholder | The placeholder of date input | string \| \[string,string] | - |  |
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | To customize the style of the popup calendar | CSSProperties | {} |  |
-| presets | The preset ranges for quick selection | { label: React.ReactNode, value: [dayjs](https://day.js.org/) }[] | - |  |
+| presets | The preset ranges for quick selection | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | prevIcon | The custom prev icon | ReactNode | - | 4.17.0 |
 | size | To determine the size of the input box, the height of `large` and `small`, are 40px and 24px respectively, while default size is 32px | `large` \| `middle` \| `small` | - |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
@@ -193,7 +193,7 @@ Added in `4.1.0`.
 | disabled | If disable start or end | \[boolean, boolean] | - |  |
 | disabledTime | To specify the time that cannot be selected | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | The preset ranges for quick selection | { label: React.ReactNode, value: [dayjs](https://day.js.org/)\[] }[] | - |  |
+| presets | The preset ranges for quick selection | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
 | separator | Set separator between inputs | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | To provide an additional time selection | object \| boolean | [TimePicker Options](/components/time-picker/#api) |  |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -99,7 +99,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | placeholder | The placeholder of date input | string \| \[string,string] | - |  |
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | To customize the style of the popup calendar | CSSProperties | {} |  |
-| presets | The preset ranges for quick selection | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
+| presets | The preset ranges for quick selection, Since `5.7.0`, preset value supports callback function. | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | prevIcon | The custom prev icon | ReactNode | - | 4.17.0 |
 | size | To determine the size of the input box, the height of `large` and `small`, are 40px and 24px respectively, while default size is 32px | `large` \| `middle` \| `small` | - |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
@@ -193,7 +193,7 @@ Added in `4.1.0`.
 | disabled | If disable start or end | \[boolean, boolean] | - |  |
 | disabledTime | To specify the time that cannot be selected | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | The preset ranges for quick selection | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
+| presets | The preset ranges for quick selection, Since `5.7.0`, preset value supports callback function. | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
 | separator | Set separator between inputs | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | To provide an additional time selection | object \| boolean | [TimePicker Options](/components/time-picker/#api) |  |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -99,7 +99,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | placeholder | The placeholder of date input | string \| \[string,string] | - |  |
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | To customize the style of the popup calendar | CSSProperties | {} |  |
-| presets | The preset ranges for quick selection, Since `5.7.0`, preset value supports callback function. | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
+| presets | The preset ranges for quick selection, Since `5.8.0`, preset value supports callback function. | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | prevIcon | The custom prev icon | ReactNode | - | 4.17.0 |
 | size | To determine the size of the input box, the height of `large` and `small`, are 40px and 24px respectively, while default size is 32px | `large` \| `middle` \| `small` | - |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
@@ -193,7 +193,7 @@ Added in `4.1.0`.
 | disabled | If disable start or end | \[boolean, boolean] | - |  |
 | disabledTime | To specify the time that cannot be selected | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | The preset ranges for quick selection, Since `5.7.0`, preset value supports callback function. | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
+| presets | The preset ranges for quick selection, Since `5.8.0`, preset value supports callback function. | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
 | separator | Set separator between inputs | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | To provide an additional time selection | object \| boolean | [TimePicker Options](/components/time-picker/#api) |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -101,7 +101,7 @@ import locale from 'antd/locale/zh_CN';
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | 额外的弹出日历样式 | CSSProperties | {} |  |
 | prevIcon | 自定义上一个图标 | ReactNode | - | 4.17.0 |
-| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: [dayjs](https://day.js.org/) }[] | - |  |
+| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | size | 输入框大小，`large` 高度为 40px，`small` 为 24px，默认是 32px | `large` \| `middle` \| `small` | - |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | style | 自定义输入框样式 | CSSProperties | {} |  |
@@ -194,7 +194,7 @@ import locale from 'antd/locale/zh_CN';
 | disabled | 禁用起始项 | \[boolean, boolean] | - |  |
 | disabledTime | 不可选择的时间 | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: [dayjs](https://day.js.org/)\[] }[] | - |  |
+| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
 | separator | 设置分隔符 | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker-cn#api) |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -101,7 +101,7 @@ import locale from 'antd/locale/zh_CN';
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | 额外的弹出日历样式 | CSSProperties | {} |  |
 | prevIcon | 自定义上一个图标 | ReactNode | - | 4.17.0 |
-| presets | 预设时间范围快捷选择, 自 `5.7.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
+| presets | 预设时间范围快捷选择, 自 `5.8.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | size | 输入框大小，`large` 高度为 40px，`small` 为 24px，默认是 32px | `large` \| `middle` \| `small` | - |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | style | 自定义输入框样式 | CSSProperties | {} |  |
@@ -194,7 +194,7 @@ import locale from 'antd/locale/zh_CN';
 | disabled | 禁用起始项 | \[boolean, boolean] | - |  |
 | disabledTime | 不可选择的时间 | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | 预设时间范围快捷选择，自 `5.7.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
+| presets | 预设时间范围快捷选择，自 `5.8.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
 | separator | 设置分隔符 | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker-cn#api) |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -101,7 +101,7 @@ import locale from 'antd/locale/zh_CN';
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  |
 | popupStyle | 额外的弹出日历样式 | CSSProperties | {} |  |
 | prevIcon | 自定义上一个图标 | ReactNode | - | 4.17.0 |
-| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
+| presets | 预设时间范围快捷选择, 自 `5.7.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: Dayjs \| (() => Dayjs) }\[] | - |  |
 | size | 输入框大小，`large` 高度为 40px，`small` 为 24px，默认是 32px | `large` \| `middle` \| `small` | - |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | style | 自定义输入框样式 | CSSProperties | {} |  |
@@ -194,7 +194,7 @@ import locale from 'antd/locale/zh_CN';
 | disabled | 禁用起始项 | \[boolean, boolean] | - |  |
 | disabledTime | 不可选择的时间 | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | 预设时间范围快捷选择 | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
+| presets | 预设时间范围快捷选择，自 `5.7.0` 起 value 支持函数返回值 | { label: React.ReactNode, value: (Dayjs \| (() => Dayjs))\[] }\[] | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
 | separator | 设置分隔符 | React.ReactNode | `<SwapRightOutlined />` |  |
 | showTime | 增加时间选择功能 | Object\|boolean | [TimePicker Options](/components/time-picker-cn#api) |  |

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rc-motion": "^2.7.3",
     "rc-notification": "~5.0.4",
     "rc-pagination": "~3.5.0",
-    "rc-picker": "~3.10.0",
+    "rc-picker": "~3.11.0",
     "rc-progress": "~3.4.1",
     "rc-rate": "~2.12.0",
     "rc-resize-observer": "^1.2.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolved: #43203

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    `<RangePicker />` presets support callback functions      |
| 🇨🇳 Chinese |   `<RangePicker />` 预设值支持回调函数        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41a37c9</samp>

This pull request enhances the `date-picker` and `RangePicker` components by allowing functions as values for the `presets` prop. It also updates the documentation and the dependency version of `rc-picker` accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41a37c9</samp>

*  Update `rc-picker` dependency version to use new feature of presets as functions ([link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L140-R140))
*  Import `TimeRangePickerProps` type from `antd` and use it for `rangePresets` variable in `preset-ranges.tsx` demo ([link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-47941b53aa1e36cc618ac5f7c0125bf5d4e35cba5554d6270aef2f6335771e7dR4), [link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-47941b53aa1e36cc618ac5f7c0125bf5d4e35cba5554d6270aef2f6335771e7dL24-R25))
*  Add new preset option for current time to end of day in second `RangePicker` component in `preset-ranges.tsx` demo ([link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-47941b53aa1e36cc618ac5f7c0125bf5d4e35cba5554d6270aef2f6335771e7dL46-R51))
*  Update documentation of `presets` prop in English and Chinese versions of `date-picker` component to reflect new feature and use `Dayjs` type ([link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-278af64bde59169ca85bf2d7df8a110094a7c153d88b5277c1614c365e65b910L102-R102), [link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-278af64bde59169ca85bf2d7df8a110094a7c153d88b5277c1614c365e65b910L196-R196), [link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-4f6ca776b129678ab875461618596d96f83d09613799c0180d0489e7486f0cdeL104-R104), [link](https://github.com/ant-design/ant-design/pull/43476/files?diff=unified&w=0#diff-4f6ca776b129678ab875461618596d96f83d09613799c0180d0489e7486f0cdeL197-R197))
