### PR TITLE
fix: `ConfigProvider` form validateMessages nesting error

### DIFF
--- a/components/config-provider/__tests__/form.test.tsx
+++ b/components/config-provider/__tests__/form.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import type { ValidateMessages } from 'rc-field-form/es/interface';
 import ConfigProvider from '..';
 import { render } from '../../../tests/utils';
 import type { FormInstance } from '../../form';
 import Form from '../../form';
+import Button from '../../button';
 import Input from '../../input';
+import InputNumber from '../../input-number';
 import zhCN from '../../locale/zh_CN';
 
 describe('ConfigProvider.Form', () => {
@@ -81,6 +84,105 @@ describe('ConfigProvider.Form', () => {
 
       expect(explains[0]).toHaveTextContent('必须');
       expect(explains[explains.length - 1]).toHaveTextContent('年龄必须等于17');
+    });
+
+    // copied: https://github.com/ant-design/ant-design/blob/5ce9818401f976fcb665eff2a48e5f05d17acf39/components/config-provider/__tests__/form.test.tsx#L99-L150
+    it('nested description should use the default value of this warehouse first', async () => {
+      const validateMessages: ValidateMessages = {
+        number: {
+          // eslint-disable-next-line no-template-curly-in-string
+          max: '${label} 最大值为 ${max}',
+          /**
+           * Intentionally not filling `range` to test default message
+           * default: https://github.com/ant-design/ant-design/blob/12596a06f2ff88d8a27e72f6f9bac7c63a0b2ece/components/locale/en_US.ts#L123
+           */
+          // range:
+        },
+      };
+
+      const formRef = React.createRef<FormInstance>();
+      const { container } = render(
+        <ConfigProvider form={{ validateMessages }}>
+          <Form ref={formRef} initialValues={{ age: 1, rate: 6 }}>
+            <Form.Item name="rate" rules={[{ type: 'number', max: 5 }]}>
+              <InputNumber />
+            </Form.Item>
+            <Form.Item name="age" rules={[{ type: 'number', max: 99, min: 18 }]}>
+              <InputNumber />
+            </Form.Item>
+          </Form>
+        </ConfigProvider>,
+      );
+
+      await act(async () => {
+        try {
+          await formRef.current?.validateFields();
+        } catch (e) {
+          // Do nothing
+        }
+      });
+
+      await act(async () => {
+        jest.runAllTimers();
+        await Promise.resolve();
+      });
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(container.querySelectorAll('.ant-form-item-explain')).toHaveLength(2);
+      expect(container.querySelectorAll('.ant-form-item-explain')[0]).toHaveTextContent(
+        'rate 最大值为 5',
+      );
+      expect(container.querySelectorAll('.ant-form-item-explain')[1]).toHaveTextContent(
+        'age must be between 18-99',
+      );
+    });
+
+    // https://github.com/ant-design/ant-design/issues/43210
+    it('should merge parent ConfigProvider validateMessages', async () => {
+      const MyForm = () => (
+        <Form>
+          <Form.Item name="name" label="Name" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Button type="primary" htmlType="submit">
+            Submit
+          </Button>
+        </Form>
+      );
+
+      const { container, getAllByRole, getAllByText } = render(
+        <ConfigProvider>
+          <MyForm />
+          <ConfigProvider form={{ validateMessages: { required: 'Required' } }}>
+            <MyForm />
+            <ConfigProvider>
+              <MyForm />
+            </ConfigProvider>
+          </ConfigProvider>
+        </ConfigProvider>,
+      );
+
+      const submitButtons = getAllByRole('button');
+      expect(submitButtons).toHaveLength(3);
+      submitButtons.forEach((button) => {
+        button.click();
+      });
+
+      await act(async () => {
+        jest.runAllTimers();
+        await Promise.resolve();
+      });
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(container.querySelectorAll('.ant-form-item-explain-error')).toHaveLength(3);
+      expect(getAllByText('Please enter Name')).toHaveLength(1);
+      expect(getAllByText('Required')).toHaveLength(2);
     });
   });
 

--- a/components/config-provider/__tests__/form.test.tsx
+++ b/components/config-provider/__tests__/form.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import type { ValidateMessages } from 'rc-field-form/es/interface';
 import ConfigProvider from '..';
-import { render } from '../../../tests/utils';
+import { render, waitFakeTimer, fireEvent } from '../../../tests/utils';
 import type { FormInstance } from '../../form';
 import Form from '../../form';
 import Button from '../../button';
@@ -167,18 +167,10 @@ describe('ConfigProvider.Form', () => {
 
       const submitButtons = getAllByRole('button');
       expect(submitButtons).toHaveLength(3);
-      submitButtons.forEach((button) => {
-        button.click();
-      });
 
-      await act(async () => {
-        jest.runAllTimers();
-        await Promise.resolve();
-      });
+      submitButtons.forEach((b) => fireEvent.click(b));
 
-      act(() => {
-        jest.runAllTimers();
-      });
+      await waitFakeTimer();
 
       expect(container.querySelectorAll('.ant-form-item-explain-error')).toHaveLength(3);
       expect(getAllByText('Please enter Name')).toHaveLength(1);

--- a/components/config-provider/context.tsx
+++ b/components/config-provider/context.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ValidateMessages } from 'rc-field-form/lib/interface';
 import type { RequiredMark } from '../form/Form';
 import type { Locale } from '../locale-provider';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
@@ -45,6 +46,7 @@ export interface ConfigConsumerProps {
   virtual?: boolean;
   dropdownMatchSelectWidth?: boolean;
   form?: {
+    validateMessages?: ValidateMessages;
     requiredMark?: RequiredMark;
     colon?: boolean;
   };

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -2,6 +2,7 @@ import IconContext from '@ant-design/icons/lib/components/Context';
 import type { ValidateMessages } from 'rc-field-form/lib/interface';
 import useMemo from 'rc-util/lib/hooks/useMemo';
 import * as React from 'react';
+import { merge } from 'rc-util/lib/utils/set';
 import type { RequiredMark } from '../form/Form';
 import ValidateMessagesContext from '../form/validateMessagesContext';
 import type { Locale } from '../locale-provider';
@@ -224,16 +225,17 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = props => {
   );
 
   let childNode = children;
-  // Additional Form provider
-  let validateMessages: ValidateMessages = {};
 
-  if (locale) {
-    validateMessages =
-      locale.Form?.defaultValidateMessages || defaultLocale.Form?.defaultValidateMessages || {};
-  }
-  if (form && form.validateMessages) {
-    validateMessages = { ...validateMessages, ...form.validateMessages };
-  }
+  const validateMessages = React.useMemo(
+    () =>
+      merge(
+        defaultLocale.Form?.defaultValidateMessages || {},
+        memoedConfig.locale?.Form?.defaultValidateMessages || {},
+        memoedConfig.form?.validateMessages || {},
+        form?.validateMessages || {},
+      ),
+    [memoedConfig, form?.validateMessages],
+  );
 
   if (Object.keys(validateMessages).length > 0) {
     childNode = (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

**background:** https://github.com/ant-design/ant-design/pull/43239#issuecomment-1623146062

**nesting error:** https://github.com/ant-design/ant-design/issues/43210

**feature case**: https://github.com/ant-design/ant-design/blob/5ce9818401f976fcb665eff2a48e5f05d17acf39/components/config-provider/__tests__/form.test.tsx#L100-L150

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: `<ConfigProvider />` form validateMessages nesting error      |
| 🇨🇳 Chinese |      修复  `<ConfigProvider />` 表单校验信息嵌套使用错误    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6222f5e</samp>

Added a new feature to `ConfigProvider` component that allows customizing form validation messages. Updated the `ConfigConsumerProps` interface and the `components/config-provider/__tests__/form.test.tsx` file to support this feature. Enhanced the performance and reliability of `validateMessages` prop handling in `ConfigProvider`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6222f5e</samp>

*  Add `validateMessages` prop to `ConfigProvider` component and its context to allow custom messages for form validation ([link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-c16968ab5764529d52167a023f7200c2f911fbec858d6e5e930090bce222b0a2R49), [link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R5), [link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L227-R238))
*  Use `merge` function from `rc-util` and `useMemo` hook to improve the logic for merging `validateMessages` from multiple nested `ConfigProvider` components ([link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L227-R238))
*  Import `ValidateMessages` type from `rc-field-form` and `merge` function from `rc-util` in `components/config-provider/context.tsx` and `components/config-provider/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-c16968ab5764529d52167a023f7200c2f911fbec858d6e5e930090bce222b0a2R2), [link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R5))
*  Add two test cases in `components/config-provider/__tests__/form.test.tsx` to check the behavior of nested `ConfigProvider` components with different `validateMessages` props ([link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-de3be3adfc940c32e15832efa3031f3feb0a595049bb80dd6351875fdf0b3270L3-R10), [link](https://github.com/ant-design/ant-design/pull/43480/files?diff=unified&w=0#diff-de3be3adfc940c32e15832efa3031f3feb0a595049bb80dd6351875fdf0b3270R88-R186))
