### PR TITLE
fix: notification placement via app component

### DIFF
--- a/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -48,3 +48,39 @@ exports[`renders components/app/demo/basic.tsx extend context correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders components/app/demo/config.tsx extend context correctly 1`] = `
+<div
+  class="ant-app"
+>
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right: 8px;"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Message for only one
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Notification for bottomLeft
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/components/app/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo.test.ts.snap
@@ -48,3 +48,39 @@ exports[`renders components/app/demo/basic.tsx correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders components/app/demo/config.tsx correctly 1`] = `
+<div
+  class="ant-app"
+>
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right:8px"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Message for only one
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          Notification for bottomLeft
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
+import type { NotificationConfig } from 'antd/es/notification/interface';
 import App from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render, waitFakeTimer } from '../../../tests/utils';
 import type { AppConfig } from '../context';
 import { AppConfigContext } from '../context';
-import { NotificationConfig } from 'antd/es/notification/interface';
 
 describe('App', () => {
   mountTest(App);

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { render, waitFakeTimer } from '../../../tests/utils';
 import type { AppConfig } from '../context';
 import { AppConfigContext } from '../context';
+import { NotificationConfig } from 'antd/es/notification/interface';
 
 describe('App', () => {
   mountTest(App);
@@ -121,6 +122,46 @@ describe('App', () => {
 
     expect(config?.message).toStrictEqual({ maxCount: 11, top: 20 });
     expect(config?.notification).toStrictEqual({ maxCount: 30, bottom: 41 });
+  });
+
+  it('should respect notification placement config from props in priority', async () => {
+    let consumedConfig: AppConfig | undefined;
+
+    const Consumer = () => {
+      const { notification } = App.useApp();
+      consumedConfig = React.useContext(AppConfigContext);
+
+      useEffect(() => {
+        notification.success({ message: 'Notification 1' });
+        notification.success({ message: 'Notification 2' });
+        notification.success({ message: 'Notification 3' });
+      }, [notification]);
+
+      return <div />;
+    };
+
+    const config: NotificationConfig = {
+      placement: 'bottomLeft',
+      top: 100,
+      bottom: 50,
+    };
+
+    const Wrapper = () => (
+      <App notification={config}>
+        <Consumer />
+      </App>
+    );
+
+    render(<Wrapper />);
+    await waitFakeTimer();
+
+    expect(consumedConfig?.notification).toStrictEqual(config);
+    expect(document.querySelector('.ant-notification-topRight')).not.toBeInTheDocument();
+    expect(document.querySelector('.ant-notification-bottomLeft')).toHaveStyle({
+      top: '',
+      left: '0px',
+      bottom: '50px',
+    });
   });
 
   it('support className', () => {

--- a/components/app/demo/basic.md
+++ b/components/app/demo/basic.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-获取 `message`、`notification`、`modal` 静态方法。
+获取 `message`、`notification`、`modal` 实例。
 
 ## en-US
 
-Static method for `message`, `notification`, `modal`.
+Get instance for `message`, `notification`, `modal`.

--- a/components/app/demo/config.md
+++ b/components/app/demo/config.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+对 `message`、`notification` 进行配置。
+
+## en-US
+
+Config for `message`, `notification`.

--- a/components/app/demo/config.tsx
+++ b/components/app/demo/config.tsx
@@ -3,7 +3,7 @@ import { App, Button, Space } from 'antd';
 
 // Sub page
 const MyPage = () => {
-  const { message, modal, notification } = App.useApp();
+  const { message, notification } = App.useApp();
 
   const showMessage = () => {
     message.success('Success!');

--- a/components/app/demo/config.tsx
+++ b/components/app/demo/config.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { App, Button, Space } from 'antd';
+
+// Sub page
+const MyPage = () => {
+  const { message, modal, notification } = App.useApp();
+
+  const showMessage = () => {
+    message.success('Success!');
+  };
+
+  const showNotification = () => {
+    notification.info({
+      message: `Notification`,
+      description: 'Hello, Ant Design!!',
+    });
+  };
+
+  return (
+    <Space>
+      <Button type="primary" onClick={showMessage}>
+        Message for only one
+      </Button>
+      <Button type="primary" onClick={showNotification}>
+        Notification for bottomLeft
+      </Button>
+    </Space>
+  );
+};
+
+// Entry component
+export default () => (
+  <App message={{ maxCount: 1 }} notification={{ placement: 'bottomLeft' }}>
+    <MyPage />
+  </App>
+);

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -18,7 +18,8 @@ Application wrapper for some global usages.
 ## Examples
 
 <!-- prettier-ignore -->
-<code src="./demo/basic.tsx">basic</code>
+<code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/config.tsx">Hooks config</code>
 
 ## How to use
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -20,6 +20,7 @@ demo:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本用法</code>
+<code src="./demo/config.tsx">Hooks 配置</code>
 
 ## 如何使用
 

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -17,6 +17,7 @@ import { getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
+const DEFAULT_PLACEMENT: NotificationPlacement = 'topRight';
 
 // ==============================================================================
 // ==                                  Holder                                  ==
@@ -38,6 +39,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     prefixCls: staticPrefixCls,
     getContainer: staticGetContainer,
     maxCount,
+    placement,
     rtl,
     onAllRemoved,
   } = props;
@@ -46,8 +48,12 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
   // =============================== Style ===============================
-  const getStyle = (placement: NotificationPlacement): React.CSSProperties =>
-    getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
+  const getStyle = (): React.CSSProperties =>
+    getPlacementStyle(
+      placement ?? DEFAULT_PLACEMENT,
+      top ?? DEFAULT_OFFSET,
+      bottom ?? DEFAULT_OFFSET,
+    );
 
   // Style
   const [, hashId] = useStyle(prefixCls);

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-
 import classNames from 'classnames';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { ComponentStyleConfig } from '../config-provider/context';

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -39,7 +39,6 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     prefixCls: staticPrefixCls,
     getContainer: staticGetContainer,
     maxCount,
-    placement: placementFromProps,
     rtl,
     onAllRemoved,
   } = props;
@@ -48,11 +47,8 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
   // =============================== Style ===============================
-  const placementValue = placementFromProps ?? DEFAULT_PLACEMENT;
-  // prioritize placement from global config but use value from props when global config is not available
-  // if both are undefined, use default placement of `DEFAULT_PLACEMENT`
   const getStyle = (placement: NotificationPlacement): React.CSSProperties =>
-    getPlacementStyle(placement ?? placementValue, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
+    getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
 
   // Style
   const [, hashId] = useStyle(prefixCls);

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -41,7 +41,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     prefixCls: staticPrefixCls,
     getContainer: staticGetContainer,
     maxCount,
-    placement,
+    placement: placementFromProps,
     rtl,
     onAllRemoved,
   } = props;
@@ -50,12 +50,11 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
   // =============================== Style ===============================
-  const getStyle = (): React.CSSProperties =>
-    getPlacementStyle(
-      placement ?? DEFAULT_PLACEMENT,
-      top ?? DEFAULT_OFFSET,
-      bottom ?? DEFAULT_OFFSET,
-    );
+  const placementValue = placementFromProps ?? DEFAULT_PLACEMENT;
+  // prioritize placement from global config but use value from props when global config is not available
+  // if both are undefined, use default placement of `DEFAULT_PLACEMENT`
+  const getStyle = (placement: NotificationPlacement): React.CSSProperties =>
+    getPlacementStyle(placement ?? placementValue, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
 
   // Style
   const [, hashId] = useStyle(prefixCls);
@@ -133,7 +132,8 @@ export function useInternalNotification(
       const realCloseIcon = getCloseIcon(noticePrefixCls, closeIcon);
 
       return originOpen({
-        placement: 'topRight',
+        // use placement from props instead of hard-coding "topRight"
+        placement: notificationConfig?.placement ?? DEFAULT_PLACEMENT,
         ...restConfig,
         content: (
           <PureContent

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,17 +1,19 @@
+import * as React from 'react';
+
 import classNames from 'classnames';
 import { useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
-import * as React from 'react';
+
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { ComponentStyleConfig } from '../config-provider/context';
-import { PureContent, getCloseIcon } from './PurePanel';
 import type {
   ArgsProps,
   NotificationConfig,
   NotificationInstance,
   NotificationPlacement,
 } from './interface';
+import { getCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
Closes [43467](https://github.com/ant-design/ant-design/issues/43467)

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix notification placement not being respected  when passed via App component        |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a918b74</samp>

This pull request improves the notification feature of the `App` component by adding a new test case, refactoring the `useNotification` file, and supporting custom notification config props. It also fixes some code style and consistency issues in the notification components and functions.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a918b74</samp>

*  Import `NotificationConfig` type and add test case for `App` component to check notification placement config from props ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-52400589dcfd21bced4d2c624c0fbb235acac6ec308f1cf4c3fa37fcc8e80cf8R8), [link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-52400589dcfd21bced4d2c624c0fbb235acac6ec308f1cf4c3fa37fcc8e80cf8R127-R166))
*  Reorder import statements in `useNotification` file to follow convention ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL1-R9))
*  Define `DEFAULT_PLACEMENT` constant and use it as fallback value for notification placement ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfR22), [link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL49-R57), [link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL128-R136))
*  Import `getCloseIcon` and `PureContent` components from `PurePanel` file and use them in `useNotification` file to avoid duplication ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfR16))
*  Add `placement` prop to `Holder` component and pass it to `useRcNotification` hook to create notification container element ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfR44))
*  Modify `getStyle` function in `Holder` component to use placement value from props, global config, or default value ([link](https://github.com/ant-design/ant-design/pull/43522/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL49-R57))
