### PR TITLE
fix: rethrow error in ActionButton's onOk callback

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -55,12 +55,10 @@ const ActionButton: React.FC<ActionButtonProps> = props => {
         clickedRef.current = false;
       },
       (e: Error) => {
-        // Emit error when catch promise reject
-        // eslint-disable-next-line no-console
-        console.error(e);
         // See: https://github.com/ant-design/ant-design/issues/6183
         setLoading(false, true);
         clickedRef.current = false;
+        return Promise.reject(e);
       },
     );
   };

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -21,7 +21,7 @@ jest.mock('rc-motion');
 describe('Modal.confirm triggers callbacks correctly', () => {
   // Inject CSSMotion to replace with No transition support
   const MockCSSMotion = genCSSMotion(false);
-  Object.keys(MockCSSMotion).forEach(key => {
+  Object.keys(MockCSSMotion).forEach((key) => {
     (CSSMotion as any)[key] = (MockCSSMotion as any)[key];
   });
 
@@ -169,6 +169,9 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should emit error when onOk return Promise.reject', async () => {
+    const mockFn = jest.fn();
+    globalThis.addEventListener('unhandledrejection', mockFn);
+
     const error = new Error('something wrong');
     await open({
       onOk: () => Promise.reject(error),
@@ -179,7 +182,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     // wait promise
     await waitFakeTimer();
 
-    expect(errorSpy).toHaveBeenCalledWith(error);
+    expect(mockFn).toHaveBeenCalled();
+    globalThis.removeEventListener('unhandledrejection', mockFn);
   });
 
   it('shows animation when close', async () => {
@@ -214,7 +218,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('should close modals when click confirm button', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         Modal[type]?.({ title: 'title', content: 'content' });
         await waitFakeTimer();
@@ -260,12 +264,12 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('should not close modals when click confirm button when onOk has argument', () => {
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         Modal[type]?.({
           title: 'title',
           content: 'content',
-          onOk: _ => null, // eslint-disable-line no-unused-vars
+          onOk: (_) => null, // eslint-disable-line no-unused-vars
         });
         await waitFakeTimer();
         expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
@@ -278,7 +282,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be update by new config', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -305,7 +309,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be update by call function', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -318,7 +322,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
           'ant-btn-loading',
         );
         expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].style.color).toBe('red');
-        instance.update(prevConfig => ({
+        instance.update((prevConfig) => ({
           ...prevConfig,
           okButtonProps: {
             ...prevConfig.okButtonProps,
@@ -341,7 +345,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be destroy', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -359,7 +363,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   it('could be Modal.destroyAll', async () => {
     // Show
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       Modal[type]?.({
         title: 'title',
         content: 'content',
@@ -368,7 +372,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     await waitFakeTimer();
 
-    ['info', 'success', 'warning', 'error'].forEach(type => {
+    ['info', 'success', 'warning', 'error'].forEach((type) => {
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
     });
 
@@ -377,7 +381,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     await waitFakeTimer();
 
-    ['info', 'success', 'warning', 'error'].forEach(type => {
+    ['info', 'success', 'warning', 'error'].forEach((type) => {
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
     });
   });
@@ -402,7 +406,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     await waitFakeTimer();
 
     const instances: ReturnType<ModalFunc>[] = [];
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       const instance = Modal[type]?.({
         title: 'title',
         content: 'content',
@@ -560,13 +564,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('the callback close should be a method when onCancel has a close parameter', () => {
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the close icon to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           closable: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -581,13 +585,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       });
     });
 
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`press ESC to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           keyboard: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -604,13 +608,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       });
     });
 
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the mask to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           maskClosable: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -632,7 +636,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     const mock = jest.fn();
 
     Modal.confirm({
-      onCancel: close => mock(close),
+      onCancel: (close) => mock(close),
     });
 
     await waitFakeTimer();
@@ -645,7 +649,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   it('close can close modal when onCancel has a close parameter', async () => {
     Modal.confirm({
-      onCancel: close => close(),
+      onCancel: (close) => close(),
     });
 
     await waitFakeTimer();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
在当前的实现中，当 Modal 组件中的 onOk 回调抛出异常后会被默默处理掉，导致全局的异常处理器无法捕获当前的异常。

在实际代码中，很经常会注册全局的异常处理器来捕获那些未处理的异常，比如全局错误提示或者错误上报等等，这里吞掉异常，导致全局的异常处理器无法正常工作。

在 5.0 版本中该问题已被修复，目前这个 PR 的代码完全参照5.0的实现 #40018 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Allow users to handle promise rejections in ActionButton's onOk callback |
| 🇨🇳 Chinese | 让用户能够处理 ActionButton 中 onOk 回调中的 Promise 异常 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 464efb6</samp>

Fix modal footer buttons loading state bug by rejecting promise on `ActionButton` error. Return a rejected promise from `components/_util/ActionButton.tsx` when the `onClick` handler throws an error, instead of logging it.

### 🔍 Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 464efb6</samp>

* Return rejected promise when `onClick` handler throws error in `ActionButton` component ([link](https://github.com/ant-design/ant-design/pull/43535/files?diff=unified&w=0#diff-87d6be5f51fe1b2da545c92af66c2d3ef4e04db2cd3cfb661c442decfac3eaefL58-R61))
