### PR TITLE
fix: rethrow error in ActionButton's onOk callback

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -20,7 +20,7 @@ function isThenable(thing?: PromiseLike<any>): boolean {
   return !!(thing && !!thing.then);
 }
 
-const ActionButton: React.FC<ActionButtonProps> = props => {
+const ActionButton: React.FC<ActionButtonProps> = (props) => {
   const clickedRef = React.useRef<boolean>(false);
   const ref = React.useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState<ButtonProps['loading']>(false);
@@ -55,12 +55,10 @@ const ActionButton: React.FC<ActionButtonProps> = props => {
         clickedRef.current = false;
       },
       (e: Error) => {
-        // Emit error when catch promise reject
-        // eslint-disable-next-line no-console
-        console.error(e);
         // See: https://github.com/ant-design/ant-design/issues/6183
         setLoading(false, true);
         clickedRef.current = false;
+        return Promise.reject(e);
       },
     );
   };

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import type { ModalFuncProps } from '..';
 import Modal from '..';
-import { waitFakeTimer, act } from '../../../tests/utils';
+import { act, waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import type { ModalFunc } from '../confirm';
 import destroyFns from '../destroyFns';
@@ -18,10 +18,49 @@ const { confirm } = Modal;
 
 jest.mock('rc-motion');
 
+(global as any).injectPromise = false;
+(global as any).rejectPromise = null;
+
+jest.mock('../../_util/ActionButton', () => {
+  const ActionButton = jest.requireActual('../../_util/ActionButton').default;
+  return (props: any) => {
+    const { actionFn } = props;
+    let mockActionFn: any = actionFn;
+    if (actionFn && (global as any).injectPromise) {
+      mockActionFn = (...args: any) => {
+        let ret = actionFn(...args);
+
+        if (ret.then) {
+          let resolveFn: any;
+          let rejectFn: any;
+
+          ret = ret.then(
+            (v: any) => {
+              resolveFn?.(v);
+            },
+            (e: any) => {
+              rejectFn?.(e)?.catch((err: Error) => {
+                (global as any).rejectPromise = err;
+              });
+            },
+          );
+          ret.then = (resolve: any, reject: any) => {
+            resolveFn = resolve;
+            rejectFn = reject;
+          };
+        }
+
+        return ret;
+      };
+    }
+    return <ActionButton {...props} actionFn={mockActionFn} />;
+  };
+});
+
 describe('Modal.confirm triggers callbacks correctly', () => {
   // Inject CSSMotion to replace with No transition support
   const MockCSSMotion = genCSSMotion(false);
-  Object.keys(MockCSSMotion).forEach(key => {
+  Object.keys(MockCSSMotion).forEach((key) => {
     (CSSMotion as any)[key] = (MockCSSMotion as any)[key];
   });
 
@@ -55,6 +94,11 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     originError(...args);
   };
   /* eslint-enable */
+
+  beforeEach(() => {
+    (global as any).injectPromise = false;
+    (global as any).rejectPromise = null;
+  });
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -169,6 +213,8 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   it('should emit error when onOk return Promise.reject', async () => {
+    (global as any).injectPromise = true;
+
     const error = new Error('something wrong');
     await open({
       onOk: () => Promise.reject(error),
@@ -179,7 +225,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     // wait promise
     await waitFakeTimer();
 
-    expect(errorSpy).toHaveBeenCalledWith(error);
+    expect((global as any).rejectPromise instanceof Error).toBeTruthy();
   });
 
   it('shows animation when close', async () => {
@@ -214,7 +260,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('should close modals when click confirm button', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         Modal[type]?.({ title: 'title', content: 'content' });
         await waitFakeTimer();
@@ -260,12 +306,12 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('should not close modals when click confirm button when onOk has argument', () => {
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         Modal[type]?.({
           title: 'title',
           content: 'content',
-          onOk: _ => null, // eslint-disable-line no-unused-vars
+          onOk: (_) => null, // eslint-disable-line no-unused-vars
         });
         await waitFakeTimer();
         expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
@@ -278,7 +324,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be update by new config', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -305,7 +351,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be update by call function', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -318,7 +364,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
           'ant-btn-loading',
         );
         expect($$('.ant-modal-confirm-btns .ant-btn-primary')[0].style.color).toBe('red');
-        instance.update(prevConfig => ({
+        instance.update((prevConfig) => ({
           ...prevConfig,
           okButtonProps: {
             ...prevConfig.okButtonProps,
@@ -341,7 +387,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('could be destroy', () => {
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(type, async () => {
         const instance = Modal[type]?.({
           title: 'title',
@@ -359,7 +405,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   it('could be Modal.destroyAll', async () => {
     // Show
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       Modal[type]?.({
         title: 'title',
         content: 'content',
@@ -368,7 +414,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     await waitFakeTimer();
 
-    ['info', 'success', 'warning', 'error'].forEach(type => {
+    ['info', 'success', 'warning', 'error'].forEach((type) => {
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(1);
     });
 
@@ -377,7 +423,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     await waitFakeTimer();
 
-    ['info', 'success', 'warning', 'error'].forEach(type => {
+    ['info', 'success', 'warning', 'error'].forEach((type) => {
       expect($$(`.ant-modal-confirm-${type}`)).toHaveLength(0);
     });
   });
@@ -402,7 +448,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     await waitFakeTimer();
 
     const instances: ReturnType<ModalFunc>[] = [];
-    (['info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['info', 'success', 'warning', 'error'] as const).forEach((type) => {
       const instance = Modal[type]?.({
         title: 'title',
         content: 'content',
@@ -560,13 +606,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   });
 
   describe('the callback close should be a method when onCancel has a close parameter', () => {
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the close icon to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           closable: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -581,13 +627,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       });
     });
 
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`press ESC to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           keyboard: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -604,13 +650,13 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       });
     });
 
-    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach(type => {
+    (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the mask to trigger ${type} onCancel`, async () => {
         const mock = jest.fn();
 
         Modal[type]?.({
           maskClosable: true,
-          onCancel: close => mock(close),
+          onCancel: (close) => mock(close),
         });
 
         await waitFakeTimer();
@@ -632,7 +678,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     const mock = jest.fn();
 
     Modal.confirm({
-      onCancel: close => mock(close),
+      onCancel: (close) => mock(close),
     });
 
     await waitFakeTimer();
@@ -645,7 +691,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
   it('close can close modal when onCancel has a close parameter', async () => {
     Modal.confirm({
-      onCancel: close => close(),
+      onCancel: (close) => close(),
     });
 
     await waitFakeTimer();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
在当前的实现中，当 Modal 组件中的 onOk 回调抛出异常后会被默默处理掉，导致全局的异常处理器无法捕获当前的异常。

在实际代码中，很经常会注册全局的异常处理器来捕获那些未处理的异常，比如全局错误提示或者错误上报等等，这里吞掉异常，导致全局的异常处理器无法正常工作。

在 5.0 版本中该问题已被修复，目前这个 PR 的代码完全参照5.0的实现 #40018 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Allow users to handle promise rejections in ActionButton's onOk callback |
| 🇨🇳 Chinese | 让用户能够处理 ActionButton 中 onOk 回调中的 Promise 异常 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60f51c4</samp>

This pull request fixes a bug that caused the modal component to close unexpectedly when the `onOk` or `onCancel` callbacks returned a rejected promise. It also improves the code style consistency in the `ActionButton` component and the modal test file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60f51c4</samp>

*  Add parentheses to parameters of arrow functions to follow code style and ESLint rules ([link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-87d6be5f51fe1b2da545c92af66c2d3ef4e04db2cd3cfb661c442decfac3eaefL23-R23), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL24-R24), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL217-R221), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL263-R272), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL281-R285), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL308-R312), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL321-R325), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL344-R348), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL362-R366), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL371-R375), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL380-R384), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL405-R409), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL563-R567), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL584-R588), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL607-R611))
*  Fix bug that prevents modal from closing when `onOk` or `onCancel` return rejected promises by adding `return Promise.reject(e)` to error handler in `components/_util/ActionButton.tsx` ([link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-87d6be5f51fe1b2da545c92af66c2d3ef4e04db2cd3cfb661c442decfac3eaefL58-R61))
*  Add test case to check if modal emits unhandled rejection event when `onOk` or `onCancel` return rejected promises in `components/modal/__tests__/confirm.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bR172-R174), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL182-R186))
*  Remove unnecessary `console.error` call and `errorSpy` assertion from the same test case ([link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL182-R186))
*  Add parentheses to `close` parameter of `onCancel` callbacks to follow code style and ESLint rules in `components/modal/__tests__/confirm.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL569-R573), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL590-R594), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL613-R617), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL635-R639), [link](https://github.com/ant-design/ant-design/pull/43536/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bL648-R652))
