### PR TITLE
fix: update changelog & optimize type

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -607,7 +607,7 @@ timeline: true
 - 💄 Optimize `boxShadow` tokens. [#40516](https://github.com/ant-design/ant-design/pull/40516)
 - TypeScript
   - 🤖 Optimize Badge Tag Tooltip `color` type definition. [#39871](https://github.com/ant-design/ant-design/pull/39871)
-  - 🤖 Add `Breakpoint` `ThmeConfig` `GlobalToken` type export. [#40508](https://github.com/ant-design/ant-design/pull/40508) [@Kamahl19](https://github.com/Kamahl19)
+  - 🤖 Add `Breakpoint` `ThemeConfig` `GlobalToken` type export. [#40508](https://github.com/ant-design/ant-design/pull/40508) [@Kamahl19](https://github.com/Kamahl19)
   - 🤖 Update Upload `fileList` type. [#40585](https://github.com/ant-design/ant-design/pull/40585)
   - 🤖 Remove Tour ForwardRefRenderFunction. [#39924](https://github.com/ant-design/ant-design/pull/39924)
 - 🌐 Localization

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -608,7 +608,7 @@ timeline: true
 - 💄 优化 `boxShadow` token 分级。[#40516](https://github.com/ant-design/ant-design/pull/40516)
 - TypeScript
   - 🤖 优化 Badge Tag Tooltip `color` 类型定义。[#39871](https://github.com/ant-design/ant-design/pull/39871)
-  - 🤖 新增 `Breakpoint` `ThmeConfig` `GlobalToken` 类型导出。[#40508](https://github.com/ant-design/ant-design/pull/40508) [@Kamahl19](https://github.com/Kamahl19)
+  - 🤖 新增 `Breakpoint` `ThemeConfig` `GlobalToken` 类型导出。[#40508](https://github.com/ant-design/ant-design/pull/40508) [@Kamahl19](https://github.com/Kamahl19)
   - 🤖 更新 Upload `fileList` 类型。[#40585](https://github.com/ant-design/ant-design/pull/40585)
   - 🤖 移除 Tour ForwardRefRenderFunction。[#39924](https://github.com/ant-design/ant-design/pull/39924)
 - 🌐 国际化

--- a/components/list/context.ts
+++ b/components/list/context.ts
@@ -1,7 +1,8 @@
 import React from 'react';
+import type { ListGridType } from '.';
 
 export interface ListConsumerProps {
-  grid?: any;
+  grid?: ListGridType;
   itemLayout?: string;
 }
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -152,7 +152,7 @@ const InternalSelect = <
   } else if (mode === 'combobox') {
     mergedNotFound = null;
   } else {
-    mergedNotFound = renderEmpty?.('Select') || <DefaultRenderEmpty componentName="Select" />;
+    mergedNotFound = renderEmpty?.('Select') || <DefaultRenderEmpty componentName='Select' />;
   }
 
   // ===================== Icons =====================
@@ -165,7 +165,10 @@ const InternalSelect = <
     prefixCls,
   });
 
-  const selectProps = omit(props as typeof props & { itemIcon: any }, ['suffixIcon', 'itemIcon']);
+  const selectProps = omit(props as typeof props & { itemIcon: React.ReactNode }, [
+    'suffixIcon',
+    'itemIcon',
+  ]);
 
   const rcSelectRtlDropdownClassName = classNames(
     popupClassName || dropdownClassName,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
<img width="282" alt="grid" src="https://github.com/ant-design/ant-design/assets/117748716/94820f66-1d1a-4b33-b295-894ec0e0a29d">

![image](https://github.com/ant-design/ant-design/assets/117748716/b9a8cffc-9838-4b58-8ac3-aa21aa62c05a)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    update changelog & optimize type       |
| 🇨🇳 Chinese |   更新changelog并且优化类型        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7746af</samp>

This pull request fixes some minor issues in the TypeScript code and documentation of the `Select` and `List` components. It corrects a typo in the `ThemeConfig` type export in the changelogs and improves the type definition of the `grid` prop in the `ListConsumerProps` interface.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7746af</samp>

* Fix typo in `ThemeConfig` type export in TypeScript changelogs for version 5.2.0 ([link](https://github.com/ant-design/ant-design/pull/43544/files?diff=unified&w=0#diff-e961ad288c43a2feb2d56b696e10c0b670d652dbb17c76c9aa0452d45157977cL610-R610),[link](https://github.com/ant-design/ant-design/pull/43544/files?diff=unified&w=0#diff-1224d5ca5233fdeba67ba2e2dc6fa3e615905253f35dc132c4b4b86f51f9eab4L611-R611))
* Improve type definition of `grid` prop in `ListConsumerProps` interface by using `ListGridType` type from `components/list/context.ts` ([link](https://github.com/ant-design/ant-design/pull/43544/files?diff=unified&w=0#diff-15eaf19d2b83d1774be03ca96c6ec911695331c7929740115774a1b1db64f670L2-R5))
* Replace double quotes with single quotes in `componentName` prop of `DefaultRenderEmpty` component in `InternalSelect` component from `components/select/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43544/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L155-R155))
* Improve type definition of `itemIcon` prop in `selectProps` object by using `React.ReactNode` type from `components/select/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43544/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L168-R171))
