### PR TITLE
fix: uniformly set height and border on inputs

### DIFF
--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -39,8 +39,8 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
     colorTextDescription,
     motionDurationMid,
     colorPrimary,
-    controlHeight,
     inputPaddingHorizontal,
+    inputPaddingVertical,
     colorBgContainer,
     colorTextDisabled,
     borderRadiusSM,
@@ -147,8 +147,7 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
           '&-input': {
             ...resetComponent(token),
             width: '100%',
-            height: controlHeight - 2 * lineWidth,
-            padding: `0 ${inputPaddingHorizontal}px`,
+            padding: `${inputPaddingVertical}px ${inputPaddingHorizontal}px`,
             textAlign: 'start',
             backgroundColor: 'transparent',
             border: 0,
@@ -303,6 +302,7 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
 const genAffixWrapperStyles: GenerateStyle<InputNumberToken> = (token: InputNumberToken) => {
   const {
     componentCls,
+    inputPaddingVertical,
     inputPaddingHorizontal,
     inputAffixPadding,
     controlWidth,
@@ -355,7 +355,7 @@ const genAffixWrapperStyles: GenerateStyle<InputNumberToken> = (token: InputNumb
       },
 
       [`input${componentCls}-input`]: {
-        padding: 0,
+        padding: `${inputPaddingVertical}px 0`,
       },
 
       '&::before': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/43528

### 💡 Background and solution

uniformly set height and border on inputs

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input and InputNumber align issue.          |
| 🇨🇳 Chinese |  修复 Input 和 InputNumber 行内对齐问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0722c8</samp>

This pull request enhances the style and consistency of the `InputNumber` and `Input` components. It removes the redundant border from the `InputNumber` wrapper and adjusts the height calculation of the `Input` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0722c8</samp>

* Remove border from input number wrapper to fix overlap with buttons ([link](https://github.com/ant-design/ant-design/pull/43548/files?diff=unified&w=0#diff-63d0bbc4ed8cb1745da77de552d75aa0fd581ef3eb2d25d0108b2d55eb5f1857L63-R63))
* Add border to input number input to match basic input style and improve consistency ([link](https://github.com/ant-design/ant-design/pull/43548/files?diff=unified&w=0#diff-63d0bbc4ed8cb1745da77de552d75aa0fd581ef3eb2d25d0108b2d55eb5f1857L154-R154))
* Adjust height of basic input to account for border width instead of hard-coding 1px ([link](https://github.com/ant-design/ant-design/pull/43548/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aR142))
