### PR TITLE
fix(date-picker): update demo about cell-render in date-picker

### DIFF
--- a/components/date-picker/demo/cell-render.tsx
+++ b/components/date-picker/demo/cell-render.tsx
@@ -6,7 +6,8 @@ const { RangePicker } = DatePicker;
 const App: React.FC = () => (
   <Space direction="vertical" size={12}>
     <DatePicker
-      cellRender={(current) => {
+      cellRender={(current, info) => {
+        if (info.type !== 'date') return info.originNode;
         const style: React.CSSProperties = {};
         if (current.date() === 1) {
           style.border = '1px solid #1677ff';
@@ -20,7 +21,8 @@ const App: React.FC = () => (
       }}
     />
     <RangePicker
-      cellRender={(current) => {
+      cellRender={(current, info) => {
+        if (info.type !== 'date') return info.originNode;
         const style: React.CSSProperties = {};
         if (current.date() === 1) {
           style.border = '1px solid #1677ff';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #43595

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update demo about cell-render in date-picker |
| 🇨🇳 Chinese | 更新日期选择器关于 cell-render 的示例  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c17e11e</samp>

Enhanced `cellRender` prop of date picker components to support custom rendering for different cell types. This allows users to customize the appearance and behavior of the date picker cells according to their needs.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c17e11e</samp>

*  Modify `cellRender` prop of `DatePicker` and `RangePicker` to accept `info` parameter with cell type and origin node ([link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL9-R10), [link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL23-R25))
*  Return origin node for non-date cells in custom renderer to avoid unnecessary elements or styles ([link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL9-R10), [link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL23-R25))
*  Update demo code in `components/date-picker/demo/cell-render.tsx` to demonstrate the new feature and usage of `info` parameter ([link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL9-R10), [link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL23-R25))
*  Add test cases in `components/date-picker/__tests__/cellRender.test.tsx` to verify the correct rendering of different cell types with custom renderer ([link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL9-R10), [link](https://github.com/ant-design/ant-design/pull/43597/files?diff=unified&w=0#diff-7bef207684561bc2802ba1dde4264ee5a219524db1d1a45ff643a2579948c15eL23-R25))
