### PR TITLE
fix: Button ts

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -343,4 +343,15 @@ describe('Button', () => {
     );
     expect(window.getComputedStyle(container.querySelector('#link')!).pointerEvents).toBe('none');
   });
+
+  it('Correct type', () => {
+    const onBtnClick: React.MouseEventHandler<HTMLButtonElement> = () => {};
+    const onAnchorClick: React.MouseEventHandler<HTMLAnchorElement> = () => {};
+
+    const button = <Button onClick={onBtnClick} />;
+    const anchor = <Button href="https://ant.design" onClick={onAnchorClick} />;
+
+    expect(button).toBeTruthy();
+    expect(anchor).toBeTruthy();
+  });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -27,7 +27,9 @@ import useStyle from './style';
 
 export type LegacyButtonType = ButtonType | 'danger';
 
-export function convertLegacyProps(type?: LegacyButtonType): ButtonProps {
+export function convertLegacyProps(
+  type?: LegacyButtonType,
+): Pick<BaseButtonProps, 'danger' | 'type'> {
   if (type === 'danger') {
     return { danger: true };
   }
@@ -66,7 +68,9 @@ export type NativeButtonProps = {
 } & BaseButtonProps &
   Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick'>;
 
-export type ButtonProps = Partial<AnchorButtonProps & NativeButtonProps>;
+export type ButtonProps = AnchorButtonProps | NativeButtonProps;
+
+type InternalButtonProps = Partial<AnchorButtonProps & NativeButtonProps>;
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
   ButtonProps & React.RefAttributes<HTMLElement>
@@ -121,7 +125,7 @@ const InternalButton: React.ForwardRefRenderFunction<
     classNames: customClassNames,
     style: customStyle = {},
     ...rest
-  } = props;
+  } = props as InternalButtonProps;
 
   const { getPrefixCls, autoInsertSpaceInButton, direction, button } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('btn', customizePrefixCls);
@@ -214,7 +218,7 @@ const InternalButton: React.ForwardRefRenderFunction<
 
   const iconType = innerLoading ? 'loading' : icon;
 
-  const linkButtonRestProps = omit(rest as ButtonProps & { navigate: any }, ['navigate']);
+  const linkButtonRestProps = omit(rest as InternalButtonProps & { navigate: any }, ['navigate']);
 
   const classes = classNames(
     prefixCls,

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -77,7 +77,11 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
           </Button>
         )}
         <ActionButton
-          buttonProps={{ size: 'small', ...convertLegacyProps(okType), ...okButtonProps }}
+          buttonProps={{
+            size: 'small',
+            ...convertLegacyProps(okType),
+            ...okButtonProps,
+          }}
           actionFn={onConfirm}
           close={close}
           prefixCls={getPrefixCls('btn')}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #43608

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Adjust Button definition to correct handle `onClick` type.          |
| 🇨🇳 Chinese |     调整 Button 类型以正确处理 `onClick` 定义。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70500f8</samp>

This pull request refactors the `button` component to use a union type for the props, adds a new test case for the button type, and formats the `PurePanel` component with prettier. These changes aim to improve the type safety, test quality, and code style of the components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70500f8</samp>

*  Refactor the button component to use a union type instead of a partial type for the props, which improves the type safety and readability of the code ([link](https://github.com/ant-design/ant-design/pull/43629/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L30-R32), [link](https://github.com/ant-design/ant-design/pull/43629/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L69-R74), [link](https://github.com/ant-design/ant-design/pull/43629/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L124-R128), [link](https://github.com/ant-design/ant-design/pull/43629/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L217-R221) in `components/button/button.tsx`)
* Format the code in `components/popconfirm/PurePanel.tsx` to follow the prettier rules and improve the readability of the code ([link](https://github.com/ant-design/ant-design/pull/43629/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L80-R84))
