### PR TITLE
docs(form): update faq for scrollToFirstError

### DIFF
--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -602,7 +602,7 @@ See similar issues: [#28370](https://github.com/ant-design/ant-design/issues/283
 
 2. multiple forms on same page
 
-If there are multiple forms on the page, and there are duplicate same `name` form item , the form scroll probably may find the form item with the same name in another form. You need to set a different `name` for the `Form` component to distinguish it.
+If there are multiple forms on the page, and there are duplicate same `name` form item, the form scroll probably may find the form item with the same name in another form. You need to set a different `name` for the `Form` component to distinguish it.
 
 ### Continue, why not use `ref` to bind element?
 

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -592,11 +592,17 @@ React can not get correct interaction of controlled component with async value u
 }
 </style>
 
-### `scrollToFirstError` and `scrollToField` not working on custom form control?
+### `scrollToFirstError` and `scrollToField` not working?
+
+1. use custom form control
 
 See similar issues: [#28370](https://github.com/ant-design/ant-design/issues/28370) [#27994](https://github.com/ant-design/ant-design/issues/27994)
 
 `scrollToFirstError` and `scrollToField` deps on `id` attribute passed to form control, please make sure that it hasn't been ignored in your custom form control. Check [codesandbox](https://codesandbox.io/s/antd-reproduction-template-forked-25nul?file=/index.js) for solution.
+
+2. multiple forms on same page
+
+If there are multiple forms on the page, and there are duplicate same `name` form item , the form scroll probably may find the form item with the same name in another form. You need to set a different `name` for the `Form` component to distinguish it.
 
 ### Continue, why not use `ref` to bind element?
 

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -591,11 +591,17 @@ React 中异步更新会导致受控组件交互行为异常。当用户交互�
 }
 </style>
 
-### 自定义表单控件 `scrollToFirstError` 和 `scrollToField` 失效？
+### `scrollToFirstError` 和 `scrollToField` 失效？
+
+1. 使用了自定义表单控件
 
 类似问题：[#28370](https://github.com/ant-design/ant-design/issues/28370) [#27994](https://github.com/ant-design/ant-design/issues/27994)
 
 滚动依赖于表单控件元素上绑定的 `id` 字段，如果自定义控件没有将 `id` 赋到正确的元素上，这个功能将失效。你可以参考这个 [codesandbox](https://codesandbox.io/s/antd-reproduction-template-forked-25nul?file=/index.js)。
+
+2. 页面内有多个表单
+
+页面内如果有多个表单，且存在表单项 `name` 重复，表单滚动定位可能会查找到另一个表单的同名表单项上。需要给表单 `Form` 组件设置不同的 `name` 以区分。
 
 ### 继上，为何不通过 `ref` 绑定元素？
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

遇到了 scrollToFirstError 不生效的问题，经排查是因为一个页面中存在多个 Form 且未设置 name 属性且存在相同 field name，滚动定位查找 dom 时查找到了其他表单内的同名表单项。

因为文档中未描述 scrollToFirstError 与 Form name 的关联，故补充方便后续相同问题查询

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Form docs:   update faq for scrollToFirstError     |
| 🇨🇳 Chinese |     Form 文档：补充了 faq 中的 scrollToFirstError 问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c0bb37</samp>

Updated the section on `scrollToFirstError` and `scrollToField` in the Form component documentation (`components/form/index.en-US.md` and `components/form/index.zh-CN.md`) to explain the possible causes of these features not working.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c0bb37</samp>

*  Clarify the conditions that may cause `scrollToFirstError` and `scrollToField` to not work in Form component documentation ([link](https://github.com/ant-design/ant-design/pull/43640/files?diff=unified&w=0#diff-28baad7eca32a14feb2ed5fdcee826cb1d27ee818bcbcaa6c9a8ed368c9b16e5L595-R606), [link](https://github.com/ant-design/ant-design/pull/43640/files?diff=unified&w=0#diff-f17ef6685c42eb193b5735088ef3c54e36aca982b8464077915301cabb1d4b8fL594-R605))
