### PR TITLE
fix: Steps keyboard switch

### DIFF
--- a/components/steps/style/index.tsx
+++ b/components/steps/style/index.tsx
@@ -1,6 +1,6 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import type { CSSProperties } from 'react';
-import { resetComponent } from '../../style';
+import { genFocusOutline, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genStepsCustomIconStyle from './custom-icon';
@@ -171,6 +171,7 @@ const genStepsItemStatusStyle = (status: StepItemStatusEnum, token: StepsToken):
 const genStepsItemStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
   const { componentCls, motionDurationSlow } = token;
   const stepsItemCls = `${componentCls}-item`; // .ant-steps-item
+  const stepItemIconCls = `${stepsItemCls}-icon`;
 
   return {
     [stepsItemCls]: {
@@ -189,12 +190,18 @@ const genStepsItemStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
     },
     [`${stepsItemCls}-container`]: {
       outline: 'none',
+
+      [`&:focus-visible`]: {
+        [stepItemIconCls]: {
+          ...genFocusOutline(token),
+        },
+      },
     },
-    [`${stepsItemCls}-icon, ${stepsItemCls}-content`]: {
+    [`${stepItemIconCls}, ${stepsItemCls}-content`]: {
       display: 'inline-block',
       verticalAlign: 'top',
     },
-    [`${stepsItemCls}-icon`]: {
+    [stepItemIconCls]: {
       width: token.iconSize,
       height: token.iconSize,
       marginTop: 0,

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rc-segmented": "~2.2.0",
     "rc-select": "~14.5.0",
     "rc-slider": "~10.1.0",
-    "rc-steps": "~6.0.0",
+    "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.32.1",
     "rc-tabs": "~12.9.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43634

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Steps with clickable can not trigger by keyboard.        |
| 🇨🇳 Chinese |  修复 Steps 配置可点击时不能通过键盘操作的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b4ce3b</samp>

Improved the keyboard accessibility and alignment of the `Steps` component. Updated the `rc-steps` dependency and added a focus outline style to the steps item icon in `components/steps/style/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b4ce3b</samp>

*  Add focus outline style to steps item icon for keyboard accessibility ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L3-R3), [link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6R174), [link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L192-R204))
  - Import `genFocusOutline` function from `../../style` to generate outline style ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L3-R3))
  - Define `stepItemIconCls` variable to store class name of icon element ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6R174))
  - Apply `genFocusOutline` function to icon element when container element is focused with `:focus-visible` pseudo-class ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7c302bb80b5f306d72c03ca5e5fe2961248a1cdf0f41329ce9e3307110aa29d6L192-R204))
* Update `rc-steps` dependency to fix icon alignment bug ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L147-R147))
  - Bump `rc-steps` version from 6.0.0 to 6.0.1 in `package.json` ([link](https://github.com/ant-design/ant-design/pull/43644/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L147-R147))
