### PR TITLE
fix: DatePicker suffix icon should not use colorTextDisabled

### DIFF
--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -1024,6 +1024,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
     presetsWidth,
     presetsMaxWidth,
     boxShadowPopoverArrow,
+    colorTextQuaternary,
   } = token;
 
   return [
@@ -1054,7 +1055,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           cursor: 'not-allowed',
 
           [`${componentCls}-suffix`]: {
-            color: colorTextDisabled,
+            color: colorTextQuaternary,
           },
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/43553
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
这里本意应该是和占位文本一样的颜色，但是用 `colorTextPlaceholder` 也不太合适，所以先用 mapToken 了。后面有需要应该可以单独开组件 Token。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix wrong token used in DatePicker suffix.      |
| 🇨🇳 Chinese |    修复 DatePicker 后缀颜色使用 token 不当的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07ea314</samp>

This pull request enhances the date picker component's style by adding a new color variable and applying it to some text elements. It affects the file `components/date-picker/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 07ea314</samp>

* Add a new color variable `colorTextQuaternary` for the text color in the date picker component ([link](https://github.com/ant-design/ant-design/pull/43646/files?diff=unified&w=0#diff-a4f33cb3f0dfef43aa860e509b2c43fc62168efd797b258ed2cf47dfc4b1eaa4R1027))
* Use `colorTextQuaternary` instead of `colorTextDisabled` for the suffix color in the date picker component to improve visibility and avoid confusion ([link](https://github.com/ant-design/ant-design/pull/43646/files?diff=unified&w=0#diff-a4f33cb3f0dfef43aa860e509b2c43fc62168efd797b258ed2cf47dfc4b1eaa4L1057-R1058))
