### PR TITLE
docs: update docs about nextjs pages router

### DIFF
--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -148,80 +148,13 @@ export default function App({ Component, pageProps }: AppProps) {
 5. Use antd in page component
 
 ```tsx
-import {
-  Form,
-  Select,
-  InputNumber,
-  DatePicker,
-  Switch,
-  Slider,
-  Button,
-  Rate,
-  Typography,
-  Space,
-  Divider,
-} from 'antd';
-
-const { Option } = Select;
-const { Title } = Typography;
+import { Button } from 'antd';
 
 export default function Home() {
   return (
-    <>
-      <section style={{ textAlign: 'center', marginTop: 48, marginBottom: 40 }}>
-        <Space align="start">
-          <img
-            style={{ width: 40, height: 40 }}
-            src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-            alt="Ant Design"
-          />
-          <Title level={2} style={{ marginBottom: 0 }}>
-            Ant Design
-          </Title>
-        </Space>
-      </section>
-      <Divider style={{ marginBottom: 60 }}>Form</Divider>
-      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 8 }}>
-        <Form.Item label="InputNumber">
-          <InputNumber min={1} max={10} defaultValue={3} />
-          <span className="ant-form-text"> Machine</span>
-          <a href="https://ant.design">Link Text</a>
-        </Form.Item>
-        <Form.Item label="Switch">
-          <Switch defaultChecked />
-        </Form.Item>
-        <Form.Item label="Slider">
-          <Slider defaultValue={70} />
-        </Form.Item>
-        <Form.Item label="Select">
-          <Select defaultValue="lucy" style={{ width: 192 }}>
-            <Option value="jack">jack</Option>
-            <Option value="lucy">lucy</Option>
-            <Option value="disabled" disabled>
-              disabled
-            </Option>
-            <Option value="yiminghe">yiminghe</Option>
-          </Select>
-        </Form.Item>
-        <Form.Item label="DatePicker">
-          <DatePicker />
-        </Form.Item>
-        <Form.Item label="DatePicker.RangePicker">
-          <DatePicker.RangePicker />
-        </Form.Item>
-        <Form.Item label="Rate">
-          <Rate defaultValue={5} />
-        </Form.Item>
-        <Form.Item wrapperCol={{ span: 8, offset: 8 }}>
-          <Space>
-            <Button type="primary" htmlType="submit">
-              Submit
-            </Button>
-            <Button>Cancel</Button>
-          </Space>
-        </Form.Item>
-      </Form>
-    </>
+    <div className="App">
+      <Button type="primary">Button</Button>
+    </div>
   );
 }
 ```

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -51,7 +51,7 @@ We are successfully running antd components now, go build your own application!
 
 If you are using the Pages Router in Next.js and using antd as your component library, to make the antd component library work better in your Next.js application and provide a better user experience, you can try using the following method to extract and inject antd's first-screen styles into HTML to avoid page flicker.
 
-1. 安装 `@ant-design/cssinjs`
+1. Install `@ant-design/cssinjs`
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -31,8 +31,6 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```jsx
-'use client';
-
 import React from 'react';
 import { Button } from 'antd';
 
@@ -48,6 +46,187 @@ export default Home;
 OK, you should now see a blue primary button displayed on the page. Next you can choose any components of `antd` to develop your application. Visit other workflows of `Next.js` at its [User Guide](https://nextjs.org/).
 
 We are successfully running antd components now, go build your own application!
+
+## Use the Pages Router of Next.js
+
+If you are using the Pages Router in Next.js and using antd as your component library, to make the antd component library work better in your Next.js application and provide a better user experience, you can try using the following method to extract and inject antd's first-screen styles into HTML to avoid page flicker.
+
+1. 安装 `@ant-design/cssinjs`
+
+<InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
+
+2. Rewrite `pages/_document.tsx`
+
+```tsx
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const cache = createCache();
+    const originalRenderPage = ctx.renderPage;
+    ctx.renderPage = () =>
+      originalRenderPage({
+        enhanceApp: (App) => (props) => (
+          <StyleProvider cache={cache}>
+            <App {...props} />
+          </StyleProvider>
+        ),
+      });
+
+    const initialProps = await Document.getInitialProps(ctx);
+    // 1.1 extract style which had been used
+    const style = extractStyle(cache, true);
+    return {
+      ...initialProps,
+      styles: (
+        <>
+          {initialProps.styles}
+          {/* 1.2 inject css */}
+          <style dangerouslySetInnerHTML={{ __html: style }}></style>
+        </>
+      ),
+    };
+  }
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+```
+
+3. Supports custom themes
+
+```tsx
+import React from 'react';
+import { ConfigProvider } from 'antd';
+
+const withTheme = (node: JSX.Element) => (
+  <>
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#52c41a',
+        },
+      }}
+    >
+      <ConfigProvider
+        theme={{
+          token: {
+            borderRadius: 16,
+          },
+        }}
+      >
+        {node}
+      </ConfigProvider>
+    </ConfigProvider>
+  </>
+);
+
+export default withTheme;
+```
+
+4. Rewrite `pages/_app.tsx`
+
+```tsx
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+import withTheme from '../theme';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return withTheme(<Component {...pageProps} />);
+}
+```
+
+5. Use antd in page component
+
+```tsx
+import {
+  Form,
+  Select,
+  InputNumber,
+  DatePicker,
+  Switch,
+  Slider,
+  Button,
+  Rate,
+  Typography,
+  Space,
+  Divider,
+} from 'antd';
+
+const { Option } = Select;
+const { Title } = Typography;
+
+export default function Home() {
+  return (
+    <>
+      <section style={{ textAlign: 'center', marginTop: 48, marginBottom: 40 }}>
+        <Space align="start">
+          <img
+            style={{ width: 40, height: 40 }}
+            src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+            alt="Ant Design"
+          />
+          <Title level={2} style={{ marginBottom: 0 }}>
+            Ant Design
+          </Title>
+        </Space>
+      </section>
+      <Divider style={{ marginBottom: 60 }}>Form</Divider>
+      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 8 }}>
+        <Form.Item label="InputNumber">
+          <InputNumber min={1} max={10} defaultValue={3} />
+          <span className="ant-form-text"> Machine</span>
+          <a href="https://ant.design">Link Text</a>
+        </Form.Item>
+        <Form.Item label="Switch">
+          <Switch defaultChecked />
+        </Form.Item>
+        <Form.Item label="Slider">
+          <Slider defaultValue={70} />
+        </Form.Item>
+        <Form.Item label="Select">
+          <Select defaultValue="lucy" style={{ width: 192 }}>
+            <Option value="jack">jack</Option>
+            <Option value="lucy">lucy</Option>
+            <Option value="disabled" disabled>
+              disabled
+            </Option>
+            <Option value="yiminghe">yiminghe</Option>
+          </Select>
+        </Form.Item>
+        <Form.Item label="DatePicker">
+          <DatePicker />
+        </Form.Item>
+        <Form.Item label="DatePicker.RangePicker">
+          <DatePicker.RangePicker />
+        </Form.Item>
+        <Form.Item label="Rate">
+          <Rate defaultValue={5} />
+        </Form.Item>
+        <Form.Item wrapperCol={{ span: 8, offset: 8 }}>
+          <Space>
+            <Button type="primary" htmlType="submit">
+              Submit
+            </Button>
+            <Button>Cancel</Button>
+          </Space>
+        </Form.Item>
+      </Form>
+    </>
+  );
+}
+```
+
+For more detailed information, please refer to [with-nextjs-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-inline-style).
 
 ## Using Next.js App Router
 
@@ -122,8 +301,6 @@ export default theme;
 5. Use in page
 
 ```tsx
-'use client';
-
 import { Button, ConfigProvider } from 'antd';
 import React from 'react';
 import theme from './themeConfig';
@@ -138,5 +315,7 @@ const HomePage: React.FC = () => (
 
 export default HomePage;
 ```
+
+> Tips: The above method does not use sub-components such as `Select.Option` and `Typography.text` in the page, so it can be used normally. However, if you use a sub-component like this in your page, you will currently see the following warning in next.js: `Error:  Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the  imported name through.`, currently need to wait for Next.js official solution. Before again, if you use the above sub-components in your page, you can add "use client" to the first line of the page component to avoid warnings. See examples for more details: [with-sub-components](https://github.com/ant-design/ant-design-examples/blob/main/examples/with-nextjs-app-router-inline-style/src/app/with-sub-components/page.tsx).
 
 For more detailed information, please refer to [with-nextjs-app-router-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-app-router-inline-style)。

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -150,80 +150,13 @@ export default function App({ Component, pageProps }: AppProps) {
 5. 在页面中使用 antd
 
 ```tsx
-import {
-  Form,
-  Select,
-  InputNumber,
-  DatePicker,
-  Switch,
-  Slider,
-  Button,
-  Rate,
-  Typography,
-  Space,
-  Divider,
-} from 'antd';
-
-const { Option } = Select;
-const { Title } = Typography;
+import { Button } from 'antd';
 
 export default function Home() {
   return (
-    <>
-      <section style={{ textAlign: 'center', marginTop: 48, marginBottom: 40 }}>
-        <Space align="start">
-          <img
-            style={{ width: 40, height: 40 }}
-            src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-            alt="Ant Design"
-          />
-          <Title level={2} style={{ marginBottom: 0 }}>
-            Ant Design
-          </Title>
-        </Space>
-      </section>
-      <Divider style={{ marginBottom: 60 }}>Form</Divider>
-      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 8 }}>
-        <Form.Item label="数字输入框">
-          <InputNumber min={1} max={10} defaultValue={3} />
-          <span className="ant-form-text"> 台机器</span>
-          <a href="https://ant.design">链接文字</a>
-        </Form.Item>
-        <Form.Item label="开关">
-          <Switch defaultChecked />
-        </Form.Item>
-        <Form.Item label="滑动输入条">
-          <Slider defaultValue={70} />
-        </Form.Item>
-        <Form.Item label="选择器">
-          <Select defaultValue="lucy" style={{ width: 192 }}>
-            <Option value="jack">jack</Option>
-            <Option value="lucy">lucy</Option>
-            <Option value="disabled" disabled>
-              disabled
-            </Option>
-            <Option value="yiminghe">yiminghe</Option>
-          </Select>
-        </Form.Item>
-        <Form.Item label="日期选择框">
-          <DatePicker />
-        </Form.Item>
-        <Form.Item label="日期范围选择框">
-          <DatePicker.RangePicker />
-        </Form.Item>
-        <Form.Item label="评分">
-          <Rate defaultValue={5} />
-        </Form.Item>
-        <Form.Item wrapperCol={{ span: 8, offset: 8 }}>
-          <Space>
-            <Button type="primary" htmlType="submit">
-              Submit
-            </Button>
-            <Button>Cancel</Button>
-          </Space>
-        </Form.Item>
-      </Form>
-    </>
+    <div className="App">
+      <Button type="primary">Button</Button>
+    </div>
   );
 }
 ```


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

- update docs about nextjs pages router

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | update docs about nextjs pages router |
| 🇨🇳 Chinese |  更新 nextjs 关于 pages router 的相关文档  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3d49d0</samp>

This pull request improves the documentation for using antd with Next.js by introducing the `@ant-design/cssinjs` package for server-side rendering of styles, and by providing some tips and examples for optimizing the user experience. It updates both the English and Chinese versions of the `docs/react/use-with-next.md` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3d49d0</samp>

*  Remove unnecessary `'use client';` statements from both English and Chinese versions of `use-with-next` documentation ([link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L34-L35), [link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L125-L126), [link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L63-L64), [link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L125-L126))
* Add new section to both English and Chinese versions of `use-with-next` documentation, explaining how to use `@ant-design/cssinjs` package to handle antd styles on the server side and avoid page flicker ([link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4R50-R230), [link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R52-R232))
* Add tip to both English and Chinese versions of `use-with-next` documentation, warning about possible warning from Next.js when using sub-components in page components, and suggesting a workaround ([link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4R319-R320), [link](https://github.com/ant-design/ant-design/pull/43651/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R319-R320))
