### PR TITLE
fix: Button default event handler

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -351,7 +351,26 @@ describe('Button', () => {
     const button = <Button onClick={onBtnClick} />;
     const anchor = <Button href="https://ant.design" onClick={onAnchorClick} />;
 
+    const defaultBtn = (
+      <Button
+        onClick={(e) => {
+          expect(e).toBeTruthy();
+        }}
+      />
+    );
+
+    const defaultABtn = (
+      <Button
+        href="https://ant.design"
+        onClick={(e) => {
+          expect(e).toBeTruthy();
+        }}
+      />
+    );
+
     expect(button).toBeTruthy();
     expect(anchor).toBeTruthy();
+    expect(defaultBtn).toBeTruthy();
+    expect(defaultABtn).toBeTruthy();
   });
 });

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -368,9 +368,21 @@ describe('Button', () => {
       />
     );
 
+    const btnRef = React.createRef<HTMLButtonElement>();
+    const refBtn = <Button ref={btnRef} />;
+
+    const anchorRef = React.createRef<HTMLAnchorElement>();
+    const refAnchor = <Button ref={anchorRef} />;
+
+    const htmlRef = React.createRef<HTMLElement>();
+    const refHtml = <Button ref={htmlRef} />;
+
     expect(button).toBeTruthy();
     expect(anchor).toBeTruthy();
     expect(defaultBtn).toBeTruthy();
     expect(defaultABtn).toBeTruthy();
+    expect(refBtn).toBeTruthy();
+    expect(refAnchor).toBeTruthy();
+    expect(refHtml).toBeTruthy();
   });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -65,7 +65,9 @@ export interface ButtonProps extends BaseButtonProps, MergedHTMLAttributes {
   htmlType?: ButtonHTMLType;
 }
 
-type CompoundedComponent = React.ForwardRefExoticComponent<ButtonProps> & {
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  ButtonProps & React.RefAttributes<HTMLElement>
+> & {
   Group: typeof Group;
   /** @internal */
   __ANT_BUTTON: boolean;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -55,26 +55,17 @@ export interface BaseButtonProps {
   styles?: { icon: React.CSSProperties };
 }
 
-export type AnchorButtonProps = {
-  href: string;
-  target?: React.HTMLAttributeAnchorTarget;
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-} & BaseButtonProps &
-  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement>, 'type' | 'onClick'>;
+type MergedHTMLAttributes = Omit<
+  React.HTMLAttributes<HTMLElement> & React.AnchorHTMLAttributes<HTMLElement>,
+  'type'
+>;
 
-export type NativeButtonProps = {
+export interface ButtonProps extends BaseButtonProps, MergedHTMLAttributes {
+  href?: string;
   htmlType?: ButtonHTMLType;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-} & BaseButtonProps &
-  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick'>;
+}
 
-export type ButtonProps = AnchorButtonProps | NativeButtonProps;
-
-type InternalButtonProps = Partial<AnchorButtonProps & NativeButtonProps>;
-
-type CompoundedComponent = React.ForwardRefExoticComponent<
-  ButtonProps & React.RefAttributes<HTMLElement>
-> & {
+type CompoundedComponent = React.ForwardRefExoticComponent<ButtonProps> & {
   Group: typeof Group;
   /** @internal */
   __ANT_BUTTON: boolean;
@@ -125,7 +116,7 @@ const InternalButton: React.ForwardRefRenderFunction<
     classNames: customClassNames,
     style: customStyle = {},
     ...rest
-  } = props as InternalButtonProps;
+  } = props;
 
   const { getPrefixCls, autoInsertSpaceInButton, direction, button } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('btn', customizePrefixCls);
@@ -218,7 +209,7 @@ const InternalButton: React.ForwardRefRenderFunction<
 
   const iconType = innerLoading ? 'loading' : icon;
 
-  const linkButtonRestProps = omit(rest as InternalButtonProps & { navigate: any }, ['navigate']);
+  const linkButtonRestProps = omit(rest as ButtonProps & { navigate: any }, ['navigate']);
 
   const classes = classNames(
     prefixCls,
@@ -280,7 +271,7 @@ const InternalButton: React.ForwardRefRenderFunction<
 
   let buttonNode = (
     <button
-      {...(rest as NativeButtonProps)}
+      {...rest}
       type={htmlType}
       className={classes}
       style={fullStyle}

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -39,6 +39,7 @@ const DEPRECIATED_VERSION = {
   ],
   '5.6.2': ['https://github.com/ant-design/ant-design/issues/43113'],
   '5.6.3': ['https://github.com/ant-design/ant-design/issues/43190'],
+  '5.7.1': ['https://github.com/ant-design/ant-design/issues/43654'],
 };
 
 function matchDeprecated(version) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43654

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Button `onClick` missing `event` definition.       |
| 🇨🇳 Chinese |   修复 Button `onClick` 事件丢失 `event` 定义的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00f9aff</samp>

This pull request enhances the Button component by simplifying its type definitions, adding more test cases, and updating the deprecation notice for version 5.7.1.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00f9aff</samp>

*  Simplify the type definitions for the ButtonProps by merging the AnchorButtonProps and NativeButtonProps into one interface ([link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L58-R67))
* Remove the unnecessary type casting of props and rest as InternalButtonProps or NativeButtonProps, since they are already typed as ButtonProps ([link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L128-R121), [link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L221-R214), [link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L283-R276))
* Add more test cases for the Button component, covering different props, types, and refs, to improve the code coverage and ensure the expected behavior ([link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-276fe24dfac9bfa7de4a29f91e72acd80a99b1034b459bc7b7ebf2db5c47805cL354-R386))
* Add a new entry to the DEPRECIATED_VERSION object in `scripts/post-script.js`, mapping the version 5.7.1 to a GitHub issue link, to inform the users of the deprecated features or breaking changes in that version and provide a reference for the migration guide ([link](https://github.com/ant-design/ant-design/pull/43666/files?diff=unified&w=0#diff-0c429b9a01f20777bce85b2ad2472fe50f00b4ef8a404d56852f3d4dd15e905dR42))
