### PR TITLE
refactor: structure the classNames and styles of select

### DIFF
--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -141,7 +141,7 @@ describe('Select', () => {
       const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       const { container } = render(<Select dropdownClassName="legacy" open />);
       expect(errSpy).toHaveBeenCalledWith(
-        'Warning: [antd: Select] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',
+        'Warning: [antd: Select] `dropdownClassName` is deprecated. Please use `classNames.popup` instead.',
       );
       expect(container.querySelector('.legacy')).toBeTruthy();
 
@@ -169,6 +169,32 @@ describe('Select', () => {
         'Warning: [antd: Select] `showArrow` is deprecated which will be removed in next major version. It will be a default behavior, you can hide it by setting `suffixIcon` to null.',
       );
       expect(container.querySelector('.ant-select-show-arrow')).toBeTruthy();
+
+      errSpy.mockRestore();
+    });
+
+    it('deprecate popupClassName', () => {
+      resetWarned();
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { container } = render(<Select popupClassName="customer-popup" open />);
+      expect(errSpy).toHaveBeenCalledWith(
+        'Warning: [antd: Select] `popupClassName` is deprecated. Please use `classNames.popup` instead.',
+      );
+      expect(container.querySelector('.ant-select-dropdown')).toHaveClass('customer-popup');
+
+      errSpy.mockRestore();
+    });
+
+    it('deprecate rootClassName', () => {
+      resetWarned();
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { container } = render(<Select rootClassName="customer-root" />);
+      expect(errSpy).toHaveBeenCalledWith(
+        'Warning: [antd: Select] `rootClassName` is deprecated. Please use `classNames.root` instead.',
+      );
+      expect(container.querySelector('.ant-select')).toHaveClass('customer-root');
 
       errSpy.mockRestore();
     });

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -61,7 +61,7 @@ Select component to select value from options.
 | defaultOpen | Initial open state of dropdown | boolean | - |  |
 | defaultValue | Initial selected option | string \| string\[] \| <br />number \| number\[] \| <br />LabeledValue \| LabeledValue\[] | - |  |
 | disabled | Whether disabled select | boolean | false |  |
-| popupClassName | The className of dropdown menu | string | - | 4.23.0 |
+| classNames | Additional className in Select | [classNames](#classNames) | - | 5.8.0 |
 | popupMatchSelectWidth | Determine whether the popup menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | 5.5.0 |
 | dropdownRender | Customize dropdown content | (originNode: ReactNode) => ReactNode | - |  |
 | dropdownStyle | The style of dropdown menu | CSSProperties | - |  |
@@ -131,6 +131,13 @@ Select component to select value from options.
 | -------- | ----------- | ----------------------- | ------- | ------- |
 | key      | Group key   | string                  | -       |         |
 | label    | Group label | string \| React.Element | -       |         |
+
+### classNames
+
+| Property | Description                    | Type   | Default | Version |
+| -------- | ------------------------------ | ------ | ------- | ------- |
+| popup    | The className of dropdown menu | string | -       | 5.8.0   |
+| root     | The className of Select root   | string | -       | 5.8.0   |
 
 ## Design Token
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 // TODO: 4.0 - codemod should help to change `filterOption` to support node props.
-import classNames from 'classnames';
+import cls from 'classnames';
 import type { BaseSelectRef, SelectProps as RcSelectProps } from 'rc-select';
 import RcSelect, { OptGroup, Option } from 'rc-select';
 import type { OptionProps } from 'rc-select/lib/Option';
@@ -64,13 +64,19 @@ export interface SelectProps<
   placement?: SelectCommonPlacement;
   mode?: 'multiple' | 'tags';
   status?: InputStatus;
+  /** @deprecated Please use `classNames.popup` instead */
   popupClassName?: string;
   /** @deprecated Please use `popupClassName` instead */
   dropdownClassName?: string;
+  /** @deprecated Please use `classNames.root` instead */
   rootClassName?: string;
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
+  classNames?: {
+    popup?: string;
+    root?: string;
+  };
 }
 
 const SECRET_COMBOBOX_MODE_DO_NOT_USE = 'SECRET_COMBOBOX_MODE_DO_NOT_USE';
@@ -83,6 +89,7 @@ const InternalSelect = <
     prefixCls: customizePrefixCls,
     bordered = true,
     className,
+    classNames,
     rootClassName,
     getPopupContainer,
     popupClassName,
@@ -177,12 +184,12 @@ const InternalSelect = <
     'itemIcon',
   ]);
 
-  const rcSelectRtlDropdownClassName = classNames(
-    popupClassName || dropdownClassName,
+  const rcSelectRtlDropdownClassName = cls(
+    (classNames?.popup ?? popupClassName) || dropdownClassName,
     {
       [`${prefixCls}-dropdown-${direction}`]: direction === 'rtl',
     },
-    rootClassName,
+    classNames?.root ?? rootClassName,
     hashId,
   );
 
@@ -192,7 +199,7 @@ const InternalSelect = <
   const disabled = React.useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
 
-  const mergedClassName = classNames(
+  const mergedClassName = cls(
     {
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
@@ -204,7 +211,7 @@ const InternalSelect = <
     compactItemClassnames,
     select?.className,
     className,
-    rootClassName,
+    classNames?.root ?? rootClassName,
     hashId,
   );
 
@@ -223,7 +230,7 @@ const InternalSelect = <
     warning(
       !dropdownClassName,
       'Select',
-      '`dropdownClassName` is deprecated. Please use `popupClassName` instead.',
+      '`dropdownClassName` is deprecated. Please use `classNames.popup` instead.',
     );
 
     warning(
@@ -236,6 +243,18 @@ const InternalSelect = <
       !('showArrow' in props),
       'Select',
       '`showArrow` is deprecated which will be removed in next major version. It will be a default behavior, you can hide it by setting `suffixIcon` to null.',
+    );
+
+    warning(
+      !popupClassName,
+      'Select',
+      '`popupClassName` is deprecated. Please use `classNames.popup` instead.',
+    );
+
+    warning(
+      !rootClassName,
+      'Select',
+      '`rootClassName` is deprecated. Please use `classNames.root` instead.',
     );
   }
 

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -62,7 +62,7 @@ demo:
 | defaultOpen | 是否默认展开下拉菜单 | boolean | - |  |
 | defaultValue | 指定默认选中的条目 | string \| string\[] \|<br />number \| number\[] \| <br />LabeledValue \| LabeledValue\[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
-| popupClassName | 下拉菜单的 className 属性 | string | - | 4.23.0 |
+| classNames | `Select` 中额外的className | [classNames](#classNames) | - | 5.8.0 |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | 5.5.0 |
 | dropdownRender | 自定义下拉框内容 | (originNode: ReactNode) => ReactNode | - |  |
 | dropdownStyle | 下拉菜单的 style 属性 | CSSProperties | - |  |
@@ -132,6 +132,13 @@ demo:
 | ----- | ---- | ----------------------- | ------ | ---- |
 | key   | Key  | string                  | -      |      |
 | label | 组名 | string \| React.Element | -      |      |
+
+### classNames
+
+| 参数  | 说明                             | 类型   | 默认值 | 版本  |
+| ----- | -------------------------------- | ------ | ------ | ----- |
+| popup | 下拉菜单的 className 属性        | string | -      | 5.8.0 |
+| root  | `Select` 根节点的 className 属性 | string | -      | 5.8.0 |
 
 ## Design Token
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/43702

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      structure the classNames and styles of select     |
| 🇨🇳 Chinese |     将 select 的 classNames 和 styles 结构化      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b865c4e</samp>

Added a new `classNames` prop to the `Select` component to allow more control over the className of the select root and the dropdown menu. Deprecated the old `popupClassName`, `dropdownClassName`, and `rootClassName` props and updated the documentation and tests accordingly. Refactored the internal component code to use the new prop and the renamed `cls` function.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b865c4e</samp>

*  Add `classNames` prop to `Select` component to allow more customization of the className of the dropdown menu and the select root ([link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L67-R79), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R92), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L180-R192), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L195-R202), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L207-R214))
*  Mark `popupClassName`, `dropdownClassName`, and `rootClassName` props as deprecated and suggest using `classNames.popup` and `classNames.root` instead ([link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L67-R79), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L226-R233), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R247-R258))
*  Update warning message for using `dropdownClassName` prop to recommend `classNames.popup` instead of `popupClassName` ([link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-d0718964c07b2e22bedd8aa3d45046c1271bf610996945e1cbc779574ccf3795L144-R144), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L226-R233))
*  Add test cases to check deprecation warnings and className customization for `Select` component ([link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-d0718964c07b2e22bedd8aa3d45046c1271bf610996945e1cbc779574ccf3795R175-R200))
*  Update documentation for `Select` component in English and Chinese to reflect the new `classNames` prop and the deprecated props ([link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-bf56ff1410a74a10dffb8c98ad2163749383eb3d25cc89fd10e747bbd8004452L64-R64), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-bf56ff1410a74a10dffb8c98ad2163749383eb3d25cc89fd10e747bbd8004452R135-R141), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-07bf0b280d743be2023d98c096d6127d8fa2d5e9baa0c23ab8ee2a4f1c0db96bL65-R65), [link](https://github.com/ant-design/ant-design/pull/43709/files?diff=unified&w=0#diff-07bf0b280d743be2023d98c096d6127d8fa2d5e9baa0c23ab8ee2a4f1c0db96bR136-R142))
