### PR TITLE
fix: revert `ButtonProps` to its previous definition

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -55,15 +55,20 @@ export interface BaseButtonProps {
   styles?: { icon: React.CSSProperties };
 }
 
-type MergedHTMLAttributes = Omit<
-  React.HTMLAttributes<HTMLElement> & React.AnchorHTMLAttributes<HTMLElement>,
-  'type'
->;
+export type AnchorButtonProps = {
+  href: string;
+  target?: React.HTMLAttributeAnchorTarget;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+} & BaseButtonProps &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement>, 'type' | 'onClick'>;
 
-export interface ButtonProps extends BaseButtonProps, MergedHTMLAttributes {
-  href?: string;
+export type NativeButtonProps = {
   htmlType?: ButtonHTMLType;
-}
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+} & BaseButtonProps &
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick'>;
+
+export type ButtonProps = AnchorButtonProps | NativeButtonProps;
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
   ButtonProps & React.RefAttributes<HTMLElement>


### PR DESCRIPTION
Fix #43711

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
Fix #43711 

### 💡 Background and solution
See the issue for detailed description.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
