### PR TITLE
type: breadcroumb use AnyObject

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -152,10 +152,7 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
         <InternalBreadcrumbItem
           key={mergedKey}
           {...itemProps}
-          {...pickAttrs(item, {
-            data: true,
-            aria: true,
-          })}
+          {...pickAttrs(item, { data: true, aria: true })}
           className={itemClassName}
           dropdownProps={dropdownProps}
           href={href}

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -13,6 +13,7 @@ import type { DropdownProps } from '../dropdown';
 import useStyle from './style';
 import useItemRender from './useItemRender';
 import useItems from './useItems';
+import { AnyObject } from '../_util/type';
 
 export interface BreadcrumbItemType {
   key?: React.Key;
@@ -46,7 +47,7 @@ export type ItemType = Partial<BreadcrumbItemType & BreadcrumbSeparatorType>;
 
 export type InternalRouteType = Partial<BreadcrumbItemType & BreadcrumbSeparatorType>;
 
-export interface BreadcrumbProps<T extends Record<PropertyKey, any> = any> {
+export interface BreadcrumbProps<T extends AnyObject = AnyObject> {
   prefixCls?: string;
   params?: T;
   separator?: React.ReactNode;
@@ -63,7 +64,7 @@ export interface BreadcrumbProps<T extends Record<PropertyKey, any> = any> {
   itemRender?: (route: ItemType, params: T, routes: ItemType[], paths: string[]) => React.ReactNode;
 }
 
-const getPath = <T extends Record<PropertyKey, any> = any>(params: T, path?: string) => {
+const getPath = <T extends AnyObject = AnyObject>(params: T, path?: string) => {
   if (path === undefined) {
     return path;
   }
@@ -74,7 +75,7 @@ const getPath = <T extends Record<PropertyKey, any> = any>(params: T, path?: str
   return mergedPath;
 };
 
-const Breadcrumb = <T extends Record<PropertyKey, any> = any>(props: BreadcrumbProps<T>) => {
+const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) => {
   const {
     prefixCls: customizePrefixCls,
     separator = '/',

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,7 @@ import type { DropdownProps } from '../dropdown';
 import useStyle from './style';
 import useItemRender from './useItemRender';
 import useItems from './useItems';
-import { AnyObject } from '../_util/type';
+import type { AnyObject } from '../_util/type';
 
 export interface BreadcrumbItemType {
   key?: React.Key;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--

-->

### 💡 需求背景和解决方案

Breadcrumb 类型定义为使用公用的 AndObject

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   update type       |
| 🇨🇳 中文 |    更新类型定义      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d711b0</samp>

Refactor `Breadcrumb` component to use `AnyObject` type. This improves the type definition and alignment with other components in `components/breadcrumb`.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d711b0</samp>

*  Refactor the `Breadcrumb` component and its props to use the `AnyObject` type instead of `Record<PropertyKey, any>` for more flexibility and consistency ([link](https://github.com/ant-design/ant-design/pull/43717/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dR16), [link](https://github.com/ant-design/ant-design/pull/43717/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dL49-R50), [link](https://github.com/ant-design/ant-design/pull/43717/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dL66-R67), [link](https://github.com/ant-design/ant-design/pull/43717/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dL77-R78)) in `components/breadcrumb/Breadcrumb.tsx`