### PR TITLE
site: update docs Usage with Next.js

### DIFF
--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -88,14 +88,12 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
     });
 
   const initialProps = await Document.getInitialProps(ctx);
-  // 1.1 extract style which had been used
   const style = extractStyle(cache, true);
   return {
     ...initialProps,
     styles: (
       <>
         {initialProps.styles}
-        {/* 1.2 inject css */}
         <style dangerouslySetInnerHTML={{ __html: style }} />
       </>
     ),

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -60,8 +60,10 @@ If you are using the Pages Router in Next.js and using antd as your component li
 2. Rewrite `pages/_document.tsx`
 
 ```tsx
+import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
-import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import Document, { Head, Html, Main, NextScript } from 'next/document';
+import type { DocumentContext } from 'next/document';
 
 const MyDocument = () => (
   <Html lang="en">
@@ -94,7 +96,7 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
       <>
         {initialProps.styles}
         {/* 1.2 inject css */}
-        <style dangerouslySetInnerHTML={{ __html: style }}></style>
+        <style dangerouslySetInnerHTML={{ __html: style }} />
       </>
     ),
   };
@@ -122,6 +124,7 @@ export default theme;
 4. Rewrite `pages/_app.tsx`
 
 ```tsx
+import React from 'react';
 import { ConfigProvider } from 'antd';
 import type { AppProps } from 'next/app';
 import theme from './themeConfig';
@@ -138,6 +141,7 @@ export default App;
 5. Use antd in page component
 
 ```tsx
+import React from 'react';
 import { Button } from 'antd';
 
 const Home = () => (
@@ -164,9 +168,9 @@ If you are using the App Router in Next.js and using antd as your component libr
 ```tsx
 'use client';
 
+import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import { useServerInsertedHTML } from 'next/navigation';
-import React from 'react';
 
 const StyledComponentsRegistry = ({ children }: { children: React.ReactNode }) => {
   const cache = createCache();
@@ -182,10 +186,10 @@ export default StyledComponentsRegistry;
 3. Use it in `app/layout.tsx`
 
 ```tsx
-import { Inter } from 'next/font/google';
 import React from 'react';
+import { Inter } from 'next/font/google';
 import StyledComponentsRegistry from '../lib/AntdRegistry';
-import './globals.css';
+import '@/globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -224,11 +228,11 @@ export default theme;
 5. Use in page
 
 ```tsx
-import { Button, ConfigProvider } from 'antd';
 import React from 'react';
+import { Button, ConfigProvider } from 'antd';
 import theme from './themeConfig';
 
-const HomePage: React.FC = () => (
+const HomePage = () => (
   <ConfigProvider theme={theme}>
     <div className="App">
       <Button type="primary">Button</Button>

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -31,6 +31,8 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```jsx
+'use client'; // If used in Pages Router, is no need to add this line
+
 import React from 'react';
 import { Button } from 'antd';
 
@@ -76,12 +78,11 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
   const originalRenderPage = ctx.renderPage;
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) =>
-        (
-          <StyleProvider cache={cache}>
-            <App {...props} />
-          </StyleProvider>
-        ),
+      enhanceApp: (App) => (props) => (
+        <StyleProvider cache={cache}>
+          <App {...props} />
+        </StyleProvider>
+      ),
     });
 
   const initialProps = await Document.getInitialProps(ctx);
@@ -238,6 +239,6 @@ const HomePage: React.FC = () => (
 export default HomePage;
 ```
 
-> Tips: The above method does not use sub-components such as `Select.Option` and `Typography.text` in the page, so it can be used normally. However, if you use a sub-component like this in your page, you will currently see the following warning in next.js: `Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.`, currently need to wait for Next.js official solution. Before again, if you use the above sub-components in your page, you can add "use client" to the first line of the page component to avoid warnings. See examples for more details: [with-sub-components](https://github.com/ant-design/ant-design-examples/blob/main/examples/with-nextjs-app-router-inline-style/src/app/with-sub-components/page.tsx).
+> Tips: The above method does not use sub-components such as `<Select.Option />` and `<Typography.text />` in the page, so it can be used normally. However, if you use a sub-component like this in your page, you will currently see the following warning in next.js: `Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.`, currently need to wait for Next.js official solution. Before again, if you use the above sub-components in your page, you can add `"use client"` to the first line of the page component to avoid warnings. See examples for more details: [with-sub-components](https://github.com/ant-design/ant-design-examples/blob/main/examples/with-nextjs-app-router-inline-style/src/app/with-sub-components/page.tsx).
 
 For more detailed information, please refer to [with-nextjs-app-router-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-app-router-inline-style)。

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -31,7 +31,7 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```jsx
-'use client'; // 如果是在 Pages Router 中使用，则不需要加这一行
+'use client'; // 如果是在 Pages Router 中使用，则不需要加这行
 
 import React from 'react';
 import { Button } from 'antd';
@@ -60,8 +60,10 @@ export default Home;
 2. 改写 `pages/_document.tsx`
 
 ```tsx
+import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
-import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import Document, { Head, Html, Main, NextScript } from 'next/document';
+import type { DocumentContext } from 'next/document';
 
 const MyDocument = () => (
   <Html lang="en">
@@ -86,15 +88,13 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
     });
 
   const initialProps = await Document.getInitialProps(ctx);
-  // 1.1 extract style which had been used
   const style = extractStyle(cache, true);
   return {
     ...initialProps,
     styles: (
       <>
         {initialProps.styles}
-        {/* 1.2 inject css */}
-        <style dangerouslySetInnerHTML={{ __html: style }}></style>
+        <style dangerouslySetInnerHTML={{ __html: style }} />
       </>
     ),
   };
@@ -122,6 +122,7 @@ export default theme;
 4. 改写 `pages/_app.tsx`
 
 ```tsx
+import React from 'react';
 import { ConfigProvider } from 'antd';
 import type { AppProps } from 'next/app';
 import theme from './themeConfig';
@@ -138,6 +139,7 @@ export default App;
 5. 在页面中使用 antd
 
 ```tsx
+import React from 'react';
 import { Button } from 'antd';
 
 const Home = () => (
@@ -164,9 +166,9 @@ export default Home;
 ```tsx
 'use client';
 
+import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import { useServerInsertedHTML } from 'next/navigation';
-import React from 'react';
 
 const StyledComponentsRegistry = ({ children }: { children: React.ReactNode }) => {
   const cache = createCache();
@@ -182,10 +184,10 @@ export default StyledComponentsRegistry;
 3. 在 `app/layout.tsx` 中使用
 
 ```tsx
-import { Inter } from 'next/font/google';
 import React from 'react';
+import { Inter } from 'next/font/google';
 import StyledComponentsRegistry from '../lib/AntdRegistry';
-import './globals.css';
+import '@/globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -224,11 +226,11 @@ export default theme;
 5. 在页面中使用
 
 ```tsx
-import { Button, ConfigProvider } from 'antd';
 import React from 'react';
+import { Button, ConfigProvider } from 'antd';
 import theme from './themeConfig';
 
-const HomePage: React.FC = () => (
+const HomePage = () => (
   <ConfigProvider theme={theme}>
     <div className="App">
       <Button type="primary">Button</Button>

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -31,7 +31,7 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```jsx
-'use client';
+'use client'; // 如果是在 Pages Router 中使用，则不需要加这一行
 
 import React from 'react';
 import { Button } from 'antd';
@@ -78,12 +78,11 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
   const originalRenderPage = ctx.renderPage;
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) =>
-        (
-          <StyleProvider cache={cache}>
-            <App {...props} />
-          </StyleProvider>
-        ),
+      enhanceApp: (App) => (props) => (
+        <StyleProvider cache={cache}>
+          <App {...props} />
+        </StyleProvider>
+      ),
     });
 
   const initialProps = await Document.getInitialProps(ctx);
@@ -163,6 +162,8 @@ export default Home;
 2. 创建 `lib/AntdRegistry.tsx`
 
 ```tsx
+'use client';
+
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import { useServerInsertedHTML } from 'next/navigation';
 import React from 'react';
@@ -238,6 +239,6 @@ const HomePage: React.FC = () => (
 export default HomePage;
 ```
 
-> 注意: 上述方式没有在页面中使用如：`Select.Option` 、 `Typography.Text` 等子组件，因此可以正常使用。但如果你的页面中有使用类似这样的子组件，目前在 Next.js 中会看到如下警告：`Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.`，目前需等待 Next.js 官方解决。在此之前，如果你的页面中使用了上述子组件，可在页面组件第一行加上 `"use client";` 来避免警告。更多细节可以参考示例：[with-sub-components](https://github.com/ant-design/ant-design-examples/blob/main/examples/with-nextjs-app-router-inline-style/src/app/with-sub-components/page.tsx)。
+> 注意: 上述方式没有在页面中使用类似 `<Select.Option />`、`<Typography.Text />` 等子组件，因此可以正常使用。但如果你的页面中有使用类似这样的子组件，目前在 Next.js 中会看到如下警告：`Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.`，目前需等待 Next.js 官方解决。在此之前，如果你的页面中使用了上述子组件，可在页面组件第一行加上 `"use client"` 来避免警告。更多细节可以参考示例：[with-sub-components](https://github.com/ant-design/ant-design-examples/blob/main/examples/with-nextjs-app-router-inline-style/src/app/with-sub-components/page.tsx)。
 
 更多详细的细节可以参考 [with-nextjs-app-router-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-app-router-inline-style)。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | site: update docs Usage with Next.js |
| 🇨🇳 Chinese | 无需纳入 ChangeLog |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99ee2ad</samp>

This pull request improves the documentation for using ant-design with Next.js in both English and Chinese, by adding or updating comments, code snippets, and formatting. It affects the files `docs/react/use-with-next.en-US.md` and `docs/react/use-with-next.zh-CN.md`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99ee2ad</samp>

*  Add a comment to explain the `'use client'` directive in the code snippets for importing antd in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4R34-R35), [link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L34-R34))
*  Format the code snippets for using the Pages Router of Next.js in both English and Chinese documents, removing unnecessary line breaks and adding spaces before closing parentheses ([link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L79-R85), [link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L81-R85))
*  Add the `'use client'` directive to the code snippet for using the App Router of Next.js in the Chinese document, as a workaround for the warning that occurs when using sub-components in the page ([link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R165-R166))
*  Fix typos and formatting issues in the sections for using the App Router of Next.js in both English and Chinese documents, such as adding angle brackets, quotation marks, and periods ([link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L241-R242), [link](https://github.com/ant-design/ant-design/pull/43720/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L241-R242))
