### PR TITLE
fix: Layout.Header accessibility role

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -17157,7 +17157,7 @@ exports[`ConfigProvider components InputNumber prefixCls 1`] = `
 `;
 
 exports[`ConfigProvider components Layout configProvider 1`] = `
-<section
+<div
   class="config-layout config-layout-has-sider"
 >
   <aside
@@ -17168,7 +17168,7 @@ exports[`ConfigProvider components Layout configProvider 1`] = `
       class="config-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="config-layout"
   >
     <header
@@ -17180,12 +17180,12 @@ exports[`ConfigProvider components Layout configProvider 1`] = `
     <footer
       class="config-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout configProvider componentDisabled 1`] = `
-<section
+<div
   class="config-layout config-layout-has-sider"
 >
   <aside
@@ -17196,7 +17196,7 @@ exports[`ConfigProvider components Layout configProvider componentDisabled 1`] =
       class="config-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="config-layout"
   >
     <header
@@ -17208,12 +17208,12 @@ exports[`ConfigProvider components Layout configProvider componentDisabled 1`] =
     <footer
       class="config-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout configProvider componentSize large 1`] = `
-<section
+<div
   class="config-layout config-layout-has-sider"
 >
   <aside
@@ -17224,7 +17224,7 @@ exports[`ConfigProvider components Layout configProvider componentSize large 1`]
       class="config-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="config-layout"
   >
     <header
@@ -17236,12 +17236,12 @@ exports[`ConfigProvider components Layout configProvider componentSize large 1`]
     <footer
       class="config-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout configProvider componentSize middle 1`] = `
-<section
+<div
   class="config-layout config-layout-has-sider"
 >
   <aside
@@ -17252,7 +17252,7 @@ exports[`ConfigProvider components Layout configProvider componentSize middle 1`
       class="config-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="config-layout"
   >
     <header
@@ -17264,12 +17264,12 @@ exports[`ConfigProvider components Layout configProvider componentSize middle 1`
     <footer
       class="config-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout configProvider componentSize small 1`] = `
-<section
+<div
   class="config-layout config-layout-has-sider"
 >
   <aside
@@ -17280,7 +17280,7 @@ exports[`ConfigProvider components Layout configProvider componentSize small 1`]
       class="config-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="config-layout"
   >
     <header
@@ -17292,12 +17292,12 @@ exports[`ConfigProvider components Layout configProvider componentSize small 1`]
     <footer
       class="config-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout normal 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
 >
   <aside
@@ -17308,7 +17308,7 @@ exports[`ConfigProvider components Layout normal 1`] = `
       class="ant-layout-sider-children"
     />
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -17320,12 +17320,12 @@ exports[`ConfigProvider components Layout normal 1`] = `
     <footer
       class="ant-layout-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components Layout prefixCls 1`] = `
-<section
+<div
   class="prefix-Layout prefix-Layout-has-sider"
 >
   <aside
@@ -17336,7 +17336,7 @@ exports[`ConfigProvider components Layout prefixCls 1`] = `
       class="prefix-sider-children"
     />
   </aside>
-  <section
+  <div
     class="prefix-Layout"
   >
     <header
@@ -17348,8 +17348,8 @@ exports[`ConfigProvider components Layout prefixCls 1`] = `
     <footer
       class="prefix-footer"
     />
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`ConfigProvider components List configProvider 1`] = `

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,7 +9,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
     class="ant-space-item"
     style="margin-bottom: 0px;"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -30,13 +30,13 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
     style="margin-bottom: 0px;"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -45,7 +45,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       >
         Header
       </header>
-      <section
+      <div
         class="ant-layout ant-layout-has-sider"
       >
         <aside
@@ -64,20 +64,20 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
         >
           Content
         </main>
-      </section>
+      </div>
       <footer
         class="ant-layout-footer"
         style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(125, 188, 234);"
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
     style="margin-bottom: 0px;"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -86,7 +86,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       >
         Header
       </header>
-      <section
+      <div
         class="ant-layout ant-layout-has-sider"
       >
         <main
@@ -105,19 +105,19 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
             Sider
           </div>
         </aside>
-      </section>
+      </div>
       <footer
         class="ant-layout-footer"
         style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(125, 188, 234);"
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
   >
-    <section
+    <div
       class="ant-layout ant-layout-has-sider"
     >
       <aside
@@ -130,7 +130,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
           Sider
         </div>
       </aside>
-      <section
+      <div
         class="ant-layout"
       >
         <header
@@ -151,14 +151,14 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
         >
           Footer
         </footer>
-      </section>
-    </section>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders components/layout/demo/custom-trigger.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
 >
   <aside
@@ -383,7 +383,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx extend context correc
       </div>
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -426,12 +426,12 @@ exports[`renders components/layout/demo/custom-trigger.tsx extend context correc
     >
       Content
     </main>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -699,11 +699,11 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
 >
   <aside
@@ -1258,7 +1258,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
       </div>
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout site-layout"
     style="margin-left: 200px;"
   >
@@ -1484,12 +1484,12 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/responsive.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
 >
   <aside
@@ -1819,7 +1819,7 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
       </span>
     </span>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -1842,12 +1842,12 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
   style="min-height: 100vh;"
 >
@@ -2442,7 +2442,7 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       </span>
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -2492,12 +2492,12 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout layout"
 >
   <header
@@ -3318,11 +3318,11 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -3578,7 +3578,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
         </li>
       </ol>
     </nav>
-    <section
+    <div
       class="ant-layout ant-layout-has-sider"
       style="padding: 24px 0px; background: rgb(255, 255, 255);"
     >
@@ -4466,7 +4466,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
       >
         Content
       </main>
-    </section>
+    </div>
   </main>
   <footer
     class="ant-layout-footer"
@@ -4474,11 +4474,11 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -4690,7 +4690,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
       </div>
     </div>
   </header>
-  <section
+  <div
     class="ant-layout ant-layout-has-sider"
   >
     <aside
@@ -5571,7 +5571,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
         </div>
       </div>
     </aside>
-    <section
+    <div
       class="ant-layout"
       style="padding: 0px 24px 24px;"
     >
@@ -5621,7 +5621,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
       >
         Content
       </main>
-    </section>
-  </section>
-</section>
+    </div>
+  </div>
+</div>
 `;

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -9,7 +9,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
     class="ant-space-item"
     style="margin-bottom:0"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -30,13 +30,13 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
     style="margin-bottom:0"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -45,7 +45,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       >
         Header
       </header>
-      <section
+      <div
         class="ant-layout ant-layout-has-sider"
       >
         <aside
@@ -64,20 +64,20 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
         >
           Content
         </main>
-      </section>
+      </div>
       <footer
         class="ant-layout-footer"
         style="text-align:center;color:#fff;background-color:#7dbcea"
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
     style="margin-bottom:0"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <header
@@ -86,7 +86,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       >
         Header
       </header>
-      <section
+      <div
         class="ant-layout ant-layout-has-sider"
       >
         <main
@@ -105,19 +105,19 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
             Sider
           </div>
         </aside>
-      </section>
+      </div>
       <footer
         class="ant-layout-footer"
         style="text-align:center;color:#fff;background-color:#7dbcea"
       >
         Footer
       </footer>
-    </section>
+    </div>
   </div>
   <div
     class="ant-space-item"
   >
-    <section
+    <div
       class="ant-layout"
     >
       <aside
@@ -130,7 +130,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
           Sider
         </div>
       </aside>
-      <section
+      <div
         class="ant-layout"
       >
         <header
@@ -151,14 +151,14 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
         >
           Footer
         </footer>
-      </section>
-    </section>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <aside
@@ -277,7 +277,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
       />
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -320,12 +320,12 @@ exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
     >
       Content
     </main>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -476,11 +476,11 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout ant-layout-has-sider"
 >
   <aside
@@ -754,7 +754,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
       />
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout site-layout"
     style="margin-left:200px"
   >
@@ -980,12 +980,12 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <aside
@@ -1135,7 +1135,7 @@ exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
       />
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -1158,12 +1158,12 @@ exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/side.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
   style="min-height:100vh"
 >
@@ -1389,7 +1389,7 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       </span>
     </div>
   </aside>
-  <section
+  <div
     class="ant-layout"
   >
     <header
@@ -1439,12 +1439,12 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
     >
       Ant Design ©2023 Created by Ant UED
     </footer>
-  </section>
-</section>
+  </div>
+</div>
 `;
 
 exports[`renders components/layout/demo/top.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout layout"
 >
   <header
@@ -1740,11 +1740,11 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -1883,7 +1883,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
         </li>
       </ol>
     </nav>
-    <section
+    <div
       class="ant-layout"
       style="padding:24px 0;background:#ffffff"
     >
@@ -2091,7 +2091,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
       >
         Content
       </main>
-    </section>
+    </div>
   </main>
   <footer
     class="ant-layout-footer"
@@ -2099,11 +2099,11 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
   >
     Ant Design ©2023 Created by Ant UED
   </footer>
-</section>
+</div>
 `;
 
 exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
-<section
+<div
   class="ant-layout"
 >
   <header
@@ -2198,7 +2198,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
       style="display:none"
     />
   </header>
-  <section
+  <div
     class="ant-layout"
   >
     <aside
@@ -2399,7 +2399,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
         />
       </div>
     </aside>
-    <section
+    <div
       class="ant-layout"
       style="padding:0 24px 24px"
     >
@@ -2449,7 +2449,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
       >
         Content
       </main>
-    </section>
-  </section>
-</section>
+    </div>
+  </div>
+</div>
 `;

--- a/components/layout/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Layout renders string width correctly 1`] = `
 `;
 
 exports[`Layout rtl render component should be rendered correctly in RTL direction 1`] = `
-<section
+<div
   class="ant-layout ant-layout-rtl"
 />
 `;

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -6,7 +6,7 @@ import useStyle from './style';
 
 export interface GeneratorProps {
   suffixCls?: string;
-  tagName: 'header' | 'footer' | 'main' | 'section';
+  tagName: 'header' | 'footer' | 'main' | 'div';
   displayName: string;
 }
 export interface BasicProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -30,7 +30,7 @@ export const LayoutContext = React.createContext<LayoutContextProps>({
 });
 
 interface BasicPropsWithTagName extends BasicProps {
-  tagName: 'header' | 'footer' | 'main' | 'section';
+  tagName: 'header' | 'footer' | 'main' | 'div';
 }
 
 function generator({ suffixCls, tagName, displayName }: GeneratorProps) {
@@ -133,7 +133,7 @@ const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props,
 });
 
 const Layout = generator({
-  tagName: 'section',
+  tagName: 'div',
   displayName: 'Layout',
 })(BasicLayout);
 

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -45,7 +45,7 @@ function generator({ suffixCls, tagName, displayName }: GeneratorProps) {
   };
 }
 
-const Basic = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props, ref) => {
+const Basic = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     suffixCls,
@@ -70,7 +70,7 @@ const Basic = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props, ref) 
   );
 });
 
-const BasicLayout = React.forwardRef<HTMLElement, BasicPropsWithTagName>((props, ref) => {
+const BasicLayout = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((props, ref) => {
   const { direction } = React.useContext(ConfigContext);
 
   const [siders, setSiders] = React.useState<string[]>([]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
Close #43718

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
For html `<header />` elements to be treated as landmark elements, they cannot be placed within a `<section />` element. `Layout` outputs a `<section />` which strips `Layout.Header` of its `banner` role. To fix this, `Layout` can simply output a `<div />` instead.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fixed `Layout.Header` accessibility role |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4b5552</samp>

Changed `tagName` from `'section'` to `'div'` in layout components to fix rendering bug. Affected file: `components/layout/layout.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4b5552</samp>

*  Change the `tagName` property of the `GeneratorProps` and `BasicPropsWithTagName` interfaces from `'header' | 'footer' | 'main' | 'section'` to `'header' | 'footer' | 'main' | 'div'` to fix a bug where the layout components would not render properly in some browsers that do not support the HTML5 semantic elements ([link](https://github.com/ant-design/ant-design/pull/43738/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658L9-R9), [link](https://github.com/ant-design/ant-design/pull/43738/files?diff=unified&w=0#diff-f22153e3f63b1ae5f7b6d84d7ecbd52b795c4ccd564a452021da1205d7c17658L33-R33)).
