### PR TITLE
site: improve a11y score in ant.design site

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -204,7 +204,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
       <html lang="en">
         <head>
           <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+          <meta name="viewport" content="width=device-width">
           <meta name="theme-color" content="#000000">
         </head>
         <body>

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -22,7 +22,7 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
   const isMotionOff = value.includes('motion-off');
 
   return (
-    <FloatButton.Group trigger="click" icon={<ThemeIcon />}>
+    <FloatButton.Group trigger="click" icon={<ThemeIcon />} aria-label="Theme Switcher">
       <Link
         to={getLocalizedPathname('/theme-editor', isZhCN(pathname), search)}
         style={{ display: 'block', marginBottom: token.margin }}

--- a/.dumi/theme/layouts/DocLayout/index.tsx
+++ b/.dumi/theme/layouts/DocLayout/index.tsx
@@ -94,7 +94,7 @@ const DocLayout: React.FC = () => {
     <>
       <Helmet encodeSpecialCharacters={false}>
         <html
-          lang={lang}
+          lang={lang === 'cn' ? 'zh-CN' : lang}
           data-direction={direction}
           className={classNames({ rtl: direction === 'rtl' })}
         />

--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -114,6 +114,7 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
               shape={shape}
               icon={open ? closeIcon : icon}
               description={description}
+              aria-label={props['aria-label']}
             />
           </>
         ) : (

--- a/components/float-button/interface.ts
+++ b/components/float-button/interface.ts
@@ -27,6 +27,7 @@ export interface FloatButtonProps {
   target?: React.HTMLAttributeAnchorTarget;
   badge?: FloatButtonBadgeProps;
   onClick?: React.MouseEventHandler<HTMLElement>;
+  ['aria-label']?: React.HtmlHTMLAttributes<HTMLButtonElement>['aria-label'];
 }
 
 export interface FloatButtonContentProps extends React.DOMAttributes<HTMLDivElement> {

--- a/scripts/previewEditor/template.html
+++ b/scripts/previewEditor/template.html
@@ -1,11 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width" />
     <title>Ant Design CHANGELOG Generator</title>
     <script>
       // [Replacement]


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
继续优化网站 accessibility 表现。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       --    |
| 🇨🇳 Chinese |      --     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8947816</samp>

This pull request improves the accessibility and responsiveness of the documentation site and the preview editor template by adding or modifying the `lang` and `meta` attributes in the HTML files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8947816</samp>

* Remove `shrink-to-fit=no` from viewport meta tag to improve accessibility and layout ([link](https://github.com/ant-design/ant-design/pull/43751/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL207-R207))
* Add `lang` attribute to `html` tag and set it to `zh-CN` for Chinese version of documentation site, or use original language value otherwise, in `.dumi/theme/layouts/DocLayout/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43751/files?diff=unified&w=0#diff-bedc1b4864dae1cd42aff9682ee09c104a08db60b785929f6bede4898dc5fa0bL97-R97))
* Add `lang` attribute to `html` tag and set it to `en` for preview editor template in `scripts/previewEditor/template.html` ([link](https://github.com/ant-design/ant-design/pull/43751/files?diff=unified&w=0#diff-56a2bb816f6e212032085d4603ddd4c19b4a8a99bc799bd751b1099edcbfa597L2-R5))
