### PR TITLE
docs: polyfill React.use

### DIFF
--- a/.dumi/hooks/use.ts
+++ b/.dumi/hooks/use.ts
@@ -1,0 +1,22 @@
+export default function use(promise: any) {
+  if (promise.status === 'fulfilled') {
+    return promise.value;
+  } else if (promise.status === 'rejected') {
+    throw promise.reason;
+  } else if (promise.status === 'pending') {
+    throw promise;
+  } else {
+    promise.status = 'pending';
+    promise.then(
+      (result) => {
+        promise.status = 'fulfilled';
+        promise.value = result;
+      },
+      (reason) => {
+        promise.status = 'rejected';
+        promise.reason = reason;
+      },
+    );
+    throw promise;
+  }
+}

--- a/.dumi/hooks/use.ts
+++ b/.dumi/hooks/use.ts
@@ -1,7 +1,8 @@
 export default function use(promise: any) {
   if (promise.status === 'fulfilled') {
     return promise.value;
-  } else if (promise.status === 'rejected') {
+  }
+  if (promise.status === 'rejected') {
     throw promise.reason;
   } else if (promise.status === 'pending') {
     throw promise;

--- a/.dumi/pages/index/components/BannerRecommends.tsx
+++ b/.dumi/pages/index/components/BannerRecommends.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { Typography, Skeleton, Carousel } from 'antd';
 import { createStyles, css, useTheme } from 'antd-style';
 import classNames from 'classnames';
+import type { FC } from 'react';
+import { useContext } from 'react';
 import type { Extra, Icon } from './util';
 import SiteContext from '../../../theme/slots/SiteContext';
 import { getCarouselStyle, useSiteData } from './util';
 import useLocale from '../../../hooks/useLocale';
-import { FC, useContext } from 'react';
 
 const useStyle = createStyles(({ token }) => {
   const { carousel } = getCarouselStyle();

--- a/.dumi/pages/index/components/BannerRecommends.tsx
+++ b/.dumi/pages/index/components/BannerRecommends.tsx
@@ -6,6 +6,7 @@ import type { Extra, Icon } from './util';
 import SiteContext from '../../../theme/slots/SiteContext';
 import { getCarouselStyle, useSiteData } from './util';
 import useLocale from '../../../hooks/useLocale';
+import { FC, useContext } from 'react';
 
 const useStyle = createStyles(({ token }) => {
   const { carousel } = getCarouselStyle();
@@ -83,10 +84,28 @@ const RecommendItem = ({ extra, index, icons, className }: RecommendItemProps) =
   );
 };
 
-export interface BannerRecommendsProps {
-  extras?: Extra[];
-  icons?: Icon[];
-}
+export const BannerRecommendsFallback: FC = () => {
+  const { isMobile } = useContext(SiteContext);
+  const { styles } = useStyle();
+
+  const list = Array(3).fill(1);
+
+  return isMobile ? (
+    <Carousel className={styles.carousel}>
+      {list.map((extra, index) => (
+        <div key={index}>
+          <Skeleton active style={{ padding: '0 24px' }} />
+        </div>
+      ))}
+    </Carousel>
+  ) : (
+    <div className={styles.container}>
+      {list.map((_, index) => (
+        <Skeleton key={index} active />
+      ))}
+    </div>
+  );
+};
 
 export default function BannerRecommends() {
   const { styles } = useStyle();

--- a/.dumi/pages/index/components/BannerRecommends.tsx
+++ b/.dumi/pages/index/components/BannerRecommends.tsx
@@ -4,7 +4,8 @@ import { createStyles, css, useTheme } from 'antd-style';
 import classNames from 'classnames';
 import type { Extra, Icon } from './util';
 import SiteContext from '../../../theme/slots/SiteContext';
-import { getCarouselStyle } from './util';
+import { getCarouselStyle, useSiteData } from './util';
+import useLocale from '../../../hooks/useLocale';
 
 const useStyle = createStyles(({ token }) => {
   const { carousel } = getCarouselStyle();
@@ -87,9 +88,13 @@ export interface BannerRecommendsProps {
   icons?: Icon[];
 }
 
-export default function BannerRecommends({ extras = [], icons = [] }: BannerRecommendsProps) {
+export default function BannerRecommends() {
   const { styles } = useStyle();
+  const [, lang] = useLocale();
   const { isMobile } = React.useContext(SiteContext);
+  const data = useSiteData();
+  const extras = data?.extras?.[lang];
+  const icons = data?.icons;
   const first3 = extras.length === 0 ? Array(3).fill(null) : extras.slice(0, 3);
 
   return (

--- a/.dumi/pages/index/components/util.ts
+++ b/.dumi/pages/index/components/util.ts
@@ -1,7 +1,5 @@
-import * as React from 'react';
 import { css } from 'antd-style';
 import fetch from 'cross-fetch';
-import axios from 'axios';
 import use from '../../../hooks/use';
 
 export interface Author {

--- a/.dumi/pages/index/components/util.ts
+++ b/.dumi/pages/index/components/util.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { css } from 'antd-style';
+import fetch from 'cross-fetch';
+import axios from 'axios';
+import use from '../../../hooks/use';
 
 export interface Author {
   avatar: string;
@@ -80,23 +83,12 @@ export function preLoad(list: string[]) {
   }
 }
 
+const promise = fetch(`https://render.alipay.com/p/h5data/antd4-config_website-h5data.json`).then(
+  (res) => res.json(),
+);
+
 export function useSiteData(): [Partial<SiteData>, boolean] {
-  const [data, setData] = React.useState<Partial<SiteData>>({});
-  const [loading, setLoading] = React.useState<boolean>(false);
-
-  React.useEffect(() => {
-    if (Object.keys(data ?? {}).length === 0 && typeof fetch !== 'undefined') {
-      setLoading(true);
-      fetch(`https://render.alipay.com/p/h5data/antd4-config_website-h5data.json`)
-        .then((res) => res.json())
-        .then((result) => {
-          setData(result);
-          setLoading(false);
-        });
-    }
-  }, []);
-
-  return [data, loading];
+  return use(promise);
 }
 
 export const getCarouselStyle = () => ({

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -1,6 +1,5 @@
 import { createStyles, css } from 'antd-style';
 import { ConfigProvider } from 'antd';
-import { useLocale as useDumiLocale } from 'dumi';
 import React, { Suspense } from 'react';
 import useLocale from '../../hooks/useLocale';
 import Banner from './components/Banner';
@@ -9,7 +8,6 @@ import ComponentsList from './components/ComponentsList';
 import DesignFramework from './components/DesignFramework';
 import Group from './components/Group';
 import Theme from './components/Theme';
-import { useSiteData } from './components/util';
 
 const useStyle = createStyles(() => ({
   image: css`

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -1,7 +1,7 @@
 import { createStyles, css } from 'antd-style';
 import { ConfigProvider } from 'antd';
 import { useLocale as useDumiLocale } from 'dumi';
-import React from 'react';
+import React, { Suspense } from 'react';
 import useLocale from '../../hooks/useLocale';
 import Banner from './components/Banner';
 import BannerRecommends from './components/BannerRecommends';
@@ -37,16 +37,15 @@ const locales = {
 
 const Homepage: React.FC = () => {
   const [locale] = useLocale(locales);
-  const { id: localeId } = useDumiLocale();
-  const localeStr = localeId === 'zh-CN' ? 'cn' : 'en';
   const { styles } = useStyle();
-  const [siteData] = useSiteData();
 
   return (
     <ConfigProvider theme={{ algorithm: undefined }}>
       <section>
         <Banner>
-          <BannerRecommends extras={siteData?.extras?.[localeStr]} icons={siteData?.icons} />
+          <Suspense fallback="loading">
+            <BannerRecommends />
+          </Suspense>
         </Banner>
         <div>
           <Theme />

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -3,7 +3,7 @@ import { ConfigProvider } from 'antd';
 import React, { Suspense } from 'react';
 import useLocale from '../../hooks/useLocale';
 import Banner from './components/Banner';
-import BannerRecommends from './components/BannerRecommends';
+import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
 import ComponentsList from './components/ComponentsList';
 import DesignFramework from './components/DesignFramework';
 import Group from './components/Group';
@@ -41,7 +41,7 @@ const Homepage: React.FC = () => {
     <ConfigProvider theme={{ algorithm: undefined }}>
       <section>
         <Banner>
-          <Suspense fallback="loading">
+          <Suspense fallback={<BannerRecommendsFallback />}>
             <BannerRecommends />
           </Suspense>
         </Banner>

--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
     "cheerio": "1.0.0-rc.12",
     "circular-dependency-plugin": "^5.2.2",
     "cross-env": "^7.0.0",
+    "cross-fetch": "^4.0.0",
     "crypto": "^1.0.1",
     "dekko": "^0.2.1",
     "dumi": "^2.1.17",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
Polyfill React.use，用于一些异步的数据请求，比如首页的推荐文章，在 Suspense 和 renderToPipeableStream 的加持下可以实现类似 SSG 数据预请求的效果。

目前 React.use 有个小问题，由于 Suspense 结束后组件会重新渲染，所以 promise 不能直接写在组件内（useMemo 也不行），只能放在全局 scope 中。这会导致客户端额外做一次请求，不过影响不大。

**Before:**
![Kapture 2023-07-24 at 15 53 34](https://github.com/ant-design/ant-design/assets/27722486/37b87d34-ac95-4f73-9269-7794b551e897)

**After:**
![Kapture 2023-07-24 at 15 56 36](https://github.com/ant-design/ant-design/assets/27722486/1f05c8a1-7022-41f2-a53e-3b28f33e12a5)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eeb9159</samp>

This pull request refactors the site components in the `dumi` package to use hooks and Suspense for fetching and displaying site data. It also adds the `cross-fetch` module as a dependency and a new custom hook `use` for handling promises.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eeb9159</samp>

*  Add a new custom hook `use` that handles promises with suspense ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-c6965f7c68830131bb906994117817a218331546ae791f2b03f7ded25f2bb96fR1-R22))
*  Import `use` and other hooks and functions from `dumi` package in `.dumi/pages/index/components/BannerRecommends.tsx` and `.dumi/pages/index/components/util.ts` ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-6a484b82d5234dc2b8c7c367190b951e79e2d45ebe10433597c11365aee1c877L7-R8), [link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-5137c94c78aea4423103cc7e7309ec68b1d233d0dae3b03750694ea29c3206cfR3-R5))
*  Simplify `useSiteData` function to use `use` hook and return site data and loading state ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-5137c94c78aea4423103cc7e7309ec68b1d233d0dae3b03750694ea29c3206cfL83-R91))
*  Modify `BannerRecommends` component to use `useSiteData` and `useLocale` hooks and remove unnecessary props ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-6a484b82d5234dc2b8c7c367190b951e79e2d45ebe10433597c11365aee1c877L90-R97))
*  Wrap `BannerRecommends` component with `Suspense` component in `.dumi/pages/index/index.tsx` and provide fallback UI ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L4-R4), [link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L49-R48))
*  Remove unused variables and hooks for locale and language in `.dumi/pages/index/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L40-R40))
*  Add `cross-fetch` module as a dependency in `package.json` for `fetch` polyfill ([link](https://github.com/ant-design/ant-design/pull/43755/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R214))
