### PR TITLE
docs: antd component export by page level

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -109,7 +109,7 @@ const GlobalLayout: React.FC = () => {
 
   return (
     <StyleProvider
-      cache={styleCache}
+      // cache={styleCache}
       linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
     >
       <SiteContext.Provider value={siteContextValue}>

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -113,7 +113,7 @@ const GlobalLayout: React.FC = () => {
 
   useServerInsertedHTML(() => {
     const styleText = extractStyle(styleCache, true);
-    return <style data-type="antd-cssinjs">{styleText.length}</style>
+    return <style data-type="antd-cssinjs" dangerouslySetInnerHTML={{ __html: styleText }} />;
   });
 
   return (

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -4,10 +4,12 @@ import {
   logicalPropertiesLinter,
   parentSelectorLinter,
   StyleProvider,
+  extractStyle,
 } from '@ant-design/cssinjs';
 import { App, theme as antdTheme } from 'antd';
 import type { DirectionType } from 'antd/es/config-provider';
 import { createSearchParams, useOutlet, useSearchParams } from 'dumi';
+import { useServerInsertedHTML } from 'umi';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import useLayoutState from '../../hooks/useLayoutState';
 import SiteThemeProvider from '../SiteThemeProvider';
@@ -22,10 +24,10 @@ type SiteState = Partial<Omit<SiteContextProps, 'updateSiteContext'>>;
 
 const RESPONSIVE_MOBILE = 768;
 
-const styleCache = createCache();
-if (typeof global !== 'undefined') {
-  (global as any).styleCache = styleCache;
-}
+// const styleCache = createCache();
+// if (typeof global !== 'undefined') {
+//   (global as any).styleCache = styleCache;
+// }
 
 const getAlgorithm = (themes: ThemeName[] = []) =>
   themes.map((theme) => {
@@ -107,9 +109,16 @@ const GlobalLayout: React.FC = () => {
     [isMobile, direction, updateSiteConfig, theme],
   );
 
+  const [styleCache] = React.useState(() => createCache());
+
+  useServerInsertedHTML(() => {
+    const styleText = extractStyle(styleCache, true);
+    return <style data-type="antd-cssinjs">{styleText.length}</style>
+  });
+
   return (
     <StyleProvider
-      // cache={styleCache}
+      cache={styleCache}
       linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
     >
       <SiteContext.Provider value={siteContextValue}>

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -49,7 +49,7 @@ class AntdReactTechStack extends ReactTechStack {
 const resolve = (p: string): string => require.resolve(p);
 
 const RoutesPlugin = (api: IApi) => {
-  const ssrCssFileName = `ssr-${Date.now()}.css`;
+  // const ssrCssFileName = `ssr-${Date.now()}.css`;
 
   const writeCSSFile = (key: string, hashKey: string, cssString: string) => {
     const fileName = `style-${key}.${getHash(hashKey)}.css`;
@@ -157,7 +157,7 @@ const RoutesPlugin = (api: IApi) => {
   // add ssr css file to html
   api.modifyConfig((memo) => {
     memo.styles ??= [];
-    memo.styles.push(`/${ssrCssFileName}`);
+    // memo.styles.push(`/${ssrCssFileName}`);
 
     return memo;
   });

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -145,16 +145,16 @@ const RoutesPlugin = (api: IApi) => {
   });
 
   // generate ssr css file
-  api.onBuildHtmlComplete(() => {
-    // FIXME: This should not be empty @peachScript
-    const styleCache = (global as any)?.styleCache;
-    const styleText = styleCache ? extractStyle(styleCache) : '';
-    const styleTextWithoutStyleTag = styleText
-      .replace(/<style\s[^>]*>/g, '')
-      .replace(/<\/style>/g, '');
+  // api.onBuildHtmlComplete(() => {
+  //   // FIXME: This should not be empty @peachScript
+  //   const styleCache = (global as any)?.styleCache;
+  //   const styleText = styleCache ? extractStyle(styleCache) : '';
+  //   const styleTextWithoutStyleTag = styleText
+  //     .replace(/<style\s[^>]*>/g, '')
+  //     .replace(/<\/style>/g, '');
 
-    fs.writeFileSync(`./_site/${ssrCssFileName}`, styleTextWithoutStyleTag, 'utf8');
-  });
+  //   fs.writeFileSync(`./_site/${ssrCssFileName}`, styleTextWithoutStyleTag, 'utf8');
+  // });
 };
 
 export default RoutesPlugin;

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -1,4 +1,3 @@
-import { extractStyle } from '@ant-design/cssinjs';
 import type { IApi, IRoute } from 'dumi';
 import ReactTechStack from 'dumi/dist/techStacks/react';
 import fs from 'fs';

--- a/package.json
+++ b/package.json
@@ -323,5 +323,11 @@
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": "rome format --write",
     "*.{json,less,md}": "prettier --ignore-unknown --write"
+  },
+  "overrides": {
+    "umi": "4.0.0-canary.20230724.1"
+  },
+  "resolutions": {
+    "umi": "4.0.0-canary.20230724.1"
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   -        |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44fe944</samp>

The pull request migrates the documentation site from `emotion` to `@ant-design/cssinjs` for CSS-in-JS styling. It also updates the `umi` dependency to a canary version that supports SSR of the styles. These changes improve the compatibility and performance of the site.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44fe944</samp>

* Import `extractStyle` and `useServerInsertedHTML` to enable SSR of CSS-in-JS styles ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L7-R12))
* Create and use local `styleCache` variable instead of global one ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L25-R30),[link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R112-R118))
* Change CSS file name prefix from `emotion` to `style` ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-852bf1cdda6c5eb6b7652ec9ec9d2c9c497fb40eb1f3a10c2f0745fc58a0a227L56-R56))
* Modify `addLinkStyle` to accept `prepend` parameter and insert antd style before head tag ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-852bf1cdda6c5eb6b7652ec9ec9d2c9c497fb40eb1f3a10c2f0745fc58a0a227L68-R74),[link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-852bf1cdda6c5eb6b7652ec9ec9d2c9c497fb40eb1f3a10c2f0745fc58a0a227R140-R153))
* Comment out code to generate single SSR CSS file ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-852bf1cdda6c5eb6b7652ec9ec9d2c9c497fb40eb1f3a10c2f0745fc58a0a227L147-R178))
* Add `overrides` and `resolutions` to `package.json` to specify canary version of `umi` ([link](https://github.com/ant-design/ant-design/pull/43762/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R326-R331))
