### PR TITLE
chore: split antv

### DIFF
--- a/.dumi/theme/common/BehaviorMap/BehaviorMap.tsx
+++ b/.dumi/theme/common/BehaviorMap/BehaviorMap.tsx
@@ -1,0 +1,333 @@
+import G6 from '@antv/g6';
+import { createStyles, css } from 'antd-style';
+import { useRouteMeta } from 'dumi';
+import React, { useEffect, useRef } from 'react';
+
+G6.registerNode('behavior-start-node', {
+  draw: (cfg, group) => {
+    const textWidth = G6.Util.getTextSize(cfg!.label, 16)[0];
+    const size = [textWidth + 20 * 2, 48];
+    const keyShape = group!.addShape('rect', {
+      name: 'start-node',
+      attrs: {
+        width: size[0],
+        height: size[1],
+        y: -size[1] / 2,
+        radius: 8,
+        fill: '#fff',
+      },
+    });
+    group!.addShape('text', {
+      attrs: {
+        text: `${cfg!.label}`,
+        fill: 'rgba(0, 0, 0, 0.88)',
+        fontSize: 16,
+        fontWeight: 500,
+        x: 20,
+        textBaseline: 'middle',
+      },
+      name: 'start-node-text',
+    });
+    return keyShape;
+  },
+  getAnchorPoints() {
+    return [
+      [0, 0.5],
+      [1, 0.5],
+    ];
+  },
+});
+
+G6.registerNode(
+  'behavior-sub-node',
+  {
+    draw: (cfg, group) => {
+      const textWidth = G6.Util.getTextSize(cfg!.label, 14)[0];
+      const padding = 16;
+      const size = [textWidth + 16 * 2 + (cfg!.targetType ? 12 : 0) + (cfg!.link ? 20 : 0), 40];
+      const keyShape = group!.addShape('rect', {
+        name: 'sub-node',
+        attrs: {
+          width: size[0],
+          height: size[1],
+          y: -size[1] / 2,
+          radius: 8,
+          fill: '#fff',
+          cursor: 'pointer',
+        },
+      });
+      group!.addShape('text', {
+        attrs: {
+          text: `${cfg!.label}`,
+          x: cfg!.targetType ? 12 + 16 : padding,
+          fill: 'rgba(0, 0, 0, 0.88)',
+          fontSize: 14,
+          textBaseline: 'middle',
+          cursor: 'pointer',
+        },
+        name: 'sub-node-text',
+      });
+      if (cfg!.targetType) {
+        group!.addShape('rect', {
+          name: 'sub-node-type',
+          attrs: {
+            width: 8,
+            height: 8,
+            radius: 4,
+            y: -4,
+            x: 12,
+            fill: cfg!.targetType === 'mvp' ? '#1677ff' : '#A0A0A0',
+            cursor: 'pointer',
+          },
+        });
+      }
+      if (cfg!.children) {
+        const { length } = cfg!.children as any;
+        group!.addShape('rect', {
+          name: 'sub-node-children-length',
+          attrs: {
+            width: 20,
+            height: 20,
+            radius: 10,
+            y: -10,
+            x: size[0] - 4,
+            fill: '#404040',
+            cursor: 'pointer',
+          },
+        });
+        group!.addShape('text', {
+          name: 'sub-node-children-length-text',
+          attrs: {
+            text: `${length}`,
+            x: size[0] + 6 - G6.Util.getTextSize(`${length}`, 12)[0] / 2,
+            textBaseline: 'middle',
+            fill: '#fff',
+            fontSize: 12,
+            cursor: 'pointer',
+          },
+        });
+      }
+      if (cfg!.link) {
+        group!.addShape('dom', {
+          attrs: {
+            width: 16,
+            height: 16,
+            x: size[0] - 12 - 16,
+            y: -8,
+            cursor: 'pointer',
+            // DOM's html
+            html: `
+            <div style="width: 16px; height: 16px;">
+              <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <g id="页面-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                      <g id="DatePicker" transform="translate(-890.000000, -441.000000)" fill-rule="nonzero">
+                          <g id="编组-30" transform="translate(288.000000, 354.000000)">
+                              <g id="编组-7备份-7" transform="translate(522.000000, 79.000000)">
+                                  <g id="right-circle-outlinedd" transform="translate(80.000000, 8.000000)">
+                                      <rect id="矩形" fill="#000000" opacity="0" x="0" y="0" width="16" height="16"></rect>
+                                      <path d="M10.4171875,7.8984375 L6.5734375,5.1171875 C6.490625,5.0578125 6.375,5.115625 6.375,5.21875 L6.375,5.9515625 C6.375,6.1109375 6.4515625,6.2625 6.58125,6.35625 L8.853125,8 L6.58125,9.64375 C6.4515625,9.7375 6.375,9.8875 6.375,10.0484375 L6.375,10.78125 C6.375,10.8828125 6.490625,10.9421875 6.5734375,10.8828125 L10.4171875,8.1015625 C10.4859375,8.0515625 10.4859375,7.9484375 10.4171875,7.8984375 Z" id="路径" fill="#BFBFBF"></path>
+                                      <path d="M8,1 C4.134375,1 1,4.134375 1,8 C1,11.865625 4.134375,15 8,15 C11.865625,15 15,11.865625 15,8 C15,4.134375 11.865625,1 8,1 Z M8,13.8125 C4.790625,13.8125 2.1875,11.209375 2.1875,8 C2.1875,4.790625 4.790625,2.1875 8,2.1875 C11.209375,2.1875 13.8125,4.790625 13.8125,8 C13.8125,11.209375 11.209375,13.8125 8,13.8125 Z" id="形状" fill="#BFBFBF"></path>
+                                  </g>
+                              </g>
+                          </g>
+                      </g>
+                  </g>
+              </svg>
+            </div>
+          `,
+          },
+          // 在 G6 3.3 及之后的版本中，必须指定 name，可以是任意字符串，但需要在同一个自定义元素类型中保持唯一性
+          name: 'sub-node-link',
+        });
+      }
+      return keyShape;
+    },
+    getAnchorPoints() {
+      return [
+        [0, 0.5],
+        [1, 0.5],
+      ];
+    },
+    options: {
+      stateStyles: {
+        hover: {
+          stroke: '#1677ff',
+          'sub-node-link': {
+            html: `
+            <div style="width: 16px; height: 16px;">
+              <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <g id="页面-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                      <g id="DatePicker" transform="translate(-890.000000, -441.000000)" fill-rule="nonzero">
+                          <g id="编组-30" transform="translate(288.000000, 354.000000)">
+                              <g id="编组-7备份-7" transform="translate(522.000000, 79.000000)">
+                                  <g id="right-circle-outlinedd" transform="translate(80.000000, 8.000000)">
+                                      <rect id="矩形" fill="#000000" opacity="0" x="0" y="0" width="16" height="16"></rect>
+                                      <path d="M10.4171875,7.8984375 L6.5734375,5.1171875 C6.490625,5.0578125 6.375,5.115625 6.375,5.21875 L6.375,5.9515625 C6.375,6.1109375 6.4515625,6.2625 6.58125,6.35625 L8.853125,8 L6.58125,9.64375 C6.4515625,9.7375 6.375,9.8875 6.375,10.0484375 L6.375,10.78125 C6.375,10.8828125 6.490625,10.9421875 6.5734375,10.8828125 L10.4171875,8.1015625 C10.4859375,8.0515625 10.4859375,7.9484375 10.4171875,7.8984375 Z" id="路径" fill="#1677ff"></path>
+                                      <path d="M8,1 C4.134375,1 1,4.134375 1,8 C1,11.865625 4.134375,15 8,15 C11.865625,15 15,11.865625 15,8 C15,4.134375 11.865625,1 8,1 Z M8,13.8125 C4.790625,13.8125 2.1875,11.209375 2.1875,8 C2.1875,4.790625 4.790625,2.1875 8,2.1875 C11.209375,2.1875 13.8125,4.790625 13.8125,8 C13.8125,11.209375 11.209375,13.8125 8,13.8125 Z" id="形状" fill="#1677ff"></path>
+                                  </g>
+                              </g>
+                          </g>
+                      </g>
+                  </g>
+              </svg>
+            </div>
+          `,
+          },
+        },
+      },
+    },
+  },
+  'rect',
+);
+
+const dataTransform = (data: BehaviorMapItem) => {
+  const changeData = (d: any, level = 0) => {
+    const clonedData: any = {
+      ...d,
+    };
+    switch (level) {
+      case 0:
+        clonedData.type = 'behavior-start-node';
+        break;
+      case 1:
+        clonedData.type = 'behavior-sub-node';
+        clonedData.collapsed = true;
+        break;
+      default:
+        clonedData.type = 'behavior-sub-node';
+        break;
+    }
+
+    if (d.children) {
+      clonedData.children = d.children.map((child: any) => changeData(child, level + 1));
+    }
+    return clonedData;
+  };
+  return changeData(data);
+};
+
+type BehaviorMapItem = {
+  id: string;
+  label: string;
+  targetType?: 'mvp' | 'extension';
+  children?: BehaviorMapItem[];
+  link?: string;
+};
+
+const useStyle = createStyles(() => ({
+  container: css`
+    width: 100%;
+    height: 600px;
+    background-color: #f5f5f5;
+    border: 1px solid #e8e8e8;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+  `,
+  title: css`
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    font-size: 16px;
+  `,
+  tips: css`
+    display: flex;
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+  `,
+  mvp: css`
+    margin-right: 20px;
+    display: flex;
+    align-items: center;
+    &::before {
+      display: block;
+      width: 8px;
+      height: 8px;
+      margin-right: 8px;
+      background-color: #1677ff;
+      border-radius: 50%;
+      content: '';
+    }
+  `,
+  extension: css`
+    display: flex;
+    align-items: center;
+    &::before {
+      display: block;
+      width: 8px;
+      height: 8px;
+      margin-right: 8px;
+      background-color: #a0a0a0;
+      border-radius: 50%;
+      content: '';
+    }
+  `,
+}));
+
+export type BehaviorMapProps = {
+  data: BehaviorMapItem;
+};
+
+const BehaviorMap: React.FC<BehaviorMapProps> = ({ data }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const { styles } = useStyle();
+  const meta = useRouteMeta();
+
+  useEffect(() => {
+    const graph = new G6.TreeGraph({
+      container: ref.current!,
+      width: ref.current!.scrollWidth,
+      height: ref.current!.scrollHeight,
+      renderer: 'svg',
+      modes: {
+        default: ['collapse-expand', 'drag-canvas'],
+      },
+      defaultEdge: {
+        type: 'cubic-horizontal',
+        style: {
+          lineWidth: 1,
+          stroke: '#BFBFBF',
+        },
+      },
+      layout: {
+        type: 'mindmap',
+        direction: 'LR',
+        getHeight: () => 48,
+        getWidth: (node: any) => G6.Util.getTextSize(node.label, 16)[0] + 20 * 2,
+        getVGap: () => 10,
+        getHGap: () => 60,
+        getSide: (node: any) => node.data.direction,
+      },
+    });
+
+    graph.on('node:mouseenter', (e) => {
+      graph.setItemState(e.item!, 'hover', true);
+    });
+    graph.on('node:mouseleave', (e) => {
+      graph.setItemState(e.item!, 'hover', false);
+    });
+    graph.on('node:click', (e) => {
+      const { link } = e.item!.getModel();
+      if (link) {
+        window.location.hash = link as string;
+      }
+    });
+
+    graph.data(dataTransform(data));
+    graph.render();
+    graph.fitCenter();
+  }, []);
+
+  return (
+    <div ref={ref} className={styles.container}>
+      <div className={styles.title}>{`${meta.frontmatter.title} 行为模式地图`}</div>
+      <div className={styles.tips}>
+        <div className={styles.mvp}>MVP 行为目的</div>
+        <div className={styles.extension}>拓展行为目的</div>
+      </div>
+    </div>
+  );
+};
+
+export default BehaviorMap;

--- a/.dumi/theme/common/BehaviorMap/index.tsx
+++ b/.dumi/theme/common/BehaviorMap/index.tsx
@@ -9,7 +9,7 @@ const InternalBehaviorMap = React.lazy(() => import('./BehaviorMap'));
 const useStyle = createStyles(({ token, css }) => ({
   fallback: css`
     width: 100%;
-    > ${token.antCls}-skeleton {
+    > * {
       width: 100%;
       border-radius: 8px;
     }

--- a/.dumi/theme/common/BehaviorMap/index.tsx
+++ b/.dumi/theme/common/BehaviorMap/index.tsx
@@ -11,6 +11,7 @@ const useStyle = createStyles(({ token, css }) => ({
     width: 100%;
     > ${token.antCls}-skeleton {
       width: 100%;
+      border-radius: 8px;
     }
   `,
   placeholder: css`
@@ -25,7 +26,7 @@ const BehaviorMapFallback = () => {
   return (
     <div className={styles.fallback}>
       <Skeleton.Node active style={{ height: 600, width: '100%' }}>
-        <span className={styles.placeholder}>正在载入行为模式图...</span>
+        <span className={styles.placeholder}>正在载入行为模式地图...</span>
       </Skeleton.Node>
     </div>
   );

--- a/.dumi/theme/common/BehaviorMap/index.tsx
+++ b/.dumi/theme/common/BehaviorMap/index.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 import React, { Suspense } from 'react';
-import type { BehaviorMapProps } from './BehaviorMap';
 import { Skeleton } from 'antd';
 import { createStyles } from 'antd-style';
+import type { BehaviorMapProps } from './BehaviorMap';
 
 const InternalBehaviorMap = React.lazy(() => import('./BehaviorMap'));
 

--- a/.dumi/theme/common/BehaviorMap/index.tsx
+++ b/.dumi/theme/common/BehaviorMap/index.tsx
@@ -1,333 +1,40 @@
-import G6 from '@antv/g6';
-import { createStyles, css } from 'antd-style';
-import { useRouteMeta } from 'dumi';
-import React, { useEffect, useRef } from 'react';
+import type { FC } from 'react';
+import React, { Suspense } from 'react';
+import type { BehaviorMapProps } from './BehaviorMap';
+import { Skeleton } from 'antd';
+import { createStyles } from 'antd-style';
 
-G6.registerNode('behavior-start-node', {
-  draw: (cfg, group) => {
-    const textWidth = G6.Util.getTextSize(cfg!.label, 16)[0];
-    const size = [textWidth + 20 * 2, 48];
-    const keyShape = group!.addShape('rect', {
-      name: 'start-node',
-      attrs: {
-        width: size[0],
-        height: size[1],
-        y: -size[1] / 2,
-        radius: 8,
-        fill: '#fff',
-      },
-    });
-    group!.addShape('text', {
-      attrs: {
-        text: `${cfg!.label}`,
-        fill: 'rgba(0, 0, 0, 0.88)',
-        fontSize: 16,
-        fontWeight: 500,
-        x: 20,
-        textBaseline: 'middle',
-      },
-      name: 'start-node-text',
-    });
-    return keyShape;
-  },
-  getAnchorPoints() {
-    return [
-      [0, 0.5],
-      [1, 0.5],
-    ];
-  },
-});
+const InternalBehaviorMap = React.lazy(() => import('./BehaviorMap'));
 
-G6.registerNode(
-  'behavior-sub-node',
-  {
-    draw: (cfg, group) => {
-      const textWidth = G6.Util.getTextSize(cfg!.label, 14)[0];
-      const padding = 16;
-      const size = [textWidth + 16 * 2 + (cfg!.targetType ? 12 : 0) + (cfg!.link ? 20 : 0), 40];
-      const keyShape = group!.addShape('rect', {
-        name: 'sub-node',
-        attrs: {
-          width: size[0],
-          height: size[1],
-          y: -size[1] / 2,
-          radius: 8,
-          fill: '#fff',
-          cursor: 'pointer',
-        },
-      });
-      group!.addShape('text', {
-        attrs: {
-          text: `${cfg!.label}`,
-          x: cfg!.targetType ? 12 + 16 : padding,
-          fill: 'rgba(0, 0, 0, 0.88)',
-          fontSize: 14,
-          textBaseline: 'middle',
-          cursor: 'pointer',
-        },
-        name: 'sub-node-text',
-      });
-      if (cfg!.targetType) {
-        group!.addShape('rect', {
-          name: 'sub-node-type',
-          attrs: {
-            width: 8,
-            height: 8,
-            radius: 4,
-            y: -4,
-            x: 12,
-            fill: cfg!.targetType === 'mvp' ? '#1677ff' : '#A0A0A0',
-            cursor: 'pointer',
-          },
-        });
-      }
-      if (cfg!.children) {
-        const { length } = cfg!.children as any;
-        group!.addShape('rect', {
-          name: 'sub-node-children-length',
-          attrs: {
-            width: 20,
-            height: 20,
-            radius: 10,
-            y: -10,
-            x: size[0] - 4,
-            fill: '#404040',
-            cursor: 'pointer',
-          },
-        });
-        group!.addShape('text', {
-          name: 'sub-node-children-length-text',
-          attrs: {
-            text: `${length}`,
-            x: size[0] + 6 - G6.Util.getTextSize(`${length}`, 12)[0] / 2,
-            textBaseline: 'middle',
-            fill: '#fff',
-            fontSize: 12,
-            cursor: 'pointer',
-          },
-        });
-      }
-      if (cfg!.link) {
-        group!.addShape('dom', {
-          attrs: {
-            width: 16,
-            height: 16,
-            x: size[0] - 12 - 16,
-            y: -8,
-            cursor: 'pointer',
-            // DOM's html
-            html: `
-            <div style="width: 16px; height: 16px;">
-              <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                  <g id="页面-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                      <g id="DatePicker" transform="translate(-890.000000, -441.000000)" fill-rule="nonzero">
-                          <g id="编组-30" transform="translate(288.000000, 354.000000)">
-                              <g id="编组-7备份-7" transform="translate(522.000000, 79.000000)">
-                                  <g id="right-circle-outlinedd" transform="translate(80.000000, 8.000000)">
-                                      <rect id="矩形" fill="#000000" opacity="0" x="0" y="0" width="16" height="16"></rect>
-                                      <path d="M10.4171875,7.8984375 L6.5734375,5.1171875 C6.490625,5.0578125 6.375,5.115625 6.375,5.21875 L6.375,5.9515625 C6.375,6.1109375 6.4515625,6.2625 6.58125,6.35625 L8.853125,8 L6.58125,9.64375 C6.4515625,9.7375 6.375,9.8875 6.375,10.0484375 L6.375,10.78125 C6.375,10.8828125 6.490625,10.9421875 6.5734375,10.8828125 L10.4171875,8.1015625 C10.4859375,8.0515625 10.4859375,7.9484375 10.4171875,7.8984375 Z" id="路径" fill="#BFBFBF"></path>
-                                      <path d="M8,1 C4.134375,1 1,4.134375 1,8 C1,11.865625 4.134375,15 8,15 C11.865625,15 15,11.865625 15,8 C15,4.134375 11.865625,1 8,1 Z M8,13.8125 C4.790625,13.8125 2.1875,11.209375 2.1875,8 C2.1875,4.790625 4.790625,2.1875 8,2.1875 C11.209375,2.1875 13.8125,4.790625 13.8125,8 C13.8125,11.209375 11.209375,13.8125 8,13.8125 Z" id="形状" fill="#BFBFBF"></path>
-                                  </g>
-                              </g>
-                          </g>
-                      </g>
-                  </g>
-              </svg>
-            </div>
-          `,
-          },
-          // 在 G6 3.3 及之后的版本中，必须指定 name，可以是任意字符串，但需要在同一个自定义元素类型中保持唯一性
-          name: 'sub-node-link',
-        });
-      }
-      return keyShape;
-    },
-    getAnchorPoints() {
-      return [
-        [0, 0.5],
-        [1, 0.5],
-      ];
-    },
-    options: {
-      stateStyles: {
-        hover: {
-          stroke: '#1677ff',
-          'sub-node-link': {
-            html: `
-            <div style="width: 16px; height: 16px;">
-              <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                  <g id="页面-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                      <g id="DatePicker" transform="translate(-890.000000, -441.000000)" fill-rule="nonzero">
-                          <g id="编组-30" transform="translate(288.000000, 354.000000)">
-                              <g id="编组-7备份-7" transform="translate(522.000000, 79.000000)">
-                                  <g id="right-circle-outlinedd" transform="translate(80.000000, 8.000000)">
-                                      <rect id="矩形" fill="#000000" opacity="0" x="0" y="0" width="16" height="16"></rect>
-                                      <path d="M10.4171875,7.8984375 L6.5734375,5.1171875 C6.490625,5.0578125 6.375,5.115625 6.375,5.21875 L6.375,5.9515625 C6.375,6.1109375 6.4515625,6.2625 6.58125,6.35625 L8.853125,8 L6.58125,9.64375 C6.4515625,9.7375 6.375,9.8875 6.375,10.0484375 L6.375,10.78125 C6.375,10.8828125 6.490625,10.9421875 6.5734375,10.8828125 L10.4171875,8.1015625 C10.4859375,8.0515625 10.4859375,7.9484375 10.4171875,7.8984375 Z" id="路径" fill="#1677ff"></path>
-                                      <path d="M8,1 C4.134375,1 1,4.134375 1,8 C1,11.865625 4.134375,15 8,15 C11.865625,15 15,11.865625 15,8 C15,4.134375 11.865625,1 8,1 Z M8,13.8125 C4.790625,13.8125 2.1875,11.209375 2.1875,8 C2.1875,4.790625 4.790625,2.1875 8,2.1875 C11.209375,2.1875 13.8125,4.790625 13.8125,8 C13.8125,11.209375 11.209375,13.8125 8,13.8125 Z" id="形状" fill="#1677ff"></path>
-                                  </g>
-                              </g>
-                          </g>
-                      </g>
-                  </g>
-              </svg>
-            </div>
-          `,
-          },
-        },
-      },
-    },
-  },
-  'rect',
-);
-
-const dataTransform = (data: BehaviorMapItem) => {
-  const changeData = (d: any, level = 0) => {
-    const clonedData: any = {
-      ...d,
-    };
-    switch (level) {
-      case 0:
-        clonedData.type = 'behavior-start-node';
-        break;
-      case 1:
-        clonedData.type = 'behavior-sub-node';
-        clonedData.collapsed = true;
-        break;
-      default:
-        clonedData.type = 'behavior-sub-node';
-        break;
-    }
-
-    if (d.children) {
-      clonedData.children = d.children.map((child: any) => changeData(child, level + 1));
-    }
-    return clonedData;
-  };
-  return changeData(data);
-};
-
-type BehaviorMapItem = {
-  id: string;
-  label: string;
-  targetType?: 'mvp' | 'extension';
-  children?: BehaviorMapItem[];
-  link?: string;
-};
-
-const useStyle = createStyles(() => ({
-  container: css`
+const useStyle = createStyles(({ token, css }) => ({
+  fallback: css`
     width: 100%;
-    height: 600px;
-    background-color: #f5f5f5;
-    border: 1px solid #e8e8e8;
-    border-radius: 8px;
-    overflow: hidden;
-    position: relative;
+    > ${token.antCls}-skeleton {
+      width: 100%;
+    }
   `,
-  title: css`
-    position: absolute;
-    top: 20px;
-    left: 20px;
+  placeholder: css`
+    color: ${token.colorTextDescription};
     font-size: 16px;
-  `,
-  tips: css`
-    display: flex;
-    position: absolute;
-    bottom: 20px;
-    right: 20px;
-  `,
-  mvp: css`
-    margin-right: 20px;
-    display: flex;
-    align-items: center;
-    &::before {
-      display: block;
-      width: 8px;
-      height: 8px;
-      margin-right: 8px;
-      background-color: #1677ff;
-      border-radius: 50%;
-      content: '';
-    }
-  `,
-  extension: css`
-    display: flex;
-    align-items: center;
-    &::before {
-      display: block;
-      width: 8px;
-      height: 8px;
-      margin-right: 8px;
-      background-color: #a0a0a0;
-      border-radius: 50%;
-      content: '';
-    }
   `,
 }));
 
-export type BehaviorMapProps = {
-  data: BehaviorMapItem;
-};
-
-const BehaviorMap: React.FC<BehaviorMapProps> = ({ data }) => {
-  const ref = useRef<HTMLDivElement>(null);
+const BehaviorMapFallback = () => {
   const { styles } = useStyle();
-  const meta = useRouteMeta();
-
-  useEffect(() => {
-    const graph = new G6.TreeGraph({
-      container: ref.current!,
-      width: ref.current!.scrollWidth,
-      height: ref.current!.scrollHeight,
-      renderer: 'svg',
-      modes: {
-        default: ['collapse-expand', 'drag-canvas'],
-      },
-      defaultEdge: {
-        type: 'cubic-horizontal',
-        style: {
-          lineWidth: 1,
-          stroke: '#BFBFBF',
-        },
-      },
-      layout: {
-        type: 'mindmap',
-        direction: 'LR',
-        getHeight: () => 48,
-        getWidth: (node: any) => G6.Util.getTextSize(node.label, 16)[0] + 20 * 2,
-        getVGap: () => 10,
-        getHGap: () => 60,
-        getSide: (node: any) => node.data.direction,
-      },
-    });
-
-    graph.on('node:mouseenter', (e) => {
-      graph.setItemState(e.item!, 'hover', true);
-    });
-    graph.on('node:mouseleave', (e) => {
-      graph.setItemState(e.item!, 'hover', false);
-    });
-    graph.on('node:click', (e) => {
-      const { link } = e.item!.getModel();
-      if (link) {
-        window.location.hash = link as string;
-      }
-    });
-
-    graph.data(dataTransform(data));
-    graph.render();
-    graph.fitCenter();
-  }, []);
 
   return (
-    <div ref={ref} className={styles.container}>
-      <div className={styles.title}>{`${meta.frontmatter.title} 行为模式地图`}</div>
-      <div className={styles.tips}>
-        <div className={styles.mvp}>MVP 行为目的</div>
-        <div className={styles.extension}>拓展行为目的</div>
-      </div>
+    <div className={styles.fallback}>
+      <Skeleton.Node active style={{ height: 600, width: '100%' }}>
+        <span className={styles.placeholder}>正在载入行为模式图...</span>
+      </Skeleton.Node>
     </div>
   );
 };
+
+const BehaviorMap: FC<BehaviorMapProps> = (props) => (
+  <Suspense fallback={<BehaviorMapFallback />}>
+    <InternalBehaviorMap {...props} />
+  </Suspense>
+);
 
 export default BehaviorMap;

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -40,6 +40,9 @@ export default defineConfig({
   analytics: {
     ga_v2: 'UA-72788897-1',
   },
+  analyze: {
+    analyzerPort: 'auto',
+  },
   links: [
     {
       rel: 'preload',

--- a/components/date-picker/design/behavior-pattern.tsx
+++ b/components/date-picker/design/behavior-pattern.tsx
@@ -1,112 +1,115 @@
-import React from 'react';
-import BehaviorMap from '../../../.dumi/theme/common/BehaviorMap';
+import React, { Suspense } from 'react';
+
+const BehaviorMap = React.lazy(() => import('../../../.dumi/theme/common/BehaviorMap'));
 
 const BehaviorPattern = () => (
-  <BehaviorMap
-    data={{
-      id: '200000004',
-      label: '选择（输入）日期数据',
-      children: [
-        {
-          id: '500000061',
-          label: '选择时间点',
-          targetType: 'mvp',
-          children: [
-            {
-              id: '707000085',
-              label: '选择某天',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date',
-            },
-            {
-              id: '707000086',
-              label: '选择某周',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week',
-            },
-            {
-              id: '707000087',
-              label: '选择某月',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month',
-            },
-            {
-              id: '707000088',
-              label: '选择某季度',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter',
-            },
-            {
-              id: '707000089',
-              label: '选择某年',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year',
-            },
-            {
-              id: '707000090',
-              label: '选择某时间',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time',
-            },
-          ],
-        },
-        {
-          id: '200000005',
-          label: '选择时间段',
-          targetType: 'mvp',
-          children: [
-            {
-              id: '7070000851',
-              label: '选择某天至某天',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date-range',
-            },
-            {
-              id: '7070000861',
-              label: '选择某周至某周',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week-range',
-            },
-            {
-              id: '7070000871',
-              label: '选择某月至某月',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month-range',
-            },
-            {
-              id: '7070000881',
-              label: '选择某季度至某季度',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter-range',
-            },
-            {
-              id: '7070000891',
-              label: '选择某年至某年',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year-range',
-            },
-            {
-              id: '7070000901',
-              label: '选择某时间至某时间',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time-range',
-            },
-          ],
-        },
-        {
-          id: '200000006',
-          label: '快捷选择日期数据',
-          targetType: 'extension',
-          children: [
-            {
-              id: '70700008912',
-              label: '快捷选择时间点',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-time',
-            },
-            {
-              id: '70700009012',
-              label: '快捷选择时间段',
-              link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-range',
-            },
-          ],
-        },
-        {
-          id: '200000007',
-          label: '查看日期附属信息',
-          targetType: 'extension',
-          link: 'components-date-picker-index-tab-design-zh-cn-demo-date-extra-info',
-        },
-      ],
-    }}
-  />
+  <Suspense fallback="loding...">
+    <BehaviorMap
+      data={{
+        id: '200000004',
+        label: '选择（输入）日期数据',
+        children: [
+          {
+            id: '500000061',
+            label: '选择时间点',
+            targetType: 'mvp',
+            children: [
+              {
+                id: '707000085',
+                label: '选择某天',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date',
+              },
+              {
+                id: '707000086',
+                label: '选择某周',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week',
+              },
+              {
+                id: '707000087',
+                label: '选择某月',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month',
+              },
+              {
+                id: '707000088',
+                label: '选择某季度',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter',
+              },
+              {
+                id: '707000089',
+                label: '选择某年',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year',
+              },
+              {
+                id: '707000090',
+                label: '选择某时间',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time',
+              },
+            ],
+          },
+          {
+            id: '200000005',
+            label: '选择时间段',
+            targetType: 'mvp',
+            children: [
+              {
+                id: '7070000851',
+                label: '选择某天至某天',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date-range',
+              },
+              {
+                id: '7070000861',
+                label: '选择某周至某周',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week-range',
+              },
+              {
+                id: '7070000871',
+                label: '选择某月至某月',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month-range',
+              },
+              {
+                id: '7070000881',
+                label: '选择某季度至某季度',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter-range',
+              },
+              {
+                id: '7070000891',
+                label: '选择某年至某年',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year-range',
+              },
+              {
+                id: '7070000901',
+                label: '选择某时间至某时间',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time-range',
+              },
+            ],
+          },
+          {
+            id: '200000006',
+            label: '快捷选择日期数据',
+            targetType: 'extension',
+            children: [
+              {
+                id: '70700008912',
+                label: '快捷选择时间点',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-time',
+              },
+              {
+                id: '70700009012',
+                label: '快捷选择时间段',
+                link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-range',
+              },
+            ],
+          },
+          {
+            id: '200000007',
+            label: '查看日期附属信息',
+            targetType: 'extension',
+            link: 'components-date-picker-index-tab-design-zh-cn-demo-date-extra-info',
+          },
+        ],
+      }}
+    />
+  </Suspense>
 );
 
 export default BehaviorPattern;

--- a/components/date-picker/design/behavior-pattern.tsx
+++ b/components/date-picker/design/behavior-pattern.tsx
@@ -1,115 +1,112 @@
-import React, { Suspense } from 'react';
-
-const BehaviorMap = React.lazy(() => import('../../../.dumi/theme/common/BehaviorMap'));
+import React from 'react';
+import BehaviorMap from '../../../.dumi/theme/common/BehaviorMap';
 
 const BehaviorPattern = () => (
-  <Suspense fallback="loding...">
-    <BehaviorMap
-      data={{
-        id: '200000004',
-        label: '选择（输入）日期数据',
-        children: [
-          {
-            id: '500000061',
-            label: '选择时间点',
-            targetType: 'mvp',
-            children: [
-              {
-                id: '707000085',
-                label: '选择某天',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date',
-              },
-              {
-                id: '707000086',
-                label: '选择某周',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week',
-              },
-              {
-                id: '707000087',
-                label: '选择某月',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month',
-              },
-              {
-                id: '707000088',
-                label: '选择某季度',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter',
-              },
-              {
-                id: '707000089',
-                label: '选择某年',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year',
-              },
-              {
-                id: '707000090',
-                label: '选择某时间',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time',
-              },
-            ],
-          },
-          {
-            id: '200000005',
-            label: '选择时间段',
-            targetType: 'mvp',
-            children: [
-              {
-                id: '7070000851',
-                label: '选择某天至某天',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date-range',
-              },
-              {
-                id: '7070000861',
-                label: '选择某周至某周',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week-range',
-              },
-              {
-                id: '7070000871',
-                label: '选择某月至某月',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month-range',
-              },
-              {
-                id: '7070000881',
-                label: '选择某季度至某季度',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter-range',
-              },
-              {
-                id: '7070000891',
-                label: '选择某年至某年',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year-range',
-              },
-              {
-                id: '7070000901',
-                label: '选择某时间至某时间',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time-range',
-              },
-            ],
-          },
-          {
-            id: '200000006',
-            label: '快捷选择日期数据',
-            targetType: 'extension',
-            children: [
-              {
-                id: '70700008912',
-                label: '快捷选择时间点',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-time',
-              },
-              {
-                id: '70700009012',
-                label: '快捷选择时间段',
-                link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-range',
-              },
-            ],
-          },
-          {
-            id: '200000007',
-            label: '查看日期附属信息',
-            targetType: 'extension',
-            link: 'components-date-picker-index-tab-design-zh-cn-demo-date-extra-info',
-          },
-        ],
-      }}
-    />
-  </Suspense>
+  <BehaviorMap
+    data={{
+      id: '200000004',
+      label: '选择（输入）日期数据',
+      children: [
+        {
+          id: '500000061',
+          label: '选择时间点',
+          targetType: 'mvp',
+          children: [
+            {
+              id: '707000085',
+              label: '选择某天',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date',
+            },
+            {
+              id: '707000086',
+              label: '选择某周',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week',
+            },
+            {
+              id: '707000087',
+              label: '选择某月',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month',
+            },
+            {
+              id: '707000088',
+              label: '选择某季度',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter',
+            },
+            {
+              id: '707000089',
+              label: '选择某年',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year',
+            },
+            {
+              id: '707000090',
+              label: '选择某时间',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time',
+            },
+          ],
+        },
+        {
+          id: '200000005',
+          label: '选择时间段',
+          targetType: 'mvp',
+          children: [
+            {
+              id: '7070000851',
+              label: '选择某天至某天',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-date-range',
+            },
+            {
+              id: '7070000861',
+              label: '选择某周至某周',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-week-range',
+            },
+            {
+              id: '7070000871',
+              label: '选择某月至某月',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-month-range',
+            },
+            {
+              id: '7070000881',
+              label: '选择某季度至某季度',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-quarter-range',
+            },
+            {
+              id: '7070000891',
+              label: '选择某年至某年',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-year-range',
+            },
+            {
+              id: '7070000901',
+              label: '选择某时间至某时间',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-pick-time-range',
+            },
+          ],
+        },
+        {
+          id: '200000006',
+          label: '快捷选择日期数据',
+          targetType: 'extension',
+          children: [
+            {
+              id: '70700008912',
+              label: '快捷选择时间点',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-time',
+            },
+            {
+              id: '70700009012',
+              label: '快捷选择时间段',
+              link: 'components-date-picker-index-tab-design-zh-cn-demo-preset-range',
+            },
+          ],
+        },
+        {
+          id: '200000007',
+          label: '查看日期附属信息',
+          targetType: 'extension',
+          link: 'components-date-picker-index-tab-design-zh-cn-demo-date-extra-info',
+        },
+      ],
+    }}
+  />
 );
 
 export default BehaviorPattern;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
当前访问 https://ant.design/components/button-cn 会发现引入了一个 500+kb 的 chunk

![image](https://github.com/ant-design/ant-design/assets/27722486/ccff0daa-02cb-42f4-b6e9-59270018dabb)

这个 chunk 包含了 antv，相当大，但是在当前页面用不到，只有在设计页才会用到

![image](https://github.com/ant-design/ant-design/assets/27722486/358aaffd-acda-4886-bc76-2a5a62aff4aa)

分离后：

![image](https://github.com/ant-design/ant-design/assets/27722486/01c4c6f1-c5f8-4dc3-a10c-c63a2bf43325)

 进入设计页才会加载：

https://github.com/ant-design/ant-design/assets/27722486/30a72762-d107-4ce6-92a1-831654ec9c70

这波 -400kb
![image](https://github.com/ant-design/ant-design/assets/27722486/74f910de-f805-4e14-9b3b-b574be00dda2)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec002ca</samp>

This pull request improves the developer experience and the documentation site performance by introducing two changes: one that enables the webpack-bundle-analyzer plugin to use an available port automatically, and one that dynamically imports the `BehaviorMap` component for the date picker behavior patterns.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec002ca</samp>

*  Add `analyzerPort: 'auto'` option for webpack-bundle-analyzer plugin to avoid port conflicts ([link](https://github.com/ant-design/ant-design/pull/43765/files?diff=unified&w=0#diff-d6c33c311798bd8d66d8afcbff667cd5a6d78d8ac1813f70fecf4d4074420daaR43-R45))
*  Use dynamic import for `BehaviorMap` component to improve performance and loading time of documentation site ([link](https://github.com/ant-design/ant-design/pull/43765/files?diff=unified&w=0#diff-46e161641eb31412ad11e9e32a2195dee739f32667be23dca2e55ebeb7ce5a1bL1-R112))
