### PR TITLE
refactor: rewrite getCloseIcon to FC

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -109,7 +109,11 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
       eventKey="pure"
       duration={null}
       closable={closable}
-      closeIcon={<NotifCloseIcon prefixCls={prefixCls} closeIcon={closeIcon} />}
+      closeIcon={
+        closeIcon !== null && closeIcon !== false ? (
+          <NotifCloseIcon prefixCls={prefixCls} closeIcon={closeIcon} />
+        ) : null
+      }
       content={
         <PureContent
           prefixCls={noticePrefixCls}

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -20,18 +20,22 @@ export const TypeIcon = {
   loading: <LoadingOutlined />,
 };
 
-export function getCloseIcon(prefixCls: string, closeIcon?: React.ReactNode): React.ReactNode {
+interface CloseIconProps {
+  prefixCls?: string;
+  closeIcon?: React.ReactNode;
+}
+
+export const NotifCloseIcon: React.FC<CloseIconProps> = ({ prefixCls, closeIcon }) => {
   if (closeIcon === null || closeIcon === false) {
     return null;
   }
-  return (
-    closeIcon || (
-      <span className={`${prefixCls}-close-x`}>
-        <CloseOutlined className={`${prefixCls}-close-icon`} />
-      </span>
-    )
+  const defaultCloseIcon = (
+    <span className={`${prefixCls}-close-x`}>
+      <CloseOutlined className={`${prefixCls}-close-icon`} />
+    </span>
   );
-}
+  return closeIcon || defaultCloseIcon;
+};
 
 export interface PureContentProps {
   prefixCls: string;
@@ -105,7 +109,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
       eventKey="pure"
       duration={null}
       closable={closable}
-      closeIcon={getCloseIcon(prefixCls, closeIcon)}
+      closeIcon={<NotifCloseIcon prefixCls={prefixCls} closeIcon={closeIcon} />}
       content={
         <PureContent
           prefixCls={noticePrefixCls}

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -1,9 +1,10 @@
 import { UserOutlined } from '@ant-design/icons';
 import React from 'react';
 import notification, { actWrapper } from '..';
-import { act, fireEvent } from '../../../tests/utils';
+import { act, fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import { awaitPromise, triggerMotionEnd } from './util';
+import { NotifCloseIcon } from '../PurePanel';
 
 describe('notification', () => {
   beforeAll(() => {
@@ -347,5 +348,10 @@ describe('notification', () => {
     expect(document.querySelectorAll('.custom .custom-close-icon').length).toBe(1);
     expect(document.querySelectorAll('.with-null .ant-notification-notice-close').length).toBe(0);
     expect(document.querySelectorAll('.with-false .ant-notification-notice-close').length).toBe(0);
+  });
+
+  it('notification closeIcon render correctly when closeIcon is null', () => {
+    const { container } = render(<NotifCloseIcon closeIcon={null} />);
+    expect(container.childElementCount).toBe(0);
   });
 });

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -145,7 +145,10 @@ export function useInternalNotification(
           notification?.className,
         ),
         style: { ...notification?.style, ...style },
-        closeIcon: <NotifCloseIcon prefixCls={noticePrefixCls} closeIcon={closeIcon} />,
+        closeIcon:
+          closeIcon !== null && closeIcon !== false ? (
+            <NotifCloseIcon prefixCls={prefixCls} closeIcon={closeIcon} />
+          ) : null,
         closable: closeIcon !== null && closeIcon !== false,
       });
     };

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -11,7 +11,7 @@ import type {
   NotificationInstance,
   NotificationPlacement,
 } from './interface';
-import { getCloseIcon, PureContent } from './PurePanel';
+import { NotifCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
 
@@ -65,7 +65,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     className: getClassName,
     motion: getNotificationMotion,
     closable: true,
-    closeIcon: getCloseIcon(prefixCls),
+    closeIcon: <NotifCloseIcon prefixCls={prefixCls} />,
     duration: DEFAULT_DURATION,
     getContainer: () => staticGetContainer?.() || getPopupContainer?.() || document.body,
     maxCount,
@@ -123,8 +123,6 @@ export function useInternalNotification(
         ...restConfig
       } = config;
 
-      const realCloseIcon = getCloseIcon(noticePrefixCls, closeIcon);
-
       return originOpen({
         // use placement from props instead of hard-coding "topRight"
         placement: notificationConfig?.placement ?? DEFAULT_PLACEMENT,
@@ -147,8 +145,8 @@ export function useInternalNotification(
           notification?.className,
         ),
         style: { ...notification?.style, ...style },
-        closeIcon: realCloseIcon,
-        closable: !!realCloseIcon,
+        closeIcon: <NotifCloseIcon prefixCls={noticePrefixCls} closeIcon={closeIcon} />,
+        closable: closeIcon !== null && closeIcon !== false,
       });
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor: rewrite getCloseIcon to FC |
| 🇨🇳 Chinese | 将 getCloseIcon 方法重构为函数组件 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17615c7</samp>

Refactored the close icon rendering of the `Notification` component and its hooks to use a functional component `NotifCloseIcon`. This improves performance and code readability.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17615c7</samp>

*  Refactor `getCloseIcon` function into `NotifCloseIcon` component to avoid re-rendering and improve readability ([link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL23-R38), [link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL14-R14))
*  Use `NotifCloseIcon` component as `closeIcon` prop of `Notification` component in `PurePanel.tsx` and `useNotification.tsx` files ([link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccL108-R112), [link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL68-R68))
*  Remove redundant `realCloseIcon` variable from `useInternalNotification` hook in `useNotification.tsx` file ([link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL126-L127))
*  Simplify `closeIcon` and `closable` props of `notice` object in `useInternalNotification` hook using `NotifCloseIcon` component and boolean expression ([link](https://github.com/ant-design/ant-design/pull/43768/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL150-R149))