### PR TITLE
docs: enable components tree-shaking

### DIFF
--- a/.dumi/theme/antd.js
+++ b/.dumi/theme/antd.js
@@ -1,4 +1,0 @@
-// Need import for the additional core style
-// exports.styleCore = require('../components/style/reset.css');
-
-module.exports = require('../../components');

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -30,8 +30,7 @@ export default defineConfig({
     'antd/lib': path.join(__dirname, 'components'),
     'antd/es': path.join(__dirname, 'components'),
     'antd/locale': path.join(__dirname, 'components/locale'),
-    // Change antd from `index.js` to `.dumi/theme/antd.js` to remove deps of root style
-    antd: require.resolve('./.dumi/theme/antd.js'),
+    antd: path.join(__dirname, 'components'),
   },
   extraRehypePlugins: [rehypeAntd],
   extraRemarkPlugins: [remarkAntd],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
去掉不能 tree-shaking 的 antd.js，dumi 本身就支持别名引入
![image](https://github.com/ant-design/ant-design/assets/27722486/4ce434ff-a901-44d4-a4cf-47a26d3947bd)

去除后 components 降低了 170kb 左右 （536kb -> 363kb)
![image](https://github.com/ant-design/ant-design/assets/27722486/a89c3f04-c380-46bc-9a53-5d893d307a34)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |   -        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee43e87</samp>

Refactored the documentation tool to use dumi and simplified the import alias for antd components. Deleted the unused `.dumi/theme/antd.js` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee43e87</samp>

*  Refactor the documentation tool to use dumi instead of docz ([link](https://github.com/ant-design/ant-design/pull/43777/files?diff=unified&w=0#diff-d6c33c311798bd8d66d8afcbff667cd5a6d78d8ac1813f70fecf4d4074420daaL33-R33), [link](https://github.com/ant-design/ant-design/pull/43777/files?diff=unified&w=0#diff-b5f18fcb20f240f9b9ffea7a431487498483d4a46426a885529755a89c7f1855))
  - Delete the file `.dumi/theme/antd.js` that was used as an alias for antd components ([link](https://github.com/ant-design/ant-design/pull/43777/files?diff=unified&w=0#diff-b5f18fcb20f240f9b9ffea7a431487498483d4a46426a885529755a89c7f1855))
  - Change the alias for antd components from `.dumi/theme/antd.js` to `components` in `.dumirc.ts` to simplify the import path and avoid the dependency on the root style file ([link](https://github.com/ant-design/ant-design/pull/43777/files?diff=unified&w=0#diff-d6c33c311798bd8d66d8afcbff667cd5a6d78d8ac1813f70fecf4d4074420daaL33-R33))
