### PR TITLE
feat: wave effect config

### DIFF
--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -4,6 +4,7 @@ import { render, unmount } from 'rc-util/lib/React/render';
 import raf from 'rc-util/lib/raf';
 import * as React from 'react';
 import { getTargetWaveColor } from './util';
+import type { ShowWaveEffect } from './useWave';
 
 function validateNum(value: number) {
   return Number.isNaN(value) ? 0 : value;
@@ -125,7 +126,7 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
   );
 };
 
-export default function showWaveEffect(node: HTMLElement, className: string) {
+const showWaveEffect: ShowWaveEffect = (node, { className }) => {
   // Create holder
   const holder = document.createElement('div');
   holder.style.position = 'absolute';
@@ -134,4 +135,6 @@ export default function showWaveEffect(node: HTMLElement, className: string) {
   node?.insertBefore(holder, node?.firstChild);
 
   render(<WaveEffect target={node} className={className} />, holder);
-}
+};
+
+export default showWaveEffect;

--- a/components/_util/wave/index.ts
+++ b/components/_util/wave/index.ts
@@ -11,10 +11,11 @@ import useWave from './useWave';
 export interface WaveProps {
   disabled?: boolean;
   children?: React.ReactNode;
+  component?: string;
 }
 
 const Wave: React.FC<WaveProps> = (props) => {
-  const { children, disabled } = props;
+  const { children, disabled, component } = props;
   const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const containerRef = useRef<HTMLElement>(null);
 
@@ -23,7 +24,7 @@ const Wave: React.FC<WaveProps> = (props) => {
   const [, hashId] = useStyle(prefixCls);
 
   // =============================== Wave ===============================
-  const showWave = useWave(containerRef, classNames(prefixCls, hashId));
+  const showWave = useWave(containerRef, classNames(prefixCls, hashId), component);
 
   // ============================== Effect ==============================
   React.useEffect(() => {
@@ -48,7 +49,7 @@ const Wave: React.FC<WaveProps> = (props) => {
         return;
       }
 
-      showWave();
+      showWave(e);
     };
 
     // Bind events

--- a/components/_util/wave/useWave.ts
+++ b/components/_util/wave/useWave.ts
@@ -1,14 +1,40 @@
+import * as React from 'react';
+import useEvent from 'rc-util/lib/hooks/useEvent';
 import showWaveEffect from './WaveEffect';
+import { ConfigContext } from '../../config-provider';
+import useToken from '../../theme/useToken';
+import type { GlobalToken } from '../../theme';
+
+export type ShowWaveEffect = (
+  element: HTMLElement,
+  info: {
+    className: string;
+    token: GlobalToken;
+    component?: string;
+    event: MouseEvent;
+  },
+) => void;
 
 export default function useWave(
   nodeRef: React.RefObject<HTMLElement>,
   className: string,
-): VoidFunction {
-  function showWave() {
+  component?: string,
+) {
+  const { wave } = React.useContext(ConfigContext);
+  const [, token] = useToken();
+
+  const showWave = useEvent((event: MouseEvent) => {
     const node = nodeRef.current!;
 
-    showWaveEffect(node, className);
-  }
+    if (wave?.disabled || !node) {
+      return;
+    }
+
+    const { showEffect } = wave || {};
+
+    // Customize wave effect
+    (showEffect || showWaveEffect)(node, { className, token, component, event });
+  });
 
   return showWave;
 }

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -289,7 +289,11 @@ const InternalButton: React.ForwardRefRenderFunction<
   );
 
   if (!isUnBorderedButtonType(type)) {
-    buttonNode = <Wave disabled={!!innerLoading}>{buttonNode}</Wave>;
+    buttonNode = (
+      <Wave component="Button" disabled={!!innerLoading}>
+        {buttonNode}
+      </Wave>
+    );
   }
 
   return wrapSSR(buttonNode);

--- a/components/config-provider/__tests__/wave.test.tsx
+++ b/components/config-provider/__tests__/wave.test.tsx
@@ -14,6 +14,23 @@ describe('ConfigProvider.Wave', () => {
     jest.useRealTimers();
   });
 
+  it('disable', async () => {
+    const showEffect = jest.fn();
+    const onClick = jest.fn();
+
+    const { container } = render(
+      <ConfigProvider wave={{ disabled: true, showEffect }}>
+        <Button onClick={onClick} />
+      </ConfigProvider>,
+    );
+
+    fireEvent.click(container.querySelector('button')!);
+    await waitFakeTimer();
+
+    expect(onClick).toHaveBeenCalled();
+    expect(showEffect).not.toHaveBeenCalled();
+  });
+
   it('support customize effect', async () => {
     const showEffect = jest.fn();
     const onClick = jest.fn();

--- a/components/config-provider/__tests__/wave.test.tsx
+++ b/components/config-provider/__tests__/wave.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import ConfigProvider from '..';
+import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import Button from '../../button';
+
+jest.mock('rc-util/lib/Dom/isVisible', () => () => true);
+
+describe('ConfigProvider.Wave', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('support customize effect', async () => {
+    const showEffect = jest.fn();
+    const onClick = jest.fn();
+
+    const { container } = render(
+      <ConfigProvider wave={{ showEffect }}>
+        <Button onClick={onClick} />
+      </ConfigProvider>,
+    );
+
+    fireEvent.click(container.querySelector('button')!);
+    await waitFakeTimer();
+
+    expect(onClick).toHaveBeenCalled();
+    expect(showEffect).toHaveBeenCalled();
+  });
+});

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -11,6 +11,7 @@ import type { SpaceProps } from '../space';
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from '../theme/interface';
 import type { SizeType } from './SizeContext';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
+import type { ShowWaveEffect } from '../_util/wave/useWave';
 
 export const defaultIconPrefixCls = 'anticon';
 
@@ -55,6 +56,11 @@ export interface ButtonConfig extends ComponentStyleConfig {
 }
 
 export type PopupOverflow = 'viewport' | 'scroll';
+
+export interface WaveConfig {
+  disabled?: boolean;
+  showEffect?: ShowWaveEffect;
+}
 
 export interface ConfigConsumerProps {
   getTargetContainer?: () => HTMLElement;
@@ -142,6 +148,8 @@ export interface ConfigConsumerProps {
   tree?: ComponentStyleConfig;
   colorPicker?: ComponentStyleConfig;
   datePicker?: ComponentStyleConfig;
+
+  wave?: WaveConfig;
 }
 
 const defaultGetPrefixCls = (suffixCls?: string, customizePrefixCls?: string) => {

--- a/components/config-provider/demo/wave.md
+++ b/components/config-provider/demo/wave.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+波纹效果带来了灵动性。
+
+## en-US
+
+Wave effect brings dynamic.

--- a/components/config-provider/demo/wave.md
+++ b/components/config-provider/demo/wave.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-波纹效果带来了灵动性。
+波纹效果带来了灵动性，可以通过 `component` 判断来自哪个组件。
 
 ## en-US
 
-Wave effect brings dynamic.
+Wave effect brings dynamic. Use `component` to determine which component use it.

--- a/components/config-provider/demo/wave.tsx
+++ b/components/config-provider/demo/wave.tsx
@@ -1,0 +1,117 @@
+import { Button, ConfigProvider, Space } from 'antd';
+import React from 'react';
+
+type WaveConfig = NonNullable<Parameters<typeof ConfigProvider>[0]['wave']>;
+
+// Prepare effect holder
+const createHolder = (node: HTMLElement) => {
+  const div = document.createElement('div');
+  div.style.position = 'absolute';
+  div.style.inset = '0';
+  div.style.borderRadius = 'inherit';
+  div.style.background = 'transparent';
+  div.style.zIndex = '999';
+  div.style.pointerEvents = 'none';
+  div.style.overflow = 'hidden';
+  node.appendChild(div);
+
+  return div;
+};
+
+const createDot = (
+  holder: HTMLElement,
+  color: string,
+  left: number,
+  top: number,
+  size: number = 0,
+) => {
+  const dot = document.createElement('div');
+  dot.style.position = 'absolute';
+  dot.style.left = `${left}px`;
+  dot.style.top = `${top}px`;
+  dot.style.width = `${size}px`;
+  dot.style.height = `${size}px`;
+  dot.style.borderRadius = '50%';
+  dot.style.background = color;
+  dot.style.transform = 'translate(-50%, -50%)';
+  dot.style.transition = `all 1s ease-out`;
+  holder.appendChild(dot);
+
+  return dot;
+};
+
+// Inset Effect
+const showInsetEffect: WaveConfig['showEffect'] = (node, { event }) => {
+  const holder = createHolder(node);
+
+  const rect = holder.getBoundingClientRect();
+
+  const left = event.clientX - rect.left;
+  const top = event.clientY - rect.top;
+
+  const dot = createDot(holder, 'rgba(255, 255, 255, 0.65)', left, top);
+
+  // Motion
+  requestAnimationFrame(() => {
+    dot.ontransitionend = () => {
+      holder.parentElement?.removeChild(holder);
+    };
+
+    dot.style.width = '200px';
+    dot.style.height = '200px';
+    dot.style.opacity = '0';
+  });
+};
+
+// Scale Effect
+const showScaleEffect: WaveConfig['showEffect'] = (node) => {
+  const seq = [0, -15, 15, -5, 5, 0];
+  const itv = 10;
+
+  let steps = 0;
+
+  function loop() {
+    cancelAnimationFrame((node as any).effectTimeout);
+
+    (node as any).effectTimeout = requestAnimationFrame(() => {
+      const currentStep = Math.floor(steps / itv);
+      const current = seq[currentStep];
+      const next = seq[currentStep + 1];
+
+      if (!next) {
+        node.style.transform = '';
+        node.style.transition = '';
+        return;
+      }
+
+      // Trans from current to next by itv
+      const angle = current + ((next - current) / itv) * (steps % itv);
+
+      node.style.transform = `rotate(${angle}deg)`;
+      node.style.transition = 'none';
+
+      steps += 1;
+      loop();
+    });
+  }
+
+  loop();
+};
+
+// Component
+const Wrapper = ({ name, ...wave }: WaveConfig & { name: string }) => (
+  <ConfigProvider wave={wave}>
+    <Button type="primary">{name}</Button>
+  </ConfigProvider>
+);
+
+const App = () => (
+  <Space style={{ padding: 24 }} size="large">
+    <Wrapper name="Disabled" disabled />
+    <Wrapper name="Default" />
+    <Wrapper name="Inset" showEffect={showInsetEffect} />
+    <Wrapper name="Scale" showEffect={showScaleEffect} />
+  </Space>
+);
+
+export default App;

--- a/components/config-provider/demo/wave.tsx
+++ b/components/config-provider/demo/wave.tsx
@@ -41,7 +41,11 @@ const createDot = (
 };
 
 // Inset Effect
-const showInsetEffect: WaveConfig['showEffect'] = (node, { event }) => {
+const showInsetEffect: WaveConfig['showEffect'] = (node, { event, component }) => {
+  if (component !== 'Button') {
+    return;
+  }
+
   const holder = createHolder(node);
 
   const rect = holder.getBoundingClientRect();
@@ -64,7 +68,11 @@ const showInsetEffect: WaveConfig['showEffect'] = (node, { event }) => {
 };
 
 // Scale Effect
-const showScaleEffect: WaveConfig['showEffect'] = (node) => {
+const showScaleEffect: WaveConfig['showEffect'] = (node, { component }) => {
+  if (component !== 'Button') {
+    return;
+  }
+
   const seq = [0, -15, 15, -5, 5, 0];
   const itv = 10;
 

--- a/components/config-provider/demo/wave.tsx
+++ b/components/config-provider/demo/wave.tsx
@@ -5,9 +5,12 @@ type WaveConfig = NonNullable<Parameters<typeof ConfigProvider>[0]['wave']>;
 
 // Prepare effect holder
 const createHolder = (node: HTMLElement) => {
+  const { borderWidth } = getComputedStyle(node);
+  const borderWidthNum = parseInt(borderWidth, 10);
+
   const div = document.createElement('div');
   div.style.position = 'absolute';
-  div.style.inset = '0';
+  div.style.inset = `-${borderWidthNum}px`;
   div.style.borderRadius = 'inherit';
   div.style.background = 'transparent';
   div.style.zIndex = '999';

--- a/components/config-provider/demo/wave.tsx
+++ b/components/config-provider/demo/wave.tsx
@@ -67,8 +67,8 @@ const showInsetEffect: WaveConfig['showEffect'] = (node, { event, component }) =
   });
 };
 
-// Scale Effect
-const showScaleEffect: WaveConfig['showEffect'] = (node, { component }) => {
+// Shake Effect
+const showShakeEffect: WaveConfig['showEffect'] = (node, { component }) => {
   if (component !== 'Button') {
     return;
   }
@@ -118,7 +118,7 @@ const App = () => (
     <Wrapper name="Disabled" disabled />
     <Wrapper name="Default" />
     <Wrapper name="Inset" showEffect={showInsetEffect} />
-    <Wrapper name="Scale" showEffect={showScaleEffect} />
+    <Wrapper name="Shake" showEffect={showShakeEffect} />
   </Space>
 );
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -43,6 +43,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 <code src="./demo/direction.tsx">Direction</code>
 <code src="./demo/size.tsx">Component size</code>
 <code src="./demo/theme.tsx">Theme</code>
+<code src="./demo/wave.tsx">Custom Wave</code>
 <code src="./demo/prefixCls.tsx" debug>prefixCls</code>
 <code src="./demo/useConfig.tsx" debug>useConfig</code>
 
@@ -152,6 +153,7 @@ const {
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | Set Upload common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| wave | Config wave effect | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token }) => void } | - | 5.8.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -153,7 +153,7 @@ const {
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | Set Upload common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| wave | Config wave effect | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token }) => void } | - | 5.8.0 |
+| wave | Config wave effect | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -30,6 +30,7 @@ import type {
   PopupOverflow,
   Theme,
   ThemeConfig,
+  WaveConfig,
 } from './context';
 import { ConfigConsumer, ConfigContext, defaultIconPrefixCls } from './context';
 import { registerTheme } from './cssVariables';
@@ -186,6 +187,11 @@ export interface ConfigProviderProps {
   tree?: ComponentStyleConfig;
   colorPicker?: ComponentStyleConfig;
   datePicker?: ComponentStyleConfig;
+
+  /**
+   * Wave is special component which only patch on the effect of component interaction.
+   */
+  wave?: WaveConfig;
 }
 
 interface ProviderChildrenProps extends ConfigProviderProps {
@@ -322,6 +328,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tree,
     colorPicker,
     datePicker,
+    wave,
   } = props;
 
   // =================================== Warning ===================================
@@ -420,6 +427,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     tree,
     colorPicker,
     datePicker,
+    wave,
   };
 
   const config = {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -44,6 +44,7 @@ export default Demo;
 <code src="./demo/direction.tsx">方向</code>
 <code src="./demo/size.tsx">组件尺寸</code>
 <code src="./demo/theme.tsx">主题</code>
+<code src="./demo/wave.tsx">自定义波纹</code>
 <code src="./demo/prefixCls.tsx" debug>前缀</code>
 <code src="./demo/useConfig.tsx" debug>useConfig</code>
 
@@ -154,6 +155,7 @@ const {
 | tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| wave | 设置水波纹特效 | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token }) => void } | - | 5.8.0 |
 
 ## FAQ
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -155,7 +155,7 @@ const {
 | tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| wave | 设置水波纹特效 | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token }) => void } | - | 5.8.0 |
+| wave | 设置水波纹特效 | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |
 
 ## FAQ
 

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -97,7 +97,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => 
   const mergedStyle: React.CSSProperties = { ...SWITCH?.style, ...style };
 
   return wrapSSR(
-    <Wave>
+    <Wave component="Switch">
       <RcSwitch
         {...restProps}
         prefixCls={prefixCls}

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -143,7 +143,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     </span>
   );
 
-  return wrapSSR(isNeedWave ? <Wave>{tagNode}</Wave> : tagNode);
+  return wrapSSR(isNeedWave ? <Wave component="Tag">{tagNode}</Wave> : tagNode);
 };
 
 const Tag = React.forwardRef<HTMLSpanElement, TagProps>(InternalTag) as TagType;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

follow up #40111

### 💡 Background and solution


https://github.com/ant-design/ant-design/assets/5378891/436fe9eb-b948-4bcb-9d74-fbdfa02bf794



### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      ConfigProvider support `wave` to customize wave effect.     |
| 🇨🇳 Chinese |     ConfigProvider 支持 `wave` 配置以自定义水波纹效果。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7715ee2</samp>

This pull request adds a new feature to the `ConfigProvider` component that allows users to customize or disable the wave effect for buttons and other elements. It also enhances the wave effect function for different components by passing the `event` object and the `component` prop to the `Wave` component and the `useWave` hook. It updates the documentation and the demo files to reflect the new feature and adds a test file to verify the functionality. It modifies the `Button`, `Switch`, and `Tag` components to pass the `component` prop to the `Wave` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7715ee2</samp>

*  Add a new prop `component` to the `Wave` component and the `useWave` hook to pass the name of the component that uses the wave effect ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-5e13b8dfe0e60478114c2558fe5db8724b1a7392ea966738bd35980ca72e37fdL14-R18),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-5e13b8dfe0e60478114c2558fe5db8724b1a7392ea966738bd35980ca72e37fdL26-R27),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L292-R296),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L100-R100),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L146-R146))
*  Replace the original `useWave` hook with a new one that accepts the `component` argument and uses a custom `useEvent` hook to bind the wave effect function to the `click` event ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-fc6a9164144f215671163f6b1501060f193dd221f446d3dd8ec76bc19499bdd7L1-R38))
*  Check the `wave` config from the `ConfigContext` and allow customizing the wave effect function through the `showEffect` prop in the new `useWave` hook ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-fc6a9164144f215671163f6b1501060f193dd221f446d3dd8ec76bc19499bdd7L1-R38))
*  Pass the `event` object and the `token` from the theme to the wave effect function ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-5e13b8dfe0e60478114c2558fe5db8724b1a7392ea966738bd35980ca72e37fdL51-R52),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-fc6a9164144f215671163f6b1501060f193dd221f446d3dd8ec76bc19499bdd7L1-R38))
*  Convert the `showWaveEffect` function from a default export to a named export and add the `ShowWaveEffect` type annotation to it ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfR7),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL128-R129))
*  Move the default export of `showWaveEffect` to the end of the file ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL137-R140))
*  Define a new interface `WaveConfig` that represents the configuration of the wave effect with two optional properties: `disabled` and `showEffect` ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR14),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR60-R64))
*  Add a new optional property `wave` to the `ConfigProviderProps` and `ConfigConsumerProps` interfaces of type `WaveConfig` ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR151-R152),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R190-R194))
*  Pass the `wave` prop to the `ConfigContext.Provider` and the `LocaleProvider` components as part of the `config` value ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R331),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R430))
*  Export the `WaveConfig` type from the `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R33))
*  Add a new test file `wave.test.tsx` to test the `ConfigProvider` component with the `wave` prop and two custom wave effect functions ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-e15da070170e7638ceda2742d10489653ff6b04c55109e12a7f8cb039d6d5f0cR1-R33))
*  Add a new demo file `wave.tsx` to show how to use the `wave` prop of the `ConfigProvider` component to customize the wave effect with two custom wave effect functions ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-9a6da8efc06703be476b43f3cb2bd5e6e51707672ec10ba5b8b9a2485720df13R1-R125))
*  Add a new demo file `wave.md` to explain the purpose and usage of the `wave` prop in both Chinese and English languages ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-193502da1ddc3d3a3c29d5695b67ed673323ed66537b8c31cdf0b61e76fdfa84R1-R7))
*  Add a new code example to the `Examples` section of the `index.en-US.md` and `index.zh-CN.md` files that links to the `wave.tsx` demo file ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R46),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R47))
*  Add a new row to the `Component Config` table of the `index.en-US.md` and `index.zh-CN.md` files that describes the `wave` prop of the `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R156),[link](https://github.com/ant-design/ant-design/pull/43784/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R158))
