### PR TITLE
fix: CascaderProps type

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -92,30 +92,39 @@ const defaultSearchRender: ShowSearchType['render'] = (inputValue, path, prefixC
   return optionList;
 };
 
-type SingleCascaderProps<T> = Omit<RcSingleCascaderProps<T>, 'checkable' | 'options'> & {
+type SingleCascaderProps<T extends BaseOptionType> = Omit<
+  RcSingleCascaderProps<T>,
+  'checkable' | 'options'
+> & {
   multiple?: false;
 };
-type MultipleCascaderProps<T> = Omit<RcMultipleCascaderProps<T>, 'checkable' | 'options'> & {
+type MultipleCascaderProps<T extends BaseOptionType> = Omit<
+  RcMultipleCascaderProps<T>,
+  'checkable' | 'options'
+> & {
   multiple: true;
 };
 
-type UnionCascaderProps<T> = SingleCascaderProps<T> | MultipleCascaderProps<T>;
+type UnionCascaderProps<T extends BaseOptionType> =
+  | SingleCascaderProps<T>
+  | MultipleCascaderProps<T>;
 
-export type CascaderProps<DataNodeType = any> = UnionCascaderProps<DataNodeType> & {
-  multiple?: boolean;
-  size?: SizeType;
-  disabled?: boolean;
-  bordered?: boolean;
-  placement?: SelectCommonPlacement;
-  suffixIcon?: React.ReactNode;
-  options?: DataNodeType[];
-  status?: InputStatus;
-  /**
-   * @deprecated `dropdownClassName` is deprecated which will be removed in next major
-   *   version.Please use `popupClassName` instead.
-   */
-  dropdownClassName?: string;
-};
+export type CascaderProps<DataNodeType extends BaseOptionType = any> =
+  UnionCascaderProps<DataNodeType> & {
+    multiple?: boolean;
+    size?: SizeType;
+    disabled?: boolean;
+    bordered?: boolean;
+    placement?: SelectCommonPlacement;
+    suffixIcon?: React.ReactNode;
+    options?: DataNodeType[];
+    status?: InputStatus;
+    /**
+     * @deprecated `dropdownClassName` is deprecated which will be removed in next major
+     *   version.Please use `popupClassName` instead.
+     */
+    dropdownClassName?: string;
+  };
 
 export interface CascaderRef {
   focus: () => void;

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -92,16 +92,16 @@ const defaultSearchRender: ShowSearchType['render'] = (inputValue, path, prefixC
   return optionList;
 };
 
-type SingleCascaderProps = Omit<RcSingleCascaderProps, 'checkable' | 'options'> & {
+type SingleCascaderProps<T> = Omit<RcSingleCascaderProps<T>, 'checkable' | 'options'> & {
   multiple?: false;
 };
-type MultipleCascaderProps = Omit<RcMultipleCascaderProps, 'checkable' | 'options'> & {
+type MultipleCascaderProps<T> = Omit<RcMultipleCascaderProps<T>, 'checkable' | 'options'> & {
   multiple: true;
 };
 
-type UnionCascaderProps = SingleCascaderProps | MultipleCascaderProps;
+type UnionCascaderProps<T> = SingleCascaderProps<T> | MultipleCascaderProps<T>;
 
-export type CascaderProps<DataNodeType = any> = UnionCascaderProps & {
+export type CascaderProps<DataNodeType = any> = UnionCascaderProps<DataNodeType> & {
   multiple?: boolean;
   size?: SizeType;
   disabled?: boolean;


### PR DESCRIPTION
### 这个变动的性质是？

- [x] 日常 bug 修复
- [x] TypeScript 定义更新

### 🔗 相关 Issue

Cascader 组件 泛型更新


### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Cascader component type update    |
| 🇨🇳 中文 |     Cascader 组件泛型更新     |

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f13e067</samp>

Make cascader component types generic and improve type definitions. Update `components/cascader/index.tsx` to use the generic types.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f13e067</samp>

* Make the cascader component more type-safe and flexible by introducing a generic type parameter `T` for the data node type ([link](https://github.com/ant-design/ant-design/pull/43799/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L95-R104))