### PR TITLE
enhance: Not render message style if not use it yet

### DIFF
--- a/components/message/__tests__/style.test.tsx
+++ b/components/message/__tests__/style.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import message, { actWrapper } from '..';
-import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
-import { awaitPromise, triggerMotionEnd } from './util';
+import { act, render } from '../../../tests/utils';
+import { awaitPromise } from './util';
 
 describe('message.style', () => {
   beforeAll(() => {

--- a/components/message/__tests__/style.test.tsx
+++ b/components/message/__tests__/style.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
+import message, { actWrapper } from '..';
+import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import { awaitPromise, triggerMotionEnd } from './util';
+
+describe('message.style', () => {
+  beforeAll(() => {
+    actWrapper(act);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    // Clean up
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    await awaitPromise();
+  });
+
+  it('not export style if not use yet', async () => {
+    const cache = createCache();
+
+    const Demo = () => {
+      const [msg, holder] = message.useMessage();
+
+      return <StyleProvider cache={cache}>{holder}</StyleProvider>;
+    };
+
+    const { container } = render(<Demo />);
+
+    const styleText = extractStyle(cache, true);
+
+    console.log(styleText);
+
+    expect(styleText).not.toContain('.ant-message');
+  });
+});

--- a/components/message/__tests__/style.test.tsx
+++ b/components/message/__tests__/style.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import message, { actWrapper } from '..';
-import { act, render } from '../../../tests/utils';
+import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import { awaitPromise } from './util';
 
 describe('message.style', () => {
@@ -26,15 +26,32 @@ describe('message.style', () => {
     const Demo = () => {
       const [msg, holder] = message.useMessage();
 
-      return <StyleProvider cache={cache}>{holder}</StyleProvider>;
+      return (
+        <StyleProvider cache={cache}>
+          {holder}
+          <button
+            type="button"
+            onClick={() => {
+              msg.success('2333');
+            }}
+          >
+            Show
+          </button>
+        </StyleProvider>
+      );
     };
 
     const { container } = render(<Demo />);
+    await waitFakeTimer();
 
     const styleText = extractStyle(cache, true);
-
-    console.log(styleText);
-
     expect(styleText).not.toContain('.ant-message');
+
+    // Render style
+    fireEvent.click(container.querySelector('button')!);
+    await waitFakeTimer();
+
+    const styleText2 = extractStyle(cache, true);
+    expect(styleText2).toContain('.ant-message');
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Optimize message that will not render style till trigger it.      |
| 🇨🇳 Chinese |   优化 message 渲染，现在只有当触发时才会生成样式。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0c77b3</samp>

This pull request adds a new component `LazyHolder` that improves the performance and style output of the message hook. It also adds a new test file `components/message/__tests__/style.test.tsx` to verify the message component's style.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0c77b3</samp>

* Replace the `Holder` component with the `LazyHolder` component in the message hook to improve performance and reduce style output ([link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R100-R128), [link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L106-R136), [link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L225-R260))
* Call the `init` method of the `LazyHolder` component to trigger its rendering when the first message is shown, updated, or removed ([link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R144), [link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R162-R163), [link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R207-R208))
* Import the `flushSync` function from `react-dom` to force a synchronous render of the `LazyHolder` component ([link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R6))
* Add a new test file for the message component's style in `components/message/__tests__/style.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/43803/files?diff=unified&w=0#diff-0f84d734d21e6f842ea0762a16c0b3e7dbaf4f70df7331a2c1fa5f7e1bf4c5bbR1-R57))
