### PR TITLE
enhance: not extract message notification style in SSR

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -107,6 +107,24 @@ const GlobalLayout: React.FC = () => {
     [isMobile, direction, updateSiteConfig, theme],
   );
 
+  const demoPage = pathname.startsWith('/~demos');
+
+  // ============================ Render ============================
+  let content: React.ReactNode = outlet;
+
+  // Demo page should not contain App component
+  if (!demoPage) {
+    content = (
+      <App>
+        {outlet}
+        <ThemeSwitch
+          value={theme}
+          onChange={(nextTheme) => updateSiteConfig({ theme: nextTheme })}
+        />
+      </App>
+    );
+  }
+
   return (
     <StyleProvider
       cache={styleCache}
@@ -121,15 +139,7 @@ const GlobalLayout: React.FC = () => {
             },
           }}
         >
-          <App>
-            {outlet}
-            {!pathname.startsWith('/~demos') && (
-              <ThemeSwitch
-                value={theme}
-                onChange={(nextTheme) => updateSiteConfig({ theme: nextTheme })}
-              />
-            )}
-          </App>
+          {content}
         </SiteThemeProvider>
       </SiteContext.Provider>
     </StyleProvider>

--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -263,12 +263,7 @@ describe('message.hooks', () => {
     const Demo = () => {
       const [, holder] = message.useMessage();
 
-      return (
-        <StyleProvider cache={cache}>
-          {holder}
-          <button type="button">Show</button>
-        </StyleProvider>
-      );
+      return <StyleProvider cache={cache}>{holder}</StyleProvider>;
     };
 
     render(<Demo />);

--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import message from '..';
 import { fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
@@ -254,5 +255,25 @@ describe('message.hooks', () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it('not export style in SSR', () => {
+    const cache = createCache();
+
+    const Demo = () => {
+      const [, holder] = message.useMessage();
+
+      return (
+        <StyleProvider cache={cache}>
+          {holder}
+          <button type="button">Show</button>
+        </StyleProvider>
+      );
+    };
+
+    render(<Demo />);
+
+    const styleText = extractStyle(cache, true);
+    expect(styleText).not.toContain('.ant-message');
   });
 });

--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -201,4 +201,7 @@ export default genComponentStyleHook(
       token.paddingSM
     }px`,
   }),
+  {
+    clientOnly: true,
+  },
 );

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import notification from '..';
 import { fireEvent, pureRender, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
@@ -153,5 +154,20 @@ describe('notification.hooks', () => {
 
       errorSpy.mockRestore();
     });
+  });
+
+  it('not export style in SSR', () => {
+    const cache = createCache();
+
+    const Demo = () => {
+      const [, holder] = notification.useNotification();
+
+      return <StyleProvider cache={cache}>{holder}</StyleProvider>;
+    };
+
+    render(<Demo />);
+
+    const styleText = extractStyle(cache, true);
+    expect(styleText).not.toContain('.ant-notification');
   });
 });

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -300,4 +300,7 @@ export default genComponentStyleHook(
     zIndexPopup: token.zIndexPopupBase + 50,
     width: 384,
   }),
+  {
+    clientOnly: true,
+  },
 );

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -58,6 +58,10 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
     resetStyle?: boolean;
     // Deprecated token key map [["oldTokenKey", "newTokenKey"], ["oldTokenKey", "newTokenKey"]]
     deprecatedTokens?: [ComponentTokenKey<ComponentName>, ComponentTokenKey<ComponentName>][];
+    /**
+     * Only use component style in client side. Ignore in SSR.
+     */
+    clientOnly?: boolean;
   },
 ) {
   return (prefixCls: string): UseComponentStyleResult => {
@@ -71,6 +75,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
       token,
       hashId,
       nonce: () => csp?.nonce!,
+      clientOnly: options?.clientOnly,
     };
 
     // Generate style for all a tags in antd component.

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^7.0.0",
-    "@ant-design/cssinjs": "^1.13.2",
+    "@ant-design/cssinjs": "^1.14.0",
     "@ant-design/icons": "^5.1.0",
     "@ant-design/react-slick": "~1.0.0",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

message & notification is not need extract style in SSR since its only trigger in client side. And adjust home page that will not use App if in `~demo` path.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Optimize message & notification to not to extract style in SSR.     |
| 🇨🇳 Chinese |     优化 message 和 notification 渲染逻辑，现在在 SSR 环境下不会导出样式。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4559fc8</samp>

This pull request improves the SSR support for the `message` and `notification` components by using a new `clientOnly` option to skip exporting their style on the server side. It also refactors the layout component for demo pages and updates the `@ant-design/cssinjs` package.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4559fc8</samp>

*  Add `clientOnly` option to `useStyles` hook for `message` and `notification` components, which prevents exporting their styles in SSR mode ([link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR204-R206), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fR303-R305), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacR61-R64), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacR78))
*  Update `@ant-design/cssinjs` package to version `1.14.0`, which supports the `clientOnly` option and style extraction in SSR mode ([link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L112-R112))
*  Simplify rendering logic in `GlobalLayout.tsx` by using `content` variable and removing redundant check for demo page ([link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R110-R127), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L124-R142))
*  Add test cases for `message` and `notification` components to verify that their styles are not exported in SSR mode, using `StyleProvider`, `createCache`, and `extractStyle` functions from `@ant-design/cssinjs` package ([link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-3eaeb0809a3cf8c5be4961df7b85ee6fa0e1cf8b3a54afbe0121a76f39a41abcR4), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-3eaeb0809a3cf8c5be4961df7b85ee6fa0e1cf8b3a54afbe0121a76f39a41abcR259-R273), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-3265680c5cceaca26b17a379c6b390d0fd3eeab50eb739557a0f2d52182deb50R2), [link](https://github.com/ant-design/ant-design/pull/43808/files?diff=unified&w=0#diff-3265680c5cceaca26b17a379c6b390d0fd3eeab50eb739557a0f2d52182deb50R158-R172))
