### PR TITLE
feat: Form getFieldsValue support strict

### DIFF
--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -220,7 +220,7 @@ Provides array management for fields.
 | --- | --- | --- | --- | --- |
 | children | Render function | (fields: Field\[], operation: { add, remove, move }, meta: { errors }) => React.ReactNode | - |  |
 | initialValue | Config sub default value. Form `initialValues` get higher priority when conflict | any\[] | - | 4.9.0 |
-| name | Field name, support array | [NamePath](#namepath) | - |  |
+| name | Field name, support array. List is also a field, so it will return all the values by `getFieldsValue`. You can change this logic by [config](#getfieldsvalue) | [NamePath](#namepath) | - |  |
 | rules | Validate rules, only support customize validator. Should work with [ErrorList](#formerrorlist) | { validator, message }\[] | - | 4.7.0 |
 
 ```tsx
@@ -286,7 +286,7 @@ Provide linkage between forms. If a sub form with `name` prop update, it will au
 | getFieldError | Get the error messages by the field name | (name: [NamePath](#namepath)) => string\[] |  |
 | getFieldInstance | Get field instance | (name: [NamePath](#namepath)) => any | 4.4.0 |
 | getFieldsError | Get the error messages by the fields name. Return as an array | (nameList?: [NamePath](#namepath)\[]) => FieldError\[] |  |
-| getFieldsValue | Get values by a set of field names. Return according to the corresponding structure. Default return mounted field value, but you can use `getFieldsValue(true)` to get all values | (nameList?: [NamePath](#namepath)\[], filterFunc?: (meta: { touched: boolean, validating: boolean }) => boolean) => any |  |
+| getFieldsValue | Get values by a set of field names. Return according to the corresponding structure. Default return mounted field value, but you can use `getFieldsValue(true)` to get all values | [GetFieldsValue](#getfieldsvalue) |  |
 | getFieldValue | Get the value by the field name | (name: [NamePath](#namepath)) => any |  |
 | isFieldsTouched | Check if fields have been operated. Check if all fields is touched when `allTouched` is `true` | (nameList?: [NamePath](#namepath)\[], allTouched?: boolean) => boolean |  |
 | isFieldTouched | Check if a field has been operated | (name: [NamePath](#namepath)) => boolean |  |
@@ -445,6 +445,41 @@ Form only update the Field which changed to avoid full refresh perf issue. Thus 
 #### NamePath
 
 `string | number | (string | number)[]`
+
+#### GetFieldsValue
+
+`getFieldsValue` provides overloaded methods:
+
+##### getFieldsValue(nameList?: true | [NamePath](#namepath)\[], filterFunc?: FilterFunc)
+
+When `nameList` is empty, return all registered fields, including values of List (even if List has no Item children).
+
+When `nameList` is `true`, return all values in store, including unregistered fields. For example, if you set the value of an unregistered Item through `setFieldsValue`, you can also get all values through `true`.
+
+When `nameList` is an array, return the value of the specified path. Note that `nameList` is a nested array. For example, you need the value of a certain path as follows:
+
+```tsx
+// Single path
+form.getFieldsValue([['user', 'age']]);
+
+// multiple path
+form.getFieldsValue([
+  ['user', 'age'],
+  ['preset', 'account'],
+]);
+```
+
+##### getFieldsValue({ strict?: boolean, filter?: FilterFunc })
+
+New in `5.8.0`. Accept configuration parameters. When `strict` is `true`, only the value of Item will be matched. For example, in `{ list: [{ bamboo: 1, little: 2 }] }`, if List is only bound to the `bamboo` field, then `getFieldsValue({ strict: true })` will only get `{ list: [{ bamboo: 1 }] }`.
+
+#### FilterFunc
+
+用于过滤一些字段值，`meta` 会返回字段相关信息。例如可以用来获取仅被用户修改过的值等等。
+
+```tsx
+type FilterFunc = (meta: { touched: boolean; validating: boolean }) => boolean;
+```
 
 #### FieldData
 

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -221,7 +221,7 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | --- | --- | --- | --- | --- |
 | children | 渲染函数 | (fields: Field\[], operation: { add, remove, move }, meta: { errors }) => React.ReactNode | - |  |
 | initialValue | 设置子元素默认值，如果与 Form 的 `initialValues` 冲突则以 Form 为准 | any\[] | - | 4.9.0 |
-| name | 字段名，支持数组 | [NamePath](#namepath) | - |  |
+| name | 字段名，支持数组。List 本身也是字段，因而 `getFieldsValue()` 默认会返回 List 下所有值，你可以通过[参数](#getfieldsvalue)改变这一行为 | [NamePath](#namepath) | - |  |
 | rules | 校验规则，仅支持自定义规则。需要配合 [ErrorList](#formerrorlist) 一同使用。 | { validator, message }\[] | - | 4.7.0 |
 
 ```tsx
@@ -285,7 +285,7 @@ Form.List 渲染表单相关操作函数。
 | getFieldError | 获取对应字段名的错误信息 | (name: [NamePath](#namepath)) => string\[] |  |
 | getFieldInstance | 获取对应字段实例 | (name: [NamePath](#namepath)) => any | 4.4.0 |
 | getFieldsError | 获取一组字段名对应的错误信息，返回为数组形式 | (nameList?: [NamePath](#namepath)\[]) => FieldError\[] |  |
-| getFieldsValue | 获取一组字段名对应的值，会按照对应结构返回。默认返回现存字段值，当调用 `getFieldsValue(true)` 时返回所有值 | (nameList?: [NamePath](#namepath)\[], filterFunc?: (meta: { touched: boolean, validating: boolean }) => boolean) => any |  |
+| getFieldsValue | 获取一组字段名对应的值，会按照对应结构返回。默认返回现存字段值，当调用 `getFieldsValue(true)` 时返回所有值 | [GetFieldsValue](#getfieldsvalue) |  |
 | getFieldValue | 获取对应字段名的值 | (name: [NamePath](#namepath)) => any |  |
 | isFieldsTouched | 检查一组字段是否被用户操作过，`allTouched` 为 `true` 时检查是否所有字段都被操作过 | (nameList?: [NamePath](#namepath)\[], allTouched?: boolean) => boolean |  |
 | isFieldTouched | 检查对应字段是否被用户操作过 | (name: [NamePath](#namepath)) => boolean |  |
@@ -444,6 +444,41 @@ Form 仅会对变更的 Field 进行刷新，从而避免完整的组件刷新�
 #### NamePath
 
 `string | number | (string | number)[]`
+
+#### GetFieldsValue
+
+`getFieldsValue` 提供了多种重载方法：
+
+##### getFieldsValue(nameList?: true | [NamePath](#namepath)\[], filterFunc?: FilterFunc)
+
+当不提供 `nameList` 时，返回所有注册字段，这也包含 List 下所有的值（即便 List 下没有绑定 Item）。
+
+当 `nameList` 为 `true` 时，返回 store 中所有的值，包含未注册字段。例如通过 `setFieldsValue` 设置了不存在的 Item 的值，也可以通过 `true` 全部获取。
+
+当 `nameList` 为数组时，返回规定路径的值。需要注意的是，`nameList` 为嵌套数组。例如你需要某路径值应该如下：
+
+```tsx
+// 单个路径
+form.getFieldsValue([['user', 'age']]);
+
+// 多个路径
+form.getFieldsValue([
+  ['user', 'age'],
+  ['preset', 'account'],
+]);
+```
+
+##### getFieldsValue({ strict?: boolean, filter?: FilterFunc })
+
+`5.8.0` 新增接受配置参数。当 `strict` 为 `true` 时会仅匹配 Item 的值。例如 `{ list: [{ bamboo: 1, little: 2 }] }` 中，如果 List 仅绑定了 `bamboo` 字段，那么 `getFieldsValue({ strict: true })` 会只获得 `{ list: [{ bamboo: 1 }] }`。
+
+#### FilterFunc
+
+用于过滤一些字段值，`meta` 会返回字段相关信息。例如可以用来获取仅被用户修改过的值等等。
+
+```tsx
+type FilterFunc = (meta: { touched: boolean; validating: boolean }) => boolean;
+```
 
 #### FieldData
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "rc-dialog": "~9.1.0",
     "rc-drawer": "~6.2.0",
     "rc-dropdown": "~4.1.0",
-    "rc-field-form": "~1.34.0",
+    "rc-field-form": "~1.35.0",
     "rc-image": "~7.1.0",
     "rc-input": "~1.1.0",
     "rc-input-number": "~8.0.2",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #43300

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Form support `getFieldsValue({ strict: true })` to support only Item bind values.      |
| 🇨🇳 Chinese |     Form 新增 `getFieldsValue({ strict: true })` 以支持获取仅通过 Item 绑定的字段。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4747ca8</samp>

This pull request enhances the documentation and functionality of the `Form.List` and `FormInstance` components. It updates the English and Chinese documentation files to reflect the usage and options of the `getFieldsValue` function, and it upgrades the `rc-field-form` dependency to support the `strict` option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4747ca8</samp>

*  Update the `name` prop of `Form.List` to clarify that it is also a field and its values can be controlled by the `getFieldsValue` config ([link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-28baad7eca32a14feb2ed5fdcee826cb1d27ee818bcbcaa6c9a8ed368c9b16e5L223-R223), [link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-f17ef6685c42eb193b5735088ef3c54e36aca982b8464077915301cabb1d4b8fL224-R224))
*  Replace the `getFieldsValue` prop of `FormInstance` with a link to the `GetFieldsValue` section that explains the overloaded methods and parameters of the function ([link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-28baad7eca32a14feb2ed5fdcee826cb1d27ee818bcbcaa6c9a8ed368c9b16e5L289-R289), [link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-f17ef6685c42eb193b5735088ef3c54e36aca982b8464077915301cabb1d4b8fL288-R288))
*  Add the `GetFieldsValue` section to the documentation of `components/form/index.en-US.md` and `components/form/index.zh-CN.md` to describe the different ways of using the `getFieldsValue` function of `FormInstance`, including the new `strict` option introduced in version 5.8.0 ([link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-28baad7eca32a14feb2ed5fdcee826cb1d27ee818bcbcaa6c9a8ed368c9b16e5R449-R483), [link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-f17ef6685c42eb193b5735088ef3c54e36aca982b8464077915301cabb1d4b8fR448-R482))
*  Update the dependency version of `rc-field-form` to 1.35.0 in `package.json` to support the `strict` option for `getFieldsValue` ([link](https://github.com/ant-design/ant-design/pull/43828/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L131-R131))
