### PR TITLE
docs(blog): Delete duplicate zh in en document

### DIFF
--- a/docs/blog/hydrate-cssinjs.en-US.md
+++ b/docs/blog/hydrate-cssinjs.en-US.md
@@ -30,8 +30,6 @@ Application level CSS-in-JS solutions will calculate the hash value of the gener
 
 Every dynamically inserted style is also identified by hash. If the `<style />` with the hash already exists in the page, it means that inline style injection has been done in SSR. Then `<style />` does not need to be created again.
 
-你可以发现，虽然 `<style />` 的节点创建可以省略。但是因为 hash 依赖于计算出的样式内容，所以即便页面中已经有可以复用的样式内容，它仍然免不了需要计算一次。实属不划算。
-
 You can find that although the `<style />` node can be omitted, hash still deps on the calculated style content. So even if there is reusable style in the page, it still needs to be calculated once. It's really not cost-effective.
 
 ## Component-level CSS-in-JS


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
英文文档是不是不应该出现中文，而且和下文```
You can find that although the `<style />` node can be omitted, hash still deps on the calculated style content. So even if there is reusable style in the page, it still needs to be calculated once. It's really not cost-effective.``` 同样的意思
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Delete duplicate zh in en document    |
| 🇨🇳 Chinese |         删除英文文档中重复的中文  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25889e6</samp>

Removed a Chinese paragraph from `docs/blog/hydrate-cssinjs.en-US.md` and translated the rest of the blog post to English. The post discusses the benefits and drawbacks of hash-based CSS-in-JS hydration.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25889e6</samp>

* Translate the blog post from Chinese to English (`docs/blog/hydrate-cssinjs.en-US.md`)
* Remove Chinese paragraph about hash-based CSS-in-JS hydration drawback ([link](https://github.com/ant-design/ant-design/pull/43859/files?diff=unified&w=0#diff-3c8570aec4c48b3b95541c938707a23930af56f03dfd7414a3d8d9018ff43888L33-L34))
