### PR TITLE
Modify ru locale

### DIFF
--- a/components/date-picker/locale/ru_RU.ts
+++ b/components/date-picker/locale/ru_RU.ts
@@ -16,7 +16,7 @@ const locale: PickerLocale = {
     rangeYearPlaceholder: ['Начальный год', 'Год окончания'],
     rangeMonthPlaceholder: ['Начальный месяц', 'Конечный месяц'],
     rangeWeekPlaceholder: ['Начальная неделя', 'Конечная неделя'],
-    shortWeekDays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
+    shortWeekDays: ['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'],
     shortMonths: [
       'Янв',
       'Февр',

--- a/components/date-picker/locale/ru_RU.ts
+++ b/components/date-picker/locale/ru_RU.ts
@@ -31,7 +31,6 @@ const locale: PickerLocale = {
       'Нояб',
       'Дек',
     ],
-
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/date-picker/locale/ru_RU.ts
+++ b/components/date-picker/locale/ru_RU.ts
@@ -16,6 +16,7 @@ const locale: PickerLocale = {
     rangeYearPlaceholder: ['Начальный год', 'Год окончания'],
     rangeMonthPlaceholder: ['Начальный месяц', 'Конечный месяц'],
     rangeWeekPlaceholder: ['Начальная неделя', 'Конечная неделя'],
+    shortWeekDays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/date-picker/locale/ru_RU.ts
+++ b/components/date-picker/locale/ru_RU.ts
@@ -17,6 +17,21 @@ const locale: PickerLocale = {
     rangeMonthPlaceholder: ['Начальный месяц', 'Конечный месяц'],
     rangeWeekPlaceholder: ['Начальная неделя', 'Конечная неделя'],
     shortWeekDays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
+    shortMonths: [
+      'Янв',
+      'Февр',
+      'Март',
+      'Апр',
+      'Май',
+      'Июнь',
+      'Июль',
+      'Авг',
+      'Сент',
+      'Окт',
+      'Нояб',
+      'Дек',
+    ],
+
     ...CalendarLocale,
   },
   timePickerLocale: {


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

Added Russian localization for short days of the week and months

### 📝 Changelog

Added Russian localization for short days of the week and months
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Added Russian localization for short days of the week and months      |
| 🇨🇳 Chinese |    在一周和几个月的短日子里增加了俄语本地化       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cec08d</samp>

Added `shortWeekDays` and `shortMonths` properties to `components/date-picker/locale/ru_RU.ts` to provide abbreviated names for the date picker component in Russian. This is part of a larger pull request that improves localization for more languages.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cec08d</samp>

* Add support for more languages to the date picker component by updating the `locale` objects in the corresponding files under `components/date-picker/locale` ([link](https://github.com/ant-design/ant-design/pull/43893/files?diff=unified&w=0#diff-b2a1993fdbfbec78515f461f86e165f115ffc1e091873cc3ad1b97949eb72027R19-R33),                           F27
