### PR TITLE
chore: feature merge master again

### DIFF
--- a/.dumi/pages/index/components/ComponentsList.tsx
+++ b/.dumi/pages/index/components/ComponentsList.tsx
@@ -233,7 +233,7 @@ export default function ComponentsList() {
     [isMobile],
   );
 
-  const ComponentItem = ({ title, node, type, index }: ComponentItemProps) => {
+  const ComponentItem: React.FC<ComponentItemProps> = ({ title, node, type, index }) => {
     const tagColor = type === 'new' ? 'processing' : 'warning';
     const tagText = type === 'new' ? locale.new : locale.update;
 

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -461,13 +461,14 @@ export default function Theme() {
               />
             </Sider>
             <Layout className={styles.transBg} style={{ padding: '0 24px 24px' }}>
-              <Breadcrumb style={{ margin: '16px 0' }}>
-                <Breadcrumb.Item>
-                  <HomeOutlined />
-                </Breadcrumb.Item>
-                <Breadcrumb.Item menu={{ items: subMenuItems }}>Design</Breadcrumb.Item>
-                <Breadcrumb.Item>Themes</Breadcrumb.Item>
-              </Breadcrumb>
+              <Breadcrumb
+                style={{ margin: '16px 0' }}
+                items={[
+                  { title: <HomeOutlined /> },
+                  { title: 'Design', menu: { items: subMenuItems } },
+                  { title: 'Themes' },
+                ]}
+              />
               <Content>
                 <Typography.Title level={2}>{locale.customizeTheme}</Typography.Title>
                 <Card

--- a/.dumi/theme/common/PrevAndNext.tsx
+++ b/.dumi/theme/common/PrevAndNext.tsx
@@ -1,11 +1,13 @@
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import { createStyles } from 'antd-style';
 import type { ReactElement } from 'react';
-import React, { useMemo } from 'react';
+import React, { useMemo, useContext } from 'react';
 import classNames from 'classnames';
 import type { MenuItemType } from 'antd/es/menu/hooks/useItems';
 import type { MenuProps } from 'antd';
 import useMenu from '../../hooks/useMenu';
+import SiteContext from '../slots/SiteContext';
+import type { SiteContextProps } from '../slots/SiteContext';
 
 const useStyle = createStyles(({ token, css }) => {
   const { colorSplit, iconCls, fontSizeIcon } = token;
@@ -111,6 +113,8 @@ const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
 
   const [menuItems, selectedKey] = useMenu({ before, after });
 
+  const { isMobile } = useContext<SiteContextProps>(SiteContext);
+
   const [prev, next] = useMemo(() => {
     const flatMenu = flattenMenu(menuItems);
     if (!flatMenu) {
@@ -127,6 +131,10 @@ const PrevAndNext: React.FC<{ rtl?: boolean }> = ({ rtl }) => {
       flatMenu[activeMenuItemIndex + 1] as MenuItemType,
     ];
   }, [menuItems, selectedKey]);
+
+  if (isMobile) {
+    return null;
+  }
 
   return (
     <section className={styles.prevNextNav}>

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -43,6 +43,9 @@ const useStyle = createStyles(({ token, css }) => {
         }
       }
     `,
+    listMobile: css`
+      margin: 1em 0 !important;
+    `,
     toc: css`
       ${antCls}-anchor {
         ${antCls}-anchor-link-title {
@@ -114,7 +117,7 @@ const AvatarPlaceholder: React.FC<{ num?: number }> = ({ num = 3 }) => (
   </li>
 );
 
-const AuthorAvatar = ({ name, avatar }: { name: string; avatar: string }) => {
+const AuthorAvatar: React.FC<{ name: string; avatar: string }> = ({ name, avatar }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   useLayoutEffect(() => {
@@ -123,9 +126,12 @@ const AuthorAvatar = ({ name, avatar }: { name: string; avatar: string }) => {
     img.onload = () => setLoading(false);
     img.onerror = () => setError(true);
   }, []);
-
-  if (error) return null;
-  if (loading) return <Skeleton.Avatar size="small" active />;
+  if (error) {
+    return null;
+  }
+  if (loading) {
+    return <Skeleton.Avatar size="small" active />;
+  }
   return (
     <Avatar size="small" src={avatar} alt={name}>
       {name}
@@ -140,7 +146,7 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { formatMessage } = useIntl();
   const { styles } = useStyle();
   const token = useTheme();
-  const { direction } = useContext(SiteContext);
+  const { direction, isMobile } = useContext(SiteContext);
 
   const [showDebug, setShowDebug] = useLayoutState(false);
   const debugDemos = useMemo(
@@ -178,15 +184,6 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
 
   const isRTL = direction === 'rtl';
 
-  // support custom author info in frontmatter
-  // e.g.
-  // ---
-  // author:
-  //   - name: qixian
-  //     avatar: https://avatars.githubusercontent.com/u/11746742?v=4
-  //   - name: yutingzhao1991
-  //     avatar: https://avatars.githubusercontent.com/u/5378891?v=4
-  // ---
   const mergedAuthorInfos = useMemo(() => {
     const { author } = meta.frontmatter;
     if (!author) {
@@ -286,10 +283,10 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
           )}
           {meta.frontmatter.filename && (
             <ContributorsList
+              cache
               repo="ant-design"
               owner="ant-design"
-              className={styles.contributorsList}
-              cache
+              className={classNames(styles.contributorsList, { [styles.listMobile]: isMobile })}
               fileName={meta.frontmatter.filename}
               renderItem={(item, loading) => {
                 if (!item || loading) {

--- a/components/modal/useModal/index.tsx
+++ b/components/modal/useModal/index.tsx
@@ -112,7 +112,6 @@ function useModal(): readonly [
     }),
     [],
   );
-
   return [fns, <ElementsHolder key="modal-holder" ref={holderRef} />] as const;
 }
 


### PR DESCRIPTION
* site: ptimize site style in mobile

#43899 点错squash了, 重新同步一下commit

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41d0a77</samp>

Improved the theme and layout of the documentation site, and refactored some components for better readability and consistency. Hid the `PrevAndNext` component on mobile devices, and used the `items` prop for the `Breadcrumb` component. Removed an empty line in `useModal/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41d0a77</samp>

*  Annotate `ComponentItem` and `AuthorAvatar` components with `React.FC` type for consistency ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L236-R236), [link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L117-R120))
* Refactor `Breadcrumb` component to use `items` prop instead of `children` prop for conciseness ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL464-R471))
* Hide `PrevAndNext` component on mobile devices using `isMobile` value from site context ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42L4-R10), [link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42R116-R117), [link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-f11fa3a3e55666da1f421678270305039a61b104fba0d4cce4d18959b8d9cf42R135-R138))
* Add and apply `listMobile` style to contributors list on mobile devices using `isMobile` value from site context ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82R46-R48), [link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L143-R149), [link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L289-R289))
* Wrap `if` statements with curly braces for readability ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L126-R134))
* Move `cache` prop to the front of `ContributorsList` component for convention ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L289-R289))
* Remove empty line in `components/modal/useModal/index.tsx` for whitespace ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-49dc0b03c3829b5d4d2da590ad42f4b21e17b47ce4a454cdf3a72328779e7668L115))
* Remove redundant comment in `.dumi/theme/slots/Content/index.tsx` for clarity ([link](https://github.com/ant-design/ant-design/pull/43900/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L181-L189))
