### PR TITLE
fix: Anchor not trigger `getCurrentAnchor` when scroll

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -216,6 +216,8 @@ const AnchorContent: React.FC<InternalAnchorProps> = (props) => {
   };
 
   const setCurrentActiveLink = useEvent((link: string) => {
+    // FIXME: Seems a bug since this compare is not equals
+    // `activeLinkRef` is parsed value which will always trigger `onChange` event.
     if (activeLinkRef.current === link) {
       return;
     }
@@ -234,14 +236,13 @@ const AnchorContent: React.FC<InternalAnchorProps> = (props) => {
     if (animating.current) {
       return;
     }
-    if (typeof getCurrentAnchor === 'function') {
-      return;
-    }
+
     const currentActiveLink = getInternalCurrentAnchor(
       links,
       targetOffset !== undefined ? targetOffset : offsetTop || 0,
       bounds,
     );
+
     setCurrentActiveLink(currentActiveLink);
   }, [dependencyListItem, targetOffset, offsetTop]);
 

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -560,9 +560,12 @@ describe('Anchor Render', () => {
         { legacyRoot: true },
       );
 
-      expect(onChange).toHaveBeenCalledTimes(1);
-      fireEvent.click(container.querySelector(`a[href="#${hash2}"]`)!);
+      // Should be 2 times:
+      // 1. ''
+      // 2. hash1 (Since `getCurrentAnchor` still return same hash)
       expect(onChange).toHaveBeenCalledTimes(2);
+      fireEvent.click(container.querySelector(`a[href="#${hash2}"]`)!);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenLastCalledWith(`#${hash2}`);
     });
 
@@ -613,6 +616,22 @@ describe('Anchor Render', () => {
         );
         fireEvent.scroll(window || document);
       }).not.toThrow();
+    });
+
+    it('should repeat trigger when scrolling', () => {
+      const getCurrentAnchor = jest.fn();
+      render(
+        <Anchor
+          getCurrentAnchor={getCurrentAnchor}
+          items={[{ key: 'test', href: null as unknown as string, title: 'test' }]}
+        />,
+      );
+
+      for (let i = 0; i < 100; i += 1) {
+        getCurrentAnchor.mockReset();
+        fireEvent.scroll(window || document);
+        expect(getCurrentAnchor).toHaveBeenCalled();
+      }
     });
   });
 

--- a/components/anchor/index.en-US.md
+++ b/components/anchor/index.en-US.md
@@ -31,7 +31,7 @@ For displaying anchor hyperlinks on page and jumping between them.
 <code src="./demo/onChange.tsx">Listening for anchor link change</code>
 <code src="./demo/replace.tsx" iframe="200">Replace href in history</code>
 <code src="./demo/legacy-anchor.tsx" debug>Deprecated JSX demo</code>
-<code src="./demo/component-token.tsx" debug>Component Token</code>
+<code src="./demo/component-token.tsx" iframe="800" debug>Component Token</code>
 
 ## API
 

--- a/components/anchor/index.zh-CN.md
+++ b/components/anchor/index.zh-CN.md
@@ -32,7 +32,7 @@ group:
 <code src="./demo/onChange.tsx">监听锚点链接改变</code>
 <code src="./demo/replace.tsx" iframe="200">替换历史中的 href</code>
 <code src="./demo/legacy-anchor.tsx" debug>废弃的 JSX 示例</code>
-<code src="./demo/component-token.tsx" debug>组件 Token</code>
+<code src="./demo/component-token.tsx" iframe="800" debug>组件 Token</code>
 
 ## API
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref #43913

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Anchor not trigger `getCurrentAnchor` when scroll.        |
| 🇨🇳 Chinese |   修复 Anchor 在滚动时无法触发 `getCurrentAnchor` 的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c4a9ca</samp>

This pull request enhances the `Anchor` component and its documentation. It fixes a bug and adds a feature in the test cases, improves the code quality and readability of the component, and adjusts the iframe height for the examples in both English and Chinese.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c4a9ca</samp>

* Correct the expected calls and arguments for the `onChange` prop in a test case for the anchor component ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-8403f43a04d69820d83b56e860ecd221192c3094a657c45d7c6fb3291fc48ca3L563-R568))
* Add a new test case to verify that the `getCurrentAnchor` prop is repeatedly called when scrolling the window or document ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-8403f43a04d69820d83b56e860ecd221192c3094a657c45d7c6fb3291fc48ca3R620-R635))
* Remove an unnecessary condition check for the `getCurrentAnchor` prop in the anchor component logic ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L237-R239))
* Add a comment to indicate a potential bug in the comparison of the active link reference and the current anchor in the anchor component logic ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8R219-R220))
* Add a blank line for readability and consistency in the anchor component logic ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8R245))
* Increase the iframe height for an example of using a custom component token to render the anchor link content in the English and Chinese documentation (`components/anchor/index.en-US.md` and `components/anchor/index.zh-CN.md`) ([link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-8995dc1c988372ee1dbb16b8362facd78a582dad03c64a0f654cdd8331850922L34-R34), [link](https://github.com/ant-design/ant-design/pull/43916/files?diff=unified&w=0#diff-749bbd9206897f6bac06d8bef8ba085e8fa32b61d23678d0670069452d221e43L35-R35))
