### PR TITLE
fix: getCurrentLink not trigger when scroll

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -87,7 +87,7 @@ export interface AntAnchor {
   ) => void;
 }
 
-const AnchorContent: React.FC<InternalAnchorProps> = props => {
+const AnchorContent: React.FC<InternalAnchorProps> = (props) => {
   const {
     anchorPrefixCls: prefixCls,
     className = '',
@@ -119,18 +119,18 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
   const dependencyListItem: React.DependencyList[number] = JSON.stringify(links);
 
   const registerLink = React.useCallback<AntAnchor['registerLink']>(
-    link => {
+    (link) => {
       if (!links.includes(link)) {
-        setLinks(prev => [...prev, link]);
+        setLinks((prev) => [...prev, link]);
       }
     },
     [dependencyListItem],
   );
 
   const unregisterLink = React.useCallback<AntAnchor['unregisterLink']>(
-    link => {
+    (link) => {
       if (links.includes(link)) {
-        setLinks(prev => prev.filter(i => i !== link));
+        setLinks((prev) => prev.filter((i) => i !== link));
       }
     },
     [dependencyListItem],
@@ -148,7 +148,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
   const getInternalCurrentAnchor = (_links: string[], _offsetTop = 0, _bounds = 5): string => {
     const linkSections: Section[] = [];
     const container = getCurrentContainer();
-    _links.forEach(link => {
+    _links.forEach((link) => {
       const sharpLinkMatch = sharpMatcherRegx.exec(link?.toString());
       if (!sharpLinkMatch) {
         return;
@@ -188,9 +188,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
     if (animating.current) {
       return;
     }
-    if (typeof getCurrentAnchor === 'function') {
-      return;
-    }
+
     const currentActiveLink = getInternalCurrentAnchor(
       links,
       targetOffset !== undefined ? targetOffset : offsetTop || 0,
@@ -200,7 +198,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
   }, [dependencyListItem, targetOffset, offsetTop]);
 
   const handleScrollTo = React.useCallback<(link: string) => void>(
-    link => {
+    (link) => {
       setCurrentActiveLink(link);
       const container = getCurrentContainer();
       const scrollTop = getScroll(container, true);
@@ -305,7 +303,7 @@ const AnchorContent: React.FC<InternalAnchorProps> = props => {
   );
 };
 
-const Anchor: React.FC<AnchorProps> = props => {
+const Anchor: React.FC<AnchorProps> = (props) => {
   const { prefixCls: customizePrefixCls } = props;
   const { getPrefixCls } = React.useContext<ConfigConsumerProps>(ConfigContext);
   const anchorPrefixCls = getPrefixCls('anchor', customizePrefixCls);

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -381,9 +381,12 @@ describe('Anchor Render', () => {
         { legacyRoot: true },
       );
 
-      expect(onChange).toHaveBeenCalledTimes(1);
-      fireEvent.click(container.querySelector(`a[href="#${hash2}"]`)!);
+      // Should be 2 times:
+      // 1. ''
+      // 2. hash1 (Since `getCurrentAnchor` still return same hash)
       expect(onChange).toHaveBeenCalledTimes(2);
+      fireEvent.click(container.querySelector(`a[href="#${hash2}"]`)!);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenLastCalledWith(`#${hash2}`);
     });
 
@@ -430,6 +433,17 @@ describe('Anchor Render', () => {
         );
         fireEvent.scroll(window || document);
       }).not.toThrow();
+    });
+
+    it('should repeat trigger when scrolling', () => {
+      const getCurrentAnchor = jest.fn();
+      render(<Anchor getCurrentAnchor={getCurrentAnchor} />);
+
+      for (let i = 0; i < 100; i += 1) {
+        getCurrentAnchor.mockReset();
+        fireEvent.scroll(window || document);
+        expect(getCurrentAnchor).toHaveBeenCalled();
+      }
     });
   });
 });

--- a/scripts/argos-upload.js
+++ b/scripts/argos-upload.js
@@ -2,9 +2,9 @@
 // Create chunks for Argos: https://github.com/mui/material-ui/pull/23518
 // https://github.com/mui/material-ui/blob/af81aae3b292ed180e7652a665fad1be2b38a7b3/scripts/pushArgos.js
 const util = require('util');
+const childProcess = require('child_process');
 const glob = require('fast-glob');
 const lodashChunk = require('lodash/chunk');
-const childProcess = require('child_process');
 
 // eslint-disable-next-line import/no-unresolved
 const argos = require('@argos-ci/core');
@@ -35,7 +35,7 @@ async function run() {
   await Promise.all(
     chunks.map((chunk, chunkIndex) =>
       Promise.all(
-        chunk.map(screenshot => cpToTemp(screenshot, `${screenshotsChunks}/${chunkIndex}`)),
+        chunk.map((screenshot) => cpToTemp(screenshot, `${screenshotsChunks}/${chunkIndex}`)),
       ),
     ),
   );
@@ -55,7 +55,7 @@ async function run() {
   }
 }
 
-run().catch(error => {
+run().catch((error) => {
   // eslint-disable-next-line no-console
   console.error(error);
   process.exit(1);

--- a/scripts/check-commit.js
+++ b/scripts/check-commit.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-dynamic-require, no-console */
-const chalk = require('chalk');
 const path = require('path');
+const chalk = require('chalk');
 const fetch = require('isomorphic-fetch');
 const simpleGit = require('simple-git');
 

--- a/scripts/check-demo.js
+++ b/scripts/check-demo.js
@@ -1,7 +1,7 @@
 const path = require('path');
+const fs = require('fs');
 const yfm = require('yaml-front-matter');
 const glob = require('glob');
-const fs = require('fs');
 
 const demoFiles = glob.sync(path.join(process.cwd(), 'components/**/demo/*.md'));
 // eslint-disable-next-line no-restricted-syntax

--- a/scripts/check-site.js
+++ b/scripts/check-site.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-restricted-syntax */
-const fetch = require('isomorphic-fetch');
 const { join } = require('path');
+const fetch = require('isomorphic-fetch');
 const cheerio = require('cheerio');
 const glob = require('glob');
 const uniq = require('lodash/uniq');
@@ -14,14 +14,14 @@ const components = uniq(
       cwd: join(process.cwd()),
       dot: false,
     })
-    .map(path => path.replace(/(\/index)?((\.zh-cn)|(\.en-us))?\.md$/i, '')),
+    .map((path) => path.replace(/(\/index)?((\.zh-cn)|(\.en-us))?\.md$/i, '')),
 );
 
 describe('site test', () => {
   let server;
   const port = 3000;
-  const render = async path => {
-    const resp = await fetch(`http://127.0.0.1:${port}${path}`).then(async res => {
+  const render = async (path) => {
+    const resp = await fetch(`http://127.0.0.1:${port}${path}`).then(async (res) => {
       const html = await res.text();
       const $ = cheerio.load(html, { decodeEntities: false, recognizeSelfClosing: true });
       return {
@@ -33,12 +33,12 @@ describe('site test', () => {
     return resp;
   };
 
-  const handleComponentName = name => {
+  const handleComponentName = (name) => {
     const componentName = name.split('/')[1];
     return componentName.toLowerCase().replace('-', '');
   };
 
-  const expectComponent = async component => {
+  const expectComponent = async (component) => {
     const { status, $ } = await render(`/${component}/`);
     expect(status).toBe(200);
     expect($('.markdown > h1').text().toLowerCase()).toMatch(handleComponentName(component));

--- a/scripts/check-ts-demo.js
+++ b/scripts/check-ts-demo.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-await-in-loop, no-console */
 
 const path = require('path');
+const { spawn } = require('child_process');
 const glob = require('glob');
 const fs = require('fs-extra');
 const chalk = require('chalk');
-const { spawn } = require('child_process');
 
 (async () => {
   console.time('Execution...');
@@ -18,7 +18,7 @@ const { spawn } = require('child_process');
   function getTypescriptDemo(content, demoPath) {
     const lines = content.split(/[\n\r]/);
 
-    const tsxStartLine = lines.findIndex(line =>
+    const tsxStartLine = lines.findIndex((line) =>
       line.replace(/\s/g).toLowerCase().includes('```tsx'),
     );
 
@@ -72,7 +72,7 @@ const { spawn } = require('child_process');
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);
 
-  child.on('exit', async code => {
+  child.on('exit', async (code) => {
     console.timeEnd('Execution...');
 
     if (code) {

--- a/scripts/check-version-md.js
+++ b/scripts/check-version-md.js
@@ -1,7 +1,7 @@
 /* eslint no-console: 0 */
-const chalk = require('chalk');
 const fs = require('fs');
 const { join } = require('path');
+const chalk = require('chalk');
 const moment = require('moment');
 
 const getChangelogByVersion = (content, version) => {

--- a/scripts/css-variable-sync.js
+++ b/scripts/css-variable-sync.js
@@ -3,8 +3,8 @@
  * `variable.less` from the `default.less`
  */
 
-const fse = require('fs-extra');
 const path = require('path');
+const fse = require('fs-extra');
 const chalk = require('chalk');
 
 const folderPath = path.resolve(__dirname, '..', 'components', 'style', 'themes');
@@ -25,8 +25,10 @@ function replaceVariable(key, value) {
 
 function replaceVariableContent(key, content) {
   const lines = variableContent.split(/\n/);
-  const startIndex = lines.findIndex(line => line.includes(`[CSS-VARIABLE-REPLACE-BEGIN: ${key}]`));
-  const endIndex = lines.findIndex(line => line.includes(`[CSS-VARIABLE-REPLACE-END: ${key}]`));
+  const startIndex = lines.findIndex((line) =>
+    line.includes(`[CSS-VARIABLE-REPLACE-BEGIN: ${key}]`),
+  );
+  const endIndex = lines.findIndex((line) => line.includes(`[CSS-VARIABLE-REPLACE-END: ${key}]`));
 
   if (startIndex !== -1 && endIndex !== -1) {
     variableContent = [...lines.slice(0, startIndex), content, ...lines.slice(endIndex + 1)].join(

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra');
 const path = require('path');
+const fs = require('fs-extra');
 
 const { version } = require('../package.json');
 

--- a/scripts/generateLegacyLocale.js
+++ b/scripts/generateLegacyLocale.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 /** Generate legacy locale file as shadow of `/locale` to `/locale-provider`. */
 
-const glob = require('glob');
 const fs = require('fs');
+const glob = require('glob');
 const chalk = require('chalk');
 
 glob('components/locale/@(*_*|default).tsx', (er, files) => {
-  files.forEach(filePath => {
+  files.forEach((filePath) => {
     const modulePath = filePath.replace(/^components/, '..').replace('.tsx', '');
     const legacyModulePath = filePath.replace('locale', 'locale-provider');
 

--- a/scripts/post-script.js
+++ b/scripts/post-script.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
+const { spawnSync } = require('child_process');
 const fetch = require('isomorphic-fetch');
 const semver = require('semver');
 const moment = require('moment');
 const chalk = require('chalk');
-const { spawnSync } = require('child_process');
 
 const DEPRECIATED_VERSION = {
   '>= 4.21.6 < 4.22.0': ['https://github.com/ant-design/ant-design/pull/36682'],

--- a/scripts/print-changelog.js
+++ b/scripts/print-changelog.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-await-in-loop, no-console */
-const chalk = require('chalk');
 const { spawn } = require('child_process');
+const path = require('path');
+const chalk = require('chalk');
 const jsdom = require('jsdom');
 const jQuery = require('jquery');
 const fetch = require('isomorphic-fetch');
 const open = require('open');
 const fs = require('fs-extra');
-const path = require('path');
 const simpleGit = require('simple-git');
 
 const { JSDOM } = jsdom;

--- a/tests/dekko/lib.test.js
+++ b/tests/dekko/lib.test.js
@@ -1,6 +1,6 @@
+const path = require('path');
 const $ = require('dekko');
 const chalk = require('chalk');
-const path = require('path');
 
 function getFileName(filePath) {
   return filePath.slice(filePath.lastIndexOf(path.sep) + 1);
@@ -12,14 +12,14 @@ $('lib/style').isDirectory().hasFile('index.css').hasFile('default.css');
 
 $('lib/*')
   .filter(
-    filename =>
+    (filename) =>
       !filename.endsWith('index.js') &&
       !filename.endsWith('index.d.ts') &&
       !filename.endsWith('.map'),
   )
   .isDirectory()
   .filter(
-    filename =>
+    (filename) =>
       !filename.endsWith('style') && !filename.endsWith('_util') && !filename.endsWith('locale'),
   )
   .hasFile('index.js')
@@ -29,7 +29,7 @@ $('lib/*')
 $('lib/*/style').hasFile('css.js').hasFile('index.js');
 
 // locale
-const filterLocaleFile = filePath => {
+const filterLocaleFile = (filePath) => {
   const fileName = getFileName(filePath);
   return (
     !fileName.endsWith('index.js') &&
@@ -47,10 +47,12 @@ const localeProviderFiles = $('lib/locale-provider/*').filter(filterLocaleFile);
 function compare(originFiles, targetFiles, targetPath) {
   originFiles.assert(
     `not exist in '${targetPath}'. Please use 'scripts/generateLegacyLocale.js' to refresh locale files.`,
-    filePath => {
+    (filePath) => {
       const fileName = getFileName(filePath);
 
-      return targetFiles.filenames.some(targetFilePath => getFileName(targetFilePath) === fileName);
+      return targetFiles.filenames.some(
+        (targetFilePath) => getFileName(targetFilePath) === fileName,
+      );
     },
   );
 }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,5 @@
-const React = require('react');
 const util = require('util');
+const React = require('react');
 
 // eslint-disable-next-line no-console
 console.log('Current React Version:', React.version);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43913

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Anchor not trigger `getCurrentAnchor` when scroll.        |
| 🇨🇳 Chinese |   修复 Anchor 在滚动时无法触发 `getCurrentAnchor` 的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6760dcd</samp>

This pull request improves the testing and code quality of the `Anchor` component. It adds and updates test cases for the component's props, and applies a linting rule to the component's source code. It also removes some redundant code.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6760dcd</samp>

*  Simplify and improve the logic of the `getInternalCurrentAnchor` function in `Anchor.tsx` by removing an unnecessary `if` statement and returning the same hash as the `getCurrentAnchor` prop if it is provided ([link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L191-R191),[link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L308-R306))
* Update the test case for the `onChange` prop of the `Anchor` component in `Anchor.test.tsx` to reflect the new behavior of the `getInternalCurrentAnchor` function ([link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-8403f43a04d69820d83b56e860ecd221192c3094a657c45d7c6fb3291fc48ca3L384-R389))
* Add a new test case for the `getCurrentAnchor` prop of the `Anchor` component in `Anchor.test.tsx` to verify that it is repeatedly called when the window or document is scrolled ([link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-8403f43a04d69820d83b56e860ecd221192c3094a657c45d7c6fb3291fc48ca3R437-R447))
* Add parentheses around the `props` and `link` parameters of various arrow functions in `Anchor.tsx` and `AnchorContent.tsx`, following the ESLint rule `arrow-parens` that enforces consistent use of parentheses ([link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L90-R90),[link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L122-R124),[link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L131-R133),[link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L151-R151),[link](https://github.com/ant-design/ant-design/pull/43917/files?diff=unified&w=0#diff-353746edad3f07acb175d7e32c64972b87359b5a0dc4e14e4d3f1133b61e48a8L203-R201))
