### PR TITLE
chore: remove useless any & add CSSProperties type

### DIFF
--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -336,7 +336,7 @@ export default function Theme() {
       ...ThemeDefault,
       themeType,
       ...ThemesInfo[themeType],
-    } as any;
+    };
 
     setThemeData(mergedData);
     form.setFieldsValue(mergedData);
@@ -517,13 +517,13 @@ export default function Theme() {
   const posStyle: React.CSSProperties = {
     position: 'absolute',
   };
-  const leftTopImageStyle = {
+  const leftTopImageStyle: React.CSSProperties = {
     left: '50%',
     transform: 'translate3d(-900px, 0, 0)',
     top: -100,
     height: 500,
   };
-  const rightBottomImageStyle = {
+  const rightBottomImageStyle: React.CSSProperties = {
     right: '50%',
     transform: 'translate3d(750px, 0, 0)',
     bottom: -100,

--- a/.dumi/theme/common/Color/ColorStyle.tsx
+++ b/.dumi/theme/common/Color/ColorStyle.tsx
@@ -25,7 +25,7 @@ const ColorStyle = () => {
     if (index <= 10) {
       return `
 .palette-${color}-${index} {
-  background: ${(token as any)[`${color}-${index}`]};
+  background: ${token[`${color}-${index}`]};
 }
 ${makePalette(color, index + 1)}
     `;
@@ -37,7 +37,7 @@ ${makePalette(color, index + 1)}
     if (index <= 13) {
       return `
 .palette-gray-${index} {
-  background: ${(gray as any)[index]};
+  background: ${gray[index]};
 }
 ${makeGrayPalette(index + 1)}
     `;

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -130,8 +130,8 @@ const showWaveEffect: ShowWaveEffect = (node, { className }) => {
   // Create holder
   const holder = document.createElement('div');
   holder.style.position = 'absolute';
-  holder.style.left = `0px`;
-  holder.style.top = `0px`;
+  holder.style.left = '0px';
+  holder.style.top = '0px';
   node?.insertBefore(holder, node?.firstChild);
 
   render(<WaveEffect target={node} className={className} />, holder);

--- a/components/calendar/demo/customize-header.tsx
+++ b/components/calendar/demo/customize-header.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
     console.log(value.format('YYYY-MM-DD'), mode);
   };
 
-  const wrapperStyle = {
+  const wrapperStyle: React.CSSProperties = {
     width: 300,
     border: `1px solid ${token.colorBorderSecondary}`,
     borderRadius: token.borderRadiusLG,

--- a/components/collapse/demo/custom.tsx
+++ b/components/collapse/demo/custom.tsx
@@ -34,7 +34,7 @@ const getItems: (panelStyle: CSSProperties) => CollapseProps['items'] = (panelSt
 const App: React.FC = () => {
   const { token } = theme.useToken();
 
-  const panelStyle = {
+  const panelStyle: React.CSSProperties = {
     marginBottom: 24,
     background: token.colorFillAlter,
     borderRadius: token.borderRadiusLG,

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -128,7 +128,7 @@ describe('Drawer', () => {
   });
 
   it('style/drawerStyle/headerStyle/bodyStyle should work', () => {
-    const style = {
+    const style: React.CSSProperties = {
       backgroundColor: '#08c',
     };
     const { container: wrapper } = render(

--- a/components/dropdown/demo/custom-dropdown.tsx
+++ b/components/dropdown/demo/custom-dropdown.tsx
@@ -37,13 +37,13 @@ const items: MenuProps['items'] = [
 const App: React.FC = () => {
   const { token } = useToken();
 
-  const contentStyle = {
+  const contentStyle: React.CSSProperties = {
     backgroundColor: token.colorBgElevated,
     borderRadius: token.borderRadiusLG,
     boxShadow: token.boxShadowSecondary,
   };
 
-  const menuStyle = {
+  const menuStyle: React.CSSProperties = {
     boxShadow: 'none',
   };
 

--- a/components/form/demo/advanced-search.tsx
+++ b/components/form/demo/advanced-search.tsx
@@ -9,7 +9,7 @@ const AdvancedSearchForm = () => {
   const [form] = Form.useForm();
   const [expand, setExpand] = useState(false);
 
-  const formStyle = {
+  const formStyle: React.CSSProperties = {
     maxWidth: 'none',
     background: token.colorFillAlter,
     borderRadius: token.borderRadiusLG,

--- a/components/input/demo/align.tsx
+++ b/components/input/demo/align.tsx
@@ -18,7 +18,7 @@ const { Text } = Typography;
 const { Option } = Select;
 const { RangePicker } = DatePicker;
 
-const narrowStyle = {
+const narrowStyle: React.CSSProperties = {
   width: 50,
 };
 

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -196,7 +196,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const { childrenColumnName = 'children' } = mergedExpandable;
 
   const expandType = React.useMemo<ExpandType>(() => {
-    if (rawData.some((item) => (item as any)?.[childrenColumnName])) {
+    if (rawData.some((item) => item?.[childrenColumnName])) {
       return 'nest';
     }
 

--- a/components/tag/demo/animation.tsx
+++ b/components/tag/demo/animation.tsx
@@ -60,7 +60,7 @@ const App: React.FC = () => {
 
   const tagChild = tags.map(forMap);
 
-  const tagPlusStyle = {
+  const tagPlusStyle: React.CSSProperties = {
     background: token.colorBgContainer,
     borderStyle: 'dashed',
   };

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -453,16 +453,16 @@ describe('Transfer', () => {
   });
 
   it('should add custom styles when their props are provided', () => {
-    const style = {
+    const style: React.CSSProperties = {
       backgroundColor: 'red',
     };
-    const leftStyle = {
+    const leftStyle: React.CSSProperties = {
       backgroundColor: 'blue',
     };
-    const rightStyle = {
+    const rightStyle: React.CSSProperties = {
       backgroundColor: 'red',
     };
-    const operationStyle = {
+    const operationStyle: React.CSSProperties = {
       backgroundColor: 'yellow',
     };
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -251,7 +251,7 @@ describe('Typography', () => {
           const onChange = jest.fn();
 
           const className = 'test';
-          const style = { padding: 'unset' };
+          const style: React.CSSProperties = { padding: 'unset' };
 
           const { container: wrapper } = render(
             <Paragraph


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
代码风格优化有以下方面 
一、 给style代码加上type CSSProperties 
二、 去除无用的any
 1. i <= 13 符合gray的类型，所以这里可以去掉 
<img width="838" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/d25ef343-43f4-4356-8bad-c91d7d2ade0c">
2. token也不需要any
<img width="809" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/fedab88c-8097-44fb-97d4-dd41f936d54e">
3. item 类型是 anyobject ，不需要
<img width="754" alt="image" src="https://github.com/ant-design/ant-design/assets/117748716/4f7b63df-c84e-495d-a1cb-516c910b11b5">


三、反引号没插入什么变量，直接换成单引号 



<!--
1. Describe the problem and the scenario.
5. GIF or snapshot should be provided if includes UI/interactive modification.
6. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        remove useless any & add CSSProperties type   |
| 🇨🇳 Chinese |        删除无用的any 并且 增加  CSSProperties类型 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c197a93</samp>

This pull request adds explicit types for various CSS style objects in different components and demos, to improve type safety and readability. It also removes unnecessary type casts and template literals that could cause type errors or inconsistency. The files affected include `.dumi/pages/index/components/Theme/index.tsx`, `.dumi/theme/common/Color/ColorStyle.tsx`, `components/dropdown/demo/custom-dropdown.tsx`, `components/_util/wave/WaveEffect.tsx`, and several others.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c197a93</samp>

*  Remove unnecessary `as any` casts from `token` and `gray` objects in `ColorStyle.tsx` ([link](https://github.com/ant-design/ant-design/pull/43921/files?diff=unified&w=0#diff-f18c0ae50b6f2d03ee72182d1e96304ec9cc6a143f445f4f8376b6eeba22ff9cL28-R28), [link](https://github.com/ant-design/ant-design/pull/43921/files?diff=unified&w=0#diff-f18c0ae50b6f2d03ee72182d1e96304ec9cc6a143f445f4f8376b6eeba22ff9cL40-R40)) and `item` object in `InternalTable.tsx` ([link](https://github.com/ant-design/ant-design/pull/43921/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616L199-R199)), as they already have the correct types
