### PR TITLE
docs: fix nprogress

### DIFF
--- a/.dumi/theme/common/Link.tsx
+++ b/.dumi/theme/common/Link.tsx
@@ -1,31 +1,49 @@
 import type { MouseEvent } from 'react';
-import React, { forwardRef, startTransition } from 'react';
-import { useNavigate } from 'dumi';
+import React, { forwardRef, useLayoutEffect, useMemo, useTransition } from 'react';
+import { useLocation, useNavigate } from 'dumi';
+import nprogress from 'nprogress';
 
 export type LinkProps = {
-  to?: string;
+  to?: string | { pathname?: string; search?: string; hash?: string };
   children?: React.ReactNode;
   className?: string;
 };
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const { to, children, ...rest } = props;
+  const [isPending, startTransition] = useTransition();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const href = useMemo(() => {
+    if (typeof to === 'object') {
+      return `${to.pathname || pathname}${to.search || ''}${to.hash || ''}`;
+    }
+    return to;
+  }, [to]);
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    if (!to.startsWith('http')) {
+    if (!href.startsWith('http')) {
       // Should support open in new tab
       if (!e.metaKey && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
         startTransition(() => {
-          navigate(to);
+          navigate(href);
         });
       }
     }
   };
 
+  useLayoutEffect(() => {
+    if (isPending) {
+      nprogress.start();
+    } else {
+      nprogress.done();
+    }
+  }, [isPending]);
+
   return (
-    <a ref={ref} href={to} onClick={handleClick} {...rest}>
+    <a ref={ref} href={href} onClick={handleClick} {...rest}>
       {children}
     </a>
   );

--- a/.dumi/theme/slots/Header/More.tsx
+++ b/.dumi/theme/slots/Header/More.tsx
@@ -2,15 +2,19 @@ import { DownOutlined } from '@ant-design/icons';
 import { createStyles } from 'antd-style';
 import { FormattedMessage } from 'dumi';
 import React from 'react';
+import classnames from 'classnames';
 import type { MenuProps } from 'antd';
 import { Button, Dropdown } from 'antd';
 import type { SharedProps } from './interface';
 
-const useStyle = createStyles(({ css }) => ({
+const useStyle = createStyles(({ css, token }) => ({
   smallStyle: css`
     font-size: 12px;
     color: #777;
     margin-left: 0.3em;
+  `,
+  down: css`
+    color: ${token.colorTextQuaternary};
   `,
   downOutlined: css`
     font-size: 9px;
@@ -84,7 +88,9 @@ const More: React.FC<SharedProps> = ({ isRTL }) => {
     <Dropdown menu={{ items: getEcosystemGroup() }} placement="bottomRight">
       <Button size="small">
         <FormattedMessage id="app.header.menu.more" />
-        <DownOutlined className={isRTL ? styles.downOutlinedRTL : styles.downOutlined} />
+        <DownOutlined
+          className={classnames(isRTL ? styles.downOutlinedRTL : styles.downOutlined, styles.down)}
+        />
       </Button>
     </Dropdown>
   );

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormattedMessage, Link, useFullSidebarData, useLocation } from 'dumi';
+import { FormattedMessage, useFullSidebarData, useLocation } from 'dumi';
 import { MenuOutlined } from '@ant-design/icons';
 import { createStyles, css } from 'antd-style';
 import type { MenuProps } from 'antd';
@@ -8,6 +8,7 @@ import { getEcosystemGroup } from './More';
 import * as utils from '../../utils';
 import type { SharedProps } from './interface';
 import useLocale from '../../../hooks/useLocale';
+import Link from '../../common/Link';
 
 // ============================= Theme =============================
 const locales = {

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "lz-string": "^1.4.4",
     "mockdate": "^3.0.0",
     "node-notifier": "^10.0.1",
+    "nprogress": "^0.2.0",
     "open": "^9.0.0",
     "prettier": "^3.0.0",
     "prettier-plugin-jsdoc": "^1.0.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
https://github.com/umijs/dumi/issues/1812
https://github.com/umijs/dumi/pull/1793

dumi 更新后把 nprogress 和 loading 的生命周期挂钩了，但是 site 有一些是用了 transition，fallback 不会渲染，所以就不会触发 dumi 的 nprogress 逻辑。
暂时补一下 transition 的加载逻辑，后续等 dumi 的修复方案。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |       -    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87ccbb7</samp>

This pull request enhances the theme and navigation of the `dumi` documentation site. It adds a progress bar for the Link component using `nprogress`, improves the style and behavior of the `More` slot in the header, and replaces the `dumi` Link component with a custom one for the navigation header. It also updates the `package.json` file with the new dependency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87ccbb7</samp>

*  Add a progress bar for the Link component using `nprogress` and React hooks ([link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL2-R7), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL13-R31), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL27-R46), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R261))
*  Change the type of the `to` prop of the Link component to accept an object with `pathname`, `search`, and `hash` properties ([link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL2-R7), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL13-R31), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL27-R46))
*  Use the custom Link component instead of the `dumi` Link in the Header navigation ([link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L2-R2), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5R11))
*  Add a `down` CSS class for the `DownOutlined` icon in the Header more menu using `classnames` and theme colors ([link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-a9282d78e0292d805e422e5cb4cb781e9af7b10ad53b3f0ca66bfb6ccbf8fa6eL5-R10), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-a9282d78e0292d805e422e5cb4cb781e9af7b10ad53b3f0ca66bfb6ccbf8fa6eR16-R18), [link](https://github.com/ant-design/ant-design/pull/43955/files?diff=unified&w=0#diff-a9282d78e0292d805e422e5cb4cb781e9af7b10ad53b3f0ca66bfb6ccbf8fa6eL87-R93))
