### PR TITLE
fix(table): fix expand icon and column shrinking in RTL

### DIFF
--- a/components/table/style/rtl.ts
+++ b/components/table/style/rtl.ts
@@ -20,6 +20,8 @@ const genStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-row-expand-icon`]: {
+        float: 'right',
+
         '&::after': {
           transform: 'rotate(-90deg)',
         },
@@ -42,6 +44,10 @@ const genStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         '&::after': {
           insetInlineStart: 0,
           insetInlineEnd: 'unset',
+        },
+
+        [`${componentCls}-row-indent`]: {
+          float: 'right',
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/43918
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
在当前 table 处于 rtl 时，展开 icon 和展开行缩进的内容都位于左侧，其实应该位于右侧，因此使用 `float: right` 浮动至右侧来解决该问题。
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect expand icon direction and row indentation in RTL table.  |
| 🇨🇳 Chinese | 修复在 table direction 为 RTL 时展开图标的方向和展开行的缩进有误的问题。           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ebbfaf</samp>

Improve RTL support for table component. Add style properties to `genStyle` and `.ant-table-row-indent` in `components/table/style/rtl.ts` to align them to the right in RTL mode.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ebbfaf</samp>

* Add RTL support for table component by:
  - Making table elements float to the right when direction is RTL ([link](https://github.com/ant-design/ant-design/pull/43977/files?diff=unified&w=0#diff-5747d4c80ceeeedbc17e2c2ef778dad9ae35227e1df6616e2becb688be50c8d5R23-R24))
  - Aligning table row indent with table direction and avoiding overlap ([link](https://github.com/ant-design/ant-design/pull/43977/files?diff=unified&w=0#diff-5747d4c80ceeeedbc17e2c2ef778dad9ae35227e1df6616e2becb688be50c8d5R48-R51))
