### PR TITLE
docs: add full change log link

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { createStyles } from 'antd-style';
 import { HistoryOutlined } from '@ant-design/icons';
 import { Button, Drawer, Timeline, Typography } from 'antd';
+import Link from '../common/Link';
 import useLocale from '../../../hooks/useLocale';
 import useFetch from '../../../hooks/useFetch';
 

--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { createStyles } from 'antd-style';
 import { HistoryOutlined } from '@ant-design/icons';
 import { Button, Drawer, Timeline, Typography } from 'antd';
-import Link from '../common/Link';
+import Link from '../Link';
 import useLocale from '../../../hooks/useLocale';
 import useFetch from '../../../hooks/useFetch';
 

--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -28,11 +28,13 @@ export interface ComponentChangelogProps {
 
 const locales = {
   cn: {
+    full: '完整更新日志',
     changelog: '更新日志',
     loading: '加载中...',
     empty: '暂无更新',
   },
   en: {
+    full: 'Full Changelog',
     changelog: 'Changelog',
     loading: 'loading...',
     empty: 'Nothing update',
@@ -165,8 +167,13 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
       </Button>
       <Drawer
         title={locale.changelog}
+        extra={
+          <Link style={{ fontSize: 14 }} to={`/changelog${lang === 'cn' ? '-cn' : ''}`}>
+            {locale.full}
+          </Link>
+        }
         open={show}
-        width={520}
+        width="40vw"
         onClose={() => {
           setShow(false);
         }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
<img width="716" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/da0b81cc-1a9f-4e01-a278-d3809fdf2e49">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |     --      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fde260a</samp>

Improved the `ComponentChangelog` component to include a link to the full changelog page and support different languages. Fixed the `Drawer` component's width.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fde260a</samp>

* Import `Link` component from `dumi` to link to full changelog page ([link](https://github.com/ant-design/ant-design/pull/43986/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1R5))
* Add Chinese and English translations for `full` key in `locales` object ([link](https://github.com/ant-design/ant-design/pull/43986/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1R31), [link](https://github.com/ant-design/ant-design/pull/43986/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1R37))
* Add `extra` prop to `Drawer` component to render full changelog link with language suffix and change `width` prop to use relative value ([link](https://github.com/ant-design/ant-design/pull/43986/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L166-R175))
