### PR TITLE
fix: Checkbox & Radio not support customize wave

### DIFF
--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -4,6 +4,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Wave from '../wave';
 import { TARGET_CLS } from '../wave/interface';
+import Checkbox from '../../checkbox';
 
 (global as any).isVisible = true;
 
@@ -335,5 +336,17 @@ describe('Wave component', () => {
     waitRaf();
 
     expect(container.querySelector('.ant-wave')).toBeTruthy();
+  });
+
+  it('Checkbox with uncheck should not trigger wave', () => {
+    const onChange = jest.fn();
+    const { container } = render(<Checkbox defaultChecked onChange={onChange} />);
+
+    // Click
+    fireEvent.click(container.querySelector('input')!);
+    waitRaf();
+
+    expect(onChange).toHaveBeenCalled();
+    expect(container.querySelector('.ant-wave')).toBeFalsy();
   });
 });

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Wave from '../wave';
-import { DATA_WAVE_TARGET } from '../wave/interface';
+import { TARGET_CLS } from '../wave/interface';
 
 (global as any).isVisible = true;
 

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Wave from '../wave';
-import { TARGET_CLS } from '../wave/interface';
+import { DATA_WAVE_TARGET } from '../wave/interface';
 
 (global as any).isVisible = true;
 

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import classNames from 'classnames';
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Wave from '../wave';
+import { TARGET_CLS } from '../wave/interface';
 
 (global as any).isVisible = true;
 
@@ -29,7 +31,6 @@ describe('Wave component', () => {
     }
 
     (window as any).ResizeObserver = FakeResizeObserver;
-    jest.useFakeTimers();
   });
 
   afterAll(() => {
@@ -39,11 +40,14 @@ describe('Wave component', () => {
   });
 
   beforeEach(() => {
+    jest.useFakeTimers();
     (global as any).isVisible = true;
     document.body.innerHTML = '';
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await waitFakeTimer();
+
     jest.clearAllTimers();
     const styles = document.getElementsByTagName('style');
     for (let i = 0; i < styles.length; i += 1) {
@@ -65,6 +69,9 @@ describe('Wave component', () => {
   }
 
   function waitRaf() {
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
     act(() => {
       jest.advanceTimersByTime(100);
     });
@@ -237,18 +244,6 @@ describe('Wave component', () => {
     expect(document.querySelector('.ant-wave')).toBeFalsy();
   });
 
-  it('not show when is input', () => {
-    const { container } = render(
-      <Wave>
-        <input />
-      </Wave>,
-    );
-
-    fireEvent.click(container.querySelector('input')!);
-    waitRaf();
-    expect(document.querySelector('.ant-wave')).toBeFalsy();
-  });
-
   it('should not throw when click it', () => {
     expect(() => {
       const { container } = render(
@@ -321,6 +316,22 @@ describe('Wave component', () => {
 
     // Click should not throw
     fireEvent.click(elem);
+    waitRaf();
+
+    expect(container.querySelector('.ant-wave')).toBeTruthy();
+  });
+
+  it('Wave can match target', () => {
+    const { container } = render(
+      <Wave>
+        <div>
+          <div className={classNames('bamboo', TARGET_CLS)} style={{ borderColor: 'red' }} />
+        </div>
+      </Wave>,
+    );
+
+    // Click
+    fireEvent.click(container.querySelector('.bamboo')!);
     waitRaf();
 
     expect(container.querySelector('.ant-wave')).toBeTruthy();

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -13,10 +13,11 @@ function validateNum(value: number) {
 export interface WaveEffectProps {
   className: string;
   target: HTMLElement;
+  component?: string;
 }
 
 const WaveEffect: React.FC<WaveEffectProps> = (props) => {
-  const { className, target } = props;
+  const { className, target, component } = props;
   const divRef = React.useRef<HTMLDivElement>(null);
 
   const [color, setWaveColor] = React.useState<string | null>(null);
@@ -103,6 +104,8 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
     return null;
   }
 
+  const isSmallComponent = component === 'Checkbox' || component === 'Radio';
+
   return (
     <CSSMotion
       visible
@@ -120,21 +123,36 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
       }}
     >
       {({ className: motionClassName }) => (
-        <div ref={divRef} className={classNames(className, motionClassName)} style={waveStyle} />
+        <div
+          ref={divRef}
+          className={classNames(
+            className,
+            {
+              'wave-quick': isSmallComponent,
+            },
+            motionClassName,
+          )}
+          style={waveStyle}
+        />
       )}
     </CSSMotion>
   );
 };
 
-const showWaveEffect: ShowWaveEffect = (node, { className }) => {
+const showWaveEffect: ShowWaveEffect = (target, info) => {
+  // Skip for unchecked checkbox
+  if (info.component === 'Checkbox' && !target.querySelector('input')?.checked) {
+    return;
+  }
+
   // Create holder
   const holder = document.createElement('div');
   holder.style.position = 'absolute';
   holder.style.left = '0px';
   holder.style.top = '0px';
-  node?.insertBefore(holder, node?.firstChild);
+  target?.insertBefore(holder, target?.firstChild);
 
-  render(<WaveEffect target={node} className={className} />, holder);
+  render(<WaveEffect {...info} target={target} />, holder);
 };
 
 export default showWaveEffect;

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -142,10 +142,9 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
 
 const showWaveEffect: ShowWaveEffect = (target, info) => {
   const { component } = info;
-  const targetNode = target.querySelector('input');
 
   // Skip for unchecked checkbox
-  if (component === 'Checkbox' && !targetNode?.checked) {
+  if (component === 'Checkbox' && !target.querySelector('input')?.checked) {
     return;
   }
 

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -4,7 +4,7 @@ import { render, unmount } from 'rc-util/lib/React/render';
 import raf from 'rc-util/lib/raf';
 import * as React from 'react';
 import { getTargetWaveColor } from './util';
-import type { ShowWaveEffect } from './useWave';
+import { type ShowWaveEffect, TARGET_CLS } from './interface';
 
 function validateNum(value: number) {
   return Number.isNaN(value) ? 0 : value;
@@ -104,7 +104,8 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
     return null;
   }
 
-  const isSmallComponent = component === 'Checkbox' || component === 'Radio';
+  const isSmallComponent =
+    (component === 'Checkbox' || component === 'Radio') && target?.classList.contains(TARGET_CLS);
 
   return (
     <CSSMotion
@@ -140,8 +141,11 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
 };
 
 const showWaveEffect: ShowWaveEffect = (target, info) => {
+  const { component } = info;
+  const targetNode = target.querySelector('input');
+
   // Skip for unchecked checkbox
-  if (info.component === 'Checkbox' && !target.querySelector('input')?.checked) {
+  if (component === 'Checkbox' && !targetNode?.checked) {
     return;
   }
 

--- a/components/_util/wave/index.ts
+++ b/components/_util/wave/index.ts
@@ -37,7 +37,6 @@ const Wave: React.FC<WaveProps> = (props) => {
     const onClick = (e: MouseEvent) => {
       // Fix radio button click twice
       if (
-        (e.target as HTMLElement).tagName === 'INPUT' ||
         !isVisible(e.target as HTMLElement) ||
         // No need wave
         !node.getAttribute ||

--- a/components/_util/wave/interface.ts
+++ b/components/_util/wave/interface.ts
@@ -9,6 +9,7 @@ export type ShowWaveEffect = (
     token: GlobalToken;
     component?: string;
     event: MouseEvent;
+    hashId: string;
   },
 ) => void;
 

--- a/components/_util/wave/interface.ts
+++ b/components/_util/wave/interface.ts
@@ -1,0 +1,15 @@
+import type { GlobalToken } from '../../theme';
+
+export const TARGET_CLS = 'ant-wave-target';
+
+export type ShowWaveEffect = (
+  element: HTMLElement,
+  info: {
+    className: string;
+    token: GlobalToken;
+    component?: string;
+    event: MouseEvent;
+  },
+) => void;
+
+export type ShowWave = (event: MouseEvent) => void;

--- a/components/_util/wave/style.ts
+++ b/components/_util/wave/style.ts
@@ -28,6 +28,17 @@ const genWaveStyle: GenerateStyle<WaveToken> = (token) => {
         '&-active': {
           boxShadow: `0 0 0 6px currentcolor`,
           opacity: 0,
+
+          // '&.wave-quick': {
+          //   boxShadow: `0 0 0 4px currentcolor`,
+          // },
+        },
+
+        '&.wave-quick': {
+          transition: [
+            `box-shadow 0.3s ${token.motionEaseInOut}`,
+            `opacity 0.35s ${token.motionEaseInOut}`,
+          ].join(','),
         },
       },
     },

--- a/components/_util/wave/style.ts
+++ b/components/_util/wave/style.ts
@@ -28,10 +28,6 @@ const genWaveStyle: GenerateStyle<WaveToken> = (token) => {
         '&-active': {
           boxShadow: `0 0 0 6px currentcolor`,
           opacity: 0,
-
-          // '&.wave-quick': {
-          //   boxShadow: `0 0 0 4px currentcolor`,
-          // },
         },
 
         '&.wave-quick': {

--- a/components/_util/wave/useWave.ts
+++ b/components/_util/wave/useWave.ts
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import useEvent from 'rc-util/lib/hooks/useEvent';
+import raf from 'rc-util/lib/raf';
 import showWaveEffect from './WaveEffect';
 import { ConfigContext } from '../../config-provider';
 import useToken from '../../theme/useToken';
 import type { GlobalToken } from '../../theme';
+
+export const TARGET_CLS = 'ant-wave-target';
 
 export type ShowWaveEffect = (
   element: HTMLElement,
@@ -15,6 +18,8 @@ export type ShowWaveEffect = (
   },
 ) => void;
 
+type ShowWave = (event: MouseEvent) => void;
+
 export default function useWave(
   nodeRef: React.RefObject<HTMLElement>,
   className: string,
@@ -23,18 +28,31 @@ export default function useWave(
   const { wave } = React.useContext(ConfigContext);
   const [, token] = useToken();
 
-  const showWave = useEvent((event: MouseEvent) => {
+  const showWave = useEvent<ShowWave>((event) => {
     const node = nodeRef.current!;
 
     if (wave?.disabled || !node) {
       return;
     }
 
+    const targetNode = node.querySelector<HTMLElement>(`.${TARGET_CLS}`) || node;
+
     const { showEffect } = wave || {};
 
     // Customize wave effect
-    (showEffect || showWaveEffect)(node, { className, token, component, event });
+    (showEffect || showWaveEffect)(targetNode, { className, token, component, event });
   });
 
-  return showWave;
+  const rafId = React.useRef<number>();
+
+  // Merge trigger event into one for each frame
+  const showDebounceWave: ShowWave = (event) => {
+    raf.cancel(rafId.current!);
+
+    rafId.current = raf(() => {
+      showWave(event);
+    });
+  };
+
+  return showDebounceWave;
 }

--- a/components/_util/wave/useWave.ts
+++ b/components/_util/wave/useWave.ts
@@ -4,21 +4,7 @@ import raf from 'rc-util/lib/raf';
 import showWaveEffect from './WaveEffect';
 import { ConfigContext } from '../../config-provider';
 import useToken from '../../theme/useToken';
-import type { GlobalToken } from '../../theme';
-
-export const TARGET_CLS = 'ant-wave-target';
-
-export type ShowWaveEffect = (
-  element: HTMLElement,
-  info: {
-    className: string;
-    token: GlobalToken;
-    component?: string;
-    event: MouseEvent;
-  },
-) => void;
-
-type ShowWave = (event: MouseEvent) => void;
+import { TARGET_CLS, type ShowWave } from './interface';
 
 export default function useWave(
   nodeRef: React.RefObject<HTMLElement>,

--- a/components/_util/wave/useWave.ts
+++ b/components/_util/wave/useWave.ts
@@ -12,7 +12,7 @@ export default function useWave(
   component?: string,
 ) {
   const { wave } = React.useContext(ConfigContext);
-  const [, token] = useToken();
+  const [, token, hashId] = useToken();
 
   const showWave = useEvent<ShowWave>((event) => {
     const node = nodeRef.current!;
@@ -26,7 +26,7 @@ export default function useWave(
     const { showEffect } = wave || {};
 
     // Customize wave effect
-    (showEffect || showWaveEffect)(targetNode, { className, token, component, event });
+    (showEffect || showWaveEffect)(targetNode, { className, token, component, event, hashId });
   });
 
   const rafId = React.useRef<number>();

--- a/components/button/__tests__/wave.test.tsx
+++ b/components/button/__tests__/wave.test.tsx
@@ -23,6 +23,12 @@ describe('click wave effect', () => {
     const element = container.firstChild;
     // https://github.com/testing-library/user-event/issues/833
     await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).click(element as Element);
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // Second time will render wave element
     act(() => {
       jest.advanceTimersByTime(100);
     });

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -9,6 +9,8 @@ import { FormItemInputContext } from '../form/context';
 import GroupContext from './GroupContext';
 
 import useStyle from './style';
+import Wave from '../_util/wave';
+import { TARGET_CLS } from '../_util/wave/useWave';
 
 export interface AbstractCheckboxProps<T> {
   prefixCls?: string;
@@ -129,27 +131,30 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     {
       [`${prefixCls}-indeterminate`]: indeterminate,
     },
+    TARGET_CLS,
     hashId,
   );
   const ariaChecked = indeterminate ? 'mixed' : undefined;
   return wrapSSR(
-    // eslint-disable-next-line jsx-a11y/label-has-associated-control
-    <label
-      className={classString}
-      style={{ ...checkbox?.style, ...style }}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
-      <RcCheckbox
-        aria-checked={ariaChecked}
-        {...checkboxProps}
-        prefixCls={prefixCls}
-        className={checkboxClass}
-        disabled={mergedDisabled}
-        ref={ref}
-      />
-      {children !== undefined && <span>{children}</span>}
-    </label>,
+    <Wave component="Checkbox" disabled={mergedDisabled}>
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label
+        className={classString}
+        style={{ ...checkbox?.style, ...style }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        <RcCheckbox
+          aria-checked={ariaChecked}
+          {...checkboxProps}
+          prefixCls={prefixCls}
+          className={checkboxClass}
+          disabled={mergedDisabled}
+          ref={ref}
+        />
+        {children !== undefined && <span>{children}</span>}
+      </label>
+    </Wave>,
   );
 };
 

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ import GroupContext from './GroupContext';
 
 import useStyle from './style';
 import Wave from '../_util/wave';
-import { TARGET_CLS } from '../_util/wave/useWave';
+import { TARGET_CLS } from '../_util/wave/interface';
 
 export interface AbstractCheckboxProps<T> {
   prefixCls?: string;

--- a/components/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/checkbox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Checkbox rtl render component should be rendered correctly in RTL direc
   class="ant-checkbox-wrapper ant-checkbox-rtl"
 >
   <span
-    class="ant-checkbox"
+    class="ant-checkbox ant-wave-target"
   >
     <input
       class="ant-checkbox-input"

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5,7 +5,7 @@ exports[`renders components/checkbox/demo/basic.tsx extend context correctly 1`]
   class="ant-checkbox-wrapper"
 >
   <span
-    class="ant-checkbox"
+    class="ant-checkbox ant-wave-target"
   >
     <input
       class="ant-checkbox-input"
@@ -29,7 +29,7 @@ Array [
     class="ant-checkbox-wrapper"
   >
     <span
-      class="ant-checkbox ant-checkbox-indeterminate"
+      class="ant-checkbox ant-checkbox-indeterminate ant-wave-target"
     >
       <input
         aria-checked="mixed"
@@ -55,7 +55,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -75,7 +75,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -94,7 +94,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -125,7 +125,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -173,7 +173,7 @@ exports[`renders components/checkbox/demo/debug-disable-popover.tsx extend conte
     class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
     >
       <input
         checked=""
@@ -228,7 +228,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -256,7 +256,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -285,7 +285,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -313,7 +313,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -337,7 +337,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -356,7 +356,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -379,7 +379,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -398,7 +398,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -419,7 +419,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -439,7 +439,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -473,7 +473,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-disabled"
     >
       <input
         class="ant-checkbox-input"
@@ -490,7 +490,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-indeterminate ant-checkbox-disabled"
+      class="ant-checkbox ant-checkbox-indeterminate ant-wave-target ant-checkbox-disabled"
     >
       <input
         aria-checked="mixed"
@@ -508,7 +508,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
     >
       <input
         checked=""
@@ -535,7 +535,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -555,7 +555,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -574,7 +574,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -599,7 +599,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -618,7 +618,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -638,7 +638,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -663,7 +663,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
       >
         <input
           checked=""
@@ -684,7 +684,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"
@@ -704,7 +704,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"
@@ -741,7 +741,7 @@ exports[`renders components/checkbox/demo/layout.tsx extend context correctly 1`
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -764,7 +764,7 @@ exports[`renders components/checkbox/demo/layout.tsx extend context correctly 1`
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -787,7 +787,7 @@ exports[`renders components/checkbox/demo/layout.tsx extend context correctly 1`
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -810,7 +810,7 @@ exports[`renders components/checkbox/demo/layout.tsx extend context correctly 1`
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -833,7 +833,7 @@ exports[`renders components/checkbox/demo/layout.tsx extend context correctly 1`
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders components/checkbox/demo/basic.tsx correctly 1`] = `
   class="ant-checkbox-wrapper"
 >
   <span
-    class="ant-checkbox"
+    class="ant-checkbox ant-wave-target"
   >
     <input
       class="ant-checkbox-input"
@@ -27,7 +27,7 @@ Array [
     class="ant-checkbox-wrapper"
   >
     <span
-      class="ant-checkbox ant-checkbox-indeterminate"
+      class="ant-checkbox ant-checkbox-indeterminate ant-wave-target"
     >
       <input
         aria-checked="mixed"
@@ -53,7 +53,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -73,7 +73,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -92,7 +92,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -121,7 +121,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -167,7 +167,7 @@ exports[`renders components/checkbox/demo/debug-disable-popover.tsx correctly 1`
     class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
     >
       <input
         checked=""
@@ -197,7 +197,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -225,7 +225,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -254,7 +254,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -282,7 +282,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -306,7 +306,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -325,7 +325,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -348,7 +348,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -367,7 +367,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -388,7 +388,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -408,7 +408,7 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
       class="ant-checkbox-wrapper"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -436,7 +436,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-disabled"
     >
       <input
         class="ant-checkbox-input"
@@ -453,7 +453,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-indeterminate ant-checkbox-disabled"
+      class="ant-checkbox ant-checkbox-indeterminate ant-wave-target ant-checkbox-disabled"
     >
       <input
         aria-checked="mixed"
@@ -471,7 +471,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
     >
       <input
         checked=""
@@ -496,7 +496,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -516,7 +516,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -535,7 +535,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -560,7 +560,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -579,7 +579,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -599,7 +599,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
@@ -624,7 +624,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
       >
         <input
           checked=""
@@ -645,7 +645,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"
@@ -665,7 +665,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"
@@ -700,7 +700,7 @@ exports[`renders components/checkbox/demo/layout.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -723,7 +723,7 @@ exports[`renders components/checkbox/demo/layout.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -746,7 +746,7 @@ exports[`renders components/checkbox/demo/layout.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -769,7 +769,7 @@ exports[`renders components/checkbox/demo/layout.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -792,7 +792,7 @@ exports[`renders components/checkbox/demo/layout.tsx correctly 1`] = `
         class="ant-checkbox-wrapper"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"

--- a/components/checkbox/__tests__/__snapshots__/group.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/group.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CheckboxGroup passes prefixCls down to checkbox 1`] = `
     class="my-checkbox-wrapper my-checkbox-group-item"
   >
     <span
-      class="my-checkbox"
+      class="my-checkbox ant-wave-target"
     >
       <input
         class="my-checkbox-input"
@@ -28,7 +28,7 @@ exports[`CheckboxGroup passes prefixCls down to checkbox 1`] = `
     style="font-size: 12px;"
   >
     <span
-      class="my-checkbox"
+      class="my-checkbox ant-wave-target"
     >
       <input
         class="my-checkbox-input"

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -1,4 +1,3 @@
-import { Keyframes } from '@ant-design/cssinjs';
 import { genFocusOutline, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -9,19 +8,6 @@ interface CheckboxToken extends FullToken<'Checkbox'> {
   checkboxCls: string;
   checkboxSize: number;
 }
-
-// ============================== Motion ==============================
-const antCheckboxEffect = new Keyframes('antCheckboxEffect', {
-  '0%': {
-    transform: 'scale(1)',
-    opacity: 0.5,
-  },
-
-  '100%': {
-    transform: 'scale(1.6)',
-    opacity: 0,
-  },
-});
 
 // ============================== Styles ==============================
 export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
@@ -82,6 +68,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         whiteSpace: 'nowrap',
         lineHeight: 1,
         cursor: 'pointer',
+        borderRadius: token.borderRadiusSM,
 
         // To make alignment right when `controlHeight` is changed
         // Ref: https://github.com/ant-design/ant-design/issues/41564
@@ -148,13 +135,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
 
     // ===================== Hover =====================
     {
-      // Wrapper
-      [`${wrapperCls}:hover ${checkboxCls}:after`]: {
-        visibility: 'visible',
-      },
-
       // Wrapper & Wrapper > Checkbox
-
       [`
         ${wrapperCls}:not(${wrapperCls}-disabled),
         ${checkboxCls}:not(${checkboxCls}-disabled)
@@ -189,24 +170,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
             transition: `all ${token.motionDurationMid} ${token.motionEaseOutBack} ${token.motionDurationFast}`,
           },
         },
-
-        // Checked Effect
-        '&:after': {
-          position: 'absolute',
-          top: 0,
-          insetInlineStart: 0,
-          width: '100%',
-          height: '100%',
-          borderRadius: token.borderRadiusSM,
-          visibility: 'hidden',
-          border: `${token.lineWidthBold}px solid ${token.colorPrimary}`,
-          animationName: antCheckboxEffect,
-          animationDuration: token.motionDurationSlow,
-          animationTimingFunction: 'ease-in-out',
-          animationFillMode: 'backwards',
-          content: '""',
-          transition: `all ${token.motionDurationSlow}`,
-        },
       },
 
       [`
@@ -216,9 +179,6 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         [`&:hover ${checkboxCls}-inner`]: {
           backgroundColor: token.colorPrimaryHover,
           borderColor: 'transparent',
-        },
-        [`&:hover ${checkboxCls}:after`]: {
-          borderColor: token.colorPrimaryHover,
         },
       },
     },

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -12032,7 +12032,7 @@ exports[`ConfigProvider components Checkbox configProvider 1`] = `
     class="config-checkbox-wrapper"
   >
     <span
-      class="config-checkbox"
+      class="config-checkbox ant-wave-target"
     >
       <input
         class="config-checkbox-input"
@@ -12057,7 +12057,7 @@ exports[`ConfigProvider components Checkbox configProvider componentDisabled 1`]
     class="config-checkbox-wrapper config-checkbox-wrapper-disabled"
   >
     <span
-      class="config-checkbox config-checkbox-disabled"
+      class="config-checkbox ant-wave-target config-checkbox-disabled"
     >
       <input
         class="config-checkbox-input"
@@ -12083,7 +12083,7 @@ exports[`ConfigProvider components Checkbox configProvider componentSize large 1
     class="config-checkbox-wrapper"
   >
     <span
-      class="config-checkbox"
+      class="config-checkbox ant-wave-target"
     >
       <input
         class="config-checkbox-input"
@@ -12108,7 +12108,7 @@ exports[`ConfigProvider components Checkbox configProvider componentSize middle 
     class="config-checkbox-wrapper"
   >
     <span
-      class="config-checkbox"
+      class="config-checkbox ant-wave-target"
     >
       <input
         class="config-checkbox-input"
@@ -12133,7 +12133,7 @@ exports[`ConfigProvider components Checkbox configProvider componentSize small 1
     class="config-checkbox-wrapper"
   >
     <span
-      class="config-checkbox"
+      class="config-checkbox ant-wave-target"
     >
       <input
         class="config-checkbox-input"
@@ -12158,7 +12158,7 @@ exports[`ConfigProvider components Checkbox normal 1`] = `
     class="ant-checkbox-wrapper"
   >
     <span
-      class="ant-checkbox"
+      class="ant-checkbox ant-wave-target"
     >
       <input
         class="ant-checkbox-input"
@@ -12183,7 +12183,7 @@ exports[`ConfigProvider components Checkbox prefixCls 1`] = `
     class="prefix-Checkbox-wrapper"
   >
     <span
-      class="prefix-Checkbox"
+      class="prefix-Checkbox ant-wave-target"
     >
       <input
         class="prefix-Checkbox-input"
@@ -21912,7 +21912,7 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
       class="config-radio-wrapper config-radio-wrapper-checked"
     >
       <span
-        class="config-radio config-radio-checked"
+        class="config-radio ant-wave-target config-radio-checked"
       >
         <input
           checked=""
@@ -21963,7 +21963,7 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
       class="config-radio-wrapper config-radio-wrapper-checked config-radio-wrapper-disabled"
     >
       <span
-        class="config-radio config-radio-checked config-radio-disabled"
+        class="config-radio ant-wave-target config-radio-checked config-radio-disabled"
       >
         <input
           checked=""
@@ -22016,7 +22016,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
       class="config-radio-wrapper config-radio-wrapper-checked"
     >
       <span
-        class="config-radio config-radio-checked"
+        class="config-radio ant-wave-target config-radio-checked"
       >
         <input
           checked=""
@@ -22067,7 +22067,7 @@ exports[`ConfigProvider components Radio configProvider componentSize middle 1`]
       class="config-radio-wrapper config-radio-wrapper-checked"
     >
       <span
-        class="config-radio config-radio-checked"
+        class="config-radio ant-wave-target config-radio-checked"
       >
         <input
           checked=""
@@ -22118,7 +22118,7 @@ exports[`ConfigProvider components Radio configProvider componentSize small 1`] 
       class="config-radio-wrapper config-radio-wrapper-checked"
     >
       <span
-        class="config-radio config-radio-checked"
+        class="config-radio ant-wave-target config-radio-checked"
       >
         <input
           checked=""
@@ -22169,7 +22169,7 @@ exports[`ConfigProvider components Radio normal 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -22220,7 +22220,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
       class="prefix-Radio-wrapper prefix-Radio-wrapper-checked"
     >
       <span
-        class="prefix-Radio prefix-Radio-checked"
+        class="prefix-Radio ant-wave-target prefix-Radio-checked"
       >
         <input
           checked=""
@@ -26606,7 +26606,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                                   class="config-checkbox-wrapper"
                                 >
                                   <span
-                                    class="config-checkbox"
+                                    class="config-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="config-checkbox-input"
@@ -26910,7 +26910,7 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                                   class="config-checkbox-wrapper config-checkbox-wrapper-disabled"
                                 >
                                   <span
-                                    class="config-checkbox config-checkbox-disabled"
+                                    class="config-checkbox ant-wave-target config-checkbox-disabled"
                                   >
                                     <input
                                       class="config-checkbox-input"
@@ -27216,7 +27216,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                                   class="config-checkbox-wrapper"
                                 >
                                   <span
-                                    class="config-checkbox"
+                                    class="config-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="config-checkbox-input"
@@ -27520,7 +27520,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                                   class="config-checkbox-wrapper"
                                 >
                                   <span
-                                    class="config-checkbox"
+                                    class="config-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="config-checkbox-input"
@@ -27824,7 +27824,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                                   class="config-checkbox-wrapper"
                                 >
                                   <span
-                                    class="config-checkbox"
+                                    class="config-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="config-checkbox-input"
@@ -28128,7 +28128,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -28432,7 +28432,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -38221,7 +38221,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -38388,7 +38388,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -38500,7 +38500,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -38667,7 +38667,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -38779,7 +38779,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -38946,7 +38946,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -39058,7 +39058,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -39225,7 +39225,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -39337,7 +39337,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -39504,7 +39504,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
         class="config-checkbox-wrapper config-checkbox-wrapper-disabled config-transfer-list-checkbox"
       >
         <span
-          class="config-checkbox config-checkbox-disabled"
+          class="config-checkbox ant-wave-target config-checkbox-disabled"
         >
           <input
             class="config-checkbox-input"
@@ -39616,7 +39616,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -39783,7 +39783,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -39895,7 +39895,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled prefix-Transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -40062,7 +40062,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled prefix-Transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -10,7 +10,7 @@ import type { SpaceProps } from '../space';
 import type { AliasToken, MappingAlgorithm, OverrideToken } from '../theme/interface';
 import type { SizeType } from './SizeContext';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
-import type { ShowWaveEffect } from '../_util/wave/useWave';
+import type { ShowWaveEffect } from '../_util/wave/interface';
 
 export const defaultIconPrefixCls = 'anticon';
 

--- a/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -402,7 +402,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -422,7 +422,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -441,7 +441,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1143,7 +1143,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1163,7 +1163,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1182,7 +1182,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1599,7 +1599,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1619,7 +1619,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
@@ -362,7 +362,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -382,7 +382,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -401,7 +401,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1037,7 +1037,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1057,7 +1057,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1076,7 +1076,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1459,7 +1459,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1479,7 +1479,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -290,7 +290,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -309,7 +309,7 @@ Array [
           class="ant-radio-wrapper ant-radio-wrapper-checked"
         >
           <span
-            class="ant-radio ant-radio-checked"
+            class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
               checked=""
@@ -329,7 +329,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -348,7 +348,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -2828,7 +2828,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -2847,7 +2847,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -2866,7 +2866,7 @@ Array [
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -2885,7 +2885,7 @@ Array [
           class="ant-radio-wrapper ant-radio-wrapper-checked"
         >
           <span
-            class="ant-radio ant-radio-checked"
+            class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
               checked=""

--- a/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
@@ -106,7 +106,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -125,7 +125,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""
@@ -145,7 +145,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -164,7 +164,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -273,7 +273,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -292,7 +292,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -311,7 +311,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -330,7 +330,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -479,7 +479,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -736,7 +736,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"

--- a/components/empty/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.ts.snap
@@ -341,7 +341,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -492,7 +492,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -750,7 +750,7 @@ exports[`renders components/form/demo/basic.tsx extend context correctly 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox ant-checkbox-checked"
+                class="ant-checkbox ant-wave-target ant-checkbox-checked"
               >
                 <input
                   checked=""
@@ -2433,7 +2433,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked"
     >
       <input
         checked=""
@@ -2482,7 +2482,7 @@ Array [
                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
               >
                 <span
-                  class="ant-checkbox ant-checkbox-disabled"
+                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                 >
                   <input
                     class="ant-checkbox-input"
@@ -2535,7 +2535,7 @@ Array [
                   class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
                 >
                   <span
-                    class="ant-radio ant-radio-disabled"
+                    class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
                       class="ant-radio-input"
@@ -2555,7 +2555,7 @@ Array [
                   class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
                 >
                   <span
-                    class="ant-radio ant-radio-disabled"
+                    class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
                       class="ant-radio-input"
@@ -6726,7 +6726,7 @@ exports[`renders components/form/demo/dynamic-rule.tsx extend context correctly 
               class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8160,7 +8160,7 @@ exports[`renders components/form/demo/normal-login.tsx extend context correctly 
               class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox ant-checkbox-checked"
+                class="ant-checkbox ant-wave-target ant-checkbox-checked"
               >
                 <input
                   checked=""
@@ -9632,7 +9632,7 @@ exports[`renders components/form/demo/register.tsx extend context correctly 1`] 
               class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -20039,7 +20039,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -20058,7 +20058,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -20077,7 +20077,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -20233,7 +20233,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox ant-checkbox-checked"
+                      class="ant-checkbox ant-wave-target ant-checkbox-checked"
                     >
                       <input
                         checked=""
@@ -20258,7 +20258,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+                      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
                     >
                       <input
                         checked=""
@@ -20284,7 +20284,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -20308,7 +20308,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -20332,7 +20332,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -20356,7 +20356,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                     style="line-height: 32px;"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -588,7 +588,7 @@ exports[`renders components/form/demo/basic.tsx correctly 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox ant-checkbox-checked"
+                class="ant-checkbox ant-wave-target ant-checkbox-checked"
               >
                 <input
                   checked=""
@@ -1776,7 +1776,7 @@ Array [
     class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
   >
     <span
-      class="ant-checkbox ant-checkbox-checked"
+      class="ant-checkbox ant-wave-target ant-checkbox-checked"
     >
       <input
         checked=""
@@ -1825,7 +1825,7 @@ Array [
                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
               >
                 <span
-                  class="ant-checkbox ant-checkbox-disabled"
+                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                 >
                   <input
                     class="ant-checkbox-input"
@@ -1878,7 +1878,7 @@ Array [
                   class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
                 >
                   <span
-                    class="ant-radio ant-radio-disabled"
+                    class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
                       class="ant-radio-input"
@@ -1898,7 +1898,7 @@ Array [
                   class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
                 >
                   <span
-                    class="ant-radio ant-radio-disabled"
+                    class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
                       class="ant-radio-input"
@@ -3920,7 +3920,7 @@ exports[`renders components/form/demo/dynamic-rule.tsx correctly 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5369,7 +5369,7 @@ exports[`renders components/form/demo/normal-login.tsx correctly 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox ant-checkbox-checked"
+                class="ant-checkbox ant-wave-target ant-checkbox-checked"
               >
                 <input
                   checked=""
@@ -6461,7 +6461,7 @@ exports[`renders components/form/demo/register.tsx correctly 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8840,7 +8840,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -8859,7 +8859,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -8878,7 +8878,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio"
+                  class="ant-radio ant-wave-target"
                 >
                   <input
                     class="ant-radio-input"
@@ -9034,7 +9034,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox ant-checkbox-checked"
+                      class="ant-checkbox ant-wave-target ant-checkbox-checked"
                     >
                       <input
                         checked=""
@@ -9059,7 +9059,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox ant-checkbox-checked ant-checkbox-disabled"
+                      class="ant-checkbox ant-wave-target ant-checkbox-checked ant-checkbox-disabled"
                     >
                       <input
                         checked=""
@@ -9085,7 +9085,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -9109,7 +9109,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -9133,7 +9133,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"
@@ -9157,7 +9157,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                     style="line-height:32px"
                   >
                     <span
-                      class="ant-checkbox"
+                      class="ant-checkbox ant-wave-target"
                     >
                       <input
                         class="ant-checkbox-input"

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`Form form should support disabled 1`] = `
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -184,7 +184,7 @@ exports[`Form form should support disabled 1`] = `
                 class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio ant-radio-disabled"
+                  class="ant-radio ant-wave-target ant-radio-disabled"
                 >
                   <input
                     class="ant-radio-input"
@@ -204,7 +204,7 @@ exports[`Form form should support disabled 1`] = `
                 class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
               >
                 <span
-                  class="ant-radio ant-radio-disabled"
+                  class="ant-radio ant-wave-target ant-radio-disabled"
                 >
                   <input
                     class="ant-radio-input"

--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1940,7 +1940,7 @@ exports[`renders components/input-number/demo/keyboard.tsx extend context correc
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1655,7 +1655,7 @@ exports[`renders components/input-number/demo/keyboard.tsx correctly 1`] = `
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""

--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -92,7 +92,7 @@ exports[`renders components/radio/demo/basic.tsx extend context correctly 1`] = 
   class="ant-radio-wrapper"
 >
   <span
-    class="ant-radio"
+    class="ant-radio ant-wave-target"
   >
     <input
       class="ant-radio-input"
@@ -122,7 +122,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -146,7 +146,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
       class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-checked ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
           checked=""
@@ -435,7 +435,7 @@ Array [
     class="ant-radio-wrapper ant-radio-wrapper-disabled"
   >
     <span
-      class="ant-radio ant-radio-disabled"
+      class="ant-radio ant-wave-target ant-radio-disabled"
     >
       <input
         class="ant-radio-input"
@@ -454,7 +454,7 @@ Array [
     class="ant-radio-wrapper ant-radio-wrapper-disabled"
   >
     <span
-      class="ant-radio ant-radio-checked ant-radio-disabled"
+      class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
     >
       <input
         checked=""
@@ -921,7 +921,7 @@ exports[`renders components/radio/demo/radiogroup.tsx extend context correctly 1
     class="ant-radio-wrapper ant-radio-wrapper-checked"
   >
     <span
-      class="ant-radio ant-radio-checked"
+      class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
         checked=""
@@ -941,7 +941,7 @@ exports[`renders components/radio/demo/radiogroup.tsx extend context correctly 1
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -960,7 +960,7 @@ exports[`renders components/radio/demo/radiogroup.tsx extend context correctly 1
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -979,7 +979,7 @@ exports[`renders components/radio/demo/radiogroup.tsx extend context correctly 1
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1014,7 +1014,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""
@@ -1039,7 +1039,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1063,7 +1063,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1086,7 +1086,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1117,7 +1117,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1137,7 +1137,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1156,7 +1156,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1180,7 +1180,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1200,7 +1200,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1219,7 +1219,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1378,7 +1378,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
     class="ant-radio-wrapper ant-radio-wrapper-checked"
   >
     <span
-      class="ant-radio ant-radio-checked"
+      class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
         checked=""
@@ -1399,7 +1399,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1419,7 +1419,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1439,7 +1439,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1721,7 +1721,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1741,7 +1741,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1760,7 +1760,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1779,7 +1779,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1803,7 +1803,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-checked ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
           checked=""
@@ -1824,7 +1824,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1844,7 +1844,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1864,7 +1864,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`renders components/radio/demo/basic.tsx correctly 1`] = `
   class="ant-radio-wrapper"
 >
   <span
-    class="ant-radio"
+    class="ant-radio ant-wave-target"
   >
     <input
       class="ant-radio-input"
@@ -118,7 +118,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -142,7 +142,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-checked ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
           checked=""
@@ -429,7 +429,7 @@ Array [
     class="ant-radio-wrapper ant-radio-wrapper-disabled"
   >
     <span
-      class="ant-radio ant-radio-disabled"
+      class="ant-radio ant-wave-target ant-radio-disabled"
     >
       <input
         class="ant-radio-input"
@@ -448,7 +448,7 @@ Array [
     class="ant-radio-wrapper ant-radio-wrapper-disabled"
   >
     <span
-      class="ant-radio ant-radio-checked ant-radio-disabled"
+      class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
     >
       <input
         checked=""
@@ -909,7 +909,7 @@ exports[`renders components/radio/demo/radiogroup.tsx correctly 1`] = `
     class="ant-radio-wrapper ant-radio-wrapper-checked"
   >
     <span
-      class="ant-radio ant-radio-checked"
+      class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
         checked=""
@@ -929,7 +929,7 @@ exports[`renders components/radio/demo/radiogroup.tsx correctly 1`] = `
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -948,7 +948,7 @@ exports[`renders components/radio/demo/radiogroup.tsx correctly 1`] = `
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -967,7 +967,7 @@ exports[`renders components/radio/demo/radiogroup.tsx correctly 1`] = `
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1000,7 +1000,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""
@@ -1025,7 +1025,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1049,7 +1049,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1072,7 +1072,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -1101,7 +1101,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1121,7 +1121,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1140,7 +1140,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1164,7 +1164,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1184,7 +1184,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1203,7 +1203,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1360,7 +1360,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
     class="ant-radio-wrapper ant-radio-wrapper-checked"
   >
     <span
-      class="ant-radio ant-radio-checked"
+      class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
         checked=""
@@ -1381,7 +1381,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1401,7 +1401,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1421,7 +1421,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
     class="ant-radio-wrapper"
   >
     <span
-      class="ant-radio"
+      class="ant-radio ant-wave-target"
     >
       <input
         class="ant-radio-input"
@@ -1699,7 +1699,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1719,7 +1719,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1738,7 +1738,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1757,7 +1757,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1781,7 +1781,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-checked ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
           checked=""
@@ -1802,7 +1802,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1822,7 +1822,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"
@@ -1842,7 +1842,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-disabled"
     >
       <span
-        class="ant-radio ant-radio-disabled"
+        class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
           class="ant-radio-input"

--- a/components/radio/__tests__/__snapshots__/group.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/group.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
     class="my-radio-wrapper"
   >
     <span
-      class="my-radio"
+      class="my-radio ant-wave-target"
     >
       <input
         class="my-radio-input"
@@ -28,7 +28,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
     style="font-size: 12px;"
   >
     <span
-      class="my-radio"
+      class="my-radio ant-wave-target"
     >
       <input
         class="my-radio-input"

--- a/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
     class="my-radio-wrapper"
   >
     <span
-      class="my-radio"
+      class="my-radio ant-wave-target"
     >
       <input
         class="my-radio-input"
@@ -67,7 +67,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
     style="font-size: 12px;"
   >
     <span
-      class="my-radio"
+      class="my-radio ant-wave-target"
     >
       <input
         class="my-radio-input"

--- a/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Radio rtl render component should be rendered correctly in RTL directio
   class="ant-radio-wrapper ant-radio-wrapper-rtl"
 >
   <span
-    class="ant-radio"
+    class="ant-radio ant-wave-target"
   >
     <input
       class="ant-radio-input"
@@ -47,7 +47,7 @@ exports[`Radio should render correctly 1`] = `
   class="ant-radio-wrapper customized"
 >
   <span
-    class="ant-radio"
+    class="ant-radio ant-wave-target"
   >
     <input
       class="ant-radio-input"

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -11,6 +11,8 @@ import RadioGroupContext, { RadioOptionTypeContext } from './context';
 import type { RadioChangeEvent, RadioProps } from './interface';
 
 import useStyle from './style';
+import Wave from '../_util/wave';
+import { TARGET_CLS } from '../_util/wave/interface';
 
 const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (props, ref) => {
   const groupContext = React.useContext(RadioGroupContext);
@@ -37,10 +39,9 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
     ...restProps
   } = props;
   const radioPrefixCls = getPrefixCls('radio', customizePrefixCls);
-  const prefixCls =
-    (groupContext?.optionType || radioOptionTypeContext) === 'button'
-      ? `${radioPrefixCls}-button`
-      : radioPrefixCls;
+
+  const isButtonType = (groupContext?.optionType || radioOptionTypeContext) === 'button';
+  const prefixCls = isButtonType ? `${radioPrefixCls}-button` : radioPrefixCls;
 
   // Style
   const [wrapSSR, hashId] = useStyle(radioPrefixCls);
@@ -73,16 +74,24 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
   );
 
   return wrapSSR(
-    // eslint-disable-next-line jsx-a11y/label-has-associated-control
-    <label
-      className={wrapperClassString}
-      style={{ ...radio?.style, ...style }}
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
-    >
-      <RcCheckbox {...radioProps} type="radio" prefixCls={prefixCls} ref={mergedRef} />
-      {children !== undefined ? <span>{children}</span> : null}
-    </label>,
+    <Wave component="Radio" disabled={radioProps.disabled}>
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label
+        className={wrapperClassString}
+        style={{ ...radio?.style, ...style }}
+        onMouseEnter={props.onMouseEnter}
+        onMouseLeave={props.onMouseLeave}
+      >
+        <RcCheckbox
+          {...radioProps}
+          className={classNames(radioProps.className, !isButtonType && TARGET_CLS)}
+          type="radio"
+          prefixCls={prefixCls}
+          ref={mergedRef}
+        />
+        {children !== undefined ? <span>{children}</span> : null}
+      </label>
+    </Wave>,
   );
 };
 

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -1,4 +1,3 @@
-import { Keyframes } from '@ant-design/cssinjs';
 import { genFocusOutline, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -72,11 +71,6 @@ interface RadioToken extends FullToken<'Radio'> {
 }
 
 // ============================== Styles ==============================
-const antRadioEffect = new Keyframes('antRadioEffect', {
-  '0%': { transform: 'scale(1)', opacity: 0.5 },
-  '100%': { transform: 'scale(1.6)', opacity: 0 },
-});
-
 // styles from RadioGroup only
 const getGroupRadioStyle: GenerateStyle<RadioToken> = (token) => {
   const { componentCls, antCls } = token;
@@ -113,7 +107,6 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
     radioSize,
     motionDurationSlow,
     motionDurationMid,
-    motionEaseInOut,
     motionEaseInOutCirc,
     colorBgContainer,
     colorBorder,
@@ -133,7 +126,6 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
   return {
     [`${componentCls}-wrapper`]: {
       ...resetComponent(token),
-      position: 'relative',
       display: 'inline-flex',
       alignItems: 'baseline',
       marginInlineStart: 0,
@@ -167,10 +159,6 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         border: `${lineWidth}px ${lineType} ${colorPrimary}`,
         borderRadius: '50%',
         visibility: 'hidden',
-        animationName: antRadioEffect,
-        animationDuration: motionDurationSlow,
-        animationTimingFunction: motionEaseInOut,
-        animationFillMode: 'both',
         content: '""',
       },
 
@@ -181,6 +169,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         outline: 'none',
         cursor: 'pointer',
         alignSelf: 'center',
+        borderRadius: '50%',
       },
 
       [`${componentCls}-wrapper:hover &,
@@ -238,6 +227,10 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         insetInlineEnd: 0,
         insetBlockEnd: 0,
         insetInlineStart: 0,
+        width: 0,
+        height: 0,
+        padding: 0,
+        margin: 0,
         zIndex: 1,
         cursor: 'pointer',
         opacity: 0,
@@ -349,7 +342,6 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       transition: [
         `color ${motionDurationMid}`,
         `background ${motionDurationMid}`,
-        `border-color ${motionDurationMid}`,
         `box-shadow ${motionDurationMid}`,
       ].join(','),
 

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -15615,7 +15615,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -15635,7 +15635,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -15654,7 +15654,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4190,7 +4190,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -4210,7 +4210,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -4229,7 +4229,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5270,7 +5270,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -5289,7 +5289,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -4912,7 +4912,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -4931,7 +4931,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -23,6 +23,11 @@ describe('Switch', () => {
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
+    // Second time for raf to render wave effect
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
     expect(document.querySelector('.ant-wave')).toBeTruthy();
     jest.clearAllTimers();
     jest.useRealTimers();

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -574,7 +574,7 @@ exports[`Table.filter renders menu correctly 1`] = `
           class="ant-checkbox-wrapper"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -603,7 +603,7 @@ exports[`Table.filter renders menu correctly 1`] = `
           class="ant-checkbox-wrapper"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -714,7 +714,7 @@ exports[`Table.filter renders radio filter correctly 1`] = `
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"
@@ -743,7 +743,7 @@ exports[`Table.filter renders radio filter correctly 1`] = `
           class="ant-radio-wrapper"
         >
           <span
-            class="ant-radio"
+            class="ant-radio ant-wave-target"
           >
             <input
               class="ant-radio-input"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -129,7 +129,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -170,7 +170,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -211,7 +211,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -252,7 +252,7 @@ exports[`Table.rowSelection fix expand on th left when selection column fixed on
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -403,7 +403,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -462,7 +462,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -492,7 +492,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -522,7 +522,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -552,7 +552,7 @@ exports[`Table.rowSelection fix selection column on the left 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -703,7 +703,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -763,7 +763,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -794,7 +794,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -825,7 +825,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -856,7 +856,7 @@ exports[`Table.rowSelection fix selection column on the left when any other colu
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1061,7 +1061,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -1176,7 +1176,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1205,7 +1205,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1234,7 +1234,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1263,7 +1263,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1412,7 +1412,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -1527,7 +1527,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1556,7 +1556,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1585,7 +1585,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1614,7 +1614,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1763,7 +1763,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -1799,7 +1799,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1828,7 +1828,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1857,7 +1857,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -1886,7 +1886,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3147,7 +3147,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -3312,7 +3312,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -3358,7 +3358,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -3564,7 +3564,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3668,7 +3668,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3772,7 +3772,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3876,7 +3876,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3980,7 +3980,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -4084,7 +4084,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -4188,7 +4188,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -4292,7 +4292,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -4396,7 +4396,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -4500,7 +4500,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -7027,7 +7027,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                               class="ant-checkbox-wrapper ant-table-filter-dropdown-checkall"
                             >
                               <span
-                                class="ant-checkbox"
+                                class="ant-checkbox ant-wave-target"
                               >
                                 <input
                                   class="ant-checkbox-input"
@@ -7558,7 +7558,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -7604,7 +7604,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -8002,7 +8002,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                               class="ant-checkbox-wrapper ant-table-filter-dropdown-checkall"
                             >
                               <span
-                                class="ant-checkbox"
+                                class="ant-checkbox ant-wave-target"
                               >
                                 <input
                                   class="ant-checkbox-input"
@@ -8357,7 +8357,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -8403,7 +8403,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -11883,7 +11883,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -11929,7 +11929,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -13259,7 +13259,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -13305,7 +13305,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -13403,7 +13403,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                         class="ant-checkbox-wrapper"
                                       >
                                         <span
-                                          class="ant-checkbox"
+                                          class="ant-checkbox ant-wave-target"
                                         >
                                           <input
                                             class="ant-checkbox-input"
@@ -13449,7 +13449,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                         class="ant-checkbox-wrapper"
                                       >
                                         <span
-                                          class="ant-checkbox"
+                                          class="ant-checkbox ant-wave-target"
                                         >
                                           <input
                                             class="ant-checkbox-input"
@@ -13729,7 +13729,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -13775,7 +13775,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       class="ant-checkbox-input"
@@ -19019,7 +19019,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -19075,7 +19075,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -19124,7 +19124,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -19173,7 +19173,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -19222,7 +19222,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -19342,7 +19342,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""
@@ -19362,7 +19362,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -19381,7 +19381,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -19400,7 +19400,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -19425,7 +19425,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -19444,7 +19444,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -19463,7 +19463,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -19483,7 +19483,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -20120,7 +20120,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -20166,7 +20166,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -20487,7 +20487,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -20533,7 +20533,7 @@ Array [
                                     class="ant-checkbox-wrapper"
                                   >
                                     <span
-                                      class="ant-checkbox"
+                                      class="ant-checkbox ant-wave-target"
                                     >
                                       <input
                                         class="ant-checkbox-input"
@@ -21320,7 +21320,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -21340,7 +21340,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -21401,7 +21401,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -21449,7 +21449,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21491,7 +21491,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21533,7 +21533,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21575,7 +21575,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
                         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                       >
                         <span
-                          class="ant-checkbox ant-checkbox-disabled"
+                          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21758,7 +21758,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -21806,7 +21806,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21845,7 +21845,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21884,7 +21884,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21923,7 +21923,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -21962,7 +21962,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22001,7 +22001,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22040,7 +22040,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22079,7 +22079,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22118,7 +22118,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22157,7 +22157,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -22363,7 +22363,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -22685,7 +22685,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22724,7 +22724,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22763,7 +22763,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22802,7 +22802,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22841,7 +22841,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22880,7 +22880,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22919,7 +22919,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22958,7 +22958,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -22997,7 +22997,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23036,7 +23036,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23241,7 +23241,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -23279,7 +23279,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23320,7 +23320,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23361,7 +23361,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23402,7 +23402,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23443,7 +23443,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23727,7 +23727,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -23775,7 +23775,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23817,7 +23817,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23859,7 +23859,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23901,7 +23901,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23943,7 +23943,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23985,7 +23985,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24027,7 +24027,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24069,7 +24069,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24111,7 +24111,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24153,7 +24153,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24195,7 +24195,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24237,7 +24237,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24279,7 +24279,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24321,7 +24321,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24363,7 +24363,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24405,7 +24405,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24447,7 +24447,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24489,7 +24489,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24531,7 +24531,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24573,7 +24573,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24615,7 +24615,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24657,7 +24657,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24699,7 +24699,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24741,7 +24741,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24783,7 +24783,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24825,7 +24825,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24867,7 +24867,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24909,7 +24909,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24951,7 +24951,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24993,7 +24993,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25035,7 +25035,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25077,7 +25077,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25119,7 +25119,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25161,7 +25161,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25203,7 +25203,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25245,7 +25245,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25287,7 +25287,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25329,7 +25329,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25371,7 +25371,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25413,7 +25413,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25455,7 +25455,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25497,7 +25497,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25539,7 +25539,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25581,7 +25581,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25623,7 +25623,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25665,7 +25665,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25707,7 +25707,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25749,7 +25749,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25791,7 +25791,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25833,7 +25833,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -25919,7 +25919,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -26149,7 +26149,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -26188,7 +26188,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -26227,7 +26227,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -28772,7 +28772,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -28820,7 +28820,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -28869,7 +28869,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29085,7 +29085,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -29140,7 +29140,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29196,7 +29196,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29252,7 +29252,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29308,7 +29308,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29364,7 +29364,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29420,7 +29420,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29476,7 +29476,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29532,7 +29532,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -29588,7 +29588,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -2786,7 +2786,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -2997,7 +2997,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3101,7 +3101,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3205,7 +3205,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3309,7 +3309,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3413,7 +3413,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3517,7 +3517,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3621,7 +3621,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3725,7 +3725,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3829,7 +3829,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -3933,7 +3933,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -14646,7 +14646,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -14702,7 +14702,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -14751,7 +14751,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -14800,7 +14800,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -14849,7 +14849,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -14967,7 +14967,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio-wrapper ant-radio-wrapper-checked"
       >
         <span
-          class="ant-radio ant-radio-checked"
+          class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
             checked=""
@@ -14987,7 +14987,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -15006,7 +15006,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -15025,7 +15025,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio-wrapper"
       >
         <span
-          class="ant-radio"
+          class="ant-radio ant-wave-target"
         >
           <input
             class="ant-radio-input"
@@ -15050,7 +15050,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -15069,7 +15069,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -15088,7 +15088,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -15108,7 +15108,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -16531,7 +16531,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -16551,7 +16551,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -16612,7 +16612,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -16660,7 +16660,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -16702,7 +16702,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -16744,7 +16744,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -16786,7 +16786,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                       >
                         <span
-                          class="ant-checkbox ant-checkbox-disabled"
+                          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -16967,7 +16967,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -17015,7 +17015,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17054,7 +17054,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17093,7 +17093,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17132,7 +17132,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17171,7 +17171,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17210,7 +17210,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17249,7 +17249,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17288,7 +17288,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17327,7 +17327,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17366,7 +17366,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -17570,7 +17570,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -17645,7 +17645,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17684,7 +17684,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17723,7 +17723,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17762,7 +17762,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17801,7 +17801,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17840,7 +17840,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17879,7 +17879,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17918,7 +17918,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17957,7 +17957,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -17996,7 +17996,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18199,7 +18199,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Select all"
@@ -18239,7 +18239,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18282,7 +18282,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18325,7 +18325,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18368,7 +18368,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18411,7 +18411,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -18689,7 +18689,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -18737,7 +18737,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18779,7 +18779,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18821,7 +18821,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18863,7 +18863,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18905,7 +18905,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18947,7 +18947,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -18989,7 +18989,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19031,7 +19031,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19073,7 +19073,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19115,7 +19115,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19157,7 +19157,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19199,7 +19199,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19241,7 +19241,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19283,7 +19283,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19325,7 +19325,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19367,7 +19367,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19409,7 +19409,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19451,7 +19451,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19493,7 +19493,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19535,7 +19535,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19577,7 +19577,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19619,7 +19619,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19661,7 +19661,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19703,7 +19703,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19745,7 +19745,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19787,7 +19787,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19829,7 +19829,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19871,7 +19871,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19913,7 +19913,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19955,7 +19955,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -19997,7 +19997,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20039,7 +20039,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20081,7 +20081,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20123,7 +20123,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20165,7 +20165,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20207,7 +20207,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20249,7 +20249,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20291,7 +20291,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20333,7 +20333,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20375,7 +20375,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20417,7 +20417,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20459,7 +20459,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20501,7 +20501,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20543,7 +20543,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20585,7 +20585,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20627,7 +20627,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20669,7 +20669,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20711,7 +20711,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20753,7 +20753,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20795,7 +20795,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -20879,7 +20879,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             aria-label="Custom selection"
@@ -20954,7 +20954,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -20993,7 +20993,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -21032,7 +21032,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
                       class="ant-checkbox-wrapper"
                     >
                       <span
-                        class="ant-checkbox"
+                        class="ant-checkbox ant-wave-target"
                       >
                         <input
                           class="ant-checkbox-input"
@@ -23466,7 +23466,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -23514,7 +23514,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23563,7 +23563,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23777,7 +23777,7 @@ Array [
                           class="ant-checkbox-wrapper"
                         >
                           <span
-                            class="ant-checkbox"
+                            class="ant-checkbox ant-wave-target"
                           >
                             <input
                               aria-label="Select all"
@@ -23832,7 +23832,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23888,7 +23888,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -23944,7 +23944,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24000,7 +24000,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24056,7 +24056,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24112,7 +24112,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24168,7 +24168,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24224,7 +24224,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"
@@ -24280,7 +24280,7 @@ Array [
                         class="ant-checkbox-wrapper"
                       >
                         <span
-                          class="ant-checkbox"
+                          class="ant-checkbox ant-wave-target"
                         >
                           <input
                             class="ant-checkbox-input"

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2879,7 +2879,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -2899,7 +2899,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -2400,7 +2400,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""
@@ -2420,7 +2420,7 @@ Array [
       class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item"
     >
       <span
-        class="ant-checkbox ant-checkbox-checked"
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
       >
         <input
           checked=""

--- a/components/theme/useToken.ts
+++ b/components/theme/useToken.ts
@@ -52,7 +52,11 @@ export const getComputedToken = (
 };
 
 // ================================== Hook ==================================
-export default function useToken(): [Theme<SeedToken, MapToken>, GlobalToken, string] {
+export default function useToken(): [
+  theme: Theme<SeedToken, MapToken>,
+  token: GlobalToken,
+  hashId: string,
+] {
   const {
     token: rootDesignToken,
     hashed,

--- a/components/timeline/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/timeline/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -556,7 +556,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -576,7 +576,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -595,7 +595,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/timeline/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/timeline/__tests__/__snapshots__/demo.test.ts.snap
@@ -546,7 +546,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -566,7 +566,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -585,7 +585,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1482,7 +1482,7 @@ exports[`renders components/tooltip/demo/disabled.tsx extend context correctly 1
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -674,7 +674,7 @@ exports[`renders components/tooltip/demo/disabled.tsx correctly 1`] = `
       class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
     >
       <span
-        class="ant-checkbox ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
       >
         <input
           class="ant-checkbox-input"

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -15,7 +15,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -244,7 +244,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -269,7 +269,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -294,7 +294,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -319,7 +319,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -344,7 +344,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -369,7 +369,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -394,7 +394,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -419,7 +419,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -444,7 +444,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -469,7 +469,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -581,7 +581,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -810,7 +810,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -835,7 +835,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -860,7 +860,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -885,7 +885,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -910,7 +910,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -935,7 +935,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -960,7 +960,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -985,7 +985,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1010,7 +1010,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1035,7 +1035,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1087,7 +1087,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -1251,7 +1251,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1276,7 +1276,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1301,7 +1301,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1326,7 +1326,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1351,7 +1351,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1376,7 +1376,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1401,7 +1401,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1426,7 +1426,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1451,7 +1451,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1476,7 +1476,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1501,7 +1501,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1593,7 +1593,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -1757,7 +1757,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1782,7 +1782,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1807,7 +1807,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1832,7 +1832,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1857,7 +1857,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1882,7 +1882,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1907,7 +1907,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1932,7 +1932,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1957,7 +1957,7 @@ exports[`renders components/transfer/demo/basic.tsx extend context correctly 1`]
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1997,7 +1997,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -2161,7 +2161,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2187,7 +2187,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2212,7 +2212,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2237,7 +2237,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2262,7 +2262,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2288,7 +2288,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2313,7 +2313,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2338,7 +2338,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2363,7 +2363,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2389,7 +2389,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2414,7 +2414,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2506,7 +2506,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -2670,7 +2670,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2695,7 +2695,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2721,7 +2721,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2746,7 +2746,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2771,7 +2771,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2796,7 +2796,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2822,7 +2822,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2847,7 +2847,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2872,7 +2872,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -2906,7 +2906,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -3181,7 +3181,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -3398,7 +3398,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -3740,7 +3740,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -4024,7 +4024,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -4219,7 +4219,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -4267,7 +4267,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4311,7 +4311,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4354,7 +4354,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4397,7 +4397,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4440,7 +4440,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4484,7 +4484,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4527,7 +4527,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4570,7 +4570,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4613,7 +4613,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4657,7 +4657,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -4862,7 +4862,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -5057,7 +5057,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -5093,7 +5093,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5122,7 +5122,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5152,7 +5152,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5181,7 +5181,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5210,7 +5210,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5239,7 +5239,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5269,7 +5269,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5298,7 +5298,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5327,7 +5327,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -5518,7 +5518,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -5680,7 +5680,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5709,7 +5709,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5738,7 +5738,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5767,7 +5767,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5796,7 +5796,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5825,7 +5825,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5854,7 +5854,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5883,7 +5883,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5912,7 +5912,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -5941,7 +5941,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6038,7 +6038,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -6200,7 +6200,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6229,7 +6229,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6258,7 +6258,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6287,7 +6287,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6316,7 +6316,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6345,7 +6345,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6374,7 +6374,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6403,7 +6403,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6432,7 +6432,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6461,7 +6461,7 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6504,7 +6504,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -6666,7 +6666,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6691,7 +6691,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6716,7 +6716,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6741,7 +6741,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6766,7 +6766,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6791,7 +6791,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6816,7 +6816,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -6908,7 +6908,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -7070,7 +7070,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -7095,7 +7095,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -7120,7 +7120,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend co
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -7353,7 +7353,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7378,7 +7378,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7403,7 +7403,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7428,7 +7428,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7453,7 +7453,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7478,7 +7478,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7503,7 +7503,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7528,7 +7528,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7553,7 +7553,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7578,7 +7578,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7946,7 +7946,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7971,7 +7971,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -7996,7 +7996,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8021,7 +8021,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8046,7 +8046,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8071,7 +8071,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8096,7 +8096,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8121,7 +8121,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8146,7 +8146,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8171,7 +8171,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8321,7 +8321,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -8485,7 +8485,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8511,7 +8511,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8536,7 +8536,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8562,7 +8562,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8587,7 +8587,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8613,7 +8613,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8638,7 +8638,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8664,7 +8664,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8689,7 +8689,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8715,7 +8715,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8740,7 +8740,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8766,7 +8766,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8791,7 +8791,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -8817,7 +8817,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -9244,7 +9244,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -9473,7 +9473,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9498,7 +9498,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9523,7 +9523,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9548,7 +9548,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9573,7 +9573,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9598,7 +9598,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9623,7 +9623,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9648,7 +9648,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9673,7 +9673,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9698,7 +9698,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -9790,7 +9790,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -10019,7 +10019,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10044,7 +10044,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10069,7 +10069,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10094,7 +10094,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10119,7 +10119,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10144,7 +10144,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10169,7 +10169,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10194,7 +10194,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10219,7 +10219,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10244,7 +10244,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -10290,7 +10290,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -10565,7 +10565,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -10786,7 +10786,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -11128,7 +11128,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -11420,7 +11420,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -11615,7 +11615,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -11663,7 +11663,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11707,7 +11707,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11750,7 +11750,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11793,7 +11793,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11837,7 +11837,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11880,7 +11880,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11923,7 +11923,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -11966,7 +11966,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12009,7 +12009,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12053,7 +12053,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12258,7 +12258,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -12453,7 +12453,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -12489,7 +12489,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12518,7 +12518,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12547,7 +12547,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12577,7 +12577,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12606,7 +12606,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -12635,7 +12635,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -15,7 +15,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -271,7 +271,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -465,7 +465,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -523,7 +523,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -548,7 +548,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -573,7 +573,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -598,7 +598,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -623,7 +623,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -648,7 +648,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -673,7 +673,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -698,7 +698,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -723,7 +723,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -748,7 +748,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -773,7 +773,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -865,7 +865,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -923,7 +923,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -948,7 +948,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -973,7 +973,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -998,7 +998,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1023,7 +1023,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1048,7 +1048,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1073,7 +1073,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1098,7 +1098,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1123,7 +1123,7 @@ exports[`renders components/transfer/demo/basic.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1161,7 +1161,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -1219,7 +1219,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1245,7 +1245,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1270,7 +1270,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1295,7 +1295,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1320,7 +1320,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1346,7 +1346,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1371,7 +1371,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1396,7 +1396,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1421,7 +1421,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1447,7 +1447,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1472,7 +1472,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1564,7 +1564,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -1622,7 +1622,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1647,7 +1647,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1673,7 +1673,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1698,7 +1698,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1723,7 +1723,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1748,7 +1748,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1774,7 +1774,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1799,7 +1799,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1824,7 +1824,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -1858,7 +1858,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -2027,7 +2027,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -2138,7 +2138,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -2374,7 +2374,7 @@ Array [
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"
@@ -2552,7 +2552,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -2641,7 +2641,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -2689,7 +2689,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2733,7 +2733,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2776,7 +2776,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2819,7 +2819,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2862,7 +2862,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2906,7 +2906,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2949,7 +2949,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -2992,7 +2992,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3035,7 +3035,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3079,7 +3079,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3284,7 +3284,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -3373,7 +3373,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -3409,7 +3409,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3438,7 +3438,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3468,7 +3468,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3497,7 +3497,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3526,7 +3526,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3555,7 +3555,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3585,7 +3585,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3614,7 +3614,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3643,7 +3643,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -3832,7 +3832,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -4002,7 +4002,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -4116,7 +4116,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -4169,7 +4169,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4194,7 +4194,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4219,7 +4219,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4244,7 +4244,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4269,7 +4269,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4294,7 +4294,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4319,7 +4319,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4411,7 +4411,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -4464,7 +4464,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4489,7 +4489,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4514,7 +4514,7 @@ exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -4831,7 +4831,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -4889,7 +4889,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -4915,7 +4915,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -4940,7 +4940,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -4966,7 +4966,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -4991,7 +4991,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5017,7 +5017,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5042,7 +5042,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5068,7 +5068,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5093,7 +5093,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5119,7 +5119,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5144,7 +5144,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5170,7 +5170,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5195,7 +5195,7 @@ Array [
               class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox ant-checkbox-disabled"
+                class="ant-checkbox ant-wave-target ant-checkbox-disabled"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5221,7 +5221,7 @@ Array [
               class="ant-checkbox-wrapper ant-transfer-list-checkbox"
             >
               <span
-                class="ant-checkbox"
+                class="ant-checkbox ant-wave-target"
               >
                 <input
                   class="ant-checkbox-input"
@@ -5586,7 +5586,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -5822,7 +5822,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -6010,7 +6010,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -6179,7 +6179,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -6294,7 +6294,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -6530,7 +6530,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -6714,7 +6714,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -6803,7 +6803,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -6851,7 +6851,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -6895,7 +6895,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -6938,7 +6938,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -6981,7 +6981,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7025,7 +7025,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7068,7 +7068,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7111,7 +7111,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7154,7 +7154,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7197,7 +7197,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7241,7 +7241,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7446,7 +7446,7 @@ Array [
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -7535,7 +7535,7 @@ Array [
                                   class="ant-checkbox-wrapper"
                                 >
                                   <span
-                                    class="ant-checkbox"
+                                    class="ant-checkbox ant-wave-target"
                                   >
                                     <input
                                       aria-label="Select all"
@@ -7571,7 +7571,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7600,7 +7600,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7629,7 +7629,7 @@ Array [
                                 class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled"
                               >
                                 <span
-                                  class="ant-checkbox ant-checkbox-disabled"
+                                  class="ant-checkbox ant-wave-target ant-checkbox-disabled"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7659,7 +7659,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7688,7 +7688,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"
@@ -7717,7 +7717,7 @@ Array [
                                 class="ant-checkbox-wrapper"
                               >
                                 <span
-                                  class="ant-checkbox"
+                                  class="ant-checkbox ant-wave-target"
                                 >
                                   <input
                                     class="ant-checkbox-input"

--- a/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
         class="ant-checkbox-wrapper ant-checkbox-rtl ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -181,7 +181,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
         class="ant-checkbox-wrapper ant-checkbox-rtl ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -293,7 +293,7 @@ exports[`Transfer should render correctly 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-checked"
+          class="ant-checkbox ant-wave-target ant-checkbox-checked"
         >
           <input
             checked=""
@@ -347,7 +347,7 @@ exports[`Transfer should render correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-checked"
+              class="ant-checkbox ant-wave-target ant-checkbox-checked"
             >
               <input
                 checked=""
@@ -370,7 +370,7 @@ exports[`Transfer should render correctly 1`] = `
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox ant-checkbox-disabled"
+              class="ant-checkbox ant-wave-target ant-checkbox-disabled"
             >
               <input
                 class="ant-checkbox-input"
@@ -460,7 +460,7 @@ exports[`Transfer should render correctly 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -513,7 +513,7 @@ exports[`Transfer should render correctly 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -548,7 +548,7 @@ exports[`Transfer should show sorted targetKey 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -602,7 +602,7 @@ exports[`Transfer should show sorted targetKey 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -694,7 +694,7 @@ exports[`Transfer should show sorted targetKey 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -748,7 +748,7 @@ exports[`Transfer should show sorted targetKey 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -773,7 +773,7 @@ exports[`Transfer should show sorted targetKey 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -810,7 +810,7 @@ exports[`Transfer should support render value and label in item 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -864,7 +864,7 @@ exports[`Transfer should support render value and label in item 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -956,7 +956,7 @@ exports[`Transfer should support render value and label in item 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"
@@ -1068,7 +1068,7 @@ exports[`immutable data dataSource is frozen 1`] = `
         class="ant-checkbox-wrapper ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox"
+          class="ant-checkbox ant-wave-target"
         >
           <input
             class="ant-checkbox-input"
@@ -1121,7 +1121,7 @@ exports[`immutable data dataSource is frozen 1`] = `
             class="ant-checkbox-wrapper ant-transfer-list-checkbox"
           >
             <span
-              class="ant-checkbox"
+              class="ant-checkbox ant-wave-target"
             >
               <input
                 class="ant-checkbox-input"
@@ -1211,7 +1211,7 @@ exports[`immutable data dataSource is frozen 1`] = `
         class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
       >
         <span
-          class="ant-checkbox ant-checkbox-disabled"
+          class="ant-checkbox ant-wave-target ant-checkbox-disabled"
         >
           <input
             class="ant-checkbox-input"

--- a/components/transfer/__tests__/__snapshots__/list.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/list.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Transfer.List should render correctly 1`] = `
       class="ant-checkbox-wrapper ant-transfer-list-checkbox"
     >
       <span
-        class="ant-checkbox ant-checkbox-indeterminate"
+        class="ant-checkbox ant-checkbox-indeterminate ant-wave-target"
       >
         <input
           aria-checked="mixed"
@@ -64,7 +64,7 @@ exports[`Transfer.List should render correctly 1`] = `
           class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-checked"
+            class="ant-checkbox ant-wave-target ant-checkbox-checked"
           >
             <input
               checked=""
@@ -87,7 +87,7 @@ exports[`Transfer.List should render correctly 1`] = `
           class="ant-checkbox-wrapper ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox"
+            class="ant-checkbox ant-wave-target"
           >
             <input
               class="ant-checkbox-input"
@@ -109,7 +109,7 @@ exports[`Transfer.List should render correctly 1`] = `
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox"
         >
           <span
-            class="ant-checkbox ant-checkbox-disabled"
+            class="ant-checkbox ant-wave-target ant-checkbox-disabled"
           >
             <input
               class="ant-checkbox-input"

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1425,7 +1425,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1445,7 +1445,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1464,7 +1464,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1224,7 +1224,7 @@ Array [
       class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio ant-radio-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
@@ -1244,7 +1244,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"
@@ -1263,7 +1263,7 @@ Array [
       class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio"
+        class="ant-radio ant-wave-target"
       >
         <input
           class="ant-radio-input"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Checkbox & Radio not support customize wave and add className `ant-wave-target` for this case.      |
| 🇨🇳 Chinese |    修复 Checkbox 与 Radio 不支持自定义水波纹效果的问题，并添加 `ant-wave-target` className 到对应元素上。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2baf1b1</samp>

The pull request adds and refactors the wave effect feature for the checkbox and radio components, and improves the performance and consistency of the animation. It uses the `Wave` component, the `useWave` hook, the `CSSMotion` component, and the `TARGET_CLS` class name to achieve this. It also updates the test cases and the types for the wave effect feature, and changes the return type annotation of the `useToken` hook.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2baf1b1</samp>

*  Enable and customize wave effect for checkbox and radio components by wrapping them with `Wave` component and adding `TARGET_CLS` class name ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L132-R157), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL76-R94), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R12-R13), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cR14-R15))
*  Replace `Keyframes` class with `CSSMotion` component for wave effect animation, and remove unused style rules for `:after` pseudo-elements ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL1), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL13-L25), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL151-R138), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL192-L209), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL220-L222), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL1), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL75-L79), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL116), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL136), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL170-L173), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afR230-R233), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL352))
*  Add `component` prop to `WaveEffect` component and `WaveEffectProps` interface, and use it to determine if the target element is a small component that needs a quicker wave effect animation ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL16-R20), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfR107-R109), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL123-R137))
*  Add `hashId` variable to `useToken` hook and pass it to `WaveEffect` component and `showWave` function, to get the unique hash id for the wave effect style ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-fc6a9164144f215671163f6b1501060f193dd221f446d3dd8ec76bc19499bdd7L24-R17), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL129-R150), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c7df1bcdb6492386833feb362bae4ef1d4c65fd95c64381e35514a53cddb11dfL135-R158))
*  Change `showWave` function to `showDebounceWave` function and wrap it with `useEvent` hook, to merge multiple trigger events into one for each animation frame ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-fc6a9164144f215671163f6b1501060f193dd221f446d3dd8ec76bc19499bdd7L33-R43))
*  Add `act` call with `jest.advanceTimersByTime(100)` in `waitRaf` function, to simulate the requestAnimationFrame callback and advance the fake timers ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078R75-R77))
*  Move `jest.useFakeTimers()` call from global scope to `beforeEach` hook, and add `async` keyword to `afterEach` hook, to avoid affecting other tests that rely on real timers and to wait for the fake timers to finish ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L32), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L42-R50))
*  Remove test case that checks if wave effect is not shown when target is an input element, as it is no longer relevant ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078L240-L251))
*  Add test case that checks if wave effect can match target element by `TARGET_CLS` class name, to test the new feature ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-ce0ff6b61f74e292d01081cbd1a19bfd906c81db8040d8b6804223b5691cf078R323-R338))
*  Add `interface.ts` module that exports `TARGET_CLS` constant string and `ShowWaveEffect` and `ShowWave` type aliases, to define the common constants and types for the wave effect feature ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-09e4e0e89c8298cfc7a7fbd022ea98217369dc265ef6d24886ad7fbe8424cad2R1-R16))
*  Remove condition that checks if target element is an input element in `wave/index.ts`, as it is no longer relevant ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-5e13b8dfe0e60478114c2558fe5db8724b1a7392ea966738bd35980ca72e37fdL40))
*  Add style rule for `.ant-wave.wave-quick` element, to apply a different transition duration and easing function for the wave effect animation for small components ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c9ba011ec30b589636721e4ffe4cb109abc1341f6f32f7d16881f45ecd9b2caeR32-R38))
*  Add `isButtonType` variable to `radio.tsx`, to determine if the radio component is a button type or a normal type ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL40-R45))
*  Add `borderRadius` property to `checkboxCls` and `radioCls` style rules, to make them have a consistent border radius with the wave effect element ([link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efR71), [link](https://github.com/ant-design/ant-design/pull/44014/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afR172))
