### PR TITLE
fix: RangePicker allowClear does not disable the clear button

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -5,11 +5,13 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import MockDate from 'mockdate';
 import dayJsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, screen, waitFor } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 import type { PickerLocale } from '../generatePicker';
+import { closeCircleByRole, expectCloseCircle } from './utils';
 
 dayjs.extend(customParseFormat);
 
@@ -311,5 +313,17 @@ describe('DatePicker', () => {
         .querySelectorAll('.ant-picker-time-panel-column')?.[1]
         .querySelectorAll('.ant-picker-time-panel-cell').length,
     ).toBe(60);
+  });
+
+  it('allows clear by default, but disallows once allowClear set false', async () => {
+    const somepoint = dayjs('2023-08-01');
+    const { rerender } = render(<DatePicker value={somepoint} />);
+
+    const { role, options } = closeCircleByRole;
+    await userEvent.hover(screen.getByRole(role, options));
+    expectCloseCircle(true);
+
+    rerender(<DatePicker value={somepoint} allowClear={false} />);
+    await waitFor(() => expectCloseCircle(false));
   });
 });

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -316,18 +316,30 @@ describe('DatePicker', () => {
     ).toBe(60);
   });
 
-  it('allows clear by default, and when clearIcon nested within allowClear, but disallows when allowClear false', async () => {
+  it('allows or prohibits clearing as applicable', async () => {
     const somepoint = dayjs('2023-08-01');
     const { rerender } = render(<DatePicker value={somepoint} />);
 
     const { role, options } = closeCircleByRole;
     await userEvent.hover(screen.getByRole(role, options));
-    expectCloseCircle(true);
-
-    rerender(<DatePicker value={somepoint} allowClear={{ clearIcon: <CloseCircleFilled /> }} />);
-    expectCloseCircle(true);
+    await waitFor(() => expectCloseCircle(true));
 
     rerender(<DatePicker value={somepoint} allowClear={false} />);
     await waitFor(() => expectCloseCircle(false));
+
+    rerender(<DatePicker value={somepoint} allowClear={{ clearIcon: <CloseCircleFilled /> }} />);
+    await waitFor(() => expectCloseCircle(true));
+
+    rerender(
+      <DatePicker
+        value={somepoint}
+        allowClear={{ clearIcon: <div data-testid="custom-clear" /> }}
+      />,
+    );
+    await waitFor(() => expectCloseCircle(false));
+    await userEvent.hover(screen.getByTestId('custom-clear'));
+
+    rerender(<DatePicker value={somepoint} allowClear={{}} />);
+    await waitFor(() => expectCloseCircle(true));
   });
 });

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -6,6 +6,7 @@ import MockDate from 'mockdate';
 import dayJsGenerateConfig from 'rc-picker/lib/generate/dayjs';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { CloseCircleFilled } from '@ant-design/icons';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import { fireEvent, render, screen, waitFor } from '../../../tests/utils';
@@ -315,12 +316,15 @@ describe('DatePicker', () => {
     ).toBe(60);
   });
 
-  it('allows clear by default, but disallows once allowClear set false', async () => {
+  it('allows clear by default, and when clearIcon nested within allowClear, but disallows when allowClear false', async () => {
     const somepoint = dayjs('2023-08-01');
     const { rerender } = render(<DatePicker value={somepoint} />);
 
     const { role, options } = closeCircleByRole;
     await userEvent.hover(screen.getByRole(role, options));
+    expectCloseCircle(true);
+
+    rerender(<DatePicker value={somepoint} allowClear={{ clearIcon: <CloseCircleFilled /> }} />);
     expectCloseCircle(true);
 
     rerender(<DatePicker value={somepoint} allowClear={false} />);

--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -2,13 +2,13 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import type { RangeValue } from 'rc-picker/lib/interface';
 import React, { useState } from 'react';
+import userEvent from '@testing-library/user-event';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
-import { render, resetMockDate, setMockDate } from '../../../tests/utils';
+import { render, resetMockDate, setMockDate, screen, waitFor } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 import enUS from '../locale/en_US';
-
-import { closePicker, openPicker, selectCell } from './utils';
+import { closeCircleByRole, expectCloseCircle, closePicker, openPicker, selectCell } from './utils';
 
 dayjs.extend(customParseFormat);
 
@@ -126,5 +126,17 @@ describe('RangePicker', () => {
     expect(container.querySelector('.legacy')).toBeTruthy();
 
     errSpy.mockRestore();
+  });
+
+  it('allows clear by default, but disallows once allowClear set false', async () => {
+    const somepoint = dayjs('2023-08-01');
+    const { rerender } = render(<RangePicker locale={enUS} value={[somepoint, somepoint]} />);
+
+    const { role, options } = closeCircleByRole;
+    await userEvent.hover(screen.getByRole(role, options));
+    expectCloseCircle(true);
+
+    rerender(<RangePicker locale={enUS} value={[somepoint, somepoint]} allowClear={false} />);
+    await waitFor(() => expectCloseCircle(false));
   });
 });

--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -129,13 +129,16 @@ describe('RangePicker', () => {
     errSpy.mockRestore();
   });
 
-  it('allows clear by default, and when clearIcon nested within allowClear, but disallows when allowClear false', async () => {
+  it('allows or prohibits clearing as applicable', async () => {
     const somepoint = dayjs('2023-08-01');
     const { rerender } = render(<RangePicker locale={enUS} value={[somepoint, somepoint]} />);
 
     const { role, options } = closeCircleByRole;
     await userEvent.hover(screen.getByRole(role, options));
-    expectCloseCircle(true);
+    await waitFor(() => expectCloseCircle(true));
+
+    rerender(<RangePicker locale={enUS} value={[somepoint, somepoint]} allowClear={false} />);
+    await waitFor(() => expectCloseCircle(false));
 
     rerender(
       <RangePicker
@@ -144,9 +147,19 @@ describe('RangePicker', () => {
         allowClear={{ clearIcon: <CloseCircleFilled /> }}
       />,
     );
-    expectCloseCircle(true);
+    await waitFor(() => expectCloseCircle(true));
 
-    rerender(<RangePicker locale={enUS} value={[somepoint, somepoint]} allowClear={false} />);
+    rerender(
+      <RangePicker
+        locale={enUS}
+        value={[somepoint, somepoint]}
+        allowClear={{ clearIcon: <div data-testid="custom-clear" /> }}
+      />,
+    );
     await waitFor(() => expectCloseCircle(false));
+    await userEvent.hover(screen.getByTestId('custom-clear'));
+
+    rerender(<RangePicker locale={enUS} value={[somepoint, somepoint]} allowClear={{}} />);
+    await waitFor(() => expectCloseCircle(true));
   });
 });

--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -3,6 +3,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import type { RangeValue } from 'rc-picker/lib/interface';
 import React, { useState } from 'react';
 import userEvent from '@testing-library/user-event';
+import { CloseCircleFilled } from '@ant-design/icons';
 import DatePicker from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import { render, resetMockDate, setMockDate, screen, waitFor } from '../../../tests/utils';
@@ -128,12 +129,21 @@ describe('RangePicker', () => {
     errSpy.mockRestore();
   });
 
-  it('allows clear by default, but disallows once allowClear set false', async () => {
+  it('allows clear by default, and when clearIcon nested within allowClear, but disallows when allowClear false', async () => {
     const somepoint = dayjs('2023-08-01');
     const { rerender } = render(<RangePicker locale={enUS} value={[somepoint, somepoint]} />);
 
     const { role, options } = closeCircleByRole;
     await userEvent.hover(screen.getByRole(role, options));
+    expectCloseCircle(true);
+
+    rerender(
+      <RangePicker
+        locale={enUS}
+        value={[somepoint, somepoint]}
+        allowClear={{ clearIcon: <CloseCircleFilled /> }}
+      />,
+    );
     expectCloseCircle(true);
 
     rerender(<RangePicker locale={enUS} value={[somepoint, somepoint]} allowClear={false} />);

--- a/components/date-picker/__tests__/utils.ts
+++ b/components/date-picker/__tests__/utils.ts
@@ -1,5 +1,5 @@
 import type { render } from '../../../tests/utils';
-import { fireEvent } from '../../../tests/utils';
+import { fireEvent, screen } from '../../../tests/utils';
 
 export function openPicker(wrapper: ReturnType<typeof render>, index = 0) {
   fireEvent.mouseDown(wrapper.container?.querySelectorAll('input')?.[index]!);
@@ -24,4 +24,12 @@ export function selectCell(wrapper: ReturnType<typeof render>, text: string | nu
     throw new Error('Cell not match in picker panel.');
   }
   return matchCell;
+}
+
+export const closeCircleByRole = { role: 'img', options: { name: 'close-circle' } } as const;
+
+export function expectCloseCircle(shouldExist: boolean) {
+  const { role, options } = closeCircleByRole;
+  const count = shouldExist ? 1 : 0;
+  return expect(screen.queryAllByRole(role, options).length).toStrictEqual(count);
 }

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -50,6 +50,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
       dropdownClassName,
       status: customStatus,
       clearIcon,
+      allowClear,
       ...restProps
     } = props;
 
@@ -105,6 +106,11 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
 
     const locale = { ...contextLocale, ...props.locale! };
 
+    const mergedAllowClear =
+      allowClear === false && typeof clearIcon === 'undefined'
+        ? false
+        : { clearIcon: clearIcon ?? <CloseCircleFilled /> };
+
     return wrapSSR(
       <RCRangePicker<DateType>
         separator={
@@ -141,7 +147,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         components={Components}
         direction={direction}
         dropdownClassName={classNames(hashId, popupClassName || dropdownClassName)}
-        allowClear={{ clearIcon: clearIcon ?? <CloseCircleFilled /> }}
+        allowClear={mergedAllowClear}
       />,
     );
   });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -18,7 +18,12 @@ import { useLocale } from '../../locale';
 import { useCompactItemContext } from '../../space/Compact';
 import enUS from '../locale/en_US';
 import useStyle from '../style';
-import { getRangePlaceholder, getTimeProps, transPlacement2DropdownAlign } from '../util';
+import {
+  getRangePlaceholder,
+  getTimeProps,
+  mergeAllowClear,
+  transPlacement2DropdownAlign,
+} from '../util';
 import Components from './Components';
 import type { CommonPickerMethods, PickerComponentClass } from './interface';
 
@@ -106,11 +111,6 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
 
     const locale = { ...contextLocale, ...props.locale! };
 
-    const mergedAllowClear =
-      allowClear === false && typeof clearIcon === 'undefined'
-        ? false
-        : { clearIcon: clearIcon ?? <CloseCircleFilled /> };
-
     return wrapSSR(
       <RCRangePicker<DateType>
         separator={
@@ -147,7 +147,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         components={Components}
         direction={direction}
         dropdownClassName={classNames(hashId, popupClassName || dropdownClassName)}
-        allowClear={mergedAllowClear}
+        allowClear={mergeAllowClear({ clearIcon, allowClear }, <CloseCircleFilled />)}
       />,
     );
   });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -147,7 +147,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         components={Components}
         direction={direction}
         dropdownClassName={classNames(hashId, popupClassName || dropdownClassName)}
-        allowClear={mergeAllowClear({ clearIcon, allowClear }, <CloseCircleFilled />)}
+        allowClear={mergeAllowClear(allowClear, clearIcon, <CloseCircleFilled />)}
       />,
     );
   });

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -19,7 +19,12 @@ import { useLocale } from '../../locale';
 import { useCompactItemContext } from '../../space/Compact';
 import enUS from '../locale/en_US';
 import useStyle from '../style';
-import { getPlaceholder, getTimeProps, transPlacement2DropdownAlign } from '../util';
+import {
+  getPlaceholder,
+  getTimeProps,
+  mergeAllowClear,
+  transPlacement2DropdownAlign,
+} from '../util';
 import Components from './Components';
 import type { CommonPickerMethods, DatePickRef, PickerComponentClass } from './interface';
 
@@ -135,11 +140,6 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
 
         const locale = { ...contextLocale, ...props.locale! };
 
-        const mergedAllowClear =
-          allowClear === false && typeof clearIcon === 'undefined'
-            ? false
-            : { clearIcon: clearIcon ?? <CloseCircleFilled /> };
-
         return wrapSSR(
           <RCPicker<DateType>
             ref={innerRef}
@@ -183,7 +183,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               rootClassName,
               popupClassName || dropdownClassName,
             )}
-            allowClear={mergedAllowClear}
+            allowClear={mergeAllowClear({ clearIcon, allowClear }, <CloseCircleFilled />)}
           />,
         );
       },

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -183,7 +183,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               rootClassName,
               popupClassName || dropdownClassName,
             )}
-            allowClear={mergeAllowClear({ clearIcon, allowClear }, <CloseCircleFilled />)}
+            allowClear={mergeAllowClear(allowClear, clearIcon, <CloseCircleFilled />)}
           />,
         );
       },

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -55,6 +55,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           disabled: customDisabled,
           status: customStatus,
           clearIcon,
+          allowClear,
           ...restProps
         } = props;
 
@@ -134,6 +135,11 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
 
         const locale = { ...contextLocale, ...props.locale! };
 
+        const mergedAllowClear =
+          allowClear === false && typeof clearIcon === 'undefined'
+            ? false
+            : { clearIcon: clearIcon ?? <CloseCircleFilled /> };
+
         return wrapSSR(
           <RCPicker<DateType>
             ref={innerRef}
@@ -177,7 +183,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               rootClassName,
               popupClassName || dropdownClassName,
             )}
-            allowClear={{ clearIcon: clearIcon ?? <CloseCircleFilled /> }}
+            allowClear={mergedAllowClear}
           />,
         );
       },

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -161,13 +161,18 @@ export function getTimeProps<DateType, DisabledTime>(
   };
 }
 
-export type MergeAllowClearProps = Pick<PickerProps<unknown>, 'clearIcon' | 'allowClear'>;
+type AllowClear = PickerProps<unknown>['allowClear'];
+type ClearIcon = PickerProps<unknown>['clearIcon'];
 
 export function mergeAllowClear(
-  { clearIcon, allowClear }: MergeAllowClearProps,
-  defaultClearIcon: MergeAllowClearProps['clearIcon'],
+  allowClear: AllowClear,
+  clearIcon: ClearIcon,
+  defaultClearIcon: NonNullable<ClearIcon>,
 ) {
-  return allowClear === false || (typeof allowClear === 'object' && 'clearIcon' in allowClear)
-    ? allowClear
-    : ({ clearIcon: clearIcon ?? defaultClearIcon } as const);
+  if (allowClear === false) {
+    return false;
+  }
+
+  const defaults = { clearIcon: clearIcon ?? defaultClearIcon };
+  return typeof allowClear === 'object' && allowClear ? { ...defaults, ...allowClear } : defaults;
 }

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -3,7 +3,7 @@ import type { PickerMode } from 'rc-picker/lib/interface';
 import type { SharedTimeProps } from 'rc-picker/lib/panels/TimePanel';
 import type { SelectCommonPlacement } from '../_util/motion';
 import type { DirectionType } from '../config-provider';
-import type { PickerLocale } from './generatePicker';
+import type { PickerLocale, PickerProps } from './generatePicker';
 
 export function getPlaceholder(
   locale: PickerLocale,
@@ -159,4 +159,15 @@ export function getTimeProps<DateType, DisabledTime>(
   return {
     showTime: showTimeObj,
   };
+}
+
+export type MergeAllowClearProps = Pick<PickerProps<unknown>, 'clearIcon' | 'allowClear'>;
+
+export function mergeAllowClear(
+  { clearIcon, allowClear }: MergeAllowClearProps,
+  defaultClearIcon: MergeAllowClearProps['clearIcon'],
+) {
+  return allowClear === false || (typeof allowClear === 'object' && 'clearIcon' in allowClear)
+    ? allowClear
+    : ({ clearIcon: clearIcon ?? defaultClearIcon } as const);
 }

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -174,5 +174,5 @@ export function mergeAllowClear(
   }
 
   const defaults = { clearIcon: clearIcon ?? defaultClearIcon };
-  return typeof allowClear === 'object' && allowClear ? { ...defaults, ...allowClear } : defaults;
+  return typeof allowClear === 'object' ? { ...defaults, ...allowClear } : defaults;
 }

--- a/components/time-picker/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/time-picker/__tests__/__snapshots__/index.test.tsx.snap
@@ -41,31 +41,6 @@ exports[`TimePicker not render clean icon when allowClear is false 1`] = `
         </svg>
       </span>
     </span>
-    <span
-      class="ant-picker-clear"
-      role="button"
-    >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
-          fill="currentColor"
-          fill-rule="evenodd"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-          />
-        </svg>
-      </span>
-    </span>
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Fix #44012

### 💡 Background and solution

A regression was introduced in 24697bbb06a6be10dd150ac7f50bca01f88bb0b0 that results in `generatePicker` and `generateRangePicker` building the final `allowClear` prop solely from the `clearIcon` prop, without respecting `allowClear===false`. This makes it impossible for the library user to make a date picker non-clearable.

The proposed solution uses `allowClear`, as provided to the date picker, when it is `false` or an object bearing `clearIcon`. Otherwise, the final `allowClear` prop is built from the `clearIcon` prop.

~~The proposed solution skips building an icon-bearing `allowClear` prop, when the `allowClear` prop on the date picker is set to `false`, and the `clearIcon` prop on the date picker is undefined.~~

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Disable DatePicker and RangePicker clear button when allowClear prop is false |
| 🇨🇳 Chinese | 当allowClear属性为false时禁用DatePicker和RangePicker清除按钮 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 025ada1</samp>

The pull request adds a new feature to the `DatePicker` and `RangePicker` components that allows users to customize the clear icon. The pull request also improves the testing of these components by using new modules, components, and utilities. The pull request modifies the files `components/date-picker/generatePicker/generateRangePicker.tsx`, `components/date-picker/generatePicker/generateSinglePicker.tsx`, `components/date-picker/util.ts`, `components/date-picker/__tests__/DatePicker.test.tsx`, `components/date-picker/__tests__/RangePicker.test.tsx`, and `components/date-picker/__tests__/utils.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 025ada1</samp>

*  Add the `allowClear` prop to the `DatePicker` and `RangePicker` components, which can be a boolean or an object that specifies the `clearIcon` ([link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34R58), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L144-R150), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bR63), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL180-R186), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-64d79cd59dfc100bce2821bc07efac6651fb728fd8473b730597a06dd0815dceR163-R178))
* Import the `mergeAllowClear` function from the `util.ts` module in the `generateSinglePicker.tsx` and `generateRangePicker.tsx` modules, which handles the logic of the `allowClear` prop ([link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L21-R26), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL22-R27), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-64d79cd59dfc100bce2821bc07efac6651fb728fd8473b730597a06dd0815dceL6-R6))
* Add test cases for the `allowClear` prop in the `DatePicker.test.tsx` and `RangePicker.test.tsx` modules, which verify the existence and appearance of the clear icon ([link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-7fdce5d71fac3793bf16cbc035559eeb8d5565c0db96d0b9399b5265a8c471b4R318-R344), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-61e007e24e1181d91ff9aeec9b59be8e62bfdc29445d1f3e41fb8e6a1923d7d6R131-R164))
* Import new modules and components for testing, such as `userEvent`, `screen`, `waitFor`, and `CloseCircleFilled` in the `DatePicker.test.tsx` and `RangePicker.test.tsx` modules, and use them in the new test cases ([link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-7fdce5d71fac3793bf16cbc035559eeb8d5565c0db96d0b9399b5265a8c471b4L8-R15), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-61e007e24e1181d91ff9aeec9b59be8e62bfdc29445d1f3e41fb8e6a1923d7d6L5-R13), [link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-f436452bf954f2673ea2939da48fdd846304fddaaaa376bf73cbfed410ebd47cL2-R2))
* Add utility functions for querying and asserting the clear icon element in the `utils.ts` module, and use them in the new test cases ([link](https://github.com/ant-design/ant-design/pull/44015/files?diff=unified&w=0#diff-f436452bf954f2673ea2939da48fdd846304fddaaaa376bf73cbfed410ebd47cR28-R35))
