### PR TITLE
 docs(demo): add showIcon demo

### DIFF
--- a/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2691,6 +2691,35 @@ exports[`renders components/tree-select/demo/treeLine.tsx extend context correct
     style="margin-bottom: 8px;"
   >
     <button
+      aria-checked="false"
+      class="ant-switch"
+      role="switch"
+      type="button"
+    >
+      <div
+        class="ant-switch-handle"
+      />
+      <span
+        class="ant-switch-inner"
+      >
+        <span
+          class="ant-switch-inner-checked"
+        >
+          showIcon
+        </span>
+        <span
+          class="ant-switch-inner-unchecked"
+        >
+          showIcon
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-bottom: 8px;"
+  >
+    <button
       aria-checked="true"
       class="ant-switch ant-switch-checked"
       role="switch"

--- a/components/tree-select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -802,6 +802,35 @@ exports[`renders components/tree-select/demo/treeLine.tsx correctly 1`] = `
     style="margin-bottom:8px"
   >
     <button
+      aria-checked="false"
+      class="ant-switch"
+      role="switch"
+      type="button"
+    >
+      <div
+        class="ant-switch-handle"
+      />
+      <span
+        class="ant-switch-inner"
+      >
+        <span
+          class="ant-switch-inner-checked"
+        >
+          showIcon
+        </span>
+        <span
+          class="ant-switch-inner-unchecked"
+        >
+          showIcon
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+    style="margin-bottom:8px"
+  >
+    <button
       aria-checked="true"
       class="ant-switch ant-switch-checked"
       role="switch"

--- a/components/tree-select/demo/treeLine.tsx
+++ b/components/tree-select/demo/treeLine.tsx
@@ -1,32 +1,39 @@
 import React, { useState } from 'react';
+import { CarryOutOutlined } from '@ant-design/icons';
 import { Space, Switch, TreeSelect } from 'antd';
 
 const treeData = [
   {
     value: 'parent 1',
     title: 'parent 1',
+    icon: <CarryOutOutlined />,
     children: [
       {
         value: 'parent 1-0',
         title: 'parent 1-0',
+        icon: <CarryOutOutlined />,
         children: [
           {
             value: 'leaf1',
             title: 'leaf1',
+            icon: <CarryOutOutlined />,
           },
           {
             value: 'leaf2',
             title: 'leaf2',
+            icon: <CarryOutOutlined />,
           },
         ],
       },
       {
         value: 'parent 1-1',
         title: 'parent 1-1',
+        icon: <CarryOutOutlined />,
         children: [
           {
             value: 'sss',
             title: 'sss',
+            icon: <CarryOutOutlined />,
           },
         ],
       },
@@ -37,9 +44,16 @@ const treeData = [
 const App: React.FC = () => {
   const [treeLine, setTreeLine] = useState(true);
   const [showLeafIcon, setShowLeafIcon] = useState(false);
+  const [showIcon, setShowIcon] = useState<boolean>(false);
 
   return (
     <Space direction="vertical">
+      <Switch
+        checkedChildren="showIcon"
+        unCheckedChildren="showIcon"
+        checked={showIcon}
+        onChange={() => setShowIcon(!showIcon)}
+      />
       <Switch
         checkedChildren="treeLine"
         unCheckedChildren="treeLine"
@@ -57,6 +71,7 @@ const App: React.FC = () => {
         treeLine={treeLine && { showLeafIcon }}
         style={{ width: 300 }}
         treeData={treeData}
+        treeIcon={showIcon}
       />
     </Space>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
缺少一个像tree组件这样子的显示icon的demo
![image](https://github.com/ant-design/ant-design/assets/117748716/5c07f78a-4efa-4e6a-8de6-a68c5c96fa95)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      docs(demo): add showIcon demo      |
| 🇨🇳 Chinese |        增加显示图标的demo   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cb4c12</samp>

Added a custom icon feature to the `TreeSelect` demo. Modified `components/tree-select/demo/treeLine.tsx` to import an icon component and use it with a `Switch` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cb4c12</samp>

* Import `CarryOutOutlined` icon component and use it as custom icon for tree nodes ([link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeR2), [link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeL8-R24), [link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeL26-R36))
* Add `showIcon` state and `Switch` component to toggle custom icon display in demo ([link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeL40-R57), [link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeR74))
* Add `treeIcon` prop to `TreeSelect` component to control custom icon rendering ([link](https://github.com/ant-design/ant-design/pull/44019/files?diff=unified&w=0#diff-2fc074e66eb294019dc396174b3e8b3f9d041d6f0a0c67545403994ed3b2cbbeR74))
