### PR TITLE
docs: improve code previewer style

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -535,20 +535,22 @@ createRoot(document.getElementById('container')).render(<Demo />);
           </Tooltip>
         </Space>
       </section>
-      <section className={highlightClass} key="code">
-        <CodePreview
-          codes={highlightedCodes}
-          toReactComponent={toReactComponent}
-          onCodeTypeChange={(type) => setCodeType(type)}
-        />
-        {highlightedStyle ? (
-          <div key="style" className="highlight">
-            <pre>
-              <code className="css" dangerouslySetInnerHTML={{ __html: highlightedStyle }} />
-            </pre>
-          </div>
-        ) : null}
-      </section>
+      {codeExpand && (
+        <section className={highlightClass} key="code">
+          <CodePreview
+            codes={highlightedCodes}
+            toReactComponent={toReactComponent}
+            onCodeTypeChange={(type) => setCodeType(type)}
+          />
+          {highlightedStyle ? (
+            <div key="style" className="highlight">
+              <pre>
+                <code className="css" dangerouslySetInnerHTML={{ __html: highlightedStyle }} />
+              </pre>
+            </div>
+          ) : null}
+        </section>
+      )}
     </section>
   );
 

--- a/.dumi/theme/common/CodePreview.tsx
+++ b/.dumi/theme/common/CodePreview.tsx
@@ -14,26 +14,24 @@ interface CodePreviewProps {
 
 const CodePreview: React.FC<CodePreviewProps> = ({ toReactComponent, codes, onCodeTypeChange }) => {
   const langList = Object.keys(codes).sort().reverse();
-
-  let content: React.ReactNode;
-
   if (langList.length === 1) {
-    content = toReactComponent(['pre', { lang: langList[0], highlighted: codes[langList[0]] }]);
-  } else {
-    content = (
-      <Tabs
-        centered
-        onChange={onCodeTypeChange}
-        items={langList.map((lang) => ({
-          label: LANGS[lang],
-          key: lang,
-          children: toReactComponent(['pre', { lang, highlighted: codes[lang] }]),
-        }))}
-      />
-    );
+    return toReactComponent([
+      'pre',
+      { lang: langList[0], highlighted: codes[langList[0]], className: 'highlight' },
+    ]);
   }
-
-  return <div className="highlight">{content}</div>;
+  return (
+    <Tabs
+      centered
+      className="highlight"
+      onChange={onCodeTypeChange}
+      items={langList.map((lang) => ({
+        label: LANGS[lang],
+        key: lang,
+        children: toReactComponent(['pre', { lang, highlighted: codes[lang] }]),
+      }))}
+    />
+  );
 };
 
 export default CodePreview;

--- a/.dumi/theme/common/styles/Demo.tsx
+++ b/.dumi/theme/common/styles/Demo.tsx
@@ -323,6 +323,9 @@ const GlobalDemoStyles: React.FC = () => {
               background: ${token.colorBgContainer};
               border: none;
               box-shadow: unset;
+              padding: 12px 16px;
+              margin-top: -16px;
+              font-size: 13px;
             }
           }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/issues/44045

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

针对演示代码卡片做了一些调整。

- [x] 代码字体调小点，有限空间可以多展示一点代码。
- [x] 去掉多余的 padding，同样是为了多展示一点代码。
- [x] 简化 dom 结构，不点开前不渲染 dom。

预览效果：https://preview-44071-ant-design.surge.sh/components/button-cn

<img width="683" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/7b67d4d9-0752-467c-ae5d-8c04396e4a5b">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      --     |
| 🇨🇳 Chinese |     --      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d62cff</samp>

This pull request enhances the code preview feature of the demo components by adding a button to collapse or expand the code section, refactoring the `CodePreview` component, and improving the style of the button and the code. The changes affect the files `.dumi/theme/builtins/Previewer/CodePreviewer.tsx`, `.dumi/theme/common/CodePreview.tsx`, and `.dumi/theme/common/styles/Demo.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d62cff</samp>

*  Add a button to toggle the code section of the demo previewer ([link](https://github.com/ant-design/ant-design/pull/44071/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL538-R553), [link](https://github.com/ant-design/ant-design/pull/44071/files?diff=unified&w=0#diff-181338f39265840d4b593a73fc4950ee3a2e1c86ef27c46268df7bd48e64a1cbR326-R328))
* Simplify the structure and logic of the `CodePreview` component ([link](https://github.com/ant-design/ant-design/pull/44071/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL17-R34))
