### PR TITLE
fix: Carousel should support id property

### DIFF
--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -28,6 +28,15 @@ describe('Carousel', () => {
     expect(typeof innerSlider.slickNext).toBe('function');
   });
 
+  it('should support id property', () => {
+    const { container } = render(
+      <Carousel id="my-carousel">
+        <div />
+      </Carousel>,
+    );
+    expect(container.querySelector('.ant-carousel')?.getAttribute('id')).toBe('my-carousel');
+  });
+
   it('should has prev, next and go function', async () => {
     const ref = React.createRef<CarouselRef>();
     render(

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -16,6 +16,7 @@ export interface CarouselProps extends Omit<Settings, 'dots' | 'dotsClass'> {
   style?: React.CSSProperties;
   prefixCls?: string;
   rootClassName?: string;
+  id?: string;
   slickGoTo?: number;
   dotPosition?: DotPosition;
   children?: React.ReactNode;
@@ -42,6 +43,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     rootClassName,
     className: customClassName,
     style,
+    id,
     ...otherProps
   } = props;
   const { getPrefixCls, direction, carousel } = React.useContext(ConfigContext);
@@ -106,7 +108,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
   );
 
   return wrapSSR(
-    <div className={className}>
+    <div className={className} id={id}>
       <SlickCarousel
         ref={slickRef}
         {...newProps}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #44042

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Carousel do not support `id` prop.         |
| 🇨🇳 Chinese |  修复 Carousel 不支持 `id` 属性的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38cee1e</samp>

Add `id` prop to `Carousel` component and test it. This allows users to assign a unique identifier to the carousel element for accessibility or styling purposes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38cee1e</samp>

*  Add `id` prop to `Carousel` component to allow customizing the root element's id attribute ([link](https://github.com/ant-design/ant-design/pull/44079/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR19), [link](https://github.com/ant-design/ant-design/pull/44079/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbR46), [link](https://github.com/ant-design/ant-design/pull/44079/files?diff=unified&w=0#diff-1158da0914c171fa74b4fa496bef7272ca0776317fb5e222bebdf11477b191fbL109-R111))
*  Test that `Carousel` renders the `id` prop correctly on the `div` element in `components/carousel/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/44079/files?diff=unified&w=0#diff-2b4349b32a83234387e250eb04502a659a7fbf83607861aa82786e4451a81761R31-R39))
