### PR TITLE
feat: button component token

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -388,6 +388,115 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx extend context
 
 exports[`renders components/button/demo/chinese-chars-loading.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/button/demo/component-token.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical"
+>
+  <div
+    class="ant-space-item"
+    style="margin-bottom: 8px;"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center"
+      style="flex-wrap: wrap; margin-bottom: -8px;"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right: 8px; padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-text"
+          type="button"
+        >
+          <span>
+            TEXT
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right: 8px; padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          type="button"
+        >
+          <span>
+            CONTAINED
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-default"
+          type="button"
+        >
+          <span>
+            OUTLINED
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center"
+      style="flex-wrap: wrap; margin-bottom: -8px;"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right: 8px; padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-text"
+          disabled=""
+          type="button"
+        >
+          <span>
+            TEXT
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right: 8px; padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          disabled=""
+          type="button"
+        >
+          <span>
+            CONTAINED
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="padding-bottom: 8px;"
+      >
+        <button
+          class="ant-btn ant-btn-default"
+          disabled=""
+          type="button"
+        >
+          <span>
+            OUTLINED
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/button/demo/component-token.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/button/demo/danger.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -377,6 +377,113 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx correctly 1`] 
 </div>
 `;
 
+exports[`renders components/button/demo/component-token.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical"
+>
+  <div
+    class="ant-space-item"
+    style="margin-bottom:8px"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center"
+      style="flex-wrap:wrap;margin-bottom:-8px"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-text"
+          type="button"
+        >
+          <span>
+            TEXT
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          type="button"
+        >
+          <span>
+            CONTAINED
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-default"
+          type="button"
+        >
+          <span>
+            OUTLINED
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center"
+      style="flex-wrap:wrap;margin-bottom:-8px"
+    >
+      <div
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-text"
+          disabled=""
+          type="button"
+        >
+          <span>
+            TEXT
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="margin-right:8px;padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-primary"
+          disabled=""
+          type="button"
+        >
+          <span>
+            CONTAINED
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+        style="padding-bottom:8px"
+      >
+        <button
+          class="ant-btn ant-btn-default"
+          disabled=""
+          type="button"
+        >
+          <span>
+            OUTLINED
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/button/demo/danger.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/button/demo/component-token.md
+++ b/components/button/demo/component-token.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+组件 Token
+
+## en-US
+
+Component Token

--- a/components/button/demo/component-token.md
+++ b/components/button/demo/component-token.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-组件 Token
+组件 Token，模仿 MUI 风格的 Button
 
 ## en-US
 
-Component Token
+Component Token. Button with MUI style.

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Button, ConfigProvider, Space } from 'antd';
+
+const App: React.FC = () => (
+  <ConfigProvider
+    theme={{
+      components: {
+        Button: {
+          algorithm: true,
+          colorPrimary: '#1976d2',
+          controlHeight: 36,
+          primaryShadow:
+            '0px 3px 1px -2px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 1px 5px 0px rgba(0,0,0,0.12)',
+          fontWeight: 500,
+          defaultBorderColor: 'rgba(25, 118, 210, 0.5)',
+          colorText: '#1976d2',
+          defaultColor: '#1976d2',
+          borderRadius: 4,
+          colorTextDisabled: 'rgba(0, 0, 0, 0.26)',
+          colorBgContainerDisabled: 'rgba(0, 0, 0, 0.12)',
+        },
+      },
+    }}
+  >
+    <Space direction="vertical">
+      <Space wrap>
+        <Button type="text">TEXT</Button>
+        <Button type="primary">CONTAINED</Button>
+        <Button>OUTLINED</Button>
+      </Space>
+      <Space wrap>
+        <Button type="text" disabled>
+          TEXT
+        </Button>
+        <Button type="primary" disabled>
+          CONTAINED
+        </Button>
+        <Button disabled>OUTLINED</Button>
+      </Space>
+    </Space>
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -47,6 +47,7 @@ And 4 other properties additionally.
 <code src="./demo/block.tsx">Block Button</code>
 <code src="./demo/legacy-group.tsx" debug>Deprecated Button Group</code>
 <code src="./demo/chinese-chars-loading.tsx" debug>Loading style bug</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API
 

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -50,6 +50,7 @@ group:
 <code src="./demo/block.tsx">Block 按钮</code>
 <code src="./demo/legacy-group.tsx" debug>废弃的 Block 组</code>
 <code src="./demo/chinese-chars-loading.tsx" debug>加载中状态 bug 还原</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 

--- a/components/button/style/group.ts
+++ b/components/button/style/group.ts
@@ -23,7 +23,7 @@ const genButtonBorderStyle = (buttonTypeCls: string, borderColor: string) => ({
 });
 
 const genGroupStyle: GenerateStyle<ButtonToken> = (token) => {
-  const { componentCls, fontSize, lineWidth, colorPrimaryHover, colorErrorHover } = token;
+  const { componentCls, fontSize, lineWidth, groupBorderColor, colorErrorHover } = token;
 
   return {
     [`${componentCls}-group`]: [
@@ -71,7 +71,7 @@ const genGroupStyle: GenerateStyle<ButtonToken> = (token) => {
       },
 
       // Border Color
-      genButtonBorderStyle(`${componentCls}-primary`, colorPrimaryHover),
+      genButtonBorderStyle(`${componentCls}-primary`, groupBorderColor),
       genButtonBorderStyle(`${componentCls}-danger`, colorErrorHover),
     ],
   };

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -1,4 +1,5 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import type { CSSProperties } from 'react';
 import { genFocusStyle } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import { genCompactItemVerticalStyle } from '../../style/compact-item-vertical';
@@ -7,25 +8,120 @@ import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genGroupStyle from './group';
 
 /** Component only token. Which will handle additional calculation of alias token */
-export interface ComponentToken {}
+export interface ComponentToken {
+  /**
+   * @desc 文字字重
+   * @descEN Font weight of text
+   */
+  fontWeight: CSSProperties['fontWeight'];
+  /**
+   * @desc 默认按钮阴影
+   * @descEN Shadow of default button
+   */
+  defaultShadow: string;
+  /**
+   * @desc 主要按钮阴影
+   * @descEN Shadow of primary button
+   */
+  primaryShadow: string;
+  /**
+   * @desc 危险按钮阴影
+   * @descEN Shadow of danger button
+   */
+  dangerShadow: string;
+  /**
+   * @desc 主要按钮文本颜色
+   * @descEN Text color of primary button
+   */
+  primaryColor: string;
+  /**
+   * @desc 危险按钮文本颜色
+   * @descEN Text color of danger button
+   */
+  dangerColor: string;
+  /**
+   * @desc 禁用状态边框颜色
+   * @descEN Border color of disabled button
+   */
+  borderColorDisabled: string;
+  /**
+   * @desc 默认幽灵按钮文本颜色
+   * @descEN Text color of default ghost button
+   */
+  defaultGhostColor: string;
+  /**
+   * @desc 幽灵按钮背景色
+   * @descEN Background color of ghost button
+   */
+  ghostBg: string;
+  /**
+   * @desc 默认幽灵按钮边框颜色
+   * @descEN Border color of default ghost button
+   */
+  defaultGhostBorderColor: string;
+  /**
+   * @desc 按钮横向内间距
+   * @descEN Horizontal padding of button
+   */
+  paddingInline: CSSProperties['paddingInline'];
+  /**
+   * @desc 大号按钮横向内间距
+   * @descEN Horizontal padding of large button
+   */
+  paddingInlineLG: CSSProperties['paddingInline'];
+  /**
+   * @desc 小号按钮横向内间距
+   * @descEN Horizontal padding of small button
+   */
+  paddingInlineSM: CSSProperties['paddingInline'];
+  /**
+   * @desc 只有图标的按钮图标尺寸
+   * @descEN Icon size of button which only contains icon
+   */
+  onlyIconSize: number;
+  /**
+   * @desc 大号只有图标的按钮图标尺寸
+   * @descEN Icon size of large button which only contains icon
+   */
+  onlyIconSizeLG: number;
+  /**
+   * @desc 小号只有图标的按钮图标尺寸
+   * @descEN Icon size of small button which only contains icon
+   */
+  onlyIconSizeSM: number;
+  /**
+   * @desc 按钮组边框颜色
+   * @descEN Border color of button group
+   */
+  groupBorderColor: string;
+  /**
+   * @desc 链接按钮悬浮态背景色
+   * @descEN Background color of link button when hover
+   */
+  linkHoverBg: string;
+  /**
+   * @desc 文本按钮悬浮态背景色
+   * @descEN Background color of text button when hover
+   */
+  textHoverBg: string;
+}
 
 export interface ButtonToken extends FullToken<'Button'> {
   colorOutlineDefault: string;
-  buttonPaddingHorizontal: number;
+  buttonPaddingHorizontal: CSSProperties['paddingInline'];
   buttonIconOnlyFontSize: number;
-  buttonFontWeight: number;
 }
 
 // ============================== Shared ==============================
 const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSSObject => {
-  const { componentCls, iconCls, buttonFontWeight } = token;
+  const { componentCls, iconCls, fontWeight } = token;
 
   return {
     [componentCls]: {
       outline: 'none',
       position: 'relative',
       display: 'inline-block',
-      fontWeight: buttonFontWeight,
+      fontWeight,
       whiteSpace: 'nowrap',
       textAlign: 'center',
       backgroundImage: 'none',
@@ -143,7 +239,7 @@ const genRoundButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
 // =============================== Type ===============================
 const genDisabledStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   cursor: 'not-allowed',
-  borderColor: token.colorBorder,
+  borderColor: token.borderColorDisabled,
   color: token.colorTextDisabled,
   backgroundColor: token.colorBgContainerDisabled,
   boxShadow: 'none',
@@ -151,6 +247,7 @@ const genDisabledStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
 
 const genGhostButtonStyle = (
   btnCls: string,
+  background: string,
   textColor: string | false,
   borderColor: string | false,
   textColorDisabled: string | false,
@@ -160,18 +257,18 @@ const genGhostButtonStyle = (
 ): CSSObject => ({
   [`&${btnCls}-background-ghost`]: {
     color: textColor || undefined,
-    backgroundColor: 'transparent',
+    backgroundColor: background,
     borderColor: borderColor || undefined,
     boxShadow: 'none',
 
     ...genHoverActiveButtonStyle(
       btnCls,
       {
-        backgroundColor: 'transparent',
+        backgroundColor: background,
         ...hoverStyle,
       },
       {
-        backgroundColor: 'transparent',
+        backgroundColor: background,
         ...activeStyle,
       },
     ),
@@ -208,7 +305,7 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
   backgroundColor: token.colorBgContainer,
   borderColor: token.colorBorder,
 
-  boxShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlTmpOutline}`,
+  boxShadow: token.defaultShadow,
 
   ...genHoverActiveButtonStyle(
     token.componentCls,
@@ -224,8 +321,9 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
   ...genGhostButtonStyle(
     token.componentCls,
-    token.colorBgContainer,
-    token.colorBgContainer,
+    token.ghostBg,
+    token.defaultGhostColor,
+    token.defaultGhostBorderColor,
     token.colorTextDisabled,
     token.colorBorder,
   ),
@@ -248,6 +346,7 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
     ...genGhostButtonStyle(
       token.componentCls,
+      token.ghostBg,
       token.colorError,
       token.colorError,
       token.colorTextDisabled,
@@ -261,10 +360,10 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ...genSolidButtonStyle(token),
 
-  color: token.colorTextLightSolid,
+  color: token.primaryColor,
   backgroundColor: token.colorPrimary,
 
-  boxShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlOutline}`,
+  boxShadow: token.primaryShadow,
 
   ...genHoverActiveButtonStyle(
     token.componentCls,
@@ -280,6 +379,7 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
   ...genGhostButtonStyle(
     token.componentCls,
+    token.ghostBg,
     token.colorPrimary,
     token.colorPrimary,
     token.colorTextDisabled,
@@ -296,7 +396,8 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
   [`&${token.componentCls}-dangerous`]: {
     backgroundColor: token.colorError,
-    boxShadow: `0 ${token.controlOutlineWidth}px 0 ${token.colorErrorOutline}`,
+    boxShadow: token.dangerShadow,
+    color: token.dangerColor,
 
     ...genHoverActiveButtonStyle(
       token.componentCls,
@@ -310,6 +411,7 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
     ...genGhostButtonStyle(
       token.componentCls,
+      token.ghostBg,
       token.colorError,
       token.colorError,
       token.colorTextDisabled,
@@ -341,6 +443,7 @@ const genLinkButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
     token.componentCls,
     {
       color: token.colorLinkHover,
+      backgroundColor: token.linkHoverBg,
     },
     {
       color: token.colorLinkActive,
@@ -372,7 +475,7 @@ const genTextButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
     token.componentCls,
     {
       color: token.colorText,
-      backgroundColor: token.colorBgTextHover,
+      backgroundColor: token.textHoverBg,
     },
     {
       color: token.colorText,
@@ -411,6 +514,7 @@ const genTypeButtonStyle: GenerateStyle<ButtonToken> = (token) => {
     [`${componentCls}-text`]: genTextButtonStyle(token),
     [`${componentCls}-ghost`]: genGhostButtonStyle(
       token.componentCls,
+      token.ghostBg,
       token.colorBgContainer,
       token.colorBgContainer,
       token.colorTextDisabled,
@@ -433,7 +537,6 @@ const genSizeButtonStyle = (token: ButtonToken, sizePrefixCls: string = ''): CSS
   } = token;
 
   const paddingVertical = Math.max(0, (controlHeight - fontSize * lineHeight) / 2 - lineWidth);
-  const paddingHorizontal = buttonPaddingHorizontal - lineWidth;
 
   const iconOnlyCls = `${componentCls}-icon-only`;
 
@@ -443,7 +546,7 @@ const genSizeButtonStyle = (token: ButtonToken, sizePrefixCls: string = ''): CSS
       [`${componentCls}${sizePrefixCls}`]: {
         fontSize,
         height: controlHeight,
-        padding: `${paddingVertical}px ${paddingHorizontal}px`,
+        padding: `${paddingVertical}px ${buttonPaddingHorizontal}px`,
         borderRadius,
 
         [`&${iconOnlyCls}`]: {
@@ -486,9 +589,9 @@ const genSizeSmallButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const smallToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightSM,
     padding: token.paddingXS,
-    buttonPaddingHorizontal: 8, // Fixed padding
+    buttonPaddingHorizontal: token.paddingInlineSM, // Fixed padding
     borderRadius: token.borderRadiusSM,
-    buttonIconOnlyFontSize: token.fontSizeLG - 2,
+    buttonIconOnlyFontSize: token.onlyIconSizeSM,
   });
 
   return genSizeButtonStyle(smallToken, `${token.componentCls}-sm`);
@@ -498,8 +601,9 @@ const genSizeLargeButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const largeToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightLG,
     fontSize: token.fontSizeLG,
+    buttonPaddingHorizontal: token.paddingInlineLG,
     borderRadius: token.borderRadiusLG,
-    buttonIconOnlyFontSize: token.fontSizeLG + 2,
+    buttonIconOnlyFontSize: token.onlyIconSizeLG,
   });
 
   return genSizeButtonStyle(largeToken, `${token.componentCls}-lg`);
@@ -517,36 +621,58 @@ const genBlockButtonStyle: GenerateStyle<ButtonToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Button', (token) => {
-  const { controlTmpOutline, paddingContentHorizontal } = token;
+export default genComponentStyleHook(
+  'Button',
+  (token) => {
+    const { paddingInline, onlyIconSize } = token;
 
-  const buttonToken = mergeToken<ButtonToken>(token, {
-    colorOutlineDefault: controlTmpOutline,
-    buttonPaddingHorizontal: paddingContentHorizontal,
-    buttonIconOnlyFontSize: token.fontSizeLG,
-    buttonFontWeight: 400,
-  });
+    const buttonToken = mergeToken<ButtonToken>(token, {
+      buttonPaddingHorizontal: paddingInline,
+      buttonIconOnlyFontSize: onlyIconSize,
+    });
 
-  return [
-    // Shared
-    genSharedButtonStyle(buttonToken),
+    return [
+      // Shared
+      genSharedButtonStyle(buttonToken),
 
-    // Size
-    genSizeSmallButtonStyle(buttonToken),
-    genSizeBaseButtonStyle(buttonToken),
-    genSizeLargeButtonStyle(buttonToken),
+      // Size
+      genSizeSmallButtonStyle(buttonToken),
+      genSizeBaseButtonStyle(buttonToken),
+      genSizeLargeButtonStyle(buttonToken),
 
-    // Block
-    genBlockButtonStyle(buttonToken),
+      // Block
+      genBlockButtonStyle(buttonToken),
 
-    // Group (type, ghost, danger, loading)
-    genTypeButtonStyle(buttonToken),
+      // Group (type, ghost, danger, loading)
+      genTypeButtonStyle(buttonToken),
 
-    // Button Group
-    genGroupStyle(buttonToken),
+      // Button Group
+      genGroupStyle(buttonToken),
 
-    // Space Compact
-    genCompactItemStyle(token),
-    genCompactItemVerticalStyle(token),
-  ];
-});
+      // Space Compact
+      genCompactItemStyle(token),
+      genCompactItemVerticalStyle(token),
+    ];
+  },
+  (token) => ({
+    fontWeight: 400,
+    defaultShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlTmpOutline}`,
+    primaryShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlOutline}`,
+    dangerShadow: `0 ${token.controlOutlineWidth}px 0 ${token.colorErrorOutline}`,
+    primaryColor: token.colorTextLightSolid,
+    dangerColor: token.colorTextLightSolid,
+    borderColorDisabled: token.colorBorder,
+    defaultGhostColor: token.colorBgContainer,
+    ghostBg: 'transparent',
+    defaultGhostBorderColor: token.colorBgContainer,
+    paddingInline: token.paddingContentHorizontal - token.lineWidth,
+    paddingInlineLG: token.paddingContentHorizontal - token.lineWidth,
+    paddingInlineSM: 8 - token.lineWidth,
+    onlyIconSize: token.fontSizeLG,
+    onlyIconSizeSM: token.fontSizeLG - 2,
+    onlyIconSizeLG: token.fontSizeLG + 2,
+    groupBorderColor: token.colorPrimaryHover,
+    linkHoverBg: 'transparent',
+    textHoverBg: token.colorBgTextHover,
+  }),
+);

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -35,6 +35,21 @@ export interface ComponentToken {
    */
   primaryColor: string;
   /**
+   * @desc 默认按钮文本颜色
+   * @descEN Text color of default button
+   */
+  defaultColor: string;
+  /**
+   * @desc 默认按钮背景色
+   * @descEN Background color of default button
+   */
+  defaultBg: string;
+  /**
+   * @desc 默认按钮边框颜色
+   * @descEN Border color of default button
+   */
+  defaultBorderColor: string;
+  /**
    * @desc 危险按钮文本颜色
    * @descEN Text color of danger button
    */
@@ -302,8 +317,9 @@ const genPureDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token
 const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ...genSolidButtonStyle(token),
 
-  backgroundColor: token.colorBgContainer,
-  borderColor: token.colorBorder,
+  backgroundColor: token.defaultBg,
+  borderColor: token.defaultBorderColor,
+  color: token.defaultColor,
 
   boxShadow: token.defaultShadow,
 
@@ -674,5 +690,9 @@ export default genComponentStyleHook(
     groupBorderColor: token.colorPrimaryHover,
     linkHoverBg: 'transparent',
     textHoverBg: token.colorBgTextHover,
+    defaultColor: token.colorText,
+    defaultBg: token.colorBgContainer,
+    defaultBorderColor: token.colorBorder,
+    defaultBorderColorDisabled: token.colorBorder,
   }),
 );

--- a/components/theme/interface/alias.ts
+++ b/components/theme/interface/alias.ts
@@ -580,6 +580,7 @@ export interface AliasToken extends MapToken {
   screenXXLMin: number;
 
   /**
+   * @deprecated
    * Used for DefaultButton, Switch which has default outline
    * @desc 默认样式的 Outline 颜色
    * @descEN Default style outline color.

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -58,7 +58,7 @@ export default App;
 ### Avatar
 
 <!-- prettier-ignore -->
-| less 变量 | Component Token | 备注 |
+| Less variables | Component Token | Note |
 | --- | --- | --- |
 | `@avatar-size-base` | `containerSize` | - |
 | `@avatar-size-lg` | `containerSizeLG` | - |
@@ -78,7 +78,7 @@ export default App;
 ### BreadCrumb
 
 <!-- prettier-ignore -->
-| Less 变量 | Component Token | 备注 |
+| Less variables | Component Token | Note |
 | --- | --- | --- |
 | `@breadcrumb-base-color` | `itemColor` | - |
 | `@breadcrumb-last-item-color` | `lastItemColor` | - |
@@ -89,7 +89,54 @@ export default App;
 | `@breadcrumb-separator-color` | `separatorColor` | - |
 | `@breadcrumb-separator-margin` | `separatorMargin` | - |
 
-<!-- ### Button -->
+### Button
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@btn-font-weight` | `fontWeight` | - |
+| `@btn-border-radius-base` | `borderRadius` | Global Token |
+| `@btn-border-radius-sm` | `borderRadisuSM` | Global Token |
+| `@btn-border-width` | `lineWidth` | Global Token |
+| `@btn-border-style` | `lineStyle` | Global Token |
+| `@btn-shadow` | `defaultShadow` | - |
+| `@btn-primary-shadow` | `primaryShadow` | - |
+| `@btn-text-shadow` | - | Deprecated for no `text-shadow` any more |
+| `@btn-primary-color` | `primaryColor` | - |
+| `@btn-primary-bg` | `colorPrimary` | Global Token |
+| `@btn-default-color` | `colorText` | Global Token |
+| `@btn-default-bg` | `colorBgContainer` | Global Token |
+| `@btn-default-border` | `colorBorder` | Global Token |
+| `@btn-danger-color` | `dangerColor` | - |
+| `@btn-danger-bg` | `colorError` | Global Token |
+| `@btn-danger-border` | `colorError` | Global Token |
+| `@btn-disable-color` | `colorTextDisabled` | Global Token |
+| `@btn-disable-bg` | `colorBgContainerDisabled` | Global Token |
+| `@btn-disable-border` | `borderColorDisabled` | - |
+| `@btn-default-ghost-color` | `defaultGhostColor` | - |
+| `@btn-default-ghost-bg` | `ghostBg` | - |
+| `@btn-default-ghost-border` | `defaultGhostBorderColor` | - |
+| `@btn-font-size-lg` | `fontSizeLG` | Global Token |
+| `@btn-font-size-sm` | `fontSizeSM` | Global Token |
+| `@btn-padding-horizontal-base` | `paddingInline` | - |
+| `@btn-padding-horizontal-lg` | `paddingInlineLG` | - |
+| `@btn-padding-horizontal-sm` | `paddingInlineSM` | - |
+| `@btn-height-base` | `controlHeight` | Global Token |
+| `@btn-height-lg` | `controlHeightLG` | Global Token |
+| `@btn-height-sm` | `controlHeightSM` | Global Token |
+| `@btn-line-height` | `lineHeight` | Global Token |
+| `@btn-circle-size` | `controlHeight` | Global Token |
+| `@btn-circle-size-lg` | `controlHeightLG` | Global Token |
+| `@btn-circle-size-sm` | `controlHeightSM` | Global Token |
+| `@btn-square-size` | `controlHeight` | Global Token |
+| `@btn-square-size-lg` | `controlHeightLG` | Global Token |
+| `@btn-square-size-sm` | `controlHeightSM` | Global Token |
+| `@btn-square-only-icon-size` | `onlyIconSize` | - |
+| `@btn-square-only-icon-size-sm` | `onlyIconSizeSM` | - |
+| `@btn-square-only-icon-size-lg` | `onlyIconSizeLG` | - |
+| `@btn-group-border` | `groupBorderColor` | - |
+| `@btn-link-hover-bg` | `linkHoverBg` | - |
+| `@btn-text-hover-bg` | `textHoverBg` | - |
 
 ### Calendar
 
@@ -434,7 +481,7 @@ export default App;
 ### Slider
 
 <!-- prettier-ignore -->
-| Less 变量 | Component Token | 备注 |
+| Less variables | Component Token | Note |
 | --- | --- | --- |
 | `@slider-margin` | - | Could be customized with `className` or `style` |
 | `@slider-rail-background-color` | `railBg` | - |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -104,9 +104,9 @@ export default App;
 | `@btn-text-shadow` | - | 已废弃，v5 中不再有 `text-shadow` |
 | `@btn-primary-color` | `primaryColor` | - |
 | `@btn-primary-bg` | `colorPrimary` | 全局 Token |
-| `@btn-default-color` | `colorText` | 全局 Token |
-| `@btn-default-bg` | `colorBgContainer` | 全局 Token |
-| `@btn-default-border` | `colorBorder` | 全局 Token |
+| `@btn-default-color` | `defaultColor` | - |
+| `@btn-default-bg` | `defaultBg` | - |
+| `@btn-default-border` | `defaultBorderColor` | - |
 | `@btn-danger-color` | `dangerColor` | - |
 | `@btn-danger-bg` | `colorError` | 全局 Token |
 | `@btn-danger-border` | `colorError` | 全局 Token |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -89,7 +89,54 @@ export default App;
 | `@breadcrumb-separator-color` | `separatorColor` | - |
 | `@breadcrumb-separator-margin` | `separatorMargin` | - |
 
-<!-- ### Button 按钮 -->
+### Button 按钮
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@btn-font-weight` | `fontWeight` | - |
+| `@btn-border-radius-base` | `borderRadius` | 全局 Token |
+| `@btn-border-radius-sm` | `borderRadisuSM` | 全局 Token |
+| `@btn-border-width` | `lineWidth` | 全局 Token |
+| `@btn-border-style` | `lineStyle` | 全局 Token |
+| `@btn-shadow` | `defaultShadow` | - |
+| `@btn-primary-shadow` | `primaryShadow` | - |
+| `@btn-text-shadow` | - | 已废弃，v5 中不再有 `text-shadow` |
+| `@btn-primary-color` | `primaryColor` | - |
+| `@btn-primary-bg` | `colorPrimary` | 全局 Token |
+| `@btn-default-color` | `colorText` | 全局 Token |
+| `@btn-default-bg` | `colorBgContainer` | 全局 Token |
+| `@btn-default-border` | `colorBorder` | 全局 Token |
+| `@btn-danger-color` | `dangerColor` | - |
+| `@btn-danger-bg` | `colorError` | 全局 Token |
+| `@btn-danger-border` | `colorError` | 全局 Token |
+| `@btn-disable-color` | `colorTextDisabled` | 全局 Token |
+| `@btn-disable-bg` | `colorBgContainerDisabled` | 全局 Token |
+| `@btn-disable-border` | `borderColorDisabled` | - |
+| `@btn-default-ghost-color` | `defaultGhostColor` | - |
+| `@btn-default-ghost-bg` | `ghostBg` | - |
+| `@btn-default-ghost-border` | `defaultGhostBorderColor` | - |
+| `@btn-font-size-lg` | `fontSizeLG` | 全局 Token |
+| `@btn-font-size-sm` | `fontSizeSM` | 全局 Token |
+| `@btn-padding-horizontal-base` | `paddingInline` | - |
+| `@btn-padding-horizontal-lg` | `paddingInlineLG` | - |
+| `@btn-padding-horizontal-sm` | `paddingInlineSM` | - |
+| `@btn-height-base` | `controlHeight` | 全局 Token |
+| `@btn-height-lg` | `controlHeightLG` | 全局 Token |
+| `@btn-height-sm` | `controlHeightSM` | 全局 Token |
+| `@btn-line-height` | `lineHeight` | 全局 Token |
+| `@btn-circle-size` | `controlHeight` | 全局 Token |
+| `@btn-circle-size-lg` | `controlHeightLG` | 全局 Token |
+| `@btn-circle-size-sm` | `controlHeightSM` | 全局 Token |
+| `@btn-square-size` | `controlHeight` | 全局 Token |
+| `@btn-square-size-lg` | `controlHeightLG` | 全局 Token |
+| `@btn-square-size-sm` | `controlHeightSM` | 全局 Token |
+| `@btn-square-only-icon-size` | `onlyIconSize` | - |
+| `@btn-square-only-icon-size-sm` | `onlyIconSizeSM` | - |
+| `@btn-square-only-icon-size-lg` | `onlyIconSizeLG` | - |
+| `@btn-group-border` | `groupBorderColor` | - |
+| `@btn-link-hover-bg` | `linkHoverBg` | - |
+| `@btn-text-hover-bg` | `textHoverBg` | - |
 
 ### Calendar 日历
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Migrate less variables of Button to Component Token.       |
| 🇨🇳 Chinese |   迁移 Button less 变量到组件 Token。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84fa6fc</samp>

This pull request refactors the button component style and token system to use more specific and consistent names, to separate the component token from the global and alias token, and to pass some token properties as arguments to the style functions. It also updates the documentation for the button component in both English and Chinese, and marks a deprecated property in the alias token interface. The files affected are `components/button/style/group.ts`, `components/button/style/index.ts`, `docs/react/migrate-less-variables.en-US.md`, `docs/react/migrate-less-variables.zh-CN.md`, and `components/theme/interface/alias.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84fa6fc</samp>

*  Refactor the button component style and token system to use more specific and consistent token property names, and to separate the component token from the global and alias token ([link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-185e310fda7784da1ac0108f343c186327cb5df31c02786cb7c030d8dfe210ecL26-R26), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-185e310fda7784da1ac0108f343c186327cb5df31c02786cb7c030d8dfe210ecL74-R74), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R2), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L10-R117), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L28-R124), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L146-R242), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R250), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L163-R260), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L170-R271), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L211-R308), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L227-R326), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R349), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L264-R366), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R382), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L299-R400), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R414), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R446), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L375-R478), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R517), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L436), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L446-R549), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L489-R594), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L501-R606), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L520-R678), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-f6ab6e133f17bf8cfb1e390e3e6fc000340af4360bd20a8ca08175cdaacc06ccR583))
* Add a new parameter `background` to the `genGhostButtonStyle` function to pass the background color of the ghost button component as an argument, instead of using a fixed value ([link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R250), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L163-R260), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L170-R271), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R349), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R382), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R414), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R517))
* Translate the table header from Chinese to English in the `docs/react/migrate-less-variables.en-US.md` file to provide a consistent and accurate documentation for the English version of the migration guide ([link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL61-R61), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL81-R81), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL437-R484))
* Add a new section for the button component in the `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` files to document the mapping between the less variables and the component token properties for the button component ([link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL92-R140), [link](https://github.com/ant-design/ant-design/pull/44090/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L92-R140))
