### PR TITLE
chore: remove space useless style

### DIFF
--- a/components/space/style/compact.tsx
+++ b/components/space/style/compact.tsx
@@ -13,7 +13,6 @@ const genSpaceCompactStyle: GenerateStyle<SpaceToken> = (token) => {
 
   return {
     [componentCls]: {
-      display: 'inline-flex',
       '&-block': {
         display: 'flex',
         width: '100%',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Duplicated `inline-flex` style definition:

![image](https://github.com/ant-design/ant-design/assets/5378891/697dfd17-0e8a-4151-b6b4-63d5a1f63338)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Remove Space part useless style.      |
| 🇨🇳 Chinese |      移除 Space 部分未使用的样式。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14da2e1</samp>

Fix a bug in the `Space` component that prevents it from wrapping its children elements. Remove the `display: 'inline-flex'` property from `components/space/style/compact.tsx` and use `align-items: 'center'` instead.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14da2e1</samp>

* Fix a bug that prevents the `Space` component with the `compact` prop from wrapping its children elements when the available width is not enough ([link](https://github.com/ant-design/ant-design/pull/44098/files?diff=unified&w=0#diff-fc7c7ef13a00b084828f937f3b3189c8b31fec4ad8ece5dcf2f25aaf4619ae13L16))
