### PR TITLE
docs: optimize site layout

### DIFF
--- a/.dumi/pages/index/components/ComponentsList.tsx
+++ b/.dumi/pages/index/components/ComponentsList.tsx
@@ -90,6 +90,48 @@ const useStyle = createStyles(({ token }) => {
   };
 });
 
+const ComponentItem: React.FC<ComponentItemProps> = ({ title, node, type, index }) => {
+  const tagColor = type === 'new' ? 'processing' : 'warning';
+  const [locale] = useLocale(locales);
+  const tagText = type === 'new' ? locale.new : locale.update;
+  const { styles } = useStyle();
+  const { isMobile } = useContext(SiteContext);
+  const token = useTheme();
+
+  return (
+    <div className={classNames(styles.card, isMobile && styles.mobileCard)}>
+      {/* Decorator */}
+      <div
+        className={styles.cardCircle}
+        style={{
+          right: (index % 2) * -20 - 20,
+          bottom: (index % 3) * -40 - 20,
+        }}
+      />
+
+      {/* Title */}
+      <Space>
+        <Typography.Title level={4} style={{ fontWeight: 'normal', margin: 0 }}>
+          {title}
+        </Typography.Title>
+        <Tag color={tagColor}>{tagText}</Tag>
+      </Space>
+
+      <div
+        style={{
+          marginTop: token.paddingLG,
+          flex: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {node}
+      </div>
+    </div>
+  );
+};
+
 interface ComponentItemProps {
   title: React.ReactNode;
   node: React.ReactNode;
@@ -232,44 +274,6 @@ export default function ComponentsList() {
     ],
     [isMobile],
   );
-
-  const ComponentItem: React.FC<ComponentItemProps> = ({ title, node, type, index }) => {
-    const tagColor = type === 'new' ? 'processing' : 'warning';
-    const tagText = type === 'new' ? locale.new : locale.update;
-
-    return (
-      <div key={index} className={classNames(styles.card, isMobile && styles.mobileCard)}>
-        {/* Decorator */}
-        <div
-          className={styles.cardCircle}
-          style={{
-            right: (index % 2) * -20 - 20,
-            bottom: (index % 3) * -40 - 20,
-          }}
-        />
-
-        {/* Title */}
-        <Space>
-          <Typography.Title level={4} style={{ fontWeight: 'normal', margin: 0 }}>
-            {title}
-          </Typography.Title>
-          <Tag color={tagColor}>{tagText}</Tag>
-        </Space>
-
-        <div
-          style={{
-            marginTop: token.paddingLG,
-            flex: 'auto',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          {node}
-        </div>
-      </div>
-    );
-  };
 
   return isMobile ? (
     <div style={{ margin: '0 16px' }}>

--- a/.dumi/theme/SiteThemeProvider.tsx
+++ b/.dumi/theme/SiteThemeProvider.tsx
@@ -15,6 +15,7 @@ interface NewToken {
   marginFarSM: number;
   marginFar: number;
   codeFamily: string;
+  contentMarginTop: number;
 }
 
 // 通过给 antd-style 扩展 CustomToken 对象类型定义，可以为 useTheme 中增加相应的 token 对象
@@ -52,6 +53,7 @@ const SiteThemeProvider: FC<ThemeProviderProps> = ({ children, theme, ...rest })
         /** 96 */
         marginFar: token.marginXXL * 2,
         codeFamily: `'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace`,
+        contentMarginTop: 40,
       }}
     >
       {children}

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -139,7 +139,7 @@ const Overview: React.FC = () => {
   return (
     <section className="markdown" ref={sectionRef}>
       <Divider />
-      <Affix offsetTop={24} onChange={setSearchBarAffixed}>
+      <Affix offsetTop={24 + token.headerHeight} onChange={setSearchBarAffixed}>
         <div
           className={styles.componentsOverviewAffix}
           style={searchBarAffixed ? affixedStyle : {}}

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -58,6 +58,7 @@ const IconSearch: React.FC = () => {
     searchKey: '',
     theme: ThemeType.Outlined,
   });
+  const token = useTheme();
 
   const newIconNames: string[] = [];
 
@@ -111,7 +112,6 @@ const IconSearch: React.FC = () => {
   }, [displayState.searchKey, displayState.theme]);
 
   const [searchBarAffixed, setSearchBarAffixed] = useState<boolean>(false);
-  const token = useTheme();
   const { borderRadius, colorBgContainer } = token;
 
   const affixedStyle: CSSProperties = {
@@ -124,7 +124,7 @@ const IconSearch: React.FC = () => {
 
   return (
     <div className="markdown">
-      <Affix offsetTop={24} onChange={setSearchBarAffixed}>
+      <Affix offsetTop={24 + token.headerHeight} onChange={setSearchBarAffixed}>
         <div className={styles.iconSearchAffix} style={searchBarAffixed ? affixedStyle : {}}>
           <Segmented
             size="large"

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -29,6 +29,7 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
       icon={<ThemeIcon />}
       aria-label="Theme Switcher"
       badge={{ dot: true }}
+      style={{ zIndex: 1010 }}
     >
       <Link
         to={getLocalizedPathname('/theme-editor', isZhCN(pathname), search)}

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -24,7 +24,12 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
   const isHappyWork = value.includes('happy-work');
 
   return (
-    <FloatButton.Group trigger="click" icon={<ThemeIcon />} aria-label="Theme Switcher">
+    <FloatButton.Group
+      trigger="click"
+      icon={<ThemeIcon />}
+      aria-label="Theme Switcher"
+      badge={{ dot: true }}
+    >
       <Link
         to={getLocalizedPathname('/theme-editor', isZhCN(pathname), search)}
         style={{ display: 'block', marginBottom: token.margin }}
@@ -76,6 +81,7 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
         }
       /> */}
       <FloatButton
+        badge={{ dot: true }}
         icon={<SmileOutlined />}
         type={isHappyWork ? 'primary' : 'default'}
         onClick={() => {

--- a/.dumi/theme/layouts/SidebarLayout/index.tsx
+++ b/.dumi/theme/layouts/SidebarLayout/index.tsx
@@ -5,10 +5,10 @@ import CommonHelmet from '../../common/CommonHelmet';
 import Content from '../../slots/Content';
 import Sidebar from '../../slots/Sidebar';
 
-const useStyle = createStyles(({ css }) => ({
+const useStyle = createStyles(({ css, token }) => ({
   main: css`
     display: flex;
-    margin-top: 40px;
+    margin-top: ${token.contentMarginTop}px;
   `,
 }));
 

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -6,7 +6,7 @@ import DayJS from 'dayjs';
 import { FormattedMessage, useIntl, useRouteMeta, useTabMeta } from 'dumi';
 import type { ReactNode } from 'react';
 import React, { useContext, useLayoutEffect, useMemo, useState } from 'react';
-import { Affix, Anchor, Avatar, Col, Skeleton, Space, Tooltip, Typography } from 'antd';
+import { Anchor, Avatar, Col, Skeleton, Space, Tooltip, Typography } from 'antd';
 import useLayoutState from '../../../hooks/useLayoutState';
 import useLocation from '../../../hooks/useLocation';
 import EditButton from '../../common/EditButton';
@@ -55,16 +55,17 @@ const useStyle = createStyles(({ token, css }) => {
       }
     `,
     tocWrapper: css`
-      position: absolute;
-      top: 8px;
+      position: fixed;
+      top: ${token.headerHeight + token.contentMarginTop}px;
       inset-inline-end: 0;
       width: 160px;
-      margin: 12px 0;
+      margin: 0 0 12px 0;
       padding: 8px 0;
       padding-inline: 4px 8px;
       backdrop-filter: blur(8px);
       border-radius: ${token.borderRadius}px;
       box-sizing: border-box;
+      z-index: 1000;
 
       .toc-debug {
         color: ${token.purple6};
@@ -206,32 +207,30 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
     <DemoContext.Provider value={contextValue}>
       <Col xxl={20} xl={19} lg={18} md={18} sm={24} xs={24}>
         {!!meta.frontmatter.toc && (
-          <Affix>
-            <section className={styles.tocWrapper}>
-              <Anchor
-                className={styles.toc}
-                affix={false}
-                targetOffset={token.marginXXL}
-                showInkInFixed
-                items={anchorItems.map((item) => ({
-                  href: `#${item.id}`,
-                  title: item.title,
-                  key: item.id,
-                  children: item.children
-                    ?.filter((child) => showDebug || !debugDemos.includes(child.id))
-                    .map((child) => ({
-                      key: child.id,
-                      href: `#${child.id}`,
-                      title: (
-                        <span className={classNames(debugDemos.includes(child.id) && 'toc-debug')}>
-                          {child?.title}
-                        </span>
-                      ),
-                    })),
-                }))}
-              />
-            </section>
-          </Affix>
+          <section className={styles.tocWrapper}>
+            <Anchor
+              className={styles.toc}
+              affix={false}
+              targetOffset={token.marginXXL}
+              showInkInFixed
+              items={anchorItems.map((item) => ({
+                href: `#${item.id}`,
+                title: item.title,
+                key: item.id,
+                children: item.children
+                  ?.filter((child) => showDebug || !debugDemos.includes(child.id))
+                  .map((child) => ({
+                    key: child.id,
+                    href: `#${child.id}`,
+                    title: (
+                      <span className={classNames(debugDemos.includes(child.id) && 'toc-debug')}>
+                        {child?.title}
+                      </span>
+                    ),
+                  })),
+              }))}
+            />
+          </section>
         )}
         <article className={classNames(styles.articleWrapper, { rtl: isRTL })}>
           {meta.frontmatter?.title ? (

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -25,11 +25,13 @@ const useStyle = createStyles(({ token, css }) => {
 
   return {
     header: css`
-      position: relative;
-      z-index: 10;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
       max-width: 100%;
       background: ${token.colorBgContainer};
       box-shadow: ${token.boxShadowTertiary};
+      backdrop-filter: blur(8px);
 
       @media only screen and (max-width: ${token.mobileMaxWidth}px) {
         text-align: center;

--- a/.dumi/theme/slots/Sidebar/index.tsx
+++ b/.dumi/theme/slots/Sidebar/index.tsx
@@ -105,10 +105,10 @@ const useStyle = createStyles(({ token, css }) => {
 
       .main-menu-inner {
         position: sticky;
-        top: 0;
+        top: ${token.headerHeight + token.contentMarginTop}px;
         width: 100%;
         height: 100%;
-        max-height: 100vh;
+        max-height: calc(100vh - ${token.headerHeight + token.contentMarginTop}px);
         overflow: hidden;
       }
 

--- a/components/_util/PurePanel.tsx
+++ b/components/_util/PurePanel.tsx
@@ -92,25 +92,16 @@ export default function genPurePanel<ComponentProps extends BaseProps>(
     }
 
     return (
-      <ConfigProvider
-        theme={{
-          token: {
-            motion: false,
-            zIndexPopupBase: 0,
-          },
+      <div
+        ref={holderRef}
+        style={{
+          paddingBottom: popupHeight,
+          position: 'relative',
+          minWidth: popupWidth,
         }}
       >
-        <div
-          ref={holderRef}
-          style={{
-            paddingBottom: popupHeight,
-            position: 'relative',
-            minWidth: popupWidth,
-          }}
-        >
-          <Component {...mergedProps} />
-        </div>
-      </ConfigProvider>
+        <Component {...mergedProps} />
+      </div>
     );
   }
 

--- a/components/_util/PurePanel.tsx
+++ b/components/_util/PurePanel.tsx
@@ -2,6 +2,23 @@ import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
 import ConfigProvider, { ConfigContext } from '../config-provider';
 
+export function withPureRenderTheme(Component: any) {
+  return function PureRenderThemeComponent(props: any) {
+    return (
+      <ConfigProvider
+        theme={{
+          token: {
+            motion: false,
+            zIndexPopupBase: 0,
+          },
+        }}
+      >
+        <Component {...props} />
+      </ConfigProvider>
+    );
+  };
+}
+
 export interface BaseProps {
   prefixCls?: string;
   style?: React.CSSProperties;
@@ -16,7 +33,7 @@ export default function genPurePanel<ComponentProps extends BaseProps>(
 ) {
   type WrapProps = Omit<ComponentProps, 'open' | 'visible'> & { open?: boolean };
 
-  return function PurePanel(props: WrapProps) {
+  function PurePanel(props: WrapProps) {
     const { prefixCls: customizePrefixCls, style } = props;
 
     const holderRef = React.useRef<HTMLDivElement>(null);
@@ -79,6 +96,7 @@ export default function genPurePanel<ComponentProps extends BaseProps>(
         theme={{
           token: {
             motion: false,
+            zIndexPopupBase: 0,
           },
         }}
       >
@@ -94,5 +112,7 @@ export default function genPurePanel<ComponentProps extends BaseProps>(
         </div>
       </ConfigProvider>
     );
-  } as typeof Component;
+  }
+
+  return withPureRenderTheme(PurePanel);
 }

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -6,6 +6,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HJz8SZos2wgAAAAAAA
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*oC92TK44Ex8AAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 Application wrapper for some global usages.

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -7,6 +7,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HJz8SZos2wgAAAAAAA
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*oC92TK44Ex8AAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 新的包裹组件，提供重置样式和提供消费上下文的默认环境。

--- a/components/float-button/index.en-US.md
+++ b/components/float-button/index.en-US.md
@@ -1,11 +1,12 @@
 ---
 category: Components
-group: Other
+group: General
 title: FloatButton
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HS-wTIIwu0kAAAAAAAAAAAAADrJ8AQ/original
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*a0hwTY_rOSUAAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 FloatButton. Available since `5.0.0`.

--- a/components/float-button/index.zh-CN.md
+++ b/components/float-button/index.zh-CN.md
@@ -1,12 +1,13 @@
 ---
 category: Components
-group: 其他
+group: 通用
 subtitle: 悬浮按钮
 title: FloatButton
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HS-wTIIwu0kAAAAAAAAAAAAADrJ8AQ/original
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*a0hwTY_rOSUAAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 悬浮按钮。自 `5.0.0` 版本开始提供该组件。

--- a/components/modal/PurePanel.tsx
+++ b/components/modal/PurePanel.tsx
@@ -9,6 +9,7 @@ import { ConfirmContent } from './ConfirmDialog';
 import type { ModalFuncProps } from './interface';
 import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
+import { withPureRenderTheme } from '../_util/PurePanel';
 
 export interface PurePanelProps
   extends Omit<PanelProps, 'prefixCls'>,
@@ -80,4 +81,4 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   );
 };
 
-export default PurePanel;
+export default withPureRenderTheme(PurePanel);

--- a/components/qr-code/index.en-US.md
+++ b/components/qr-code/index.en-US.md
@@ -8,6 +8,7 @@ demo:
 group:
   title: Data Display
   order: 5
+tag: New
 ---
 
 Components that can convert text into QR codes, and support custom color and logo. Available since `antd@5.1.0`.

--- a/components/qr-code/index.zh-CN.md
+++ b/components/qr-code/index.zh-CN.md
@@ -9,6 +9,7 @@ demo:
 group:
   title: 数据展示
   order: 5
+tag: New
 ---
 
 能够将文本转换生成二维码的组件，支持自定义配色和 Logo 配置，自 `antd@5.1.0` 版本开始提供该组件。

--- a/components/tour/PurePanel.tsx
+++ b/components/tour/PurePanel.tsx
@@ -5,6 +5,7 @@ import { RawPurePanel as PopoverRawPurePanel } from '../popover/PurePanel';
 import type { TourStepProps } from './interface';
 import TourPanel from './panelRender';
 import useStyle from './style';
+import { withPureRenderTheme } from '../_util/PurePanel';
 
 export interface PurePanelProps extends TourStepProps {}
 
@@ -36,4 +37,4 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   );
 };
 
-export default PurePanel;
+export default withPureRenderTheme(PurePanel);

--- a/components/tour/index.en-US.md
+++ b/components/tour/index.en-US.md
@@ -6,6 +6,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*8CC_Tbe3_e4AAAAAAA
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*nF6hQpM0XtEAAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 A popup component for guiding users through a product. Available since `5.0.0`.

--- a/components/tour/index.zh-CN.md
+++ b/components/tour/index.zh-CN.md
@@ -7,6 +7,7 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*8CC_Tbe3_e4AAAAAAA
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*nF6hQpM0XtEAAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 2
+tag: New
 ---
 
 用于分步引导用户了解产品功能的气泡组件。自 `5.0.0` 版本开始提供该组件。

--- a/components/watermark/index.en-US.md
+++ b/components/watermark/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 category: Components
-group: Other
+group: Feedback
 title: Watermark
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*wr1ISY50SyYAAAAAAAAAAAAADrJ8AQ/original
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*duAQQbjHlHQAAAAAAAAAAAAADrJ8AQ/original

--- a/components/watermark/index.zh-CN.md
+++ b/components/watermark/index.zh-CN.md
@@ -1,12 +1,13 @@
 ---
 category: Components
 subtitle: 水印
-group: 其他
+group: 反馈
 title: Watermark
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*wr1ISY50SyYAAAAAAAAAAAAADrJ8AQ/original
 coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*duAQQbjHlHQAAAAAAAAAAAAADrJ8AQ/original
 demo:
   cols: 1
+tag: New
 ---
 
 给页面的某个区域加上水印。


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
1. 调整了 5.0 新组件在侧边栏的位置，并添加了 New 标签
2. 给快乐主题加了小红点
3. header 设置为了 sticky，固定 layout，侧边栏可以一直滚到底部查看全部组件
<!--
1. Describe the problem and the scenario.
4. GIF or snapshot should be provided if includes UI/interactive modification.
5. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24d702c</samp>

This pull request introduces a new theme editor feature for the ant-design library. It adds a new theme token `contentMarginTop` and uses it to adjust the layout and alignment of the site content. It also refactors some components to use theme token values and utility functions for styling and rendering. It adds a badge to the theme switch button to highlight the new feature. It also adds a `tag` property to the frontmatter of some component documentation files to mark them as new features.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 24d702c</samp>

*  Add `tag` property to the frontmatter of the documentation files for the new components `app`, `float-button`, `qr-code`, and `tour` to indicate that they are new features ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cR9), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-88905ff2c3941f956e0d1dbf8871b8f2d633992532d79997fc5be05032729291R10), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-80a107045d1a20a6bb129a0a9728f40fbdb0844205cc57fb4ea23271b99e8adcR9), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-778117125c1b0d160ec5e0ff086b12c8118fdad8b97d28f351948704a1fe1e11R10), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-97715d670d42f6224c59e289b477e433969f9948894a96f9e078c0b0d2139335R11), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-80e8f648f6b8a80820c718716bff7aa341374a962e9ecd4bbe2242e4f7ec1e59R12), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-1ad8b229c044ca1a06a7bbed19bc03af75d71e159a8b70caf2a52aa2e328b38aR9), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-8eeca01fdc999bcb32068854b6930fb0df7f5374284c2d03e3a0b7fb6d553d8cR10))
*  Move the `float-button` component from the `other` group to the `general` group in the documentation files ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-80a107045d1a20a6bb129a0a9728f40fbdb0844205cc57fb4ea23271b99e8adcL3-R3), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-778117125c1b0d160ec5e0ff086b12c8118fdad8b97d28f351948704a1fe1e11L3-R3))
*  Add a new component `ComponentItem` to render each component card in the components list page and extract it from the `ComponentsList` component ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6R93-R134), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L236-L273))
*  Modify the `offsetTop` prop of the `Affix` component in the `ComponentsList` and `IconSearch` components to ensure that the search bar is affixed below the header when scrolling ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L142-R142), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-8b799f7fc1319c44839ab462e8211e9e598d446618f5770aac912faebc536077L127-R127))
*  Add a `badge` prop with a `dot` value to the `FloatButton.Group` component in the `ThemeSwitch` component to indicate that there is a new feature in the theme editor page and add a `style` prop with a `zIndex` value of 1010 to ensure that the float button is above the header and the content ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L27-R33))
*  Remove the redundant `badge` prop from the `Link` component in the `ThemeSwitch` component ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447R85))
*  Add a new property `contentMarginTop` to the interface `NewToken` and the `SiteThemeProvider` component to define the margin-top value for the main content area in the site theme and assign a default value of 40 ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995R18), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995R56))
*  Modify the `useStyle` hook in the `SidebarLayout`, `Content`, `Header`, and `Sidebar` components to use the theme token values of `contentMarginTop`, `headerHeight`, `marginXXL`, `mobileMaxWidth`, `colorBgContainer`, `boxShadowTertiary`, and `zIndexPopupBase` from the `token` object and replace the hard-coded values ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-0203e852c7cd27a2f6c67aea218485e507f4e9f18477d08de2fd0e19f0281f5eL8-R11), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L58-R62), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L28-R34), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-df557d0ed53eb1710843e7fce2d294362941ec80e20a8bb0ed385299362e204bL108-R111))
*  Add a `zIndex` value of 1000 and a `backdropFilter` value of `blur(8px)` to the `header` style in the `useStyle` hook of the `Header` component to make the header stick to the top of the viewport and have a blurred background when scrolling ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L28-R34))
*  Add a `zIndex` value of 1000 to the `tocWrapper` style in the `useStyle` hook of the `Content` component to ensure that the table of contents is above the header and the content ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82R68))
*  Modify the `targetOffset` prop of the `Anchor` component in the `Content` component to use the `marginXXL` value from the theme token to ensure that the anchor links are aligned with the headings in the content ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L209-R233))
*  Remove the unused `Affix` and `Divider` components from the import statement in the `Content` component ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L9-R9))
*  Remove the redundant hook `useTheme` from the `IconSearch` component ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-8b799f7fc1319c44839ab462e8211e9e598d446618f5770aac912faebc536077L114))
*  Add a new function `withPureRenderTheme` to the `PurePanel` component in the `_util` folder to wrap a component with a `ConfigProvider` component that sets the theme token values of `motion` and `zIndexPopupBase` to false and 0 respectively ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6R5-R21))
*  Modify the `PurePanel` function in the `PurePanel` component in the `_util` folder to remove the type assertion, add a return statement, and change it from an arrow function to a regular function ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6L19-R36))
*  Add a `zIndexPopupBase` property to the `theme` prop of the `ConfigProvider` component in the `PurePanel` function in the `_util` folder and wrap the `PurePanel` function with the `withPureRenderTheme` function ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6R99), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-458739bbc5dc90c9430ef8ee4ea53366ddef7c5870bdaeb30ae45240c07777c6L97-R117))
*  Import the `withPureRenderTheme` function from the `PurePanel` component in the `_util` folder and wrap the `PurePanel` component with it in the `modal` and `tour` folders ([link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-9103d37c6668043c170813d54cb43ca28bc6cf111eedfc6718aeae7f540a0b27R12), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-9103d37c6668043c170813d54cb43ca28bc6cf111eedfc6718aeae7f540a0b27L83-R84), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-7348f4a7ff6e65656b442037c43f19497ece5b3d5031b19e39b0ead4c6016e07R8), [link](https://github.com/ant-design/ant-design/pull/44111/files?diff=unified&w=0#diff-7348f4a7ff6e65656b442037c43f19497ece5b3d5031b19e39b0ead4c6016e07L39-R40))
