### PR TITLE
fix: ColorPicker HEX input cursor jump bug

### DIFF
--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -296,7 +296,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -680,7 +680,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -1066,7 +1066,7 @@ exports[`renders components/color-picker/demo/change-completed.tsx extend contex
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -1450,7 +1450,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -1839,7 +1839,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -2202,7 +2202,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -2530,7 +2530,7 @@ exports[`renders components/color-picker/demo/format.tsx extend context correctl
                             <input
                               class="ant-input ant-input-sm"
                               type="text"
-                              value="1677FF"
+                              value="1677ff"
                             />
                           </span>
                         </div>
@@ -4222,7 +4222,7 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                               <input
                                 class="ant-input ant-input-sm"
                                 type="text"
-                                value="1677FF"
+                                value="1677ff"
                               />
                             </span>
                           </div>
@@ -5055,7 +5055,7 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                                 <input
                                   class="ant-input ant-input-sm"
                                   type="text"
-                                  value="1677FF"
+                                  value="1677ff"
                                 />
                               </span>
                             </div>
@@ -5446,7 +5446,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -6207,7 +6207,7 @@ exports[`renders components/color-picker/demo/pure-panel.tsx extend context corr
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>
@@ -6605,7 +6605,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -6987,7 +6987,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -7368,7 +7368,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -7763,7 +7763,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -8150,7 +8150,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -8536,7 +8536,7 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
                         <input
                           class="ant-input ant-input-sm"
                           type="text"
-                          value="1677FF"
+                          value="1677ff"
                         />
                       </span>
                     </div>
@@ -8934,7 +8934,7 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>
@@ -9323,7 +9323,7 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>
@@ -9728,7 +9728,7 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>
@@ -10110,7 +10110,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>
@@ -10494,7 +10494,7 @@ Array [
                   <input
                     class="ant-input ant-input-sm"
                     type="text"
-                    value="1677FF"
+                    value="1677ff"
                   />
                 </span>
               </div>

--- a/components/color-picker/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/index.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`ColorPicker Should panelRender work 1`] = `
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>
@@ -505,7 +505,7 @@ exports[`ColorPicker Should panelRender work 2`] = `
                     <input
                       class="ant-input ant-input-sm"
                       type="text"
-                      value="1677FF"
+                      value="1677ff"
                     />
                   </span>
                 </div>

--- a/components/color-picker/components/ColorHexInput.tsx
+++ b/components/color-picker/components/ColorHexInput.tsx
@@ -37,7 +37,7 @@ const ColorHexInput: FC<ColorHexInputProps> = ({ prefixCls, value, onChange }) =
   return (
     <Input
       className={colorHexInputPrefixCls}
-      value={hexValue?.toUpperCase()}
+      value={hexValue}
       prefix="#"
       onChange={handleHexChange}
       size="small"

--- a/components/color-picker/style/input.ts
+++ b/components/color-picker/style/input.ts
@@ -86,6 +86,7 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
           padding: `0 ${paddingXS}px`,
           [`${antCls}-input`]: {
             fontSize: fontSizeSM,
+            textTransform: 'uppercase',
             lineHeight: `${controlHeightSM - 2 * lineWidth}px`,
           },
           [`${antCls}-input-prefix`]: {


### PR DESCRIPTION
… letter,the cursor will jump to the tail,and me fixed it.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix ColorPicker HEX input cursor jump bug.   |
| 🇨🇳 Chinese |     修复 ColorPicker 色值输入框输入小写英文字母时光标跳动的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d30579a</samp>

Fixed a focus bug in the color picker hex input by using CSS instead of JavaScript to uppercase the input value. Modified the `value` and `styles` props of the `Input` component in `components/color-picker/components/ColorHexInput.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d30579a</samp>

* Fix bug where hex value input loses focus when typing lowercase letters by applying `textTransform: 'uppercase'` CSS rule instead of calling `toUpperCase` method on `value` prop of `Input` component ([link](https://github.com/ant-design/ant-design/pull/44137/files?diff=unified&w=0#diff-3ea70913f2f5e38335a70b730457daaa3827d75907311df6df24234f55c31304L40-R41))
