### PR TITLE
fix: respect use transform from slick

### DIFF
--- a/components/carousel/style/index.ts
+++ b/components/carousel/style/index.ts
@@ -20,6 +20,11 @@ export interface ComponentToken {
    * @descEN Width of active indicator
    */
   dotActiveWidth: number;
+  /**
+   * @desc 是否使用 CSS3 变换
+   * @descEn Whether to use CSS3 transforms or not
+   */
+  useTransform: boolean;
 }
 
 interface CarouselToken extends FullToken<'Carousel'> {
@@ -47,7 +52,8 @@ const genCarouselStyle: GenerateStyle<CarouselToken> = (token) => {
         WebkitTapHighlightColor: 'transparent',
 
         '.slick-track, .slick-list': {
-          transform: 'translate3d(0, 0, 0)',
+          // Transforms should not be applied at all, if user has asked for it
+          ...(token.useTransform && { transform: 'translate3d(0, 0, 0)' }),
           touchAction: 'pan-y',
         },
       },
@@ -365,6 +371,8 @@ export default genComponentStyleHook(
       dotHeight: 3,
       dotWidthActive: dotActiveWidth,
       dotActiveWidth,
+      // In Slick this property is `true` by default, so making Antd's default value also as `true`
+      useTransform: true,
     };
   },
   {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/44194

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

I had no idea how to pass props to styles
Slick has a prop named `useTransform` and ideally we need to pass that to styles and use
but I had o idea how to do that so I used tokens, at least developers will have a solution for this edge case

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Added a useTransform token to carousel so developers can restrict the usage of transform prop in carousel if they need that       |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c9dda0</samp>

Added a new option to the carousel component to toggle CSS3 transforms. Updated the style generation logic to handle the option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c9dda0</samp>

*  Add `useTransform` property to `ComponentToken` interface to control whether to use CSS3 transforms for carousel component ([link](https://github.com/ant-design/ant-design/pull/44195/files?diff=unified&w=0#diff-24c8a7b3adad15c6014a09fdd0200792fa3915c53a19bb5b9e702b6d4f0574fdR23-R27))
*  Modify `genCarouselStyle` function to conditionally apply `transform` property to `.slick-track` and `.slick-list` selectors based on `useTransform` token value ([link](https://github.com/ant-design/ant-design/pull/44195/files?diff=unified&w=0#diff-24c8a7b3adad15c6014a09fdd0200792fa3915c53a19bb5b9e702b6d4f0574fdL50-R56))
*  Set default value of `useTransform` token to `true` in `defaultToken` object to match existing behavior and ensure backward compatibility ([link](https://github.com/ant-design/ant-design/pull/44195/files?diff=unified&w=0#diff-24c8a7b3adad15c6014a09fdd0200792fa3915c53a19bb5b9e702b6d4f0574fdR374-R375))
