### PR TITLE
fix: (tabs)Unexpected color change in the click area of the mobile ta…

### DIFF
--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -663,6 +663,8 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
   return {
     [tabCls]: {
       position: 'relative',
+      WebkitTouchCallout: 'none',
+      WebkitTapHighlightColor: 'transparent',
       display: 'inline-flex',
       alignItems: 'center',
       padding: horizontalItemPadding,


### PR DESCRIPTION
…bs component

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

On mobile devices, the area that is clicked within the tabs component changes color, but under normal circumstances, it should not change color.

before

![before 00_00_00-00_00_30](https://github.com/ant-design/ant-design/assets/59329360/5c770e93-e469-4566-981f-8264b0bf15f5)




after
![after 00_00_00-00_00_30](https://github.com/ant-design/ant-design/assets/59329360/8a703fe9-786b-42f6-9154-8060fdb1d0e9)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix the issue of the tab area changing color when clicked on a mobile device.     |
| 🇨🇳 Chinese |  解决移动端点击tab区域触发颜色改变的问题  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efe4a12</samp>

Improve tabs component style on touch devices. Disable default `callout` and `highlight` effects on tabs in `components/tabs/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efe4a12</samp>

* Disable default callout and highlight effects on touch devices for tab style ([link](https://github.com/ant-design/ant-design/pull/44200/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7R666-R667))
