### PR TITLE
fix: Modal open should not block dropdown hidden

### DIFF
--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -106,6 +106,7 @@ export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = 
           outline: 0,
           WebkitOverflowScrolling: 'touch',
 
+          // Note: Firefox not support `:has` yet
           [`&:has(${componentCls}${antCls}-zoom-enter), &:has(${componentCls}${antCls}-zoom-appear)`]:
             {
               pointerEvents: 'none',

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -62,10 +62,7 @@ export interface ModalToken extends FullToken<'Modal'> {
 function box(position: React.CSSProperties['position']): React.CSSProperties {
   return {
     position,
-    top: 0,
-    insetInlineEnd: 0,
-    bottom: 0,
-    insetInlineStart: 0,
+    inset: 0,
   };
 }
 
@@ -95,6 +92,7 @@ export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = 
           zIndex: token.zIndexPopupBase,
           height: '100%',
           backgroundColor: token.colorBgMask,
+          pointerEvents: 'none',
 
           [`${componentCls}-hidden`]: {
             display: 'none',
@@ -103,6 +101,7 @@ export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = 
 
         [`${componentCls}-wrap`]: {
           ...box('fixed'),
+          zIndex: token.zIndexPopupBase,
           overflow: 'auto',
           outline: 0,
           WebkitOverflowScrolling: 'touch',
@@ -120,14 +119,6 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
     // ======================== Root =========================
     {
       [`${componentCls}-root`]: {
-        [`${componentCls}-wrap`]: {
-          zIndex: token.zIndexPopupBase,
-          position: 'fixed',
-          inset: 0,
-          overflow: 'auto',
-          outline: 0,
-          WebkitOverflowScrolling: 'touch',
-        },
         [`${componentCls}-wrap-rtl`]: {
           direction: 'rtl',
         },

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -105,6 +105,11 @@ export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = 
           overflow: 'auto',
           outline: 0,
           WebkitOverflowScrolling: 'touch',
+
+          [`&:has(${componentCls}${antCls}-zoom-enter), &:has(${componentCls}${antCls}-zoom-appear)`]:
+            {
+              pointerEvents: 'none',
+            },
         },
       },
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #43860
fix #44197

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

`createPortal` of React will bubble event which makes hovering the Modal as hovering the MenuItem. Since `rc-trigger` will not reopen when hover the hidden item. Let's make Modal show `pointsEvents: none` when motion.

ref: https://github.com/facebook/react/issues/11387

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal in Dropdown `menu.items` makes popup reopen in some case.      |
| 🇨🇳 Chinese |   修复 Modal 在 Dropdown `menu.items` 中，展开 Modal 时快速移动鼠标会使 Dropdown 重新打开的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a4478e</samp>

Simplified and fixed modal style code. Added `zIndex` and `pointerEvents` to improve zoom transition.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a4478e</samp>

*  Simplify the `box` function to use the `inset` property ([link](https://github.com/ant-design/ant-design/pull/44204/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486L65-R65))
*  Fix the bug where the modal could not be closed by clicking outside or pressing the escape key by adding `pointerEvents: 'none'` to the modal mask style ([link](https://github.com/ant-design/ant-design/pull/44204/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486R95))
*  Improve the modal appearance and behavior during the zoom transition by adding `zIndex` and `pointerEvents: 'none'` to the modal wrap style ([link](https://github.com/ant-design/ant-design/pull/44204/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486L106-R112))
*  Remove the redundant modal wrap style from the `genModalStyle` function ([link](https://github.com/ant-design/ant-design/pull/44204/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486L123-L130))
