### PR TITLE
chore: collapse token meta

### DIFF
--- a/components/badge/index.en-US.md
+++ b/components/badge/index.en-US.md
@@ -41,19 +41,7 @@ Common props ref：[Common props](/docs/react/common-props)
 ### Badge
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| color | Customize Badge dot color | string | - |  |
-| count | Number to show in badge | ReactNode | - |  |
-| classNames | Semantic DOM class | Record<SemanticDOM, string> | - | 5.7.0 |
-| dot | Whether to display a red dot instead of `count` | boolean | false |  |
-| offset | Set offset of the badge dot | \[number, number] | - |  |
-| overflowCount | Max count to show | number | 99 |  |
-| showZero | Whether to show badge when `count` is zero | boolean | false |  |
-| size | If `count` is set, `size` sets the size of badge | `default` \| `small` | - | 4.6.0 |
-| status | Set Badge as a status dot | `success` \| `processing` \| `default` \| `error` \| `warning` | - |  |
-| styles | Semantic DOM style | Record<SemanticDOM, CSSProperties> | - | 5.7.0 |
-| text | If `status` is set, `text` sets the display text of the status `dot` | ReactNode | - |  |
-| title | Text to show when hovering over the badge | string | - |  |
+| -------- | ----------- | ---- | ------- | ------- |
 
 ### Badge.Ribbon (4.5.0+)
 

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -7,9 +7,25 @@ import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
   // Component token here
+  /**
+   * @desc 折叠面板头部内边距
+   * @descEN Padding of header
+   */
   headerPadding: CSSProperties['padding'];
+  /**
+   * @desc 折叠面板头部背景
+   * @descEN Background of header
+   */
   headerBg: string;
+  /**
+   * @desc 折叠面板内容内部编辑
+   * @descEN Padding of content
+   */
   contentPadding: CSSProperties['padding'];
+  /**
+   * @desc 折叠面板内容背景
+   * @descEN Background of content
+   */
   contentBg: string;
 }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    -      |
| 🇨🇳 中文 |      -    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 366be5e</samp>

The pull request simplifies the markdown files for components by removing redundant tables of properties, and adds comments to the style tokens for components to improve readability and consistency.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 366be5e</samp>

* Remove the table of properties for the `Badge` component in `components/badge/index.en-US.md` and `components/badge/index.zh-CN.md`, as it is redundant with the TypeScript definition and the API documentation. ([link](https://github.com/ant-design/ant-design/pull/44211/files?diff=unified&w=0#diff-c8fdf756230cf3ebcb4f347ba42136a13694db1ab8c7f95bb30bbfa27fa2ca82L44-R44), )
* Add comments to the `ComponentToken` interface in `components/collapse/style/index.ts`, which defines the style variables for the `Collapse` component. The comments provide both Chinese and English descriptions for each property, following the convention of other components. ([link](https://github.com/ant-design/ant-design/pull/44211/files?diff=unified&w=0#diff-4fadcc09942a875859791f11134d4aed49b1d7245a8627f9aa5db5c0a25bcdd0L10-R28))
