### PR TITLE
fix(Button): fix fontSizeSM token not working

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -604,6 +604,7 @@ const genSizeBaseButtonStyle: GenerateStyle<ButtonToken> = (token) => genSizeBut
 const genSizeSmallButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const smallToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightSM,
+    fontSize: token.fontSizeSM,
     padding: token.paddingXS,
     buttonPaddingHorizontal: token.paddingInlineSM, // Fixed padding
     borderRadius: token.borderRadiusSM,
@@ -694,5 +695,6 @@ export default genComponentStyleHook(
     defaultBg: token.colorBgContainer,
     defaultBorderColor: token.colorBorder,
     defaultBorderColorDisabled: token.colorBorder,
+    fontSizeSM: token.fontSize,
   }),
 );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
无
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：
在 ConfigProvider 为 Button 设置 fontSizeSM token，按钮字体大小仍是fontSize token！

解决方案：
genSizeSmallButtonStyle 添加 fontSize token，并设置默认的 fontSizeSM（取 token.fontSize，即14px）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | fix(Button): fix fontSizeSM token not working |
| 🇨🇳 中文 | fix(Button): 修复 fontSizeSM token 不工作问题 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7ce463</samp>

Refactor button component to use `fontSizeSM` token for small buttons. This improves the consistency and customizability of the button styles.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7ce463</samp>

*  Add `fontSize` property to small button style using `token.fontSizeSM` variable ([link](https://github.com/ant-design/ant-design/pull/44217/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R607))
*  Create `token.fontSizeSM` variable for small button font size and set it to default button font size ([link](https://github.com/ant-design/ant-design/pull/44217/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R698))