### PR TITLE
docs: render china mirror link before hydration

### DIFF
--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -30,7 +30,8 @@ const locales = {
 
 // ============================= Style =============================
 const useStyle = createStyles(({ token }) => {
-  const { antCls, iconCls, fontFamily, headerHeight, menuItemBorder, colorPrimary } = token;
+  const { antCls, iconCls, fontFamily, headerHeight, menuItemBorder, colorPrimary, colorText } =
+    token;
 
   return {
     nav: css`
@@ -55,6 +56,17 @@ const useStyle = createStyles(({ token }) => {
             bottom: auto;
             left: 12px;
             border-width: ${menuItemBorder}px;
+          }
+
+          a {
+            color: ${colorText};
+          }
+
+          a:before {
+            position: absolute;
+            inset: 0;
+            background-color: transparent;
+            content: "";
           }
         }
 
@@ -97,7 +109,6 @@ const useStyle = createStyles(({ token }) => {
 
 export interface NavigationProps extends SharedProps {
   isMobile: boolean;
-  isClient: boolean;
   responsive: null | 'narrow' | 'crowded';
   directionText: string;
   onLangChange: () => void;
@@ -106,7 +117,6 @@ export interface NavigationProps extends SharedProps {
 
 export default ({
   isZhCN,
-  isClient,
   isMobile,
   responsive,
   directionText,
@@ -225,15 +235,22 @@ export default ({
       key: 'docs/resources',
     },
     isZhCN &&
-    isClient &&
     window.location.host !== 'ant-design.antgroup.com' &&
     window.location.host !== 'ant-design.gitee.io'
       ? {
-          label: '国内镜像',
+          label: (
+            <a href="https://ant-design.antgroup.com" target="_blank" rel="noreferrer">
+              国内镜像
+            </a>
+          ),
           key: 'mirror',
           children: [
             {
-              label: <a href="https://ant-design.antgroup.com">官方镜像</a>,
+              label: (
+                <a href="https://ant-design.antgroup.com" target="_blank" rel="noreferrer">
+                  官方镜像
+                </a>
+              ),
               icon: (
                 <img
                   alt="logo"
@@ -245,7 +262,11 @@ export default ({
               key: 'antgroup',
             },
             {
-              label: <a href="https://ant-design.gitee.io">Gitee 镜像</a>,
+              label: (
+                <a href="https://ant-design.gitee.io" target="_blank" rel="noreferrer">
+                  Gitee 镜像
+                </a>
+              ),
               icon: (
                 <img
                   alt="gitee"

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -145,13 +145,6 @@ export default ({
     activeMenuItem = 'docs/resources';
   }
 
-  const [hideChinaMirror, setHideChinaMirror] = React.useState(false);
-  React.useEffect(() => {
-    setHideChinaMirror(
-      ['ant-design.antgroup.com', 'ant-design.gitee.io'].includes(window.location.host),
-    );
-  }, []);
-
   let additional: MenuProps['items'];
 
   const additionalItems: MenuProps['items'] = [
@@ -241,7 +234,7 @@ export default ({
       ),
       key: 'docs/resources',
     },
-    isZhCN && !hideChinaMirror
+    isZhCN
       ? {
           label: (
             <a href="https://ant-design.antgroup.com" target="_blank" rel="noreferrer">

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -145,6 +145,13 @@ export default ({
     activeMenuItem = 'docs/resources';
   }
 
+  const [hideChinaMirror, setHideChinaMirror] = React.useState(true);
+  React.useEffect(() => {
+    setHideChinaMirror(
+      ['ant-design.antgroup.com', 'ant-design.gitee.io'].includes(window.location.host),
+    );
+  }, []);
+
   let additional: MenuProps['items'];
 
   const additionalItems: MenuProps['items'] = [
@@ -234,9 +241,7 @@ export default ({
       ),
       key: 'docs/resources',
     },
-    isZhCN &&
-    window.location.host !== 'ant-design.antgroup.com' &&
-    window.location.host !== 'ant-design.gitee.io'
+    isZhCN && !hideChinaMirror
       ? {
           label: (
             <a href="https://ant-design.antgroup.com" target="_blank" rel="noreferrer">

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -145,7 +145,7 @@ export default ({
     activeMenuItem = 'docs/resources';
   }
 
-  const [hideChinaMirror, setHideChinaMirror] = React.useState(true);
+  const [hideChinaMirror, setHideChinaMirror] = React.useState(false);
   React.useEffect(() => {
     setHideChinaMirror(
       ['ant-design.antgroup.com', 'ant-design.gitee.io'].includes(window.location.host),

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -127,7 +127,6 @@ interface HeaderState {
 
 // ================================= Header =================================
 const Header: React.FC = () => {
-  const [isClient, setIsClient] = React.useState(false);
   const [, lang] = useLocale();
 
   const { pkg } = useSiteData();
@@ -166,7 +165,6 @@ const Header: React.FC = () => {
   }, [location]);
 
   useEffect(() => {
-    setIsClient(typeof window !== 'undefined');
     onWindowResize();
     window.addEventListener('resize', onWindowResize);
     pingTimer.current = ping((status) => {
@@ -273,7 +271,6 @@ const Header: React.FC = () => {
   const sharedProps: SharedProps = {
     isZhCN,
     isRTL,
-    isClient,
   };
 
   const navigationNode = (

--- a/.dumi/theme/slots/Header/interface.ts
+++ b/.dumi/theme/slots/Header/interface.ts
@@ -1,5 +1,4 @@
 export interface SharedProps {
   isZhCN: boolean;
   isRTL: boolean;
-  isClient: boolean;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

两个优化，避免只有等待 js 注水后国内镜像链接才能出来。网速慢的情况下基本等不到 js 加载完。

- [x] 服务端渲染就加上国内镜像，而不是客户端才渲染。
- [x] submenu 可以直接点击打开镜像链接。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11e1578</samp>

Improved the dumi theme header and navigation. Updated the `Navigation` component to use the `colorText` token and link elements. Removed the unused `isClient` prop from the `Header` and `Navigation` components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11e1578</samp>

*  Remove `isClient` prop from `Header` and `Navigation` components as it is no longer needed after migrating to `@umijs/preset-dumi` package ([link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L276), [link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L100), [link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L109))
*  Add `colorText` token to `useStyle` function and use it to style the links in the navigation menu with a transparent pseudo-element for better accessibility ([link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L33-R34), [link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5R60-R70))
*  Change the `label` prop of the `mirror` and `Gitee 镜像` menu items from plain strings to link elements to make them consistent with other items and allow opening the mirror sites in new tabs or windows ([link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L228-R253), [link](https://github.com/ant-design/ant-design/pull/44233/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L248-R269))
