### PR TITLE
doc: upload doc line break

### DIFF
--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -98,7 +98,7 @@ Extends File with additional props.
 
 When uploading state change, it returns:
 
-```js
+```jsx
 {
   file: { /* ... */ },
   fileList: [ /* ... */ ],
@@ -108,11 +108,11 @@ When uploading state change, it returns:
 
 1. `file` File object for the current operation.
 
-   ```js
+   ```jsx
    {
       uid: 'uid',      // unique identifier, negative is recommended, to prevent interference with internally generated id
       name: 'xx.png',   // file name
-      status: 'done', // options： uploading, done, error, removed. Intercepted file by beforeUpload doesn't have a status field.
+      status: 'done' | 'uploading' | 'error' | 'removed', // Intercepted file by beforeUpload doesn't have a status field.
       response: '{"status": "success"}', // response from server
       linkProps: '{"download": "image"}', // additional HTML props of file link
       xhr: 'XMLHttpRequest{ ... }', // XMLHttpRequest Header
@@ -152,7 +152,9 @@ For compatible case, we return File object when `beforeUpload` return `false`. I
 
 ### Why sometimes Chrome can not upload?
 
-Chrome update will also break native upload. Please restart Chrome to finish the upload work. Ref:
+Chrome update will also break native upload. Please restart Chrome to finish the upload work.
+
+Ref:
 
 - [#32672](https://github.com/ant-design/ant-design/issues/32672)
 - [#32913](https://github.com/ant-design/ant-design/issues/32913)

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -99,7 +99,7 @@ demo:
 
 文件状态改变的回调，返回为：
 
-```js
+```jsx
 {
   file: { /* ... */ },
   fileList: [ /* ... */ ],
@@ -109,11 +109,11 @@ demo:
 
 1. `file` 当前操作的文件对象。
 
-   ```js
+   ```jsx
    {
       uid: 'uid',      // 文件唯一标识，建议设置为负数，防止和内部产生的 id 冲突
       name: 'xx.png',   // 文件名
-      status: 'done', // 状态有：uploading done error removed，被 beforeUpload 拦截的文件没有 status 属性
+      status: 'done' | 'uploading' | 'error' | 'removed' , //  beforeUpload 拦截的文件没有 status 状态属性
       response: '{"status": "success"}', // 服务端响应内容
       linkProps: '{"download": "image"}', // 下载链接额外的 HTML 属性
    }
@@ -136,7 +136,7 @@ demo:
 
 ### 如何显示下载链接？
 
-请使用 fileList 属性设置数组项的 url 属性进行展示控制。
+请使用 `fileList` 属性设置数组项的 `url` 属性进行展示控制。
 
 ### `customRequest` 怎么使用？
 
@@ -148,11 +148,13 @@ demo:
 
 ### `onChange` 为什么有时候返回 File 有时候返回 { originFileObj: File }？
 
-历史原因，在 `beforeUpload` 返回 `false` 时，会返回 File 对象。在下个大版本我们会统一返回 `{ originFileObj: File }` 对象。当前版本已经兼容所有场景下 `info.file.originFileObj` 获取原 File 写法。你可以提前切换。
+历史原因，在 `beforeUpload` 返回 `false` 时，会返回 `File` 对象。在下个大版本我们会统一返回 `{ originFileObj: File }` 对象。当前版本已经兼容所有场景下 `info.file.originFileObj` 获取原 `File` 写法。你可以提前切换。
 
 ### 为何有时 Chrome 点击 Upload 无法弹出文件选择框？
 
-与 antd 无关，原生上传也会失败。请重启 Chrome 浏览器，让其完成升级工作。相关 issue：
+与 `antd` 无关，原生上传也会失败。请重启 `Chrome` 浏览器，让其完成升级工作。
+
+相关 `issue`：
 
 - [#32672](https://github.com/ant-design/ant-design/issues/32672)
 - [#32913](https://github.com/ant-design/ant-design/issues/32913)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  upload  doc update       |
| 🇨🇳 Chinese |  upload  doc update     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Demo is updated/provided or not needed
- [x] Doc is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 625b010</samp>

This pull request improves the documentation of the `Upload` component in both English and Chinese. It fixes some typos, uses `jsx` code blocks for better syntax highlighting, and clarifies the `status` attribute type. It also enhances the readability of the related issues section in the Chinese document.
感觉这里 ref 换行一下清晰些
![image](https://github.com/ant-design/ant-design/assets/77056991/6167cd89-d5d4-40d5-881f-b13605143454)

![image](https://github.com/ant-design/ant-design/assets/77056991/9a9c440d-0cb4-45df-9333-d9d4b640ead3)

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 625b010</samp>

*  Updated the code block language from `js` to `jsx` in the upload component documentation, to match the JSX syntax of the file object ([link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9L101-R101), [link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L102-R102))
*  Changed the `status` attribute of the file object from a string to a union type of possible values, to make it more clear and type-safe ([link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9L111-R115), [link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L112-R116))
*  Added blank lines before the reference links and the related issues, to improve the readability and formatting of the markdown documents ([link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9L155-R158), [link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L151-R158))
*  Wrapped the `fileList`, `url`, `File`, and `antd` terms in backticks, to highlight them as code terms and make them consistent with the rest of the documents ([link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L139-R139), [link](https://github.com/ant-design/ant-design/pull/44234/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L151-R158))
