### PR TITLE
feat: Button support contentFontSize token

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -119,10 +119,24 @@ export interface ComponentToken {
    * @descEN Background color of text button when hover
    */
   textHoverBg: string;
+  /**
+   * @desc 按钮内容字体大小
+   * @descEN Font size of button content
+   */
+  contentFontSize: number;
+  /**
+   * @desc 大号按钮内容字体大小
+   * @descEN Font size of large button content
+   */
+  contentFontSizeLG: number;
+  /**
+   * @desc 小号按钮内容字体大小
+   * @descEN Font size of small button content
+   */
+  contentFontSizeSM: number;
 }
 
 export interface ButtonToken extends FullToken<'Button'> {
-  colorOutlineDefault: string;
   buttonPaddingHorizontal: CSSProperties['paddingInline'];
   buttonIconOnlyFontSize: number;
 }
@@ -599,12 +613,17 @@ const genSizeButtonStyle = (token: ButtonToken, sizePrefixCls: string = ''): CSS
   ];
 };
 
-const genSizeBaseButtonStyle: GenerateStyle<ButtonToken> = (token) => genSizeButtonStyle(token);
+const genSizeBaseButtonStyle: GenerateStyle<ButtonToken> = (token) =>
+  genSizeButtonStyle(
+    mergeToken<ButtonToken>(token, {
+      fontSize: token.contentFontSize,
+    }),
+  );
 
 const genSizeSmallButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const smallToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightSM,
-    fontSize: token.fontSizeSM,
+    fontSize: token.contentFontSizeSM,
     padding: token.paddingXS,
     buttonPaddingHorizontal: token.paddingInlineSM, // Fixed padding
     borderRadius: token.borderRadiusSM,
@@ -617,7 +636,7 @@ const genSizeSmallButtonStyle: GenerateStyle<ButtonToken> = (token) => {
 const genSizeLargeButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const largeToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightLG,
-    fontSize: token.fontSizeLG,
+    fontSize: token.contentFontSizeSM,
     buttonPaddingHorizontal: token.paddingInlineLG,
     borderRadius: token.borderRadiusLG,
     buttonIconOnlyFontSize: token.onlyIconSizeLG,
@@ -695,6 +714,8 @@ export default genComponentStyleHook(
     defaultBg: token.colorBgContainer,
     defaultBorderColor: token.colorBorder,
     defaultBorderColorDisabled: token.colorBorder,
-    fontSizeSM: token.fontSize,
+    contentFontSize: token.fontSize,
+    contentFontSizeSM: token.fontSize,
+    contentFontSizeLG: token.fontSizeLG,
   }),
 );

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -636,7 +636,7 @@ const genSizeSmallButtonStyle: GenerateStyle<ButtonToken> = (token) => {
 const genSizeLargeButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const largeToken = mergeToken<ButtonToken>(token, {
     controlHeight: token.controlHeightLG,
-    fontSize: token.contentFontSizeSM,
+    fontSize: token.contentFontSizeLG,
     buttonPaddingHorizontal: token.paddingInlineLG,
     borderRadius: token.borderRadiusLG,
     buttonIconOnlyFontSize: token.onlyIconSizeLG,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
解决 https://github.com/ant-design/ant-design/pull/44217

原 PR 直接覆盖了 Button 内 `fontSizeSM` 的值，会影响 Button 内全局 token 的使用。
添加一套 `contentFontSize` 的组件 Token 用于定制 Button 各个尺寸的文字大小
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Button support `contentFontSize` `contentFontSizeSM` `contentFontSizeLG` component token for customizing `fontSize` of each size.        |
| 🇨🇳 Chinese |     Button 组件新增 `contentFontSize` `contentFontSizeSM` `contentFontSizeLG` 三个组件 token ，用于定制各个尺寸下的字体大小。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at adc9f4f</samp>

This pull request improves the button style code by using new font size properties and fixing a bug. It also cleans up the `button token` interface by removing an unused property.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at adc9f4f</samp>

*  Add new properties to `ComponentToken` interface and remove unused property from `ButtonToken` interface ([link](https://github.com/ant-design/ant-design/pull/44257/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L122-R139))
*  Use `contentFontSize` property from token for base button style and add `fontSize` property to small button style ([link](https://github.com/ant-design/ant-design/pull/44257/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L602-R626), [link](https://github.com/ant-design/ant-design/pull/44257/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L620-R639))
*  Fix large button font size bug by using `contentFontSizeLG` property from token ([link](https://github.com/ant-design/ant-design/pull/44257/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L620-R639))
*  Add default values for new properties to `defaultButtonToken` object and align `fontSizeSM` with `fontSize` ([link](https://github.com/ant-design/ant-design/pull/44257/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L698-R719))
