### PR TITLE
feat: cascader token

### DIFF
--- a/components/cascader/style/index.ts
+++ b/components/cascader/style/index.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
 import { textEllipsis } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
@@ -20,6 +21,26 @@ export interface ComponentToken {
    * @descEN Height of dropdown
    */
   dropdownHeight: number;
+  /**
+   * @desc 选项选中时背景色
+   * @descEN Background color of selected item
+   */
+  optionSelectedBg: string;
+  /**
+   * @desc 选项选中时字重
+   * @descEN Font weight of selected item
+   */
+  optionSelectedFontWeight: CSSProperties['fontWeight'];
+  /**
+   * @desc 选项内间距
+   * @descEN Padding of menu item
+   */
+  optionPadding: CSSProperties['padding'];
+  /**
+   * @desc 选项菜单（单列）内间距
+   * @descEN Padding of menu item (single column)
+   */
+  menuPadding: CSSProperties['padding'];
 }
 
 type CascaderToken = FullToken<'Cascader'>;
@@ -32,10 +53,6 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
     &${cascaderMenuItemCls}-expand ${cascaderMenuItemCls}-expand-icon,
     ${cascaderMenuItemCls}-loading-icon
   `;
-
-  const itemPaddingVertical = Math.round(
-    (token.controlHeight - token.fontSize * token.lineHeight) / 2,
-  );
 
   return [
     // =====================================================
@@ -91,7 +108,7 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
               minWidth: token.controlItemWidth,
               height: token.dropdownHeight,
               margin: 0,
-              padding: token.paddingXXS,
+              padding: token.menuPadding,
               overflow: 'auto',
               verticalAlign: 'top',
               listStyle: 'none',
@@ -106,7 +123,7 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
                 display: 'flex',
                 flexWrap: 'nowrap',
                 alignItems: 'center',
-                padding: `${itemPaddingVertical}px ${token.paddingSM}px`,
+                padding: token.optionPadding,
                 lineHeight: token.lineHeight,
                 cursor: 'pointer',
                 transition: `all ${token.motionDurationMid}`,
@@ -130,8 +147,8 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
 
                 [`&-active:not(${cascaderMenuItemCls}-disabled)`]: {
                   [`&, &:hover`]: {
-                    fontWeight: token.fontWeightStrong,
-                    backgroundColor: token.controlItemBgActive,
+                    fontWeight: token.optionSelectedFontWeight,
+                    backgroundColor: token.optionSelectedBg,
                   },
                 },
 
@@ -170,8 +187,22 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Cascader', (token) => [genBaseStyle(token)], {
-  controlWidth: 184,
-  controlItemWidth: 111,
-  dropdownHeight: 180,
-});
+export default genComponentStyleHook(
+  'Cascader',
+  (token) => [genBaseStyle(token)],
+  (token) => {
+    const itemPaddingVertical = Math.round(
+      (token.controlHeight - token.fontSize * token.lineHeight) / 2,
+    );
+
+    return {
+      controlWidth: 184,
+      controlItemWidth: 111,
+      dropdownHeight: 180,
+      optionSelectedBg: token.controlItemBgActive,
+      optionSelectedFontWeight: token.fontWeightStrong,
+      optionPadding: `${itemPaddingVertical}px ${token.paddingSM}px`,
+      menuPadding: token.paddingXXS,
+    };
+  },
+);

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -199,7 +199,19 @@ export default App;
 | `@carousel-dot-height` | `dotHeight` | - |
 | `@carousel-dot-active-width` | `dotActiveWidth` | - |
 
-<!-- ### Cascader -->
+### Cascader
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@cascader-bg` | - | Deprecated |
+| `@cascader-item-selected-bg` | `optionSelectedBg` | - |
+| `@cascader-menu-bg` | - | Deprecated |
+| `@cascader-menu-border-color-split` | `colorSplit` | Global Token |
+| `@cascader-dropdown-vertical-padding` | `optionPadding` | - |
+| `@cascader-dropdown-edge-child-vertical-padding` | `menuPadding` | - |
+| `@cascader-dropdown-font-size` | - | Deprecated |
+| `@cascader-dropdown-line-height` | `lineHeight` | Global Token |
 
 <!-- ### Checkbox -->
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -199,7 +199,19 @@ export default App;
 | `@carousel-dot-height` | `dotHeight` | - |
 | `@carousel-dot-active-width` | `dotActiveWidth` | - |
 
-<!-- ### Cascader 级联选择 -->
+### Cascader 级联选择
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@cascader-bg` | - | 已废弃 |
+| `@cascader-item-selected-bg` | `optionSelectedBg` | - |
+| `@cascader-menu-bg` | - | 已废弃 |
+| `@cascader-menu-border-color-split` | `colorSplit` | 全局 Token |
+| `@cascader-dropdown-vertical-padding` | `optionPadding` | - |
+| `@cascader-dropdown-edge-child-vertical-padding` | `menuPadding` | - |
+| `@cascader-dropdown-font-size` | - | 已废弃 |
+| `@cascader-dropdown-line-height` | `lineHeight` | 全局 Token |
 
 ### Checkbox 多选框
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Migrate Cascader less variables to Component Token        |
| 🇨🇳 Chinese |  迁移 Cascader 组件 less 变量到组件 Token         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 863a573</samp>

This pull request adds new component tokens for the `Cascader` component, to enable more style customization and align with the design system. It also updates the documentation to reflect the new tokens and the deprecated less variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 863a573</samp>

*  Import `CSSProperties` type from `react` to use for component tokens ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fR1))
*  Add four new component tokens to `ComponentToken` interface: `optionSelectedBg`, `optionSelectedFontWeight`, `optionPadding`, and `menuPadding` ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fR24-R43))
*  Use `optionPadding` token to set the padding of the options, and remove the calculation of `itemPaddingVertical` ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fL36-L39), [link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fL109-R126))
*  Use `menuPadding` token to set the padding of the menu items, and replace `paddingXXS` token ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fL94-R111))
*  Use `optionSelectedFontWeight` and `optionSelectedBg` tokens to set the font weight and background color of the selected options, and replace `fontWeightStrong` and `controlItemBgActive` tokens ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fL133-R151))
*  Modify the default export of `genComponentStyleHook` function to pass a function that returns the default values of the new component tokens ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-ea9836bf0b7334709965e0995571f43a0466a5b7d66d2e5093b611e706c8f07fL173-R208))
*  Document the mapping and deprecation of less variables and component tokens for `Cascader` component in `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` files ([link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL202-R215), [link](https://github.com/ant-design/ant-design/pull/44261/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L202-R215))
