### PR TITLE
feat(list): list support using the componentSize configuration size from ConfigProvider

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -17472,7 +17472,7 @@ exports[`ConfigProvider components List configProvider componentDisabled 1`] = `
 
 exports[`ConfigProvider components List configProvider componentSize large 1`] = `
 <div
-  class="config-list config-list-split"
+  class="config-list config-list-lg config-list-split"
 >
   <div
     class="config-spin-nested-loading"
@@ -17576,7 +17576,7 @@ exports[`ConfigProvider components List configProvider componentSize middle 1`] 
 
 exports[`ConfigProvider components List configProvider componentSize small 1`] = `
 <div
-  class="config-list config-list-split"
+  class="config-list config-list-sm config-list-split"
 >
   <div
     class="config-spin-nested-loading"

--- a/components/list/__tests__/index.test.tsx
+++ b/components/list/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { ListProps } from '..';
 import List from '..';
+import ConfigProvider from '../../config-provider';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render } from '../../../tests/utils';
@@ -21,5 +22,21 @@ describe('List', () => {
       <List renderItem={renderItem} dataSource={dataSource} locale={locale} />,
     );
     expect(container.querySelector('div.ant-list')?.getAttribute('locale')).toBe(null);
+  });
+
+  it('should apply the componentSize of ConfigProvider', () => {
+    const { container } = render(
+      <>
+        <ConfigProvider componentSize="small">
+          <List />,
+        </ConfigProvider>
+        <ConfigProvider componentSize="large">
+          <List />,
+        </ConfigProvider>
+      </>,
+    );
+
+    expect(container.querySelector('.ant-list-sm')).toBeTruthy();
+    expect(container.querySelector('.ant-list-lg')).toBeTruthy();
   });
 });

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -19,6 +19,7 @@ import Item from './Item';
 // CSSINJS
 import { ListContext } from './context';
 import useStyle from './style';
+import useSize from '../config-provider/hooks/useSize';
 
 export type { ListItemMetaProps, ListItemProps } from './Item';
 export type { ListConsumerProps } from './context';
@@ -83,7 +84,7 @@ function List<T>({
   loadMore,
   grid,
   dataSource = [],
-  size,
+  size: customizeSize,
   header,
   footer,
   loading = false,
@@ -154,10 +155,12 @@ function List<T>({
   }
   const isLoading = loadingProp && loadingProp.spinning;
 
+  const mergedSize = useSize(customizeSize);
+
   // large => lg
   // small => sm
   let sizeCls = '';
-  switch (size) {
+  switch (mergedSize) {
     case 'large':
       sizeCls = 'lg';
       break;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/44248
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | List support using the componentSize configuration size from ConfigProvider          |
| 🇨🇳 Chinese | List 支持使用 ConfigProvider 的 componentSize 配置 size           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dea7efd</samp>

Renamed the `size` prop of the List component to `customizeSize` and added support for inheriting the size value from ConfigProvider. Added a test case to verify the new behavior.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dea7efd</samp>

* Rename the `size` prop of the List component to `customizeSize` and use the `useSize` hook to get the merged size value from the prop and the ConfigProvider componentSize prop ([link](https://github.com/ant-design/ant-design/pull/44267/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R22), [link](https://github.com/ant-design/ant-design/pull/44267/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L86-R87), [link](https://github.com/ant-design/ant-design/pull/44267/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L157-R163), components/list/index.tsx)
