### PR TITLE
fix: `Descriptions` key prop issue

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -323,13 +323,17 @@ describe('Descriptions', () => {
 
   it('Should Descriptions not throw react key prop error in jsx mode', () => {
     render(
-      <Descriptions>
-        <Descriptions.Item key="1">Test key prop</Descriptions.Item>
+      <Descriptions title="User Info">
+        <Descriptions.Item key="1" label="UserName">
+          Zhou Maomao
+        </Descriptions.Item>
+        <Descriptions.Item label="Telephone">1810000000</Descriptions.Item>
       </Descriptions>,
     );
-    // expect(errorSpy).not.toHaveBeenCalledWith(
-    //   'Warning: DescriptionsItem: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)',
-    // );
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('`key` is not a prop'),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -320,4 +320,16 @@ describe('Descriptions', () => {
     const view = nestDesc.querySelector('.ant-descriptions-view');
     expect(getComputedStyle(view!).border).toBeFalsy();
   });
+
+  it('Should Descriptions not throw react key prop error in jsx mode', () => {
+    render(
+      <Descriptions>
+        <Descriptions.Item key="1">Test key prop</Descriptions.Item>
+      </Descriptions>,
+    );
+    // expect(errorSpy).not.toHaveBeenCalledWith(
+    //   'Warning: DescriptionsItem: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)',
+    // );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/components/descriptions/hooks/useRow.ts
+++ b/components/descriptions/hooks/useRow.ts
@@ -27,7 +27,7 @@ function getFilledItem(
 
 // Convert children into items
 const transChildren2Items = (childNodes?: React.ReactNode) =>
-  toArray(childNodes).map((node) => node?.props);
+  toArray(childNodes).map((node) => ({ ...node?.props }));
 
 // Calculate the sum of span in a row
 function getCalcRows(rowItems: DescriptionsItemType[], mergedColumn: number) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #44250
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/21119589/b282d0cf-ad76-4314-8689-cb6b34ce834a)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix a bug in the `Descriptions`  where the throws react key error       |
| 🇨🇳 Chinese |  修复描述列表抛出 React key 的错误        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e65729</samp>

Fix a react key prop error in `Descriptions` component when using jsx mode. Clone child props instead of mutating them in `useRow` hook. Add a test case for the bug fix.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e65729</samp>

*  Prevent react key prop error in Descriptions component when using jsx mode ([link](https://github.com/ant-design/ant-design/pull/44278/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R323-R338))
  - Modify the transChildren2Items function in `components/descriptions/hooks/useRow.ts` to clone the props of each child node instead of mutating them ([link](https://github.com/ant-design/ant-design/pull/44278/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL30-R30))
