### PR TITLE
feat: tree token

### DIFF
--- a/components/theme/interface/components.ts
+++ b/components/theme/interface/components.ts
@@ -54,6 +54,8 @@ import type { ComponentToken as TimelineComponentToken } from '../../timeline/st
 import type { ComponentToken as TooltipComponentToken } from '../../tooltip/style';
 import type { ComponentToken as TourComponentToken } from '../../tour/style';
 import type { ComponentToken as TransferComponentToken } from '../../transfer/style';
+import type { ComponentToken as TreeComponentToken } from '../../tree/style';
+import type { ComponentToken as TreeSelectComponentToken } from '../../tree-select/style';
 import type { ComponentToken as TypographyComponentToken } from '../../typography/style';
 import type { ComponentToken as UploadComponentToken } from '../../upload/style';
 
@@ -102,8 +104,8 @@ export interface ComponentTokenMap {
   Statistic?: StatisticComponentToken;
   Switch?: SwitchComponentToken;
   Tag?: TagComponentToken;
-  Tree?: {};
-  TreeSelect?: {};
+  Tree?: TreeComponentToken;
+  TreeSelect?: TreeSelectComponentToken;
   Typography?: TypographyComponentToken;
   Timeline?: TimelineComponentToken;
   Transfer?: TransferComponentToken;

--- a/components/tree-select/__tests__/demo-extend.test.ts
+++ b/components/tree-select/__tests__/demo-extend.test.ts
@@ -1,3 +1,3 @@
 import { extendTest } from '../../../tests/shared/demoTest';
 
-extendTest('tree-select');
+extendTest('tree-select', { skip: ['component-token.tsx'] });

--- a/components/tree-select/__tests__/demo.test.tsx
+++ b/components/tree-select/__tests__/demo.test.tsx
@@ -3,6 +3,7 @@ import demoTest, { rootPropsTest } from '../../../tests/shared/demoTest';
 
 demoTest('tree-select', {
   testRootProps: false,
+  skip: ['component-token.tsx'],
 });
 
 rootPropsTest('tree-select', (TreeSelect, props) => <TreeSelect {...props} />, {

--- a/components/tree-select/demo/component-token.md
+++ b/components/tree-select/demo/component-token.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+组件 Token
+
+## en-US
+
+Component Token

--- a/components/tree-select/demo/component-token.tsx
+++ b/components/tree-select/demo/component-token.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { ConfigProvider, TreeSelect } from 'antd';
+
+const treeData = [
+  {
+    value: 'parent 1',
+    title: 'parent 1',
+    children: [
+      {
+        value: 'parent 1-0',
+        title: 'parent 1-0',
+        children: [
+          {
+            value: 'leaf1',
+            title: 'leaf1',
+          },
+          {
+            value: 'leaf2',
+            title: 'leaf2',
+          },
+        ],
+      },
+      {
+        value: 'parent 1-1',
+        title: 'parent 1-1',
+        children: [
+          {
+            value: 'leaf3',
+            title: <b style={{ color: '#08c' }}>leaf3</b>,
+          },
+        ],
+      },
+    ],
+  },
+];
+const App: React.FC = () => {
+  const [value, setValue] = useState<string>();
+
+  const onChange = (newValue: string) => {
+    setValue(newValue);
+  };
+
+  return (
+    <ConfigProvider
+      theme={{
+        components: {
+          TreeSelect: {
+            nodeHoverBg: '#fff2f0',
+            nodeSelectedBg: '#ffa39e',
+          },
+        },
+      }}
+    >
+      <TreeSelect
+        showSearch
+        style={{ width: '100%' }}
+        value={value}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        placeholder="Please select"
+        allowClear
+        treeDefaultExpandAll
+        onChange={onChange}
+        treeData={treeData}
+      />
+    </ConfigProvider>
+  );
+};
+
+export default App;

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -27,6 +27,7 @@ Tree selection control.
 <code src="./demo/status.tsx">Status</code>
 <code src="./demo/suffix.tsx" debug>Suffix</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API
 

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -28,6 +28,7 @@ demo:
 <code src="./demo/status.tsx">自定义状态</code>
 <code src="./demo/suffix.tsx" debug>后缀图标</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 

--- a/components/tree-select/style/index.ts
+++ b/components/tree-select/style/index.ts
@@ -1,7 +1,10 @@
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
 import type { AliasToken, FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
-import { genTreeStyle } from '../../tree/style';
+import type { TreeSharedToken } from '../../tree/style';
+import { genTreeStyle, initComponentToken } from '../../tree/style';
+
+export interface ComponentToken extends TreeSharedToken {}
 
 interface TreeSelectToken extends FullToken<'TreeSelect'> {
   treePrefixCls: string;
@@ -25,7 +28,7 @@ const genBaseStyle: GenerateStyle<TreeSelectToken> = (token) => {
         // ====================== Tree ======================
         genTreeStyle(
           treePrefixCls,
-          mergeToken<AliasToken>(token, { colorBgContainer: colorBgElevated }),
+          mergeToken<AliasToken & TreeSharedToken>(token, { colorBgContainer: colorBgElevated }),
         ),
         {
           [treeCls]: {
@@ -64,8 +67,12 @@ const genBaseStyle: GenerateStyle<TreeSelectToken> = (token) => {
 
 // ============================== Export ==============================
 export default function useTreeSelectStyle(prefixCls: string, treePrefixCls: string) {
-  return genComponentStyleHook('TreeSelect', (token) => {
-    const treeSelectToken = mergeToken<TreeSelectToken>(token, { treePrefixCls });
-    return [genBaseStyle(treeSelectToken)];
-  })(prefixCls);
+  return genComponentStyleHook(
+    'TreeSelect',
+    (token) => {
+      const treeSelectToken = mergeToken<TreeSelectToken>(token, { treePrefixCls });
+      return [genBaseStyle(treeSelectToken)];
+    },
+    initComponentToken,
+  )(prefixCls);
 }

--- a/components/tree/__tests__/demo-extend.test.ts
+++ b/components/tree/__tests__/demo-extend.test.ts
@@ -1,3 +1,3 @@
 import { extendTest } from '../../../tests/shared/demoTest';
 
-extendTest('tree', { skip: ['big-data.tsx', 'virtual-scroll.tsx'] });
+extendTest('tree', { skip: ['big-data.tsx', 'virtual-scroll.tsx', 'component-token.tsx'] });

--- a/components/tree/__tests__/demo.test.ts
+++ b/components/tree/__tests__/demo.test.ts
@@ -1,3 +1,3 @@
 import demoTest from '../../../tests/shared/demoTest';
 
-demoTest('tree', { skip: ['big-data.tsx', 'virtual-scroll.tsx'] });
+demoTest('tree', { skip: ['big-data.tsx', 'virtual-scroll.tsx', 'component-token.tsx'] });

--- a/components/tree/demo/component-token.md
+++ b/components/tree/demo/component-token.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+组件 Token
+
+## en-US
+
+Component Token

--- a/components/tree/demo/component-token.tsx
+++ b/components/tree/demo/component-token.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ConfigProvider, Tree } from 'antd';
+import type { DataNode, TreeProps } from 'antd/es/tree';
+
+const treeData: DataNode[] = [
+  {
+    title: 'parent 1',
+    key: '0-0',
+    children: [
+      {
+        title: 'parent 1-0',
+        key: '0-0-0',
+        disabled: true,
+        children: [
+          {
+            title: 'leaf',
+            key: '0-0-0-0',
+            disableCheckbox: true,
+          },
+          {
+            title: 'leaf',
+            key: '0-0-0-1',
+          },
+        ],
+      },
+      {
+        title: 'parent 1-1',
+        key: '0-0-1',
+        children: [{ title: <span style={{ color: '#1677ff' }}>sss</span>, key: '0-0-1-0' }],
+      },
+    ],
+  },
+];
+
+const App: React.FC = () => {
+  const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
+    console.log('selected', selectedKeys, info);
+  };
+
+  const onCheck: TreeProps['onCheck'] = (checkedKeys, info) => {
+    console.log('onCheck', checkedKeys, info);
+  };
+
+  return (
+    <ConfigProvider
+      theme={{
+        components: {
+          Tree: {
+            nodeHoverBg: '#fff2f0',
+            nodeSelectedBg: '#ffa39e',
+          },
+        },
+      }}
+    >
+      <Tree
+        checkable
+        defaultExpandedKeys={['0-0-0', '0-0-1']}
+        defaultSelectedKeys={['0-0-0', '0-0-1']}
+        defaultCheckedKeys={['0-0-0', '0-0-1']}
+        onSelect={onSelect}
+        onCheck={onCheck}
+        treeData={treeData}
+      />
+    </ConfigProvider>
+  );
+};
+
+export default App;

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -30,6 +30,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 <code src="./demo/drag-debug.tsx" debug>Drag Debug</code>
 <code src="./demo/big-data.tsx" debug>Big data</code>
 <code src="./demo/block-node.tsx">Block Node</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API
 
@@ -126,7 +127,7 @@ Before `3.4.0`: The number of treeNodes can be very large, but when `checkable=t
 
 ## Design Token
 
-<ComponentTokenTable component="Transfer"></ComponentTokenTable>
+<ComponentTokenTable component="Tree"></ComponentTokenTable>
 
 ## FAQ
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -31,6 +31,7 @@ demo:
 <code src="./demo/drag-debug.tsx" debug>Drag Debug</code>
 <code src="./demo/big-data.tsx" debug>大数据</code>
 <code src="./demo/block-node.tsx">占据整行</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 
@@ -128,7 +129,7 @@ demo:
 
 ## Design Token
 
-<ComponentTokenTable component="Transfer"></ComponentTokenTable>
+<ComponentTokenTable component="Tree"></ComponentTokenTable>
 
 ## FAQ
 

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -3,8 +3,39 @@ import { Keyframes } from '@ant-design/cssinjs';
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
 import { genFocusOutline, resetComponent } from '../../style';
 import { genCollapseMotion } from '../../style/motion';
-import type { DerivativeToken } from '../../theme/internal';
+import type { AliasToken, DerivativeToken, FullToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+
+export interface TreeSharedToken {
+  /**
+   * @desc 节点标题高度
+   * @descEN Node title height
+   */
+  titleHeight: number;
+  /**
+   * @desc 节点悬浮态背景色
+   * @descEN Background color of hovered node
+   */
+  nodeHoverBg: string;
+  /**
+   * @desc 节点选中态背景色
+   * @descEN Background color of selected node
+   */
+  nodeSelectedBg: string;
+}
+
+export interface ComponentToken extends TreeSharedToken {
+  /**
+   * @desc 目录树节点选中文字颜色
+   * @descEN Text color of selected directory node
+   */
+  directoryNodeSelectedColor: string;
+  /**
+   * @desc 目录树节点选中背景色
+   * @descEN Background color of selected directory node
+   */
+  directoryNodeSelectedBg: string;
+}
 
 // ============================ Keyframes =============================
 const treeNodeFX = new Keyframes('ant-tree-node-fx-do-not-use', {
@@ -55,15 +86,14 @@ const getDropIndicatorStyle = (prefixCls: string, token: DerivativeToken) => ({
 });
 
 // =============================== Base ===============================
-type TreeToken = DerivativeToken & {
+type TreeToken = FullToken<'Tree'> & {
   treeCls: string;
   treeNodeCls: string;
   treeNodePadding: number;
-  treeTitleHeight: number;
 };
 
 export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => {
-  const { treeCls, treeNodeCls, treeNodePadding, treeTitleHeight } = token;
+  const { treeCls, treeNodeCls, treeNodePadding, titleHeight, nodeSelectedBg, nodeHoverBg } = token;
   const treeCheckBoxMarginHorizontal = token.paddingXS;
 
   return {
@@ -163,8 +193,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           [`${treeCls}-draggable-icon`]: {
             // https://github.com/ant-design/ant-design/issues/41915
             flexShrink: 0,
-            width: treeTitleHeight,
-            lineHeight: `${treeTitleHeight}px`,
+            width: titleHeight,
+            lineHeight: `${titleHeight}px`,
             textAlign: 'center',
             visibility: 'visible',
             opacity: 0.2,
@@ -190,7 +220,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         userSelect: 'none',
         '&-unit': {
           display: 'inline-block',
-          width: treeTitleHeight,
+          width: titleHeight,
         },
       },
 
@@ -205,9 +235,9 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         position: 'relative',
         flex: 'none',
         alignSelf: 'stretch',
-        width: treeTitleHeight,
+        width: titleHeight,
         margin: 0,
-        lineHeight: `${treeTitleHeight}px`,
+        lineHeight: `${titleHeight}px`,
         textAlign: 'center',
         cursor: 'pointer',
         userSelect: 'none',
@@ -239,7 +269,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           '&:before': {
             position: 'absolute',
             top: 0,
-            insetInlineEnd: treeTitleHeight / 2,
+            insetInlineEnd: titleHeight / 2,
             bottom: -treeNodePadding,
             marginInlineStart: -1,
             borderInlineEnd: `1px solid ${token.colorBorder}`,
@@ -248,8 +278,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
           '&:after': {
             position: 'absolute',
-            width: (treeTitleHeight / 2) * 0.8,
-            height: treeTitleHeight / 2,
+            width: (titleHeight / 2) * 0.8,
+            height: titleHeight / 2,
             borderBottom: `1px solid ${token.colorBorder}`,
             content: '""',
           },
@@ -267,30 +297,30 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeCls}-node-content-wrapper, ${treeCls}-checkbox + span`]: {
         position: 'relative',
         zIndex: 'auto',
-        minHeight: treeTitleHeight,
+        minHeight: titleHeight,
         margin: 0,
         padding: `0 ${token.paddingXS / 2}px`,
         color: 'inherit',
-        lineHeight: `${treeTitleHeight}px`,
+        lineHeight: `${titleHeight}px`,
         background: 'transparent',
         borderRadius: token.borderRadius,
         cursor: 'pointer',
         transition: `all ${token.motionDurationMid}, border 0s, line-height 0s, box-shadow 0s`,
 
         '&:hover': {
-          backgroundColor: token.controlItemBgHover,
+          backgroundColor: nodeHoverBg,
         },
 
         [`&${treeCls}-node-selected`]: {
-          backgroundColor: token.controlItemBgActive,
+          backgroundColor: nodeSelectedBg,
         },
 
         // Icon
         [`${treeCls}-iconEle`]: {
           display: 'inline-block',
-          width: treeTitleHeight,
-          height: treeTitleHeight,
-          lineHeight: `${treeTitleHeight}px`,
+          width: titleHeight,
+          height: titleHeight,
+          lineHeight: `${titleHeight}px`,
           textAlign: 'center',
           verticalAlign: 'top',
 
@@ -307,7 +337,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
       // ==================== Draggable =====================
       [`${treeCls}-node-content-wrapper`]: {
-        lineHeight: `${treeTitleHeight}px`,
+        lineHeight: `${titleHeight}px`,
         userSelect: 'none',
 
         ...getDropIndicatorStyle(prefixCls, token),
@@ -330,7 +360,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             '&:before': {
               position: 'absolute',
               top: 0,
-              insetInlineEnd: treeTitleHeight / 2,
+              insetInlineEnd: titleHeight / 2,
               bottom: -treeNodePadding,
               borderInlineEnd: `1px solid ${token.colorBorder}`,
               content: '""',
@@ -361,7 +391,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             '&:before': {
               top: 'auto !important',
               bottom: 'auto !important',
-              height: `${treeTitleHeight / 2}px !important`,
+              height: `${titleHeight / 2}px !important`,
             },
           },
         },
@@ -372,7 +402,13 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
 // ============================ Directory =============================
 export const genDirectoryStyle = (token: TreeToken): CSSObject => {
-  const { treeCls, treeNodeCls, treeNodePadding } = token;
+  const {
+    treeCls,
+    treeNodeCls,
+    treeNodePadding,
+    directoryNodeSelectedBg,
+    directoryNodeSelectedColor,
+  } = token;
 
   return {
     [`${treeCls}${treeCls}-directory`]: {
@@ -418,7 +454,7 @@ export const genDirectoryStyle = (token: TreeToken): CSSObject => {
           },
 
           [`&${treeCls}-node-selected`]: {
-            color: token.colorTextLightSolid,
+            color: directoryNodeSelectedColor,
             background: 'transparent',
           },
         },
@@ -429,17 +465,17 @@ export const genDirectoryStyle = (token: TreeToken): CSSObject => {
             &:hover::before,
             &::before
           `]: {
-            background: token.colorPrimary,
+            background: directoryNodeSelectedBg,
           },
 
           // >>> Switcher
           [`${treeCls}-switcher`]: {
-            color: token.colorTextLightSolid,
+            color: directoryNodeSelectedColor,
           },
 
           // >>> Title
           [`${treeCls}-node-content-wrapper`]: {
-            color: token.colorTextLightSolid,
+            color: directoryNodeSelectedColor,
             background: 'transparent',
           },
         },
@@ -449,18 +485,19 @@ export const genDirectoryStyle = (token: TreeToken): CSSObject => {
 };
 
 // ============================== Merged ==============================
-export const genTreeStyle = (prefixCls: string, token: DerivativeToken): CSSInterpolation => {
+export const genTreeStyle = (
+  prefixCls: string,
+  token: AliasToken & TreeSharedToken,
+): CSSInterpolation => {
   const treeCls = `.${prefixCls}`;
   const treeNodeCls = `${treeCls}-treenode`;
 
   const treeNodePadding = token.paddingXS / 2;
-  const treeTitleHeight = token.controlHeightSM;
 
   const treeToken = mergeToken<TreeToken>(token, {
     treeCls,
     treeNodeCls,
     treeNodePadding,
-    treeTitleHeight,
   });
 
   return [
@@ -471,11 +508,32 @@ export const genTreeStyle = (prefixCls: string, token: DerivativeToken): CSSInte
   ];
 };
 
-// ============================== Export ==============================
-export default genComponentStyleHook('Tree', (token, { prefixCls }) => [
-  {
-    [token.componentCls]: getCheckboxStyle(`${prefixCls}-checkbox`, token),
+export const initComponentToken = (token: AliasToken): TreeSharedToken => {
+  const { controlHeightSM } = token;
+
+  return {
+    titleHeight: controlHeightSM,
+    nodeHoverBg: token.controlItemBgHover,
+    nodeSelectedBg: token.controlItemBgActive,
+  };
+};
+
+export default genComponentStyleHook(
+  'Tree',
+  (token, { prefixCls }) => [
+    {
+      [token.componentCls]: getCheckboxStyle(`${prefixCls}-checkbox`, token),
+    },
+    genTreeStyle(prefixCls, token),
+    genCollapseMotion(token),
+  ],
+  (token) => {
+    const { colorTextLightSolid, colorPrimary } = token;
+
+    return {
+      ...initComponentToken(token),
+      directoryNodeSelectedColor: colorTextLightSolid,
+      directoryNodeSelectedBg: colorPrimary,
+    };
   },
-  genTreeStyle(prefixCls, token),
-  genCollapseMotion(token),
-]);
+);

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -797,7 +797,7 @@ Mentions 提及
 | `@tooltip-arrow-color` | - | 同 `@tooltip-bg`，已废弃 |
 | `@tooltip-border-radius` | `borderRadius` | 全局 Token |
 
-Transfer 穿梭框
+### Transfer 穿梭框
 
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |
@@ -811,7 +811,18 @@ Transfer 穿梭框
 | `@transfer-item-padding-vertical` | `itemPaddingBlock` | - |
 | `@transfer-list-search-icon-top` | - | 已废弃 |
 
-<!-- ### Tree 树形控件 -->
+### Tree 树形控件
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@tree-bg` | `colorBgContainer` | 全局 Token |
+| `@tree-title-height` | `titleHeight` | - |
+| `@tree-child-padding` | - | 已废弃 |
+| `@tree-directory-selected-color` | `directoryNodeSelectedColor` | - |
+| `@tree-directory-selected-bg` | `directoryNodeSelectedBg` | - |
+| `@tree-node-hover-bg` | `nodeHoverBg` | - |
+| `@tree-node-selected-bg` | `nodeSelectedBg` | - |
 
 ### Typography 排版
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Migrate Tree less variables to Component Token      |
| 🇨🇳 Chinese |        迁移 Tree 组件 less 变量到组件 Token   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 551661d</samp>

This pull request adds support for theming the `Tree` and `TreeSelect` components using component tokens. It refactors the style modules to use the new theme system and tokens, and fixes some type and token initialization issues. It also adds demo examples and documentation for the component token feature in both English and Chinese, and modifies the test files to skip the demo examples that are not suitable for snapshot testing.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 551661d</samp>

*  Add component token demo examples for tree and tree-select components ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-066fd7696d6a98ec131f26e48f30681c937de5921786d8053d5860a1e5015576R1-R7), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-628e379c994283bedec096dfbbda1d2ba0614d4902352ffc64c838b11c91cb87R1-R69), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-67fb1d73a3cbf7e60aa552471171ffb2286892b8fbe70d468b9a1a4f97fcd7dbR30), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-37a35689e4d561f7759c3571816c85e4a758edb82b398926cbd632dbc0c91145R31), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-1728232f682d58b4d222560bc61e436c2a59a4347f3c47138a902db67c4e5878R1-R7), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a58fe26fd8a63f860c047f323e2444cc808e833daf48c3894ea54e11385a9098R1-R68), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-02cdc797e1338024879c3cdfa6c1d35d7beb888c68654f9cecd9d46eb8b53ff9R33), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-0bdf37a1fc0ec124fb3aa391932eaa134bd1de8c6f766f5e4082edbc30ce6c42R34))
*  Import and export component token type definitions for tree and tree-select components ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bR57-R58), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-1d8c7d2026da8b02ccc59970cea90849086b133e4b8f55d59ae475ac814d9e1bL105-R108), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-c01ae53de3785d9ccea6872587f1ebcf51ff86fd62a8570034d932e7c94baaf3L4-R8), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L6-R39))
*  Modify and simplify tree component token and style definitions ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L58-R96), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L166-R197), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L193-R223), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L208-R240), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L242-R272), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L251-R282), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L270-R304), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L281-R315), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L291-R323), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L310-R340), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L333-R363), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L364-R394), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L375-R411), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L421-R457), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L432-R478), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L452-R495), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L463), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L474-R539))
*  Initialize component token with default values from alias token for tree and tree-select components ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-c01ae53de3785d9ccea6872587f1ebcf51ff86fd62a8570034d932e7c94baaf3L67-R77), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L474-R539))
*  Fix typo in component name for component token table in tree documentation ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-02cdc797e1338024879c3cdfa6c1d35d7beb888c68654f9cecd9d46eb8b53ff9L129-R130), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-0bdf37a1fc0ec124fb3aa391932eaa134bd1de8c6f766f5e4082edbc30ce6c42L131-R132))
*  Skip component token demo files in snapshot testing for tree and tree-select components ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-46fd6ec12a057f14df46e7e20f8d801e8b853c78458a0463099a08bee99a3ac2L3-R3), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-835a60e707a4b3e565dab40a1992f6d67261a98608a3af52b7c59083585f7b28R6), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-48aa1b3a6588750b7bce36674059e4a5941270f209e638e98be497d821775ff3L3-R3), [link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-82b8ea5dfaf2dedca5f27493c2669e24eb4a86883ff10d77a0cf9510dce7e40bL3-R3))
*  Fix missing heading level in migrate-less-variables documentation ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L800-R800))
*  Add tree section to migrate-less-variables documentation ([link](https://github.com/ant-design/ant-design/pull/44282/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L814-R826))
