### PR TITLE
feat: Avatar support size from ConfigProvider

### DIFF
--- a/components/avatar/AvatarContext.ts
+++ b/components/avatar/AvatarContext.ts
@@ -8,6 +8,6 @@ export interface AvatarContextType {
   shape?: 'circle' | 'square';
 }
 
-const AvatarContext = React.createContext<AvatarContextType>({ size: 'default', shape: undefined });
+const AvatarContext = React.createContext<AvatarContextType>({ size: undefined, shape: undefined });
 
 export default AvatarContext;

--- a/components/avatar/AvatarContext.ts
+++ b/components/avatar/AvatarContext.ts
@@ -8,6 +8,6 @@ export interface AvatarContextType {
   shape?: 'circle' | 'square';
 }
 
-const AvatarContext = React.createContext<AvatarContextType>({ size: undefined, shape: undefined });
+const AvatarContext = React.createContext<AvatarContextType>({});
 
 export default AvatarContext;

--- a/components/avatar/__tests__/Avatar.test.tsx
+++ b/components/avatar/__tests__/Avatar.test.tsx
@@ -4,6 +4,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
 import useBreakpoint from '../../grid/hooks/useBreakpoint';
+import ConfigProvider from '../../config-provider';
 
 jest.mock('../../grid/hooks/useBreakpoint');
 
@@ -204,5 +205,20 @@ describe('Avatar Render', () => {
     expect(avatars?.[1]).toHaveClass('ant-avatar-circle');
     expect(avatars?.[2]).toHaveClass('ant-avatar-square');
     expect(avatars?.[3]).toHaveClass('ant-avatar-circle');
+  });
+
+  it('should apply the componentSize of CP', () => {
+    const { container } = render(
+      <>
+        <ConfigProvider componentSize="small">
+          <Avatar>test</Avatar>
+        </ConfigProvider>
+        <ConfigProvider componentSize="large">
+          <Avatar>test</Avatar>
+        </ConfigProvider>
+      </>,
+    );
+    expect(container.querySelector('.ant-avatar-sm')).toBeTruthy();
+    expect(container.querySelector('.ant-avatar-lg')).toBeTruthy();
   });
 });

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -107,7 +107,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
     ...others
   } = props;
 
-  const size = useSize((ctxSize) => customSize || avatarCtx?.size || ctxSize || 'default');
+  const size = useSize((ctxSize) => customSize ?? avatarCtx?.size ?? ctxSize ?? 'default');
 
   const needResponsive = Object.keys(typeof size === 'object' ? size || {} : {}).some((key) =>
     ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].includes(key),

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -10,6 +10,7 @@ import useBreakpoint from '../grid/hooks/useBreakpoint';
 import type { AvatarContextType, AvatarSize } from './AvatarContext';
 import AvatarContext from './AvatarContext';
 import useStyle from './style';
+import useSize from '../config-provider/hooks/useSize';
 
 export interface AvatarProps {
   /** Shape of avatar, options: `circle`, `square` */
@@ -93,7 +94,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
   const {
     prefixCls: customizePrefixCls,
     shape,
-    size: customSize = 'default',
+    size: customSize,
     src,
     srcSet,
     icon,
@@ -106,7 +107,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
     ...others
   } = props;
 
-  const size = customSize === 'default' ? avatarCtx?.size : customSize;
+  const size = useSize((ctxSize) => customSize || avatarCtx?.size || ctxSize || 'default');
 
   const needResponsive = Object.keys(typeof size === 'object' ? size || {} : {}).some((key) =>
     ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].includes(key),

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -599,7 +599,7 @@ exports[`ConfigProvider components Avatar configProvider componentDisabled 1`] =
 
 exports[`ConfigProvider components Avatar configProvider componentSize large 1`] = `
 <span
-  class="config-avatar config-avatar-circle"
+  class="config-avatar config-avatar-lg config-avatar-circle"
 >
   <span
     class="config-avatar-string"
@@ -621,7 +621,7 @@ exports[`ConfigProvider components Avatar configProvider componentSize middle 1`
 
 exports[`ConfigProvider components Avatar configProvider componentSize small 1`] = `
 <span
-  class="config-avatar config-avatar-circle"
+  class="config-avatar config-avatar-sm config-avatar-circle"
 >
   <span
     class="config-avatar-string"
@@ -17493,7 +17493,7 @@ exports[`ConfigProvider components List configProvider componentSize large 1`] =
               class="config-list-item-meta-avatar"
             >
               <span
-                class="config-avatar config-avatar-circle config-avatar-image"
+                class="config-avatar config-avatar-lg config-avatar-circle config-avatar-image"
               >
                 <img
                   src="https://xsgames.co/randomusers/avatar.php?g=pixel"
@@ -17597,7 +17597,7 @@ exports[`ConfigProvider components List configProvider componentSize small 1`] =
               class="config-list-item-meta-avatar"
             >
               <span
-                class="config-avatar config-avatar-circle config-avatar-image"
+                class="config-avatar config-avatar-sm config-avatar-circle config-avatar-image"
               >
                 <img
                   src="https://xsgames.co/randomusers/avatar.php?g=pixel"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Avatar support size from ConfigProvider |
| 🇨🇳 Chinese | Avatar 支持使用 CP 配置 size |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 573af54</samp>

This pull request enhances the `Avatar` component to support the `componentSize` feature of the `ConfigProvider` component. It also refactors the `size` property and adds a test case for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 573af54</samp>

*  Remove default value of `size` property and use `useSize` hook to apply `componentSize` from `ConfigProvider` as fallback value for `Avatar` component ([link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efR13),[link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL96-R97),[link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL109-R110))
*  Change default value of `size` property in `AvatarContext` to `undefined` to allow `Avatar` component to use `componentSize` from `ConfigProvider` ([link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-ed0541927f27afd8572abefb310376dc0621835f8e150544987f7dfd44f6f2a8L11-R11))
*  Import `ConfigProvider` component and add test case to check that `Avatar` component can apply `componentSize` from `ConfigProvider` when no `size` is specified by user or context ([link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-fa94f4208bc139f7a0daaa5b065e8212d2d2b56cdff66e3326c2b256f4911af7R7),[link](https://github.com/ant-design/ant-design/pull/44288/files?diff=unified&w=0#diff-fa94f4208bc139f7a0daaa5b065e8212d2d2b56cdff66e3326c2b256f4911af7R209-R223))