### PR TITLE
feat: Modal footer support custom render function

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -110,6 +110,7 @@ export function ConfirmContent(
   const cancelBtnCtxValue: ConfirmCancelBtnProps = {
     autoFocusButton,
     cancelTextLocale,
+    mergedOkCancel,
     ...resetProps,
   };
 

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -47,22 +47,15 @@ export function ConfirmContent(
 ) {
   const {
     icon,
-    onCancel,
-    onOk,
-    close,
-    onConfirm,
-    isSilent,
     okText,
-    okButtonProps,
     cancelText,
-    cancelButtonProps,
     confirmPrefixCls,
-    rootPrefixCls,
     type,
     okCancel,
     footer,
     // Legacy for static function usage
     locale: staticLocale,
+    ...resetProps
   } = props;
 
   warning(
@@ -94,7 +87,6 @@ export function ConfirmContent(
     }
   }
 
-  const okType = props.okType || 'primary';
   // 默认为 true，保持向下兼容
   const mergedOkCancel = okCancel ?? type === 'confirm';
 
@@ -111,26 +103,14 @@ export function ConfirmContent(
   // ================= Context Value =================
   const confirmBtnCtxValue: ConfirmOkBtnProps = {
     autoFocusButton,
-    close,
-    isSilent,
-    okButtonProps,
-    rootPrefixCls,
     okTextLocale,
-    okType,
-    onConfirm,
-    onOk,
+    ...resetProps,
   };
 
   const cancelBtnCtxValue: ConfirmCancelBtnProps = {
     autoFocusButton,
-    cancelButtonProps,
     cancelTextLocale,
-    isSilent,
-    mergedOkCancel,
-    rootPrefixCls,
-    close,
-    onCancel,
-    onConfirm,
+    ...resetProps,
   };
 
   const confirmBtnCtxValueMemo = React.useMemo(

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -131,12 +131,12 @@ export function ConfirmContent(
       {footer === undefined || typeof footer === 'function' ? (
         <ModalContextProvider value={btnCtxValueMemo}>
           <div className={`${confirmPrefixCls}-btns`}>
-            {footer === undefined
-              ? footerOriginNode
-              : footer?.(footerOriginNode, {
+            {typeof footer === 'function'
+              ? footer(footerOriginNode, {
                   ConfirmBtn,
                   CancelBtn,
-                })}
+                })
+              : footerOriginNode}
           </div>
         </ModalContextProvider>
       ) : (

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -160,7 +160,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     direction,
     prefixCls,
     wrapClassName,
-    rootPrefixCls = '',
+    rootPrefixCls,
     iconPrefixCls,
     theme,
     bodyStyle,
@@ -211,8 +211,12 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         open={open}
         title=""
         footer={null}
-        transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}
-        maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
+        transitionName={getTransitionName(rootPrefixCls || '', 'zoom', props.transitionName)}
+        maskTransitionName={getTransitionName(
+          rootPrefixCls || '',
+          'fade',
+          props.maskTransitionName,
+        )}
         mask={mask}
         maskClosable={maskClosable}
         maskStyle={maskStyle}

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -1,21 +1,21 @@
+import * as React from 'react';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import classNames from 'classnames';
-import * as React from 'react';
+
 import { getTransitionName } from '../_util/motion';
 import warning from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';
 import ConfigProvider from '../config-provider';
 import { useLocale } from '../locale';
-import Dialog from './Modal';
-import type { ModalFuncProps, ModalLocale } from './interface';
-import type { ConfirmCancelBtnProps } from './components/ConfirmCancelBtn';
 import CancelBtn from './components/ConfirmCancelBtn';
-import type { ConfirmOkBtnProps } from './components/ConfirmOkBtn';
 import ConfirmBtn from './components/ConfirmOkBtn';
-import { ConfirmCancelBtnContextProvider, ConfirmOkBtnProvider } from './context';
+import type { ModalContextProps } from './context';
+import { ModalContextProvider } from './context';
+import type { ModalFuncProps, ModalLocale } from './interface';
+import Dialog from './Modal';
 
 export interface ConfirmDialogProps extends ModalFuncProps {
   afterClose?: () => void;
@@ -27,7 +27,7 @@ export interface ConfirmDialogProps extends ModalFuncProps {
    */
   onConfirm?: (confirmed: boolean) => void;
   autoFocusButton?: null | 'ok' | 'cancel';
-  rootPrefixCls: string;
+  rootPrefixCls?: string;
   iconPrefixCls?: string;
   theme?: ThemeConfig;
 
@@ -101,27 +101,14 @@ export function ConfirmContent(
   const cancelTextLocale = cancelText || mergedLocale?.cancelText;
 
   // ================= Context Value =================
-  const confirmBtnCtxValue: ConfirmOkBtnProps = {
-    autoFocusButton,
-    okTextLocale,
-    ...resetProps,
-  };
-
-  const cancelBtnCtxValue: ConfirmCancelBtnProps = {
+  const btnCtxValue: ModalContextProps = {
     autoFocusButton,
     cancelTextLocale,
+    okTextLocale,
     mergedOkCancel,
     ...resetProps,
   };
-
-  const confirmBtnCtxValueMemo = React.useMemo(
-    () => confirmBtnCtxValue,
-    [...Object.values(confirmBtnCtxValue)],
-  );
-  const cancelBtnCtxValueMemo = React.useMemo(
-    () => cancelBtnCtxValue,
-    [...Object.values(cancelBtnCtxValue)],
-  );
+  const btnCtxValueMemo = React.useMemo(() => btnCtxValue, [...Object.values(btnCtxValue)]);
 
   // ====================== Footer Origin Node ======================
   const footerOriginNode = (
@@ -142,18 +129,16 @@ export function ConfirmContent(
       </div>
 
       {footer === undefined || typeof footer === 'function' ? (
-        <ConfirmOkBtnProvider value={confirmBtnCtxValueMemo}>
-          <ConfirmCancelBtnContextProvider value={cancelBtnCtxValueMemo}>
-            <div className={`${confirmPrefixCls}-btns`}>
-              {footer === undefined
-                ? footerOriginNode
-                : footer?.(footerOriginNode, {
-                    ConfirmBtn,
-                    CancelBtn,
-                  })}
-            </div>
-          </ConfirmCancelBtnContextProvider>
-        </ConfirmOkBtnProvider>
+        <ModalContextProvider value={btnCtxValueMemo}>
+          <div className={`${confirmPrefixCls}-btns`}>
+            {footer === undefined
+              ? footerOriginNode
+              : footer?.(footerOriginNode, {
+                  ConfirmBtn,
+                  CancelBtn,
+                })}
+          </div>
+        </ModalContextProvider>
       ) : (
         footer
       )}
@@ -175,7 +160,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     direction,
     prefixCls,
     wrapClassName,
-    rootPrefixCls,
+    rootPrefixCls = '',
     iconPrefixCls,
     theme,
     bodyStyle,

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -11,7 +11,7 @@ import type { ThemeConfig } from '../config-provider';
 import ConfigProvider from '../config-provider';
 import { useLocale } from '../locale';
 import CancelBtn from './components/ConfirmCancelBtn';
-import ConfirmBtn from './components/ConfirmOkBtn';
+import OkBtn from './components/ConfirmOkBtn';
 import type { ModalContextProps } from './context';
 import { ModalContextProvider } from './context';
 import type { ModalFuncProps, ModalLocale } from './interface';
@@ -114,7 +114,7 @@ export function ConfirmContent(
   const footerOriginNode = (
     <>
       <CancelBtn />
-      <ConfirmBtn />
+      <OkBtn />
     </>
   );
 
@@ -133,7 +133,7 @@ export function ConfirmContent(
           <div className={`${confirmPrefixCls}-btns`}>
             {typeof footer === 'function'
               ? footer(footerOriginNode, {
-                  ConfirmBtn,
+                  OkBtn,
                   CancelBtn,
                 })
               : footerOriginNode}

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -94,7 +94,11 @@ const Modal: React.FC<ModalProps> = (props) => {
   }
 
   const dialogFooter =
-    footer === undefined ? <Footer {...props} onOk={handleOk} onCancel={handleCancel} /> : footer;
+    footer === undefined || typeof footer === 'function' ? (
+      <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
+    ) : (
+      footer
+    );
 
   const [mergedClosable, mergedCloseIcon] = useClosable(
     closable,

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
 import Dialog from 'rc-dialog';
-import * as React from 'react';
+
 import useClosable from '../_util/hooks/useClosable';
 import { getTransitionName } from '../_util/motion';
 import { canUseDocElement } from '../_util/styleChecker';
@@ -9,10 +10,10 @@ import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { NoFormStyle } from '../form/context';
 import { NoCompactStyle } from '../space/Compact';
+import { usePanelRef } from '../watermark/context';
 import type { ModalProps, MousePosition } from './interface';
 import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
-import { usePanelRef } from '../watermark/context';
 
 let mousePosition: MousePosition;
 
@@ -93,13 +94,9 @@ const Modal: React.FC<ModalProps> = (props) => {
     warning(!('visible' in props), 'Modal', '`visible` is deprecated, please use `open` instead.');
   }
 
-  const dialogFooter =
-    footer === undefined || typeof footer === 'function' ? (
-      <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
-    ) : (
-      footer
-    );
-
+  const dialogFooter = footer !== null && (
+    <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
+  );
   const [mergedClosable, mergedCloseIcon] = useClosable(
     closable,
     closeIcon,

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -133,4 +133,20 @@ describe('Modal', () => {
     render(<Modal open footer={<div className="custom-footer">footer</div>} />);
     expect(document.querySelector('.custom-footer')).toBeTruthy();
   });
+
+  it('Should custom footer function work', () => {
+    render(
+      <Modal
+        open
+        footer={(_, { ConfirmBtn, CancelBtn }) => (
+          <>
+            <ConfirmBtn />
+            <CancelBtn />
+            <div className="custom-footer-ele">footer-ele</div>
+          </>
+        )}
+      />,
+    );
+    expect(document.querySelector('.custom-footer-ele')).toBeTruthy();
+  });
 });

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
+
 import type { ModalProps } from '..';
 import Modal from '..';
+import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
-import { resetWarned } from '../../_util/warning';
 
 jest.mock('rc-util/lib/Portal');
 
@@ -138,9 +139,9 @@ describe('Modal', () => {
     render(
       <Modal
         open
-        footer={(_, { ConfirmBtn, CancelBtn }) => (
+        footer={(_, { OkBtn, CancelBtn }) => (
           <>
-            <ConfirmBtn />
+            <OkBtn />
             <CancelBtn />
             <div className="custom-footer-ele">footer-ele</div>
           </>

--- a/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -483,6 +483,40 @@ exports[`renders components/modal/demo/footer.tsx extend context correctly 1`] =
 
 exports[`renders components/modal/demo/footer.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/modal/demo/footer-render.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right: 8px;"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        Open Modal
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        Open Modal Confirm
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`renders components/modal/demo/footer-render.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/modal/demo/hooks.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
@@ -465,6 +465,38 @@ exports[`renders components/modal/demo/footer.tsx correctly 1`] = `
 </button>
 `;
 
+exports[`renders components/modal/demo/footer-render.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right:8px"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        Open Modal
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        Open Modal Confirm
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`renders components/modal/demo/hooks.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -845,4 +845,21 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('Should custom footer function work width confirm', async () => {
+    Modal.confirm({
+      content: 'hai',
+      footer: (_, { ConfirmBtn, CancelBtn }) => (
+        <>
+          <ConfirmBtn />
+          <CancelBtn />
+          <div className="custom-footer-ele">footer-ele</div>
+        </>
+      ),
+    });
+
+    await waitFakeTimer();
+
+    expect(document.querySelector('.custom-footer-ele')).toBeTruthy();
+  });
 });

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -1,10 +1,11 @@
+import * as React from 'react';
 import { SmileOutlined } from '@ant-design/icons';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { resetWarned } from 'rc-util/lib/warning';
-import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
+
 import type { ModalFuncProps } from '..';
 import Modal from '..';
 import { act, waitFakeTimer } from '../../../tests/utils';
@@ -849,9 +850,9 @@ describe('Modal.confirm triggers callbacks correctly', () => {
   it('Should custom footer function work width confirm', async () => {
     Modal.confirm({
       content: 'hai',
-      footer: (_, { ConfirmBtn, CancelBtn }) => (
+      footer: (_, { OkBtn, CancelBtn }) => (
         <>
-          <ConfirmBtn />
+          <OkBtn />
           <CancelBtn />
           <div className="custom-footer-ele">footer-ele</div>
         </>

--- a/components/modal/components/ConfirmCancelBtn.tsx
+++ b/components/modal/components/ConfirmCancelBtn.tsx
@@ -9,7 +9,7 @@ export interface ConfirmCancelBtnProps
     ConfirmDialogProps,
     'cancelButtonProps' | 'isSilent' | 'rootPrefixCls' | 'close' | 'onConfirm' | 'onCancel'
   > {
-  autoFocusButton?: false | 'ok' | 'cancel';
+  autoFocusButton?: false | 'ok' | 'cancel' | null;
   cancelTextLocale?:
     | string
     | number

--- a/components/modal/components/ConfirmCancelBtn.tsx
+++ b/components/modal/components/ConfirmCancelBtn.tsx
@@ -1,0 +1,53 @@
+import type { FC } from 'react';
+import React, { useContext } from 'react';
+import ActionButton from '../../_util/ActionButton';
+import { ConfirmCancelBtnContext } from '../context';
+import type { ConfirmDialogProps } from '../ConfirmDialog';
+
+export interface ConfirmCancelBtnProps
+  extends Pick<
+    ConfirmDialogProps,
+    'cancelButtonProps' | 'isSilent' | 'rootPrefixCls' | 'close' | 'onConfirm' | 'onCancel'
+  > {
+  autoFocusButton?: false | 'ok' | 'cancel';
+  cancelTextLocale?:
+    | string
+    | number
+    | true
+    | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+    | Iterable<React.ReactNode>;
+  mergedOkCancel?: boolean;
+}
+
+const ConfirmCancelBtn: FC = () => {
+  const {
+    autoFocusButton,
+    cancelButtonProps,
+    cancelTextLocale,
+    isSilent,
+    mergedOkCancel,
+    rootPrefixCls,
+    close,
+    onCancel,
+    onConfirm,
+  } = useContext(ConfirmCancelBtnContext);
+  return (
+    mergedOkCancel && (
+      <ActionButton
+        isSilent={isSilent}
+        actionFn={onCancel}
+        close={(...args: any[]) => {
+          close?.(...args);
+          onConfirm?.(false);
+        }}
+        autoFocus={autoFocusButton === 'cancel'}
+        buttonProps={cancelButtonProps}
+        prefixCls={`${rootPrefixCls}-btn`}
+      >
+        {cancelTextLocale}
+      </ActionButton>
+    )
+  );
+};
+
+export default ConfirmCancelBtn;

--- a/components/modal/components/ConfirmCancelBtn.tsx
+++ b/components/modal/components/ConfirmCancelBtn.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import React, { useContext } from 'react';
+
 import ActionButton from '../../_util/ActionButton';
-import { ConfirmCancelBtnContext } from '../context';
 import type { ConfirmDialogProps } from '../ConfirmDialog';
+import { ModalContext } from '../context';
 
 export interface ConfirmCancelBtnProps
   extends Pick<
@@ -30,7 +31,7 @@ const ConfirmCancelBtn: FC = () => {
     close,
     onCancel,
     onConfirm,
-  } = useContext(ConfirmCancelBtnContext);
+  } = useContext(ModalContext);
   return (
     mergedOkCancel && (
       <ActionButton

--- a/components/modal/components/ConfirmOkBtn.tsx
+++ b/components/modal/components/ConfirmOkBtn.tsx
@@ -9,7 +9,7 @@ export interface ConfirmOkBtnProps
     ConfirmDialogProps,
     'close' | 'isSilent' | 'okType' | 'okButtonProps' | 'rootPrefixCls' | 'onConfirm' | 'onOk'
   > {
-  autoFocusButton?: false | 'ok' | 'cancel';
+  autoFocusButton?: false | 'ok' | 'cancel' | null;
   okTextLocale?:
     | string
     | number
@@ -33,7 +33,7 @@ const ConfirmOkBtn: FC = () => {
   return (
     <ActionButton
       isSilent={isSilent}
-      type={okType}
+      type={okType || 'primary'}
       actionFn={onOk}
       close={(...args: any[]) => {
         close?.(...args);

--- a/components/modal/components/ConfirmOkBtn.tsx
+++ b/components/modal/components/ConfirmOkBtn.tsx
@@ -1,0 +1,51 @@
+import type { FC } from 'react';
+import React, { useContext } from 'react';
+import ActionButton from '../../_util/ActionButton';
+import { ConfirmOkBtnContext } from '../context';
+import type { ConfirmDialogProps } from '../ConfirmDialog';
+
+export interface ConfirmOkBtnProps
+  extends Pick<
+    ConfirmDialogProps,
+    'close' | 'isSilent' | 'okType' | 'okButtonProps' | 'rootPrefixCls' | 'onConfirm' | 'onOk'
+  > {
+  autoFocusButton?: false | 'ok' | 'cancel';
+  okTextLocale?:
+    | string
+    | number
+    | true
+    | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+    | Iterable<React.ReactNode>;
+}
+
+const ConfirmOkBtn: FC = () => {
+  const {
+    autoFocusButton,
+    close,
+    isSilent,
+    okButtonProps,
+    rootPrefixCls,
+    okTextLocale,
+    okType,
+    onConfirm,
+    onOk,
+  } = useContext(ConfirmOkBtnContext);
+  return (
+    <ActionButton
+      isSilent={isSilent}
+      type={okType}
+      actionFn={onOk}
+      close={(...args: any[]) => {
+        close?.(...args);
+        onConfirm?.(true);
+      }}
+      autoFocus={autoFocusButton === 'ok'}
+      buttonProps={okButtonProps}
+      prefixCls={`${rootPrefixCls}-btn`}
+    >
+      {okTextLocale}
+    </ActionButton>
+  );
+};
+
+export default ConfirmOkBtn;

--- a/components/modal/components/ConfirmOkBtn.tsx
+++ b/components/modal/components/ConfirmOkBtn.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import React, { useContext } from 'react';
+
 import ActionButton from '../../_util/ActionButton';
-import { ConfirmOkBtnContext } from '../context';
 import type { ConfirmDialogProps } from '../ConfirmDialog';
+import { ModalContext } from '../context';
 
 export interface ConfirmOkBtnProps
   extends Pick<
@@ -29,7 +30,7 @@ const ConfirmOkBtn: FC = () => {
     okType,
     onConfirm,
     onOk,
-  } = useContext(ConfirmOkBtnContext);
+  } = useContext(ModalContext);
   return (
     <ActionButton
       isSilent={isSilent}

--- a/components/modal/components/NormalCancelBtn.tsx
+++ b/components/modal/components/NormalCancelBtn.tsx
@@ -1,0 +1,25 @@
+import type { FC } from 'react';
+import React, { useContext } from 'react';
+import Button from '../../button';
+import { NormalCancelBtnContext } from '../context';
+import type { ModalProps } from '../interface';
+
+export interface NormalCancelBtnProps extends Pick<ModalProps, 'cancelButtonProps' | 'onCancel'> {
+  cancelTextLocale?:
+    | string
+    | number
+    | true
+    | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+    | Iterable<React.ReactNode>;
+}
+
+const NormalCancelBtn: FC = () => {
+  const { cancelButtonProps, cancelTextLocale, onCancel } = useContext(NormalCancelBtnContext);
+  return (
+    <Button onClick={onCancel} {...cancelButtonProps}>
+      {cancelTextLocale}
+    </Button>
+  );
+};
+
+export default NormalCancelBtn;

--- a/components/modal/components/NormalCancelBtn.tsx
+++ b/components/modal/components/NormalCancelBtn.tsx
@@ -1,7 +1,8 @@
 import type { FC } from 'react';
 import React, { useContext } from 'react';
+
 import Button from '../../button';
-import { NormalCancelBtnContext } from '../context';
+import { ModalContext } from '../context';
 import type { ModalProps } from '../interface';
 
 export interface NormalCancelBtnProps extends Pick<ModalProps, 'cancelButtonProps' | 'onCancel'> {
@@ -14,7 +15,7 @@ export interface NormalCancelBtnProps extends Pick<ModalProps, 'cancelButtonProp
 }
 
 const NormalCancelBtn: FC = () => {
-  const { cancelButtonProps, cancelTextLocale, onCancel } = useContext(NormalCancelBtnContext);
+  const { cancelButtonProps, cancelTextLocale, onCancel } = useContext(ModalContext);
   return (
     <Button onClick={onCancel} {...cancelButtonProps}>
       {cancelTextLocale}

--- a/components/modal/components/NormalOkBtn.tsx
+++ b/components/modal/components/NormalOkBtn.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react';
+import React, { useContext } from 'react';
+import Button from '../../button';
+import { NormalOkBtnContext } from '../context';
+import type { ModalProps } from '../interface';
+import { convertLegacyProps } from '../../button/button';
+
+export interface NormalOkBtnProps
+  extends Pick<ModalProps, 'confirmLoading' | 'okType' | 'okButtonProps' | 'onOk'> {
+  okTextLocale?:
+    | string
+    | number
+    | true
+    | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+    | Iterable<React.ReactNode>;
+}
+
+const NormalOkBtn: FC = () => {
+  const { confirmLoading, okButtonProps, okType, okTextLocale, onOk } =
+    useContext(NormalOkBtnContext);
+  return (
+    <Button
+      {...convertLegacyProps(okType)}
+      loading={confirmLoading}
+      onClick={onOk}
+      {...okButtonProps}
+    >
+      {okTextLocale}
+    </Button>
+  );
+};
+
+export default NormalOkBtn;

--- a/components/modal/components/NormalOkBtn.tsx
+++ b/components/modal/components/NormalOkBtn.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react';
 import React, { useContext } from 'react';
+
 import Button from '../../button';
-import { NormalOkBtnContext } from '../context';
-import type { ModalProps } from '../interface';
 import { convertLegacyProps } from '../../button/button';
+import { ModalContext } from '../context';
+import type { ModalProps } from '../interface';
 
 export interface NormalOkBtnProps
   extends Pick<ModalProps, 'confirmLoading' | 'okType' | 'okButtonProps' | 'onOk'> {
@@ -16,8 +17,7 @@ export interface NormalOkBtnProps
 }
 
 const NormalOkBtn: FC = () => {
-  const { confirmLoading, okButtonProps, okType, okTextLocale, onOk } =
-    useContext(NormalOkBtnContext);
+  const { confirmLoading, okButtonProps, okType, okTextLocale, onOk } = useContext(ModalContext);
   return (
     <Button
       {...convertLegacyProps(okType)}

--- a/components/modal/context.ts
+++ b/components/modal/context.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import type { NormalCancelBtnProps } from './components/NormalCancelBtn';
+import type { NormalOkBtnProps } from './components/NormalOkBtn';
+import type { ConfirmCancelBtnProps } from './components/ConfirmCancelBtn';
+import type { ConfirmOkBtnProps } from './components/ConfirmOkBtn';
+
+export const NormalCancelBtnContext = React.createContext<NormalCancelBtnProps>(
+  {} as NormalCancelBtnProps,
+);
+export const NormalOkBtnContext = React.createContext<NormalOkBtnProps>({} as NormalOkBtnProps);
+export const ConfirmCancelBtnContext = React.createContext<ConfirmCancelBtnProps>(
+  {} as ConfirmCancelBtnProps,
+);
+export const ConfirmOkBtnContext = React.createContext<ConfirmOkBtnProps>({} as ConfirmOkBtnProps);
+
+export const { Provider: NormalCancelBtnContextProvider } = NormalCancelBtnContext;
+export const { Provider: NormalOkBtnContextProvider } = NormalOkBtnContext;
+export const { Provider: ConfirmCancelBtnContextProvider } = ConfirmCancelBtnContext;
+export const { Provider: ConfirmOkBtnProvider } = ConfirmOkBtnContext;

--- a/components/modal/context.ts
+++ b/components/modal/context.ts
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import type { NormalCancelBtnProps } from './components/NormalCancelBtn';
-import type { NormalOkBtnProps } from './components/NormalOkBtn';
 import type { ConfirmCancelBtnProps } from './components/ConfirmCancelBtn';
 import type { ConfirmOkBtnProps } from './components/ConfirmOkBtn';
+import type { NormalCancelBtnProps } from './components/NormalCancelBtn';
+import type { NormalOkBtnProps } from './components/NormalOkBtn';
 
-export const NormalCancelBtnContext = React.createContext<NormalCancelBtnProps>(
-  {} as NormalCancelBtnProps,
-);
-export const NormalOkBtnContext = React.createContext<NormalOkBtnProps>({} as NormalOkBtnProps);
-export const ConfirmCancelBtnContext = React.createContext<ConfirmCancelBtnProps>(
-  {} as ConfirmCancelBtnProps,
-);
-export const ConfirmOkBtnContext = React.createContext<ConfirmOkBtnProps>({} as ConfirmOkBtnProps);
+export type ModalContextProps = NormalCancelBtnProps &
+  NormalOkBtnProps &
+  ConfirmOkBtnProps &
+  ConfirmCancelBtnProps;
 
-export const { Provider: NormalCancelBtnContextProvider } = NormalCancelBtnContext;
-export const { Provider: NormalOkBtnContextProvider } = NormalOkBtnContext;
-export const { Provider: ConfirmCancelBtnContextProvider } = ConfirmCancelBtnContext;
-export const { Provider: ConfirmOkBtnProvider } = ConfirmOkBtnContext;
+export const ModalContext = React.createContext<ModalContextProps>({} as ModalContextProps);
+
+export const { Provider: ModalContextProvider } = ModalContext;

--- a/components/modal/demo/footer-render.md
+++ b/components/modal/demo/footer-render.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义页脚渲染函数，支持在原有基础上进行扩展。
+
+## en-US
+
+Customize the footer rendering function to support extensions on top of the original.

--- a/components/modal/demo/footer-render.tsx
+++ b/components/modal/demo/footer-render.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Button, Modal, Space } from 'antd';
+
+const App: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  const showModal = () => {
+    setOpen(true);
+  };
+  const handleOk = () => {
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+  return (
+    <>
+      <Space>
+        <Button type="primary" onClick={showModal}>
+          Open Modal
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => {
+            Modal.confirm({
+              title: 'Confirm',
+              content: 'Bla bla ...',
+              footer: (_, { ConfirmBtn, CancelBtn }) => (
+                <>
+                  <Button>Custom Button</Button>
+                  <CancelBtn />
+                  <ConfirmBtn />
+                </>
+              ),
+            });
+          }}
+        >
+          Open Modal Confirm
+        </Button>
+      </Space>
+      <Modal
+        open={open}
+        title="Title"
+        onOk={handleOk}
+        onCancel={handleCancel}
+        footer={(_, { ConfirmBtn, CancelBtn }) => (
+          <>
+            <Button>Custom Button</Button>
+            <CancelBtn />
+            <ConfirmBtn />
+          </>
+        )}
+      >
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+      </Modal>
+    </>
+  );
+};
+
+export default App;

--- a/components/modal/demo/footer-render.tsx
+++ b/components/modal/demo/footer-render.tsx
@@ -26,11 +26,11 @@ const App: React.FC = () => {
             Modal.confirm({
               title: 'Confirm',
               content: 'Bla bla ...',
-              footer: (_, { ConfirmBtn, CancelBtn }) => (
+              footer: (_, { OkBtn, CancelBtn }) => (
                 <>
                   <Button>Custom Button</Button>
                   <CancelBtn />
-                  <ConfirmBtn />
+                  <OkBtn />
                 </>
               ),
             });
@@ -44,11 +44,11 @@ const App: React.FC = () => {
         title="Title"
         onOk={handleOk}
         onCancel={handleCancel}
-        footer={(_, { ConfirmBtn, CancelBtn }) => (
+        footer={(_, { OkBtn, CancelBtn }) => (
           <>
             <Button>Custom Button</Button>
             <CancelBtn />
-            <ConfirmBtn />
+            <OkBtn />
           </>
         )}
       >

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -54,7 +54,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |  |
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false |  |
 | focusTriggerAfterClose | Whether need to focus trigger element after dialog is closed | boolean | true | 4.9.0 |
-| footer | Footer content, set as `footer={null}` when you don't need default buttons | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | (OK and Cancel buttons) |  |
+| footer | Footer content, set as `footer={null}` when you don't need default buttons | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | (OK and Cancel buttons) |  |
 | forceRender | Force render Modal | boolean | false |  |
 | getContainer | The mounted node for Modal but still display at fullscreen | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | Whether support press esc to close | boolean | true |  |
@@ -104,7 +104,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | className | The className of container | string | - |  |
 | closeIcon | Custom close icon. 5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | content | Content | ReactNode | - |  |
-| footer | Footer content, set as `footer: null` when you don't need default buttons | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | - | 5.9.0 |
+| footer | Footer content, set as `footer: null` when you don't need default buttons | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | Custom icon | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | keyboard | Whether support press esc to close | boolean | true |  |
@@ -180,6 +180,14 @@ return <div>{contextHolder}</div>;
 // Return `true` when click `onOk` and `false` when click `onCancel`
 const confirmed = await modal.confirm({ ... });
 ```
+
+## footerRenderParams
+
+<!-- prettier-ignore -->
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| originNode | default node | React.ReactNode                   | -      |
+| extra      | extended options | { ConfirmBtn: FC; CancelBtn: FC } | -      |
 
 ## Design Token
 

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -22,6 +22,7 @@ Additionally, if you need show a simple confirmation dialog, you can use [`App.u
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/async.tsx">Asynchronously close</code>
 <code src="./demo/footer.tsx">Customized Footer</code>
+<code src="./demo/footer-render.tsx">Customized Footer render function</code>
 <code src="./demo/hooks.tsx">Use hooks to get context</code>
 <code src="./demo/locale.tsx">Internationalization</code>
 <code src="./demo/manual.tsx">Manual to update destroy</code>
@@ -53,7 +54,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | confirmLoading | Whether to apply loading visual effect for OK button or not | boolean | false |  |
 | destroyOnClose | Whether to unmount child components on onClose | boolean | false |  |
 | focusTriggerAfterClose | Whether need to focus trigger element after dialog is closed | boolean | true | 4.9.0 |
-| footer | Footer content, set as `footer={null}` when you don't need default buttons | ReactNode | (OK and Cancel buttons) |  |
+| footer | Footer content, set as `footer={null}` when you don't need default buttons | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | (OK and Cancel buttons) |  |
 | forceRender | Force render Modal | boolean | false |  |
 | getContainer | The mounted node for Modal but still display at fullscreen | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | Whether support press esc to close | boolean | true |  |
@@ -103,7 +104,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | className | The className of container | string | - |  |
 | closeIcon | Custom close icon. 5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | content | Content | ReactNode | - |  |
-| footer | Footer content, set as `footer: null` when you don't need default buttons | ReactNode | - | 5.1.0 |
+| footer | Footer content, set as `footer: null` when you don't need default buttons | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | Custom icon | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | keyboard | Whether support press esc to close | boolean | true |  |

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -187,7 +187,7 @@ const confirmed = await modal.confirm({ ... });
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | originNode | default node | React.ReactNode                   | -      |
-| extra      | extended options | { ConfirmBtn: FC; CancelBtn: FC } | -      |
+| extra      | extended options | { OkBtn: FC; CancelBtn: FC } | -      |
 
 ## Design Token
 

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -55,7 +55,7 @@ demo:
 | confirmLoading | 确定按钮 loading | boolean | false |  |
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |  |
 | focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true | 4.9.0 |
-| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | (确定取消按钮) | 5.9.0 |
+| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | (确定取消按钮) | 5.9.0 |
 | forceRender | 强制渲染 Modal | boolean | false |  |
 | getContainer | 指定 Modal 挂载的节点，但依旧为全屏展示，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
@@ -105,7 +105,7 @@ demo:
 | className | 容器类名 | string | - |  |
 | closeIcon | 自定义关闭图标。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | content | 内容 | ReactNode | - |  |
-| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | - | 5.9.0 |
+| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | 自定义图标 | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
@@ -181,6 +181,14 @@ return <div>{contextHolder}</div>;
 //点击 `onOk` 时返回 `true`，点击 `onCancel` 时返回 `false`
 const confirmed = await modal.confirm({ ... });
 ```
+
+## footerRenderParams
+
+<!-- prettier-ignore -->
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| originNode | 默认节点 | React.ReactNode                   | -      |
+| extra      | 扩展选项 | { ConfirmBtn: FC; CancelBtn: FC } | -      |
 
 ## Design Token
 

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -23,6 +23,7 @@ demo:
 <code src="./demo/basic.tsx">基本</code>
 <code src="./demo/async.tsx">异步关闭</code>
 <code src="./demo/footer.tsx">自定义页脚</code>
+<code src="./demo/footer-render.tsx">自定义页脚渲染函数</code>
 <code src="./demo/hooks.tsx">使用 hooks 获得上下文</code>
 <code src="./demo/locale.tsx">国际化</code>
 <code src="./demo/manual.tsx">手动更新和移除</code>
@@ -54,7 +55,7 @@ demo:
 | confirmLoading | 确定按钮 loading | boolean | false |  |
 | destroyOnClose | 关闭时销毁 Modal 里的子元素 | boolean | false |  |
 | focusTriggerAfterClose | 对话框关闭后是否需要聚焦触发元素 | boolean | true | 4.9.0 |
-| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | ReactNode | (确定取消按钮) |  |
+| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer={null}` | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | (确定取消按钮) | 5.9.0 |
 | forceRender | 强制渲染 Modal | boolean | false |  |
 | getContainer | 指定 Modal 挂载的节点，但依旧为全屏展示，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |
@@ -104,7 +105,7 @@ demo:
 | className | 容器类名 | string | - |  |
 | closeIcon | 自定义关闭图标。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
 | content | 内容 | ReactNode | - |  |
-| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | ReactNode | - | 5.1.0 |
+| footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | (originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | 指定 Modal 挂载的 HTML 节点, false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | 自定义图标 | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -188,7 +188,7 @@ const confirmed = await modal.confirm({ ... });
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | originNode | 默认节点 | React.ReactNode                   | -      |
-| extra      | 扩展选项 | { ConfirmBtn: FC; CancelBtn: FC } | -      |
+| extra      | 扩展选项 | { OkBtn: FC; CancelBtn: FC } | -      |
 
 ## Design Token
 

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -2,6 +2,10 @@ import type { FC } from 'react';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
 import type { DirectionType } from '../config-provider';
 
+export type ModalFooterRender = (
+  originNode: React.ReactNode,
+  extra: { ConfirmBtn: FC; CancelBtn: FC },
+) => React.ReactNode;
 export interface ModalProps {
   /** Whether the modal dialog is visible or not */
   open?: boolean;
@@ -23,9 +27,7 @@ export interface ModalProps {
   /** Width of the modal dialog */
   width?: string | number;
   /** Footer content */
-  footer?:
-    | ((originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode)
-    | React.ReactNode;
+  footer?: ModalFooterRender | React.ReactNode;
   /** Text of the OK button */
   okText?: React.ReactNode;
   /** Button `type` of the OK button */

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -1,3 +1,4 @@
+import type { FC } from 'react';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
 import type { DirectionType } from '../config-provider';
 
@@ -22,7 +23,9 @@ export interface ModalProps {
   /** Width of the modal dialog */
   width?: string | number;
   /** Footer content */
-  footer?: React.ReactNode;
+  footer?:
+    | ((originNode: React.ReactNode, extra: { ConfirmBtn: FC; CancelBtn: FC }) => React.ReactNode)
+    | React.ReactNode;
   /** Text of the OK button */
   okText?: React.ReactNode;
   /** Button `type` of the OK button */
@@ -101,7 +104,7 @@ export interface ModalFuncProps {
   direction?: DirectionType;
   bodyStyle?: React.CSSProperties;
   closeIcon?: React.ReactNode;
-  footer?: React.ReactNode;
+  footer?: ModalProps['footer'];
   modalRender?: (node: React.ReactNode) => React.ReactNode;
   focusTriggerAfterClose?: boolean;
 }

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
+
 import type { ButtonProps, LegacyButtonType } from '../button/button';
 import type { DirectionType } from '../config-provider';
 
 export type ModalFooterRender = (
   originNode: React.ReactNode,
-  extra: { ConfirmBtn: FC; CancelBtn: FC },
+  extra: { OkBtn: FC; CancelBtn: FC },
 ) => React.ReactNode;
 export interface ModalProps {
   /** Whether the modal dialog is visible or not */

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -1,11 +1,14 @@
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import React from 'react';
-import Button from '../button';
-import { convertLegacyProps } from '../button/button';
 import { DisabledContextProvider } from '../config-provider/DisabledContext';
 import { useLocale } from '../locale';
 import type { ModalProps } from './interface';
 import { getConfirmLocale } from './locale';
+import type { NormalCancelBtnProps } from './components/NormalCancelBtn';
+import type { NormalOkBtnProps } from './components/NormalOkBtn';
+import { NormalCancelBtnContextProvider, NormalOkBtnContextProvider } from './context';
+import NormalOkBtn from './components/NormalOkBtn';
+import NormalCancelBtn from './components/NormalCancelBtn';
 
 export function renderCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) {
   return (
@@ -42,23 +45,58 @@ export const Footer: React.FC<
     onCancel,
     okButtonProps,
     cancelButtonProps,
+    footer,
   } = props;
 
   const [locale] = useLocale('Modal', getConfirmLocale());
 
+  // ================== Locale Text ==================
+  const okTextLocale = okText || locale?.okText;
+  const cancelTextLocale = cancelText || locale?.cancelText;
+
+  // ================= Context Value =================
+  const confirmBtnCtxValue: NormalOkBtnProps = {
+    confirmLoading,
+    okButtonProps,
+    okTextLocale,
+    okType,
+    onOk,
+  };
+
+  const cancelBtnCtxValue: NormalCancelBtnProps = {
+    cancelButtonProps,
+    cancelTextLocale,
+    onCancel,
+  };
+
+  const confirmBtnCtxValueMemo = React.useMemo(
+    () => confirmBtnCtxValue,
+    [...Object.values(confirmBtnCtxValue)],
+  );
+  const cancelBtnCtxValueMemo = React.useMemo(
+    () => cancelBtnCtxValue,
+    [...Object.values(cancelBtnCtxValue)],
+  );
+
+  const footerOriginNode = (
+    <>
+      <NormalCancelBtn />
+      <NormalOkBtn />
+    </>
+  );
+
   return (
     <DisabledContextProvider disabled={false}>
-      <Button onClick={onCancel} {...cancelButtonProps}>
-        {cancelText || locale?.cancelText}
-      </Button>
-      <Button
-        {...convertLegacyProps(okType)}
-        loading={confirmLoading}
-        onClick={onOk}
-        {...okButtonProps}
-      >
-        {okText || locale?.okText}
-      </Button>
+      <NormalOkBtnContextProvider value={confirmBtnCtxValueMemo}>
+        <NormalCancelBtnContextProvider value={cancelBtnCtxValueMemo}>
+          {typeof footer === 'function'
+            ? footer?.(footerOriginNode, {
+                ConfirmBtn: NormalOkBtn,
+                CancelBtn: NormalCancelBtn,
+              })
+            : footerOriginNode}
+        </NormalCancelBtnContextProvider>
+      </NormalOkBtnContextProvider>
     </DisabledContextProvider>
   );
 };

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -90,7 +90,7 @@ export const Footer: React.FC<
       <NormalOkBtnContextProvider value={confirmBtnCtxValueMemo}>
         <NormalCancelBtnContextProvider value={cancelBtnCtxValueMemo}>
           {typeof footer === 'function'
-            ? footer?.(footerOriginNode, {
+            ? footer(footerOriginNode, {
                 ConfirmBtn: NormalOkBtn,
                 CancelBtn: NormalCancelBtn,
               })

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -1,14 +1,14 @@
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import React from 'react';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
+
 import { DisabledContextProvider } from '../config-provider/DisabledContext';
 import { useLocale } from '../locale';
+import NormalCancelBtn from './components/NormalCancelBtn';
+import NormalOkBtn from './components/NormalOkBtn';
+import type { ModalContextProps } from './context';
+import { ModalContextProvider } from './context';
 import type { ModalProps } from './interface';
 import { getConfirmLocale } from './locale';
-import type { NormalCancelBtnProps } from './components/NormalCancelBtn';
-import type { NormalOkBtnProps } from './components/NormalOkBtn';
-import { NormalCancelBtnContextProvider, NormalOkBtnContextProvider } from './context';
-import NormalOkBtn from './components/NormalOkBtn';
-import NormalCancelBtn from './components/NormalCancelBtn';
 
 export function renderCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) {
   return (
@@ -55,28 +55,18 @@ export const Footer: React.FC<
   const cancelTextLocale = cancelText || locale?.cancelText;
 
   // ================= Context Value =================
-  const confirmBtnCtxValue: NormalOkBtnProps = {
+  const btnCtxValue: ModalContextProps = {
     confirmLoading,
     okButtonProps,
+    cancelButtonProps,
     okTextLocale,
+    cancelTextLocale,
     okType,
     onOk,
-  };
-
-  const cancelBtnCtxValue: NormalCancelBtnProps = {
-    cancelButtonProps,
-    cancelTextLocale,
     onCancel,
   };
 
-  const confirmBtnCtxValueMemo = React.useMemo(
-    () => confirmBtnCtxValue,
-    [...Object.values(confirmBtnCtxValue)],
-  );
-  const cancelBtnCtxValueMemo = React.useMemo(
-    () => cancelBtnCtxValue,
-    [...Object.values(cancelBtnCtxValue)],
-  );
+  const btnCtxValueMemo = React.useMemo(() => btnCtxValue, [...Object.values(btnCtxValue)]);
 
   const footerOriginNode = (
     <>
@@ -87,16 +77,14 @@ export const Footer: React.FC<
 
   return (
     <DisabledContextProvider disabled={false}>
-      <NormalOkBtnContextProvider value={confirmBtnCtxValueMemo}>
-        <NormalCancelBtnContextProvider value={cancelBtnCtxValueMemo}>
-          {typeof footer === 'function'
-            ? footer(footerOriginNode, {
-                ConfirmBtn: NormalOkBtn,
-                CancelBtn: NormalCancelBtn,
-              })
-            : footerOriginNode}
-        </NormalCancelBtnContextProvider>
-      </NormalOkBtnContextProvider>
+      <ModalContextProvider value={btnCtxValueMemo}>
+        {typeof footer === 'function'
+          ? footer(footerOriginNode, {
+              ConfirmBtn: NormalOkBtn,
+              CancelBtn: NormalCancelBtn,
+            })
+          : footerOriginNode}
+      </ModalContextProvider>
     </DisabledContextProvider>
   );
 };

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -75,7 +75,7 @@ export const Footer: React.FC<
     </>
   );
 
-  return (
+  return footer === undefined || typeof footer === 'function' ? (
     <DisabledContextProvider disabled={false}>
       <ModalContextProvider value={btnCtxValueMemo}>
         {typeof footer === 'function'
@@ -86,5 +86,7 @@ export const Footer: React.FC<
           : footerOriginNode}
       </ModalContextProvider>
     </DisabledContextProvider>
+  ) : (
+    footer
   );
 };

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -80,7 +80,7 @@ export const Footer: React.FC<
       <ModalContextProvider value={btnCtxValueMemo}>
         {typeof footer === 'function'
           ? footer(footerOriginNode, {
-              ConfirmBtn: NormalOkBtn,
+              OkBtn: NormalOkBtn,
               CancelBtn: NormalCancelBtn,
             })
           : footerOriginNode}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #44297
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/21119589/807a92d0-f965-431c-9772-212e570f02ec)
![image](https://github.com/ant-design/ant-design/assets/21119589/5f4dca7a-53b4-46c5-a802-7326731d1628)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Modal footer support custom render function       |
| 🇨🇳 Chinese |   模态框页脚支持自定义函数渲染        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 641db8d</samp>

This pull request adds a new feature to the `Modal` component and its methods, allowing users to customize the footer rendering function with the `footer` prop. It also refactors the footer buttons into separate components and uses context to pass the props. It updates the documentation, the type definitions, and the test cases accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 641db8d</samp>

*  Add custom footer rendering function feature to `Modal` and `Modal.confirm` methods ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L128-R175), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-a3edcd43b644d0539a67f65e68ba30d6acb77a12531a6a71d1e26a008a9d752cL97-R101), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L25-R28), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L104-R107), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-0868ee605478aef1b7a7e4508dce443964207f1dd966d82be9bf7e9b16a31aa5L56-R57), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-0868ee605478aef1b7a7e4508dce443964207f1dd966d82be9bf7e9b16a31aa5L106-R107), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L57-R58), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L107-R108), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-9986bf447ebc48c235cde6505736c4ce7affbb8eb8a06e94e5867cbd7fdb5626R1-R7))
  * Use `ConfirmCancelBtn` and `ConfirmOkBtn` components to replace `ActionButton` in `ConfirmContent` function ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L103-R152), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-6691f460299001edf2b16e7eb0c931e8b83b62a914b008ea30137d165d4a6e0cR1-R53), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-71736387db0730fabaa7b99e3ccc9b8b27a66eaf90fa37cb49bc0dfe13e01db6R1-R51))
  * Use `NormalCancelBtn` and `NormalOkBtn` components to replace `Button` in `Footer` function ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-28fe880db90aca35d37607b3087393a1815128428f281a9a8394d5dc34475371L45-R99), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-4412ef1c364cdc5292e369c306bdc533f0a9ea2fed460bc17428c029c4260117R1-R25), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-bb2cdcb0b65a2807dff0587a2fbc3492482676baa9a6c4fcfceea49bde289f88R1-R33))
  * Use context and context providers to pass props to footer buttons ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L15-R20), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-4ef6f5e7931e5a0f21fdbe8a76438b465de983cf564272b4d19a00fe66d73a08R1-R20), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-28fe880db90aca35d37607b3087393a1815128428f281a9a8394d5dc34475371L3-R11))
  * Support `footer` prop as a function that receives origin node and extra components as arguments ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L128-R175), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-a3edcd43b644d0539a67f65e68ba30d6acb77a12531a6a71d1e26a008a9d752cL97-R101), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L25-R28), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L104-R107), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-0868ee605478aef1b7a7e4508dce443964207f1dd966d82be9bf7e9b16a31aa5L56-R57), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-0868ee605478aef1b7a7e4508dce443964207f1dd966d82be9bf7e9b16a31aa5L106-R107), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L57-R58), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L107-R108), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-9986bf447ebc48c235cde6505736c4ce7affbb8eb8a06e94e5867cbd7fdb5626R1-R7), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d33a63c2b07982f75c8cec9567d82bcb1d2fa244617a37252109343a4ded9d6fR1-R65))
  * Add examples and documentation for the feature in both Chinese and English ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-9986bf447ebc48c235cde6505736c4ce7affbb8eb8a06e94e5867cbd7fdb5626R1-R7), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d33a63c2b07982f75c8cec9567d82bcb1d2fa244617a37252109343a4ded9d6fR1-R65), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-0868ee605478aef1b7a7e4508dce443964207f1dd966d82be9bf7e9b16a31aa5R25), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3R26))
* Add test cases to check custom footer rendering function feature in `Modal` and `Modal.confirm` methods ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-5b32c615603a02b35bc7b0b1651031eb23c5af3d939495dc127088d2efcd58b0R136-R151), [link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bR848-R864))
* Remove unused import of `ActionButton` from `ConfirmDialog` ([link](https://github.com/ant-design/ant-design/pull/44318/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L7))
