### PR TITLE
fix: WaterMark clip logic

### DIFF
--- a/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,7 +9,7 @@ exports[`renders components/watermark/demo/basic.tsx extend context correctly 1`
     style="height: 500px;"
   />
   <div
-    style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 220px;"
+    style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px;"
   />
 </div>
 `;
@@ -49,7 +49,7 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
       style="z-index: 10; width: 100%; max-width: 800px; position: relative;"
     />
     <div
-      style="z-index: 11; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 220px;"
+      style="z-index: 11; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px;"
     />
   </div>
   <form
@@ -536,7 +536,7 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
                 />
                 <div
                   class="ant-slider-track"
-                  style="left: 0%; width: 16%;"
+                  style="left: 0%; width: 15.151515151515152%;"
                 />
                 <div
                   class="ant-slider-step"
@@ -544,11 +544,11 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
                 <div
                   aria-disabled="false"
                   aria-valuemax="100"
-                  aria-valuemin="0"
+                  aria-valuemin="1"
                   aria-valuenow="16"
                   class="ant-slider-handle"
                   role="slider"
-                  style="left: 16%; transform: translateX(-50%);"
+                  style="left: 15.151515151515152%; transform: translateX(-50%);"
                   tabindex="0"
                 />
                 <div

--- a/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
@@ -163,7 +163,7 @@ exports[`renders components/watermark/demo/custom.tsx correctly 1`] = `
                 />
                 <div
                   class="ant-slider-track"
-                  style="left:0%;width:16%"
+                  style="left:0%;width:15.151515151515152%"
                 />
                 <div
                   class="ant-slider-step"
@@ -171,11 +171,11 @@ exports[`renders components/watermark/demo/custom.tsx correctly 1`] = `
                 <div
                   aria-disabled="false"
                   aria-valuemax="100"
-                  aria-valuemin="0"
+                  aria-valuemin="1"
                   aria-valuenow="16"
                   class="ant-slider-handle"
                   role="slider"
-                  style="left:16%;transform:translateX(-50%)"
+                  style="left:15.151515151515152%;transform:translateX(-50%)"
                   tabindex="0"
                 />
               </div>

--- a/components/watermark/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/watermark/__tests__/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Watermark Image watermark snapshot 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 440px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px;"
     />
   </div>
 </div>
@@ -20,7 +20,7 @@ exports[`Watermark Interleaved watermark backgroundSize is correct 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 600px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 720px;"
     />
   </div>
 </div>
@@ -33,7 +33,7 @@ exports[`Watermark Invalid image watermark 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 440px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px;"
     />
   </div>
 </div>
@@ -46,7 +46,7 @@ exports[`Watermark MutationObserver should work properly 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 232px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 229px;"
     />
   </div>
 </div>
@@ -59,7 +59,7 @@ exports[`Watermark Observe the modification of style 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: -250px -250px; background-image: url('data:image/png;base64,00'); background-size: 232px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: -250px -250px; background-image: url('data:image/png;base64,00'); background-size: 229px;"
     />
   </div>
 </div>
@@ -85,7 +85,7 @@ exports[`Watermark The watermark should render successfully 1`] = `
     style="position: relative;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 220px;"
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px;"
     />
   </div>
 </div>

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -53,7 +53,7 @@ describe('Watermark', () => {
       />,
     );
     const target = container.querySelector<HTMLDivElement>('.watermark div');
-    expect(target?.style.backgroundSize).toBe('600px');
+    expect(target?.style.backgroundSize).toBe('720px');
     expect(container).toMatchSnapshot();
   });
 

--- a/components/watermark/demo/custom.tsx
+++ b/components/watermark/demo/custom.tsx
@@ -103,7 +103,7 @@ const App: React.FC = () => {
           <ColorPicker />
         </Form.Item>
         <Form.Item name="fontSize" label="FontSize">
-          <Slider step={1} min={0} max={100} />
+          <Slider step={1} min={1} max={100} />
         </Form.Item>
         <Form.Item name="zIndex" label="zIndex">
           <Slider step={1} min={0} max={100} />

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -111,7 +111,6 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
       watermarkRef.current = undefined;
     }
   };
-  console.log('>>>>', getPixelRatio());
 
   const appendWatermark = (base64Url: string, markWidth: number) => {
     if (containerRef.current && watermarkRef.current) {
@@ -143,18 +142,24 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
     if (!image && ctx.measureText) {
       ctx.font = `${Number(fontSize)}px ${fontFamily}`;
       const contents = Array.isArray(content) ? content : [content];
-      const widths = contents.map((item) => ctx.measureText(item!).width);
-      defaultWidth = Math.ceil(Math.max(...widths));
-      defaultHeight = Number(fontSize) * contents.length + (contents.length - 1) * FontGap;
+      const sizes = contents.map((item) => {
+        const metrics = ctx.measureText(item!);
+
+        return [metrics.width, metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent];
+      });
+      defaultWidth = Math.ceil(Math.max(...sizes.map((size) => size[0])));
+      defaultHeight =
+        Math.ceil(Math.max(...sizes.map((size) => size[1]))) * contents.length +
+        (contents.length - 1) * FontGap;
     }
     return [width ?? defaultWidth, height ?? defaultHeight] as const;
   };
 
   const getClips = useClips();
 
-  const drawClips = (dataURL: string, width: number) => {
-    appendWatermark(dataURL, width);
-  };
+  // const drawClips = (dataURL: string, width: number) => {
+  //   appendWatermark(dataURL, width);
+  // };
 
   // const fillTexts = (
   //   ctx: CanvasRenderingContext2D,
@@ -288,7 +293,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
           gapY,
         );
 
-        drawClips(textClips, clipWidth);
+        appendWatermark(textClips, clipWidth);
       }
     }
   };

--- a/components/watermark/useClips.ts
+++ b/components/watermark/useClips.ts
@@ -46,7 +46,7 @@ export default function useClips() {
     const { color, fontSize, fontStyle, fontWeight, fontFamily } = font;
     const mergedFontSize = Number(fontSize) * ratio;
 
-    ctx.font = `${fontStyle} normal ${fontWeight} ${mergedFontSize}px/${textHeight}px ${fontFamily}`;
+    ctx.font = `${fontStyle} normal ${fontWeight} ${mergedFontSize}px/${height}px ${fontFamily}`;
     ctx.fillStyle = color;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
@@ -98,10 +98,10 @@ export default function useClips() {
     const cutWidth = right - left;
     const cutHeight = bottom - top;
 
-    rCtx.restore();
-    rCtx.translate(realMaxSize / 2, realMaxSize / 2);
-    rCtx.fillStyle = 'rgba(255, 0,0,0.1)';
-    rCtx.fillRect(left, top, cutWidth, cutHeight);
+    // rCtx.restore();
+    // rCtx.translate(realMaxSize / 2, realMaxSize / 2);
+    // rCtx.fillStyle = 'rgba(255, 0,0,0.1)';
+    // rCtx.fillRect(left, top, cutWidth, cutHeight);
 
     // ================ Fill Alternate ================
     const realGapX = gapX * ratio;
@@ -110,6 +110,7 @@ export default function useClips() {
     const filledHeight = cutHeight + realGapY;
 
     const [fCtx, fCanvas] = prepareCanvas(filledWidth, filledHeight);
+    // document.body.appendChild(canvas);
     // document.body.appendChild(rCanvas);
     // document.body.appendChild(fCanvas);
 

--- a/components/watermark/useClips.ts
+++ b/components/watermark/useClips.ts
@@ -1,0 +1,137 @@
+import type { WatermarkProps } from '.';
+
+const FontGap = 3;
+
+function prepareCanvas(
+  width: number,
+  height: number,
+  ratio: number = 1,
+): [
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  realWidth: number,
+  realHeight: number,
+] {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const realWidth = width * ratio;
+  const realHeight = height * ratio;
+  canvas.setAttribute('width', `${realWidth}px`);
+  canvas.setAttribute('height', `${realHeight}px`);
+  ctx.save();
+
+  return [ctx, canvas, realWidth, realHeight];
+}
+
+/**
+ * Get the clips of text content.
+ * This is a lazy hook function since SSR no need this
+ */
+export default function useClips() {
+  // Get single clips
+  function getClips(
+    content: NonNullable<WatermarkProps['content']>,
+    rotate: number,
+    ratio: number,
+    width: number,
+    height: number,
+    font: Required<NonNullable<WatermarkProps['font']>>,
+    gapX: number,
+    gapY: number,
+  ): [dataURL: string, finalWidth: number, finalHeight: number] {
+    // ===================== Text =====================
+    const [ctx, canvas, textWidth, textHeight] = prepareCanvas(width, height, ratio);
+
+    const { color, fontSize, fontStyle, fontWeight, fontFamily } = font;
+    const mergedFontSize = Number(fontSize) * ratio;
+
+    ctx.font = `${fontStyle} normal ${fontWeight} ${mergedFontSize}px/${textHeight}px ${fontFamily}`;
+    ctx.fillStyle = color;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    const contents = Array.isArray(content) ? content : [content];
+    contents?.forEach((item, index) => {
+      ctx.fillText(item ?? '', textWidth / 2, index * (mergedFontSize + FontGap * ratio));
+    });
+
+    // ==================== Rotate ====================
+    const angle = (Math.PI / 180) * Number(rotate);
+    const maxSize = Math.max(width, height);
+    const [rCtx, rCanvas, realMaxSize] = prepareCanvas(maxSize, maxSize, ratio);
+
+    // Copy from `ctx` and rotate
+    rCtx.translate(realMaxSize / 2, realMaxSize / 2);
+    rCtx.rotate(angle);
+    rCtx.drawImage(canvas, -textWidth / 2, -textHeight / 2);
+
+    // Get boundary of rotated text
+    function getRotatePos(x: number, y: number) {
+      const targetX = x * Math.cos(angle) - y * Math.sin(angle);
+      const targetY = x * Math.sin(angle) + y * Math.cos(angle);
+      return [targetX, targetY];
+    }
+
+    let left = 0;
+    let right = 0;
+    let top = 0;
+    let bottom = 0;
+
+    const halfWidth = textWidth / 2;
+    const halfHeight = textHeight / 2;
+    const points = [
+      [0 - halfWidth, 0 - halfHeight],
+      [0 + halfWidth, 0 - halfHeight],
+      [0 + halfWidth, 0 + halfHeight],
+      [0 - halfWidth, 0 + halfHeight],
+    ];
+    points.forEach(([x, y]) => {
+      const [targetX, targetY] = getRotatePos(x, y);
+      left = Math.min(left, targetX);
+      right = Math.max(right, targetX);
+      top = Math.min(top, targetY);
+      bottom = Math.max(bottom, targetY);
+    });
+
+    const cutLeft = left + realMaxSize / 2;
+    const cutTop = top + realMaxSize / 2;
+    const cutWidth = right - left;
+    const cutHeight = bottom - top;
+
+    rCtx.restore();
+    rCtx.translate(realMaxSize / 2, realMaxSize / 2);
+    rCtx.fillStyle = 'rgba(255, 0,0,0.1)';
+    rCtx.fillRect(left, top, cutWidth, cutHeight);
+
+    // ================ Fill Alternate ================
+    const realGapX = gapX * ratio;
+    const realGapY = gapY * ratio;
+    const filledWidth = (cutWidth + realGapX) * 2;
+    const filledHeight = cutHeight + realGapY;
+
+    const [fCtx, fCanvas] = prepareCanvas(filledWidth, filledHeight);
+    // document.body.appendChild(rCanvas);
+    // document.body.appendChild(fCanvas);
+
+    function drawImg(targetX = 0, targetY = 0) {
+      fCtx.drawImage(
+        rCanvas,
+        cutLeft,
+        cutTop,
+        cutWidth,
+        cutHeight,
+        targetX,
+        targetY,
+        cutWidth,
+        cutHeight,
+      );
+    }
+    drawImg();
+    drawImg(cutWidth + realGapX, -cutHeight / 2 - realGapY / 2);
+    drawImg(cutWidth + realGapX, +cutHeight / 2 + realGapY / 2);
+
+    return [fCanvas.toDataURL(), filledWidth / ratio, filledHeight / ratio];
+  }
+
+  return getClips;
+}

--- a/components/watermark/utils.ts
+++ b/components/watermark/utils.ts
@@ -14,18 +14,6 @@ export function getPixelRatio() {
   return window.devicePixelRatio || 1;
 }
 
-/** Rotate with the watermark as the center point */
-export function rotateWatermark(
-  ctx: CanvasRenderingContext2D,
-  rotateX: number,
-  rotateY: number,
-  rotate: number,
-) {
-  ctx.translate(rotateX, rotateY);
-  ctx.rotate((Math.PI / 180) * Number(rotate));
-  ctx.translate(-rotateX, -rotateY);
-}
-
 /** Whether to re-render the watermark */
 export const reRendering = (mutation: MutationRecord, watermarkElement?: HTMLElement) => {
   let flag = false;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

#### 🚨 Before

![Kapture 2023-08-21 at 17 57 09](https://github.com/ant-design/ant-design/assets/5378891/234aa2f6-6d72-48ef-8450-0e7274ab0149)

#### 🎉 After

![Kapture 2023-08-21 at 18 00 38](https://github.com/ant-design/ant-design/assets/5378891/ab6bf235-0a18-494c-b3a4-c6a0ec6fdf19)



### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Watermark can not be fully shown when `content` is too long.       |
| 🇨🇳 Chinese |    Fix Watermark 的 `content` 内容过长时无法完整显示的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8702488</samp>

Refactored the watermark component to use a custom hook `useClips` for clip generation and alignment, fixed a bug in the custom watermark demo, and updated the test case accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8702488</samp>

*  Refactor the watermark rendering logic to use the `useClips` hook and fix some issues ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L200-R199), [link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L120-R116), [link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L141-R151), [link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-e74de8cfb7d6f9243c101cce673937f42777adc732547f8ef936d6ae1a92e001R1-R136))
  - Extract the clip generation logic into a separate hook in `components/watermark/useClips.ts` for better readability and maintainability ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-e74de8cfb7d6f9243c101cce673937f42777adc732547f8ef936d6ae1a92e001R1-R136))
  - Update the background size style of the watermark element to use the clip width returned by the `useClips` hook instead of the previous calculation based on the gap and mark width ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L120-R116))
  - Update the `getMarkSize` function to use the font bounding box metrics instead of the font size to calculate the default width and height of the watermark text ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L141-R151))
  - Replace the previous watermark rendering logic with the new logic that uses the `useClips` hook to generate the clips of the text or image content, rotate them, and fill them in an alternate pattern ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L200-R199))
* Update the expected background size of the watermark component in the test case to match the new logic of calculating the clip width in the `useClips` hook ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-09e48387fb55cf0737e5d58290892068215dd51b1aa43558679d3ffed6dae497L56-R56))
* Fix a bug in the custom watermark demo where the slider for the font size could be set to zero, which would cause an error in the canvas rendering ([link](https://github.com/ant-design/ant-design/pull/44321/files?diff=unified&w=0#diff-26c21a1646213a2bfb681dfe72825f676943f442103ea720c4765ab70a71f0c7L106-R106))
