### PR TITLE
docs: add fallback for previewer

### DIFF
--- a/.dumi/theme/builtins/Previewer/index.tsx
+++ b/.dumi/theme/builtins/Previewer/index.tsx
@@ -1,10 +1,36 @@
 import React, { Suspense } from 'react';
 import type { IPreviewerProps } from 'dumi';
+import { Skeleton } from 'antd';
+import { createStyles } from 'antd-style';
 
 const Previewer = React.lazy(() => import('./Previewer'));
 
-export default (props: IPreviewerProps) => (
-  <Suspense fallback={null}>
-    <Previewer {...props} />
-  </Suspense>
-);
+const useStyle = createStyles(({ css }) => ({
+  skeletonWrapper: css`
+    width: 100% !important;
+    height: 500px;
+    margin-bottom: 16px;
+  `,
+}));
+
+export default (props: IPreviewerProps) => {
+  const { styles } = useStyle();
+  return (
+    <Suspense
+      fallback={
+        <Skeleton.Node
+          active
+          className={styles.skeletonWrapper}
+          style={{
+            width: '100%',
+            height: '100%',
+          }}
+        >
+          {' '}
+        </Skeleton.Node>
+      }
+    >
+      <Previewer {...props} />
+    </Suspense>
+  );
+};

--- a/components/skeleton/Node.tsx
+++ b/components/skeleton/Node.tsx
@@ -4,12 +4,10 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { SkeletonElementProps } from './Element';
 import useStyle from './style';
-import type { CSSProperties } from 'react';
 
 export interface SkeletonNodeProps extends Omit<SkeletonElementProps, 'size' | 'shape'> {
   fullSize?: boolean;
   children?: React.ReactNode;
-  rootStyle?: CSSProperties;
 }
 
 const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
@@ -20,7 +18,6 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
     style,
     active,
     children,
-    rootStyle,
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
@@ -40,7 +37,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
   const content = children ?? <DotChartOutlined />;
 
   return wrapSSR(
-    <div className={cls} style={rootStyle}>
+    <div className={cls}>
       <div className={classNames(`${prefixCls}-image`, className)} style={style}>
         {content}
       </div>

--- a/components/skeleton/Node.tsx
+++ b/components/skeleton/Node.tsx
@@ -4,10 +4,12 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { SkeletonElementProps } from './Element';
 import useStyle from './style';
+import type { CSSProperties } from 'react';
 
 export interface SkeletonNodeProps extends Omit<SkeletonElementProps, 'size' | 'shape'> {
   fullSize?: boolean;
   children?: React.ReactNode;
+  rootStyle?: CSSProperties;
 }
 
 const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
@@ -18,6 +20,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
     style,
     active,
     children,
+    rootStyle,
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
@@ -37,7 +40,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
   const content = children ?? <DotChartOutlined />;
 
   return wrapSSR(
-    <div className={cls}>
+    <div className={cls} style={rootStyle}>
       <div className={classNames(`${prefixCls}-image`, className)} style={style}>
         {content}
       </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac7a9ee</samp>

Added a `rootStyle` prop to the `Skeleton` component to allow customizing its appearance. Used the `Skeleton` component to create a loading fallback for the `Previewer` component in the documentation theme.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac7a9ee</samp>

* Import and use `Skeleton` and `createStyles` to create a fallback UI for `Previewer` when loading asynchronously ([link](https://github.com/ant-design/ant-design/pull/44327/files?diff=unified&w=0#diff-d4c2b096e898ee55c192cd1d13952ec5c5be4c1ff563d0ccaba74d8555e19adaL3-R36),   )
* Add `rootStyle` prop to `SkeletonNodeProps` and pass it to `wrapSSR` and root `div` of `SkeletonNode` to allow custom CSS styles for skeleton nodes ([link](https://github.com/ant-design/ant-design/pull/44327/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13L7-R12), [link](https://github.com/ant-design/ant-design/pull/44327/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13R23), [link](https://github.com/ant-design/ant-design/pull/44327/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13L40-R43))
