### PR TITLE
feat: Spin token

### DIFF
--- a/components/spin/style/index.tsx
+++ b/components/spin/style/index.tsx
@@ -10,13 +10,25 @@ export interface ComponentToken {
    * @descEN Height of content area
    */
   contentHeight: number;
+  /**
+   * @desc 加载图标尺寸
+   * @descEN Loading icon size
+   */
+  dotSize: number;
+  /**
+   * @desc 小号加载图标尺寸
+   * @descEN Small loading icon size
+   */
+  dotSizeSM: number;
+  /**
+   * @desc 大号加载图标尺寸
+   * @descEN Large loading icon size
+   */
+  dotSizeLG: number;
 }
 
 interface SpinToken extends FullToken<'Spin'> {
   spinDotDefault: string;
-  spinDotSize: number;
-  spinDotSizeSM: number;
-  spinDotSizeLG: number;
 }
 
 const antSpinMove = new Keyframes('antSpinMove', {
@@ -61,43 +73,43 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
           position: 'absolute',
           top: '50%',
           insetInlineStart: '50%',
-          margin: -token.spinDotSize / 2,
+          margin: -token.dotSize / 2,
         },
 
         [`${token.componentCls}-text`]: {
           position: 'absolute',
           top: '50%',
           width: '100%',
-          paddingTop: (token.spinDotSize - token.fontSize) / 2 + 2,
+          paddingTop: (token.dotSize - token.fontSize) / 2 + 2,
           textShadow: `0 1px 2px ${token.colorBgContainer}`, // FIXME: shadow
           fontSize: token.fontSize,
         },
 
         [`&${token.componentCls}-show-text ${token.componentCls}-dot`]: {
-          marginTop: -(token.spinDotSize / 2) - 10,
+          marginTop: -(token.dotSize / 2) - 10,
         },
 
         '&-sm': {
           [`${token.componentCls}-dot`]: {
-            margin: -token.spinDotSizeSM / 2,
+            margin: -token.dotSizeSM / 2,
           },
           [`${token.componentCls}-text`]: {
-            paddingTop: (token.spinDotSizeSM - token.fontSize) / 2 + 2,
+            paddingTop: (token.dotSizeSM - token.fontSize) / 2 + 2,
           },
           [`&${token.componentCls}-show-text ${token.componentCls}-dot`]: {
-            marginTop: -(token.spinDotSizeSM / 2) - 10,
+            marginTop: -(token.dotSizeSM / 2) - 10,
           },
         },
 
         '&-lg': {
           [`${token.componentCls}-dot`]: {
-            margin: -(token.spinDotSizeLG / 2),
+            margin: -(token.dotSizeLG / 2),
           },
           [`${token.componentCls}-text`]: {
-            paddingTop: (token.spinDotSizeLG - token.fontSize) / 2 + 2,
+            paddingTop: (token.dotSizeLG - token.fontSize) / 2 + 2,
           },
           [`&${token.componentCls}-show-text ${token.componentCls}-dot`]: {
-            marginTop: -(token.spinDotSizeLG / 2) - 10,
+            marginTop: -(token.dotSizeLG / 2) - 10,
           },
         },
       },
@@ -147,15 +159,15 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
     [`${token.componentCls}-dot`]: {
       position: 'relative',
       display: 'inline-block',
-      fontSize: token.spinDotSize,
+      fontSize: token.dotSize,
       width: '1em',
       height: '1em',
 
       '&-item': {
         position: 'absolute',
         display: 'block',
-        width: (token.spinDotSize - token.marginXXS / 2) / 2,
-        height: (token.spinDotSize - token.marginXXS / 2) / 2,
+        width: (token.dotSize - token.marginXXS / 2) / 2,
+        height: (token.dotSize - token.marginXXS / 2) / 2,
         backgroundColor: token.colorPrimary,
         borderRadius: '100%',
         transform: 'scale(0.75)',
@@ -205,21 +217,21 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
 
     // small
     [`&-sm ${token.componentCls}-dot`]: {
-      fontSize: token.spinDotSizeSM,
+      fontSize: token.dotSizeSM,
 
       i: {
-        width: (token.spinDotSizeSM - token.marginXXS / 2) / 2,
-        height: (token.spinDotSizeSM - token.marginXXS / 2) / 2,
+        width: (token.dotSizeSM - token.marginXXS / 2) / 2,
+        height: (token.dotSizeSM - token.marginXXS / 2) / 2,
       },
     },
 
     // large
     [`&-lg ${token.componentCls}-dot`]: {
-      fontSize: token.spinDotSizeLG,
+      fontSize: token.dotSizeLG,
 
       i: {
-        width: (token.spinDotSizeLG - token.marginXXS) / 2,
-        height: (token.spinDotSizeLG - token.marginXXS) / 2,
+        width: (token.dotSizeLG - token.marginXXS) / 2,
+        height: (token.dotSizeLG - token.marginXXS) / 2,
       },
     },
 
@@ -235,13 +247,13 @@ export default genComponentStyleHook(
   (token) => {
     const spinToken = mergeToken<SpinToken>(token, {
       spinDotDefault: token.colorTextDescription,
-      spinDotSize: token.controlHeightLG / 2,
-      spinDotSizeSM: token.controlHeightLG * 0.35,
-      spinDotSizeLG: token.controlHeight,
     });
     return [genSpinStyle(spinToken)];
   },
-  {
+  (token) => ({
     contentHeight: 400,
-  },
+    dotSize: token.controlHeightLG / 2,
+    dotSizeSM: token.controlHeightLG * 0.35,
+    dotSizeLG: token.controlHeight,
+  }),
 );

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -15,7 +15,6 @@ We could configure global token and component token for each component through t
 
 ```tsx
 import React from 'react';
-
 import { Checkbox, ConfigProvider, Radio } from 'antd';
 
 const App: React.FC = () => (

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -14,8 +14,9 @@ This document contains the correspondence between all the less variables related
 We could configure global token and component token for each component through the `theme` property of ConfigProvider.
 
 ```tsx
-import { Checkbox, ConfigProvider, Radio } from 'antd';
 import React from 'react';
+
+import { Checkbox, ConfigProvider, Radio } from 'antd';
 
 const App: React.FC = () => (
   <ConfigProvider
@@ -669,6 +670,15 @@ export default App;
 | `@slider-dot-border-color-active` | `dotActiveBorderColor` | - |
 | `@slider-disabled-color` | `trackBgDisabled` | - |
 | `@slider-disabled-background-color` | - | Deprecated |
+
+### Spin
+
+<!-- prettier-ignore -->
+| Less variables | Component Token | Note |
+| --- | --- | --- |
+| `@spin-dot-size-sm` | `dotSizeSM` | - |
+| `@spin-dot-size` | `dotSize` | - |
+| `@spin-dot-size-lg` | `dotSizeLG` | - |
 
 ### Statistic
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -14,8 +14,9 @@ title: 从 Less 变量到 Design Token
 通过 ConfigProvider 的 `theme` 属性，我们可以对每一个组件单独配置全局 Token 和组件 Token
 
 ```tsx
-import { Checkbox, ConfigProvider, Radio } from 'antd';
 import React from 'react';
+
+import { Checkbox, ConfigProvider, Radio } from 'antd';
 
 const App: React.FC = () => (
   <ConfigProvider
@@ -667,6 +668,15 @@ Mentions 提及
 | `@slider-dot-border-color-active` | `dotActiveBorderColor` | - |
 | `@slider-disabled-color` | `trackBgDisabled` | - |
 | `@slider-disabled-background-color` | - | 已废弃 |
+
+### Spin 加载中
+
+<!-- prettier-ignore -->
+| Less 变量 | Component Token | 备注 |
+| --- | --- | --- |
+| `@spin-dot-size-sm` | `dotSizeSM` | - |
+| `@spin-dot-size` | `dotSize` | - |
+| `@spin-dot-size-lg` | `dotSizeLG` | - |
 
 ### Statistic 统计数值
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -15,7 +15,6 @@ title: 从 Less 变量到 Design Token
 
 ```tsx
 import React from 'react';
-
 import { Checkbox, ConfigProvider, Radio } from 'antd';
 
 const App: React.FC = () => (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Migrate Spin less variables to Component token      |
| 🇨🇳 Chinese |      迁移 Spin 组件 less 变量到组件 Token     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd1404e</samp>

Refactored the `Spin` component style code to use `dotSize` properties instead of `spinDotSize`. Updated the documentation for migrating from Less variables to Component Token in both English and Chinese, with code examples and a new section for the `Spin` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd1404e</samp>

*  Rename `spinDotSize`, `spinDotSizeSM`, and `spinDotSizeLG` to `dotSize`, `dotSizeSM`, and `dotSizeLG` in the `ComponentToken` interface and update the `genSpinStyle` function to use the new names in `components/spin/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L13-R31), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L64-R76), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L71-R83), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L77-R100), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L94-R112), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L150-R162), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L157-R170), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L208-R224), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L218-R234))
* Refactor the `spinToken` constant to use a function that returns the default values for `dotSize`, `dotSizeSM`, and `dotSizeLG` based on the `token` parameter in `components/spin/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-3a2474e4dab48a16cce22c61f21d534393edcd5b4131bb0089537002750eba24L238-R258))
* Reorder the imports and add a blank line between the React import and the antd imports in the code examples in `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aL17-R20), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739L17-R20))
* Add the `Spin` and `Spin 加载中` sections to document the mapping between the Less variables and the Component Token for the Spin component in `docs/react/migrate-less-variables.en-US.md` and `docs/react/migrate-less-variables.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-999566baa64628c49813370e7cb13c3c8f5e0c99ef8fe9cec7c5052985c10d9aR674-R682), [link](https://github.com/ant-design/ant-design/pull/44334/files?diff=unified&w=0#diff-dff3e0a0a5fae848621e55da4e2adaf0ec6c57d5e29d3f601799c8898c280739R672-R680))
