### PR TITLE
docs: prevent highlight code initially

### DIFF
--- a/.dumi/theme/builtins/Previewer/index.tsx
+++ b/.dumi/theme/builtins/Previewer/index.tsx
@@ -1,7 +1,9 @@
 import React, { Suspense } from 'react';
 import type { IPreviewerProps } from 'dumi';
-import { Skeleton } from 'antd';
+import { Skeleton, Alert } from 'antd';
 import { createStyles } from 'antd-style';
+
+const { ErrorBoundary } = Alert;
 
 const Previewer = React.lazy(() => import('./Previewer'));
 
@@ -16,21 +18,23 @@ const useStyle = createStyles(({ css }) => ({
 export default (props: IPreviewerProps) => {
   const { styles } = useStyle();
   return (
-    <Suspense
-      fallback={
-        <Skeleton.Node
-          active
-          className={styles.skeletonWrapper}
-          style={{
-            width: '100%',
-            height: '100%',
-          }}
-        >
-          {' '}
-        </Skeleton.Node>
-      }
-    >
-      <Previewer {...props} />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <Skeleton.Node
+            active
+            className={styles.skeletonWrapper}
+            style={{
+              width: '100%',
+              height: '100%',
+            }}
+          >
+            {' '}
+          </Skeleton.Node>
+        }
+      >
+        <Previewer {...props} />
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/.dumi/theme/common/CodePreview.tsx
+++ b/.dumi/theme/common/CodePreview.tsx
@@ -1,37 +1,101 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
+import Prism from 'prismjs';
+import toReactElement from 'jsonml-to-react-element';
+import JsonML from 'jsonml.js/lib/utils';
 import { Tabs } from 'antd';
 
 const LANGS = {
   tsx: 'TypeScript',
   jsx: 'JavaScript',
+  style: 'CSS',
 };
 
 interface CodePreviewProps {
-  codes?: Record<PropertyKey, string>;
-  toReactComponent?: (node: any) => React.ReactNode;
+  sourceCode?: string;
+  jsxCode?: string;
+  styleCode?: string;
   onCodeTypeChange?: (activeKey: string) => void;
 }
 
-const CodePreview: React.FC<CodePreviewProps> = ({ toReactComponent, codes, onCodeTypeChange }) => {
-  const langList = Object.keys(codes).sort().reverse();
+function toReactComponent(jsonML: any) {
+  return toReactElement(jsonML, [
+    [
+      (node: any) => JsonML.isElement(node) && JsonML.getTagName(node) === 'pre',
+      (node: any, index: any) => {
+        // ref: https://github.com/benjycui/bisheng/blob/master/packages/bisheng/src/bisheng-plugin-highlight/lib/browser.js#L7
+        const attr = JsonML.getAttributes(node);
+        return React.createElement(
+          'pre',
+          {
+            key: index,
+            className: `language-${attr.lang}`,
+          },
+          React.createElement('code', {
+            dangerouslySetInnerHTML: { __html: attr.highlighted },
+          }),
+        );
+      },
+    ],
+  ]);
+}
+
+const CodePreview: React.FC<CodePreviewProps> = ({
+  sourceCode = '',
+  jsxCode = '',
+  styleCode = '',
+  onCodeTypeChange,
+}) => {
+  // 避免 Tabs 数量不稳定的闪动问题
+  const initialCodes = {};
+  if (sourceCode) {
+    initialCodes.tsx = '';
+  }
+  if (jsxCode) {
+    initialCodes.jsx = '';
+  }
+  if (styleCode) {
+    initialCodes.style = '';
+  }
+  const [highlightedCodes, setHighlightedCodes] = React.useState(initialCodes);
+
+  useEffect(() => {
+    const codes = {
+      tsx: Prism.highlight(sourceCode, Prism.languages.javascript, 'jsx'),
+      jsx: Prism.highlight(jsxCode, Prism.languages.javascript, 'jsx'),
+      style: Prism.highlight(styleCode, Prism.languages.css, 'css'),
+    };
+    // 去掉空的代码类型
+    Object.keys(codes).forEach((key) => {
+      if (!codes[key]) {
+        delete codes[key];
+      }
+    });
+    setHighlightedCodes(codes);
+  }, [jsxCode, sourceCode, styleCode]);
+
+  const langList = Object.keys(highlightedCodes);
+  const items = useMemo(
+    () =>
+      langList.map((lang) => ({
+        label: LANGS[lang],
+        key: lang,
+        children: toReactComponent(['pre', { lang, highlighted: highlightedCodes[lang] }]),
+      })),
+    [JSON.stringify(highlightedCodes)],
+  );
+
+  if (!langList.length) {
+    return null;
+  }
+
   if (langList.length === 1) {
     return toReactComponent([
       'pre',
-      { lang: langList[0], highlighted: codes[langList[0]], className: 'highlight' },
+      { lang: langList[0], highlighted: highlightedCodes[langList[0]], className: 'highlight' },
     ]);
   }
-  return (
-    <Tabs
-      centered
-      className="highlight"
-      onChange={onCodeTypeChange}
-      items={langList.map((lang) => ({
-        label: LANGS[lang],
-        key: lang,
-        children: toReactComponent(['pre', { lang, highlighted: codes[lang] }]),
-      }))}
-    />
-  );
+
+  return <Tabs centered className="highlight" onChange={onCodeTypeChange} items={items} />;
 };
 
 export default CodePreview;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
- [x] 避免页面加载时就运行 Prima.hightlight 这种高消耗操作，现在展开代码才会运行。
- [x] Prima.hightlight 移出 render，放到 useEffect 里去。
- [x] CSS tab 的样式也顺便统一掉。

缺点是 Table 页面点击展开全部代码，会有一点点卡。

<img width="628" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/57abda24-9617-44bf-9e1d-2253755ed25c">

性能对比效果

| 线上 | 修改后 |
| --- | --- |
| <img width="1781" alt="截屏2023-08-23 下午7 41 12" src="https://github.com/ant-design/ant-design/assets/507615/db46c2e4-5641-4342-bb71-cb0a98f56d0a"> | <img width="1781" alt="截屏2023-08-23 下午7 41 09" src="https://github.com/ant-design/ant-design/assets/507615/121474ce-f4f8-41c8-8224-d558b4e102d2"> |





### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32cebc9</samp>

No summary available (Limit exceeded: required to process 52276 tokens, but only 50000 are allowed per call)

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32cebc9</samp>

No walkthrough available (Limit exceeded: required to process 52276 tokens, but only 50000 are allowed per call)
