### PR TITLE
fix: Table should not crash if filterDropdown is boolean

### DIFF
--- a/components/menu/OverrideContext.tsx
+++ b/components/menu/OverrideContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { NoCompactStyle } from '../space/Compact';
 import type { MenuProps } from './menu';
-import { supportRef } from 'rc-util/lib/ref';
+import { supportNodeRef } from 'rc-util';
 
 // Used for Dropdown only
 export interface OverrideContextProps {
@@ -35,16 +35,12 @@ export const OverrideProvider = React.forwardRef<
     ],
   );
 
-  const shouldRef =
-    typeof children !== 'string' &&
-    typeof children !== 'number' &&
-    typeof children !== 'boolean' &&
-    supportRef(children);
-
   return (
     <OverrideContext.Provider value={context}>
       <NoCompactStyle>
-        {shouldRef ? React.cloneElement(children as React.ReactElement, { ref }) : children}
+        {supportNodeRef(children)
+          ? React.cloneElement(children as React.ReactElement, { ref })
+          : children}
       </NoCompactStyle>
     </OverrideContext.Provider>
   );

--- a/components/menu/OverrideContext.tsx
+++ b/components/menu/OverrideContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { NoCompactStyle } from '../space/Compact';
 import type { MenuProps } from './menu';
+import { supportRef } from 'rc-util/lib/ref';
 
 // Used for Dropdown only
 export interface OverrideContextProps {
@@ -34,9 +35,17 @@ export const OverrideProvider = React.forwardRef<
     ],
   );
 
+  const shouldRef =
+    typeof children !== 'string' &&
+    typeof children !== 'number' &&
+    typeof children !== 'boolean' &&
+    supportRef(children);
+
   return (
     <OverrideContext.Provider value={context}>
-      <NoCompactStyle>{React.cloneElement(children as React.ReactElement, { ref })}</NoCompactStyle>
+      <NoCompactStyle>
+        {shouldRef ? React.cloneElement(children as React.ReactElement, { ref }) : children}
+      </NoCompactStyle>
     </OverrideContext.Provider>
   );
 });

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2835,7 +2835,7 @@ describe('Table.filter', () => {
     );
   });
 
-  it.only('should not crash when filterDropdown is boolean', () => {
+  it('should not crash when filterDropdown is boolean', () => {
     const tableProps = {
       key: 'stabletable',
       rowKey: 'name',

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2834,4 +2834,24 @@ describe('Table.filter', () => {
       true,
     );
   });
+
+  it.only('should not crash when filterDropdown is boolean', () => {
+    const tableProps = {
+      key: 'stabletable',
+      rowKey: 'name',
+      dataSource: [],
+      columns: [
+        {
+          title: 'Name',
+          dataIndex: 'name',
+          filterDropdown: true,
+        },
+      ],
+    };
+
+    const { container } = render(createTable(tableProps));
+
+    // User opens filter Dropdown.
+    fireEvent.click(container.querySelector('.ant-dropdown-trigger.ant-table-filter-trigger')!);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "rc-tree": "~5.7.6",
     "rc-tree-select": "~5.11.0",
     "rc-upload": "~4.3.0",
-    "rc-util": "^5.32.0",
+    "rc-util": "^5.37.0",
     "scroll-into-view-if-needed": "^3.0.3",
     "throttle-debounce": "^5.0.0"
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/44351
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table that would crash when `filterDropdown` do not support `ref`.          |
| 🇨🇳 Chinese |    修复 Table 组件 `filterDropdown` 不支持 `ref` 时报错的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fab89f5</samp>

Improved the menu component's ref handling and added a regression test for the table component's filter dropdown. These changes fix a bug and enhance the performance and usability of the components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fab89f5</samp>

* Import `supportRef` function to check children's ref support ([link](https://github.com/ant-design/ant-design/pull/44357/files?diff=unified&w=0#diff-fab289ecf381929ccfd1ab5e53c7170d3e249910d5774f13f2a76eca26bb6630R4))
* Modify `OverrideProvider` component to conditionally clone children with ref ([link](https://github.com/ant-design/ant-design/pull/44357/files?diff=unified&w=0#diff-fab289ecf381929ccfd1ab5e53c7170d3e249910d5774f13f2a76eca26bb6630L37-R48))
* Add test case for table component with boolean `filterDropdown` prop ([link](https://github.com/ant-design/ant-design/pull/44357/files?diff=unified&w=0#diff-d86c8b951332164873bf880555e68c0e38dfd36612b14396f4c001b7f2d1187fR2837-R2856))
* Prevent table component crash when `filterDropdown` is boolean (issue #32879, [link](https://github.com/ant-design/ant-design/pull/44357/files?diff=unified&w=0#diff-d86c8b951332164873bf880555e68c0e38dfd36612b14396f4c001b7f2d1187fR2837-R2856))
