### PR TITLE
fix: rm useless form inline style

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -362,10 +362,6 @@ const genInlineStyle: GenerateStyle<FormToken> = (token) => {
           flexWrap: 'nowrap',
         },
 
-        '&-with-help': {
-          marginBottom: token.marginLG,
-        },
-
         [`> ${formItemCls}-label,
         > ${formItemCls}-control`]: {
           display: 'inline-block',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #44251

### 💡 Background and solution

#17327 里重构 Form 搬了一些样式，之后 Form.Item 的 `help` 重构测量方法但是这里没有移除。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form `inline` layout show extra bottom margin when validation failed.      |
| 🇨🇳 Chinese |    修复 Form `inline` 布局在校验失败时出现额外空行的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ea55fd</samp>

Fix form item margin bug with inline style and help text. Remove unnecessary code from `components/form/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ea55fd</samp>

* Remove redundant margin for form items with inline style and help text ([link](https://github.com/ant-design/ant-design/pull/44360/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L365-L368))
