### PR TITLE
ColorPresets: fix duplicate keys

### DIFF
--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -59,9 +59,9 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
     children: (
       <div className={`${colorPresetsPrefixCls}-items`}>
         {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
-          preset.colors.map((presetColor: Color) => (
+          preset.colors.map((presetColor: Color, index: number) => (
             <ColorBlock
-              key={`preset-${presetColor.toHexString()}`}
+              key={`preset-${index}-${presetColor.toHexString()}`}
               color={generateColor(presetColor).toRgbString()}
               prefixCls={prefixCls}
               className={classNames(`${colorPresetsPrefixCls}-color`, {

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -61,6 +61,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
         {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
           preset.colors.map((presetColor: Color, index: number) => (
             <ColorBlock
+              // eslint-disable-next-line react/no-array-index-key
               key={`preset-${index}-${presetColor.toHexString()}`}
               color={generateColor(presetColor).toRgbString()}
               prefixCls={prefixCls}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Close #44361

### 📝 Changelog

Bugfix [#44361]: Add the current index to key

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 080ad90</samp>

Modified the `key` prop of `ColorBlock` to prevent duplicate keys in `ColorPresets`. This improved the rendering and accessibility of the color picker component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 080ad90</samp>

* Add `index` to `key` prop of `ColorBlock` component to avoid duplicate keys ([link](https://github.com/ant-design/ant-design/pull/44370/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L62-R64))
