### PR TITLE
refactor(notification): reduce the configuration parameter code

### DIFF
--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -71,7 +71,7 @@ function getGlobalContext() {
 
   return {
     prefixCls: mergedPrefixCls,
-    container: mergedContainer,
+    getContainer: () => mergedContainer!,
     duration,
     rtl,
     maxCount,
@@ -85,20 +85,7 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const initializeMessageConfig = (): ConfigOptions => {
-    const { prefixCls, container, maxCount, duration, rtl, top } = getGlobalContext();
-
-    return {
-      prefixCls,
-      getContainer: () => container!,
-      maxCount,
-      duration,
-      rtl,
-      top,
-    };
-  };
-
-  const [messageConfig, setMessageConfig] = React.useState<ConfigOptions>(initializeMessageConfig);
+  const [messageConfig, setMessageConfig] = React.useState<ConfigOptions>(getGlobalContext);
 
   const [api, holder] = useInternalMessage(messageConfig);
 
@@ -108,7 +95,7 @@ const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
   const theme = global.getTheme();
 
   const sync = () => {
-    setMessageConfig(initializeMessageConfig);
+    setMessageConfig(getGlobalContext);
   };
 
   React.useEffect(sync, []);

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { render } from 'rc-util/lib/React/render';
 import * as React from 'react';
+import { render } from 'rc-util/lib/React/render';
+
 import ConfigProvider, { globalConfig, warnContext } from '../config-provider';
-import PurePanel from './PurePanel';
 import type {
   ArgsProps,
   ConfigOptions,
@@ -12,6 +12,7 @@ import type {
   NoticeType,
   TypeOpen,
 } from './interface';
+import PurePanel from './PurePanel';
 import useMessage, { useInternalMessage } from './useMessage';
 import { wrapPromiseFn } from './util';
 
@@ -84,7 +85,7 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const initializeMessageConfig: () => ConfigOptions = () => {
+  const initializeMessageConfig = (): ConfigOptions => {
     const { prefixCls, container, maxCount, duration, rtl, top } = getGlobalContext();
 
     return {

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { render } from 'rc-util/lib/React/render';
 import * as React from 'react';
+import { render } from 'rc-util/lib/React/render';
+
 import ConfigProvider, { globalConfig, warnContext } from '../config-provider';
-import PurePanel from './PurePanel';
 import type { ArgsProps, GlobalConfigProps, NotificationInstance } from './interface';
+import PurePanel from './PurePanel';
 import useNotification, { useInternalNotification } from './useNotification';
 
 let notification: GlobalNotification | null = null;
@@ -59,7 +60,7 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const initializeNotificationConfig: () => GlobalConfigProps = () => {
+  const initializeNotificationConfig = (): GlobalConfigProps => {
     const { prefixCls, container, maxCount, rtl, top, bottom } = getGlobalContext();
 
     return {

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -46,7 +46,7 @@ function getGlobalContext() {
 
   return {
     prefixCls: mergedPrefixCls,
-    container: mergedContainer,
+    getContainer: () => mergedContainer!,
     rtl,
     maxCount,
     top,
@@ -60,22 +60,8 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const initializeNotificationConfig = (): GlobalConfigProps => {
-    const { prefixCls, container, maxCount, rtl, top, bottom } = getGlobalContext();
-
-    return {
-      prefixCls,
-      getContainer: () => container!,
-      maxCount,
-      rtl,
-      top,
-      bottom,
-    };
-  };
-
-  const [notificationConfig, setNotificationConfig] = React.useState<GlobalConfigProps>(
-    initializeNotificationConfig,
-  );
+  const [notificationConfig, setNotificationConfig] =
+    React.useState<GlobalConfigProps>(getGlobalContext);
 
   const [api, holder] = useInternalNotification(notificationConfig);
 
@@ -85,7 +71,7 @@ const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
   const theme = global.getTheme();
 
   const sync = () => {
-    setNotificationConfig(initializeNotificationConfig);
+    setNotificationConfig(getGlobalContext);
   };
 
   React.useEffect(sync, []);

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -59,21 +59,24 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const [prefixCls, setPrefixCls] = React.useState<string>();
-  const [container, setContainer] = React.useState<HTMLElement | ShadowRoot>();
-  const [maxCount, setMaxCount] = React.useState<number>();
-  const [rtl, setRTL] = React.useState<boolean>();
-  const [top, setTop] = React.useState<number>();
-  const [bottom, setBottom] = React.useState<number>();
+  const initializeNotificationConfig: () => GlobalConfigProps = () => {
+    const { prefixCls, container, maxCount, rtl, top, bottom } = getGlobalContext();
 
-  const [api, holder] = useInternalNotification({
-    prefixCls,
-    getContainer: () => container!,
-    maxCount,
-    rtl,
-    top,
-    bottom,
-  });
+    return {
+      prefixCls,
+      getContainer: () => container!,
+      maxCount,
+      rtl,
+      top,
+      bottom,
+    };
+  };
+
+  const [notificationConfig, setNotificationConfig] = React.useState<GlobalConfigProps>(
+    initializeNotificationConfig,
+  );
+
+  const [api, holder] = useInternalNotification(notificationConfig);
 
   const global = globalConfig();
   const rootPrefixCls = global.getRootPrefixCls();
@@ -81,21 +84,7 @@ const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
   const theme = global.getTheme();
 
   const sync = () => {
-    const {
-      prefixCls: nextGlobalPrefixCls,
-      container: nextGlobalContainer,
-      maxCount: nextGlobalMaxCount,
-      rtl: nextGlobalRTL,
-      top: nextTop,
-      bottom: nextBottom,
-    } = getGlobalContext();
-
-    setPrefixCls(nextGlobalPrefixCls);
-    setContainer(nextGlobalContainer);
-    setMaxCount(nextGlobalMaxCount);
-    setRTL(nextGlobalRTL);
-    setTop(nextTop);
-    setBottom(nextBottom);
+    setNotificationConfig(initializeNotificationConfig);
   };
 
   React.useEffect(sync, []);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/pull/40718
### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
把 notification 获取配置部分的代码省略了一些。
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Reduce the configuration parameter code for notification         |
| 🇨🇳 Chinese | 减少 notification 配置参数代码          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83d8752</samp>

Improved the state management of the `message` and `notification` components by using context and refactoring. This makes the code more consistent, efficient, and readable.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83d8752</samp>

*  Rename `initializeMessageConfig` to `getMessageConfig` and use it to initialize and update the state of `messageConfig` in `components/message/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/44372/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L87-R87), [link](https://github.com/ant-design/ant-design/pull/44372/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L100-R100), [link](https://github.com/ant-design/ant-design/pull/44372/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L110-R110))
* Replace multiple state variables with a single `notificationConfig` object and add a new function `getNotificationConfig` to get the current configuration from the global context in `components/notification/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/44372/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L62-R79), [link](https://github.com/ant-design/ant-design/pull/44372/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L84-R86))
