### PR TITLE
feat✨(transfer):Add a new direction parameter for filterOption function

### DIFF
--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -43,7 +43,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | dataSource | Used for setting the source data. The elements that are part of this array will be present the left column. Except the elements whose keys are included in `targetKeys` prop | [RecordType extends TransferItem = TransferItem](https://github.com/ant-design/ant-design/blob/1bf0bab2a7bc0a774119f501806e3e0e3a6ba283/components/transfer/index.tsx#L12)\[] | \[] |  |
 | disabled | Whether disabled transfer | boolean | false |  |
 | selectionsIcon | custom dropdown icon | React.ReactNode |  | 5.8.0 |
-| filterOption | A function to determine whether an item should show in search result list, only works when searching | (inputValue, option): boolean | - |  |
+| filterOption | A function to determine whether an item should show in search result list, only works when searching | (inputValue, option, direction: `left` \| `right`): boolean | - |  |
 | footer | A function used for rendering the footer | (props, { direction }) => ReactNode | - | direction: 4.17.0 |
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -90,7 +90,7 @@ export interface TransferProps<RecordType> {
   titles?: React.ReactNode[];
   operations?: string[];
   showSearch?: boolean;
-  filterOption?: (inputValue: string, item: RecordType) => boolean;
+  filterOption?: (inputValue: string, item: RecordType, direction: TransferDirection) => boolean;
   locale?: Partial<TransferLocale>;
   footer?: (
     props: TransferListProps<RecordType>,

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -46,7 +46,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*yv12S4sSRAEAAA
 | dataSource | 数据源，其中的数据将会被渲染到左边一栏中，`targetKeys` 中指定的除外 | [RecordType extends TransferItem = TransferItem](https://github.com/ant-design/ant-design/blob/1bf0bab2a7bc0a774119f501806e3e0e3a6ba283/components/transfer/index.tsx#L12)\[] | \[] |  |
 | disabled | 是否禁用 | boolean | false |  |
 | selectionsIcon | 自定义下拉菜单图标 | React.ReactNode |  | 5.8.0 |
-| filterOption | 根据搜索内容进行筛选，接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option): boolean | - |  |
+| filterOption | 根据搜索内容进行筛选，接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option, direction: `left` \| `right`): boolean | - |  |
 | footer | 底部渲染函数 | (props, { direction }) => ReactNode | - | direction: 4.17.0 |
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -48,7 +48,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   prefixCls: string;
   titleText: React.ReactNode;
   dataSource: RecordType[];
-  filterOption?: (filterText: string, item: RecordType) => boolean;
+  filterOption?: (filterText: string, item: RecordType, direction: TransferDirection) => boolean;
   style?: React.CSSProperties;
   checkedKeys: string[];
   handleFilter: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -128,7 +128,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
 
   const matchFilter = (text: string, item: RecordType) => {
     if (filterOption) {
-      return filterOption(filterValue, item);
+      return filterOption(filterValue, item, direction);
     }
     return text.includes(filterValue);
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      feat✨(transfer):Add a new direction parameter for filterOption function     |
| 🇨🇳 Chinese |      transfer 组件的 filterOption 函数新增 direction 入参     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f377ef1</samp>

Enhanced the `filterOption` prop and function of the `Transfer` component to support custom filtering based on the column direction. Updated the documentation and the code interface to reflect this change.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f377ef1</samp>

*  Add `direction` parameter to `filterOption` prop in `Transfer` component to allow custom filtering logic based on column direction ([link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c165dbeb24339c042fcc975a9b661af8947ea942457cf8935f29817ac86033a9L46-R46), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdL93-R93), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-f25eb82686b163c8fb19e3d453b3c168ce5311046d76e7b3a1192173b676ea97L49-R49), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415L51-R51), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415L131-R131))
*  Update `index.en-US.md` and `index.zh-CN.md` to document the new `direction` parameter in `filterOption` prop ([link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c165dbeb24339c042fcc975a9b661af8947ea942457cf8935f29817ac86033a9L46-R46), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-f25eb82686b163c8fb19e3d453b3c168ce5311046d76e7b3a1192173b676ea97L49-R49))
*  Pass `direction` value from `Transfer` component to `TransferList` component and use it for filtering in `list.tsx` ([link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415L51-R51), [link](https://github.com/ant-design/ant-design/pull/44413/files?diff=unified&w=0#diff-c6feaf8f7f09d7e3901905a89bc11ecd461a7340d5a8e8ea4dbc994a77bdc415L131-R131))
