### PR TITLE
fix : type error at align property in dropdown

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -4,6 +4,7 @@ import RcDropdown from 'rc-dropdown';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
+import type { AlignType } from '@rc-component/trigger';
 import * as React from 'react';
 import genPurePanel from '../_util/PurePanel';
 import type { AdjustOverflow } from '../_util/placements';
@@ -28,23 +29,10 @@ const Placements = [
   'bottom',
 ] as const;
 
-type Placement = (typeof Placements)[number];
+type Placement = typeof Placements[number];
 type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter'>;
 
 type OverlayFunc = () => React.ReactElement;
-
-type Align = {
-  points?: [string, string];
-  offset?: [number, number];
-  targetOffset?: [number, number];
-  overflow?: {
-    adjustX?: boolean;
-    adjustY?: boolean;
-  };
-  useCssRight?: boolean;
-  useCssBottom?: boolean;
-  useCssTransform?: boolean;
-};
 
 export type DropdownArrowOptions = {
   pointAtCenter?: boolean;
@@ -60,7 +48,7 @@ export interface DropdownProps {
   open?: boolean;
   disabled?: boolean;
   destroyPopupOnHide?: boolean;
-  align?: Align;
+  align?: AlignType;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   prefixCls?: string;
   className?: string;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/44397

### 💡 Background and solution

- Problem: When using a string contains percentage at offset in align property in Dropdown, we will get a type error, because antd library declare offset as a array contains 2 numbers in here . However, because antd Dropdown will pass this value to rc- dropdown, and rc - dropdown accept percentage value as string in this field, so using something like '-105%' still works. 

- Solution: Change the type of align property in antd-dropdown to the same type as align property in rc-dropdown.

- Note: There is a same problem with antd-submenu and rc-submenu popupOffset property. antd - submenu pass this value to rc-submenu, then rc- submenu pass to align property in rc-trigger. However, popupOffset in both rc-submenu and antd-sub menu have type: [number, number], but AlignType["offset"] has type : Array(number | `${number}%`), that lead to the same problem as above. I hope who has access to both repositories can fix it 

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the type error with align property  in Dropdown component |
| 🇨🇳 Chinese |  修復 Dropdown 組件中align屬性的類型錯誤 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1e4ec5</samp>

Refactor the `align` prop of the `Dropdown` component to use a common type from an external package. This improves code quality and type safety.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1e4ec5</samp>

*  Refactor the `align` prop of the `Dropdown` component to use the common `AlignType` type from the `@rc-component/trigger` package ([link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR7),[link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL31-R36),[link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL63-R51))
  * Import the `AlignType` type from the `@rc-component/trigger` package in `components/dropdown/dropdown.tsx` ([link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR7))
  * Remove the custom `Align` type definition in `components/dropdown/dropdown.tsx` ([link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL31-R36))
  * Change the type of the `align` prop in the `DropdownProps` interface from `Align` to `AlignType` in `components/dropdown/dropdown.tsx` ([link](https://github.com/ant-design/ant-design/pull/44423/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL63-R51))
