### PR TITLE
fix: Tour panel token & home support dark mode

### DIFF
--- a/.dumi/hooks/useDark.tsx
+++ b/.dumi/hooks/useDark.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const DarkContext = React.createContext(false);
+
+export default function useDark() {
+  return React.useContext(DarkContext);
+}

--- a/.dumi/pages/index/components/ComponentsList.tsx
+++ b/.dumi/pages/index/components/ComponentsList.tsx
@@ -1,21 +1,23 @@
 /* eslint-disable react/jsx-pascal-case */
 import React, { useContext } from 'react';
-import dayjs from 'dayjs';
 import { CustomerServiceOutlined, QuestionCircleOutlined, SyncOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Carousel,
+  DatePicker,
+  FloatButton,
+  Modal,
+  Progress,
+  Space,
+  Tag,
+  Tour,
+  Typography,
+} from 'antd';
 import { createStyles, css, useTheme } from 'antd-style';
 import classNames from 'classnames';
-import {
-  Space,
-  Typography,
-  Tour,
-  Tag,
-  DatePicker,
-  Alert,
-  Modal,
-  FloatButton,
-  Progress,
-  Carousel,
-} from 'antd';
+import dayjs from 'dayjs';
+
+import useDark from '../../../hooks/useDark';
 import useLocale from '../../../hooks/useLocale';
 import SiteContext from '../../../theme/slots/SiteContext';
 import { getCarouselStyle } from './util';
@@ -55,40 +57,45 @@ const locales = {
   },
 };
 
-const useStyle = createStyles(({ token }) => {
-  const { carousel } = getCarouselStyle();
+const useStyle = () => {
+  const isRootDark = useDark();
 
-  return {
-    card: css`
-      border-radius: ${token.borderRadius}px;
-      background: #f5f8ff;
-      padding: ${token.paddingXL}px;
-      flex: none;
-      overflow: hidden;
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
+  return createStyles(({ token }) => {
+    const { carousel } = getCarouselStyle();
 
-      > * {
+    return {
+      card: css`
+        border-radius: ${token.borderRadius}px;
+        border: 1px solid ${isRootDark ? token.colorBorder : 'transparent'};
+        background: ${isRootDark ? token.colorBgContainer : '#f5f8ff'};
+        padding: ${token.paddingXL}px;
         flex: none;
-      }
-    `,
-    cardCircle: css`
-      position: absolute;
-      width: 120px;
-      height: 120px;
-      background: #1677ff;
-      border-radius: 50%;
-      filter: blur(40px);
-      opacity: 0.1;
-    `,
-    mobileCard: css`
-      height: 395px;
-    `,
-    carousel,
-  };
-});
+        overflow: hidden;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+
+        > * {
+          flex: none;
+        }
+      `,
+      cardCircle: css`
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        background: #1677ff;
+        border-radius: 50%;
+        filter: blur(40px);
+        opacity: 0.1;
+      `,
+      mobileCard: css`
+        height: 395px;
+      `,
+      carousel,
+    };
+  })();
+};
 
 const ComponentItem: React.FC<ComponentItemProps> = ({ title, node, type, index }) => {
   const tagColor = type === 'new' ? 'processing' : 'warning';

--- a/.dumi/pages/index/components/DesignFramework.tsx
+++ b/.dumi/pages/index/components/DesignFramework.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
+import { Col, Row, Typography } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { Link, useLocation } from 'dumi';
-import { Col, Row, Typography } from 'antd';
+
+import useDark from '../../../hooks/useDark';
 import useLocale from '../../../hooks/useLocale';
-import * as utils from '../../../theme/utils';
 import SiteContext from '../../../theme/slots/SiteContext';
+import * as utils from '../../../theme/utils';
 
 const SECONDARY_LIST = [
   {
@@ -60,12 +62,17 @@ const locales = {
   },
 };
 
-const useStyle = createStyles(({ token, css }) => ({
-  card: css`
+const useStyle = () => {
+  const isRootDark = useDark();
+
+  return createStyles(({ token, css }) => ({
+    card: css`
       padding: ${token.paddingSM}px;
       border-radius: ${token.borderRadius * 2}px;
-      background: #fff;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 1px 6px -1px rgba(0, 0, 0, 0.02),
+      background: ${isRootDark ? 'rgba(0,0,0,0.45)' : token.colorBgElevated};
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.03),
+        0 1px 6px -1px rgba(0, 0, 0, 0.02),
         0 2px 4px rgba(0, 0, 0, 0.02);
 
       img {
@@ -75,18 +82,19 @@ const useStyle = createStyles(({ token, css }) => ({
       }
     `,
 
-  cardMini: css`
+    cardMini: css`
       display: block;
       border-radius: ${token.borderRadius * 2}px;
       padding: ${token.paddingMD}px ${token.paddingLG}px;
-      background: rgba(0, 0, 0, 0.02);
-      border: 1px solid rgba(0, 0, 0, 0.06);
+      background: ${isRootDark ? 'rgba(0,0,0,0.25)' : 'rgba(0, 0, 0, 0.02)'};
+      border: 1px solid ${isRootDark ? 'rgba(255,255,255, 0.45)' : 'rgba(0, 0, 0, 0.06)'};
 
       img {
         height: 48px;
       }
     `,
-}));
+  }))();
+};
 
 export default function DesignFramework() {
   const [locale] = useLocale(locales);

--- a/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { AntDesignOutlined, CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  ColorPicker,
+  Dropdown,
+  Input,
+  message,
+  Modal,
+  Progress,
+  Select,
+  Slider,
+  Steps,
+  Switch,
+  Tooltip,
+} from 'antd';
+import { createStyles } from 'antd-style';
+import classNames from 'classnames';
+
+import useLocale from '../../../../hooks/useLocale';
+
+const { _InternalPanelDoNotUseOrYouWillBeFired: ModalPanel } = Modal;
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalTooltip } = Tooltip;
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalMessage } = message;
+
+const locales = {
+  cn: {
+    range: '设置范围',
+    text: 'Ant Design 5.0 使用 CSS-in-JS 技术以提供动态与混合主题的能力。与此同时，我们使用组件级别的 CSS-in-JS 解决方案，让你的应用获得更好的性能。',
+  },
+  en: {
+    range: 'Set Range',
+    text: 'Ant Design 5.0 use CSS-in-JS technology to provide dynamic & mix theme ability. And which use component level CSS-in-JS solution get your application a better performance.',
+  },
+};
+
+const useStyle = createStyles(({ token, css }) => {
+  const gap = token.padding;
+
+  return {
+    holder: css`
+      width: 500px;
+      display: flex;
+      flex-direction: column;
+      row-gap: ${gap}px;
+      opacity: 0.65;
+    `,
+
+    flex: css`
+      display: flex;
+      flex-wrap: nowrap;
+      column-gap: ${gap}px;
+    `,
+    ptg_20: css`
+      flex: 0 1 20%;
+    `,
+    ptg_none: css`
+      flex: none;
+    `,
+    block: css`
+      background-color: ${token.colorBgContainer};
+      padding: ${token.paddingXS}px ${token.paddingSM}px;
+      border-radius: ${token.borderRadius}px;
+      border: 1px solid ${token.colorBorder};
+    `,
+    noMargin: css`
+      margin: 0;
+    `,
+  };
+});
+
+export interface ComponentsBlockProps {
+  className?: string;
+}
+
+export default function ComponentsBlock(props: ComponentsBlockProps) {
+  const { className } = props;
+
+  const [locale] = useLocale(locales);
+  const { styles } = useStyle();
+
+  return (
+    <div className={classNames(className, styles.holder)}>
+      <ModalPanel title="Ant Design 5.0" width="100%">
+        {locale.text}
+      </ModalPanel>
+
+      <Alert message="Info Text" type="info" />
+
+      {/* Line */}
+      <div className={styles.flex}>
+        <ColorPicker style={{ flex: 'none' }} />
+        <div style={{ flex: 'none' }}>
+          <Dropdown.Button
+            menu={{
+              items: new Array(5).fill(null).map((_, index) => ({
+                key: `opt${index}`,
+                label: `Option ${index}`,
+              })),
+            }}
+          >
+            Dropdown
+          </Dropdown.Button>
+        </div>
+
+        <Select
+          style={{ flex: 'auto' }}
+          mode="multiple"
+          maxTagCount="responsive"
+          defaultValue={[{ value: 'apple' }, { value: 'banana' }]}
+          options={[
+            {
+              value: 'apple',
+              label: 'Apple',
+            },
+            {
+              value: 'banana',
+              label: 'Banana',
+            },
+            {
+              value: 'orange',
+              label: 'Orange',
+            },
+            {
+              value: 'watermelon',
+              label: 'Watermelon',
+            },
+          ]}
+        />
+
+        <Input style={{ flex: 'none', width: 120 }} />
+      </div>
+
+      <Progress
+        style={{ margin: 0 }}
+        percent={100}
+        strokeColor={{ '0%': '#108ee9', '100%': '#87d068' }}
+      />
+      <Progress style={{ margin: 0 }} percent={33} status="exception" />
+
+      <Steps
+        current={1}
+        items={[
+          {
+            title: 'Finished',
+          },
+          {
+            title: 'In Progress',
+          },
+          {
+            title: 'Waiting',
+          },
+        ]}
+      />
+
+      {/* Line */}
+      <div className={styles.block}>
+        <Slider
+          style={{ marginInline: 20 }}
+          range
+          marks={{
+            0: '0°C',
+            26: '26°C',
+            37: '37°C',
+            100: {
+              style: {
+                color: '#f50',
+              },
+              label: <strong>100°C</strong>,
+            },
+          }}
+          defaultValue={[26, 37]}
+        />
+      </div>
+
+      {/* Line */}
+      <div className={styles.flex}>
+        <Button className={styles.ptg_20} type="primary">
+          Primary
+        </Button>
+        <Button className={styles.ptg_20} type="primary" danger>
+          Danger
+        </Button>
+        <Button className={styles.ptg_20}>Default</Button>
+        <Button className={styles.ptg_20} type="dashed">
+          Dashed
+        </Button>
+        <Button className={styles.ptg_20} icon={<AntDesignOutlined />}>
+          Icon
+        </Button>
+      </div>
+
+      {/* Line */}
+      <div className={styles.block}>
+        <div className={styles.flex}>
+          <Switch
+            className={styles.ptg_none}
+            defaultChecked
+            checkedChildren={<CheckOutlined />}
+            unCheckedChildren={<CloseOutlined />}
+          />
+
+          <Checkbox.Group
+            className={styles.ptg_none}
+            options={['Apple', 'Pear', 'Orange']}
+            defaultValue={['Apple']}
+          />
+        </div>
+      </div>
+
+      <div>
+        <InternalMessage content="Ant Design 5.0 is here!" type="success" />
+      </div>
+
+      <InternalTooltip
+        title="Hello, Ant Design 5.0 is here!"
+        placement="topLeft"
+        className={styles.noMargin}
+      />
+
+      <Alert message="Success Text" type="success" />
+    </div>
+  );
+}

--- a/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
@@ -29,10 +29,44 @@ const locales = {
   cn: {
     range: '设置范围',
     text: 'Ant Design 5.0 使用 CSS-in-JS 技术以提供动态与混合主题的能力。与此同时，我们使用组件级别的 CSS-in-JS 解决方案，让你的应用获得更好的性能。',
+    infoText: '信息内容展示',
+    dropdown: '下拉菜单',
+    finished: '已完成',
+    inProgress: '进行中',
+    waiting: '等待中',
+    option: '选项',
+    apple: '苹果',
+    banana: '香蕉',
+    orange: '橘子',
+    watermelon: '西瓜',
+    primary: '主要按钮',
+    danger: '危险按钮',
+    default: '默认按钮',
+    dashed: '虚线按钮',
+    icon: '图标按钮',
+    hello: '你好，Ant Design!',
+    release: 'Ant Design 5.0 正式发布！',
   },
   en: {
     range: 'Set Range',
     text: 'Ant Design 5.0 use CSS-in-JS technology to provide dynamic & mix theme ability. And which use component level CSS-in-JS solution get your application a better performance.',
+    infoText: 'Info Text',
+    dropdown: 'Dropdown',
+    finished: 'Finished',
+    inProgress: 'In Progress',
+    waiting: 'Waiting',
+    option: 'Option',
+    apple: 'Apple',
+    banana: 'Banana',
+    orange: 'Orange',
+    watermelon: 'Watermelon',
+    primary: 'Primary',
+    danger: 'Danger',
+    default: 'Default',
+    dashed: 'Dashed',
+    icon: 'Icon',
+    hello: 'Hello, Ant Design!',
+    release: 'Ant Design 5.0 is released!',
   },
 };
 
@@ -87,7 +121,7 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
         {locale.text}
       </ModalPanel>
 
-      <Alert message="Info Text" type="info" />
+      <Alert message={locale.infoText} type="info" />
 
       {/* Line */}
       <div className={styles.flex}>
@@ -97,11 +131,11 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
             menu={{
               items: new Array(5).fill(null).map((_, index) => ({
                 key: `opt${index}`,
-                label: `Option ${index}`,
+                label: `${locale.option} ${index}`,
               })),
             }}
           >
-            Dropdown
+            {locale.dropdown}
           </Dropdown.Button>
         </div>
 
@@ -113,19 +147,19 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
           options={[
             {
               value: 'apple',
-              label: 'Apple',
+              label: locale.apple,
             },
             {
               value: 'banana',
-              label: 'Banana',
+              label: locale.banana,
             },
             {
               value: 'orange',
-              label: 'Orange',
+              label: locale.orange,
             },
             {
               value: 'watermelon',
-              label: 'Watermelon',
+              label: locale.watermelon,
             },
           ]}
         />
@@ -144,13 +178,13 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
         current={1}
         items={[
           {
-            title: 'Finished',
+            title: locale.finished,
           },
           {
-            title: 'In Progress',
+            title: locale.inProgress,
           },
           {
-            title: 'Waiting',
+            title: locale.waiting,
           },
         ]}
       />
@@ -178,17 +212,17 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
       {/* Line */}
       <div className={styles.flex}>
         <Button className={styles.ptg_20} type="primary">
-          Primary
+          {locale.primary}
         </Button>
         <Button className={styles.ptg_20} type="primary" danger>
-          Danger
+          {locale.danger}
         </Button>
-        <Button className={styles.ptg_20}>Default</Button>
+        <Button className={styles.ptg_20}>{locale.default}</Button>
         <Button className={styles.ptg_20} type="dashed">
-          Dashed
+          {locale.dashed}
         </Button>
         <Button className={styles.ptg_20} icon={<AntDesignOutlined />}>
-          Icon
+          {locale.icon}
         </Button>
       </div>
 
@@ -204,23 +238,19 @@ export default function ComponentsBlock(props: ComponentsBlockProps) {
 
           <Checkbox.Group
             className={styles.ptg_none}
-            options={['Apple', 'Pear', 'Orange']}
-            defaultValue={['Apple']}
+            options={[locale.apple, locale.banana, locale.orange]}
+            defaultValue={[locale.apple]}
           />
         </div>
       </div>
 
       <div>
-        <InternalMessage content="Ant Design 5.0 is here!" type="success" />
+        <InternalMessage content={locale.release} type="success" />
       </div>
 
-      <InternalTooltip
-        title="Hello, Ant Design 5.0 is here!"
-        placement="topLeft"
-        className={styles.noMargin}
-      />
+      <InternalTooltip title={locale.hello} placement="topLeft" className={styles.noMargin} />
 
-      <Alert message="Success Text" type="success" />
+      <Alert message="Ant Design love you!" type="success" />
     </div>
   );
 }

--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Button, Space, Typography } from 'antd';
+import { createStyles, useTheme } from 'antd-style';
+import { Link, useLocation } from 'dumi';
+
+import useLocale from '../../../../hooks/useLocale';
+import SiteContext from '../../../../theme/slots/SiteContext';
+import * as utils from '../../../../theme/utils';
+import { GroupMask } from '../Group';
+import ComponentsBlock from './ComponentsBlock';
+
+const locales = {
+  cn: {
+    slogan: '助力设计开发者「更灵活」地搭建出「更美」的产品，让用户「快乐工作」～',
+    start: '开始使用',
+    designLanguage: '设计语言',
+  },
+  en: {
+    slogan:
+      'Help designers/developers building beautiful products more flexible and working with happiness',
+    start: 'Getting Started',
+    designLanguage: 'Design Language',
+  },
+};
+
+const useStyle = createStyles(({ token, css }) => {
+  const textShadow = `0 0 3px ${token.colorBgContainer}`;
+
+  return {
+    holder: css`
+      height: 520px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      overflow: hidden;
+      perspective: 800px;
+      row-gap: ${token.marginXL}px;
+    `,
+
+    typography: css`
+      text-align: center;
+      position: relative;
+      z-index: 1;
+      text-shadow: ${new Array(5)
+        .fill(null)
+        .map(() => textShadow)
+        .join(', ')};
+
+      h1 {
+        font-family: AliPuHui, ${token.fontFamily} !important;
+        font-weight: 900 !important;
+        font-size: ${token.fontSizeHeading2 * 2}px !important;
+        line-height: ${token.lineHeightHeading2} !important;
+      }
+
+      p {
+        font-size: ${token.fontSizeLG}px !important;
+        font-weight: normal !important;
+        margin-bottom: 0;
+      }
+    `,
+
+    block: css`
+      position: absolute;
+      inset-inline-end: 0;
+      top: -38px;
+      transform: rotate3d(24, -83, 45, 57deg);
+    `,
+
+    child: css`
+      position: relative;
+      z-index: 1;
+    `,
+  };
+});
+
+export interface PreviewBannerProps {
+  children?: React.ReactNode;
+}
+
+export default function PreviewBanner(props: PreviewBannerProps) {
+  const { children } = props;
+
+  const [locale] = useLocale(locales);
+  const { styles } = useStyle();
+  const { isMobile } = React.useContext(SiteContext);
+  const token = useTheme();
+  const { pathname, search } = useLocation();
+  const isZhCN = utils.isZhCN(pathname);
+
+  return (
+    <GroupMask>
+      {/* Image Left Top */}
+      <img
+        style={{ position: 'absolute', left: isMobile ? -120 : 0, top: 0, width: 240 }}
+        src="https://gw.alipayobjects.com/zos/bmw-prod/49f963db-b2a8-4f15-857a-270d771a1204.svg"
+        alt="bg"
+      />
+      {/* Image Right Top */}
+      <img
+        style={{ position: 'absolute', right: isMobile ? 0 : '40%', bottom: 120, width: 240 }}
+        src="https://gw.alipayobjects.com/zos/bmw-prod/e152223c-bcae-4913-8938-54fda9efe330.svg"
+        alt="bg"
+      />
+
+      <div className={styles.holder}>
+        <ComponentsBlock className={styles.block} />
+
+        <Typography className={styles.typography}>
+          <h1>Ant Design 5.0</h1>
+          <p>{locale.slogan}</p>
+        </Typography>
+
+        <Space size="middle" style={{ marginBottom: token.marginXL }}>
+          <Link to={utils.getLocalizedPathname('/components/overview/', isZhCN, search)}>
+            <Button size="large" type="primary">
+              {locale.start}
+            </Button>
+          </Link>
+          <Link to={utils.getLocalizedPathname('/docs/spec/introduce/', isZhCN, search)}>
+            <Button size="large">{locale.designLanguage}</Button>
+          </Link>
+        </Space>
+
+        <div className={styles.child}>{children}</div>
+      </div>
+    </GroupMask>
+  );
+}

--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Space, Typography } from 'antd';
+import { Button, ConfigProvider, Space, Typography } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { Link, useLocation } from 'dumi';
 
@@ -25,6 +25,8 @@ const locales = {
 
 const useStyle = createStyles(({ token, css }) => {
   const textShadow = `0 0 3px ${token.colorBgContainer}`;
+  const { direction } = React.useContext(ConfigProvider.ConfigContext);
+  const isRTL = direction === 'rtl';
 
   return {
     holder: css`
@@ -67,7 +69,7 @@ const useStyle = createStyles(({ token, css }) => {
       position: absolute;
       inset-inline-end: 0;
       top: -38px;
-      transform: rotate3d(24, -83, 45, 57deg);
+      transform: ${isRTL ? 'rotate3d(24, 83, -45, 57deg)' : 'rotate3d(24, -83, 45, 57deg)'};
     `,
 
     child: css`

--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -43,6 +43,7 @@ const useStyle = createStyles(({ token, css }) => {
       text-align: center;
       position: relative;
       z-index: 1;
+      padding-inline: ${token.paddingXL}px;
       text-shadow: ${new Array(5)
         .fill(null)
         .map(() => textShadow)
@@ -106,7 +107,8 @@ export default function PreviewBanner(props: PreviewBannerProps) {
       />
 
       <div className={styles.holder}>
-        <ComponentsBlock className={styles.block} />
+        {/* Mobile not show the component preview */}
+        {!isMobile && <ComponentsBlock className={styles.block} />}
 
         <Typography className={styles.typography}>
           <h1>Ant Design 5.0</h1>

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -1,15 +1,12 @@
-import { TinyColor } from '@ctrl/tinycolor';
+import * as React from 'react';
+import { defaultAlgorithm, defaultTheme } from '@ant-design/compatible';
 import {
   BellOutlined,
   FolderOutlined,
   HomeOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons';
-import { createStyles, css, useTheme } from 'antd-style';
-import * as React from 'react';
-import classNames from 'classnames';
-import { defaultTheme, defaultAlgorithm } from '@ant-design/compatible';
-import { useLocation } from 'dumi';
+import { TinyColor } from '@ctrl/tinycolor';
 import type { MenuProps } from 'antd';
 import {
   Breadcrumb,
@@ -21,24 +18,29 @@ import {
   Menu,
   Radio,
   Space,
-  Typography,
   theme,
+  Typography,
 } from 'antd';
+import { createStyles, css, useTheme } from 'antd-style';
 import type { Color } from 'antd/es/color-picker';
 import { generateColor } from 'antd/es/color-picker/util';
-import * as utils from '../../../../theme/utils';
+import classNames from 'classnames';
+import { useLocation } from 'dumi';
+
+import useDark from '../../../../hooks/useDark';
 import useLocale from '../../../../hooks/useLocale';
+import Link from '../../../../theme/common/Link';
 import SiteContext from '../../../../theme/slots/SiteContext';
+import * as utils from '../../../../theme/utils';
 import Group from '../Group';
 import { getCarouselStyle } from '../util';
 import BackgroundImage from './BackgroundImage';
 import ColorPicker from './ColorPicker';
+import { DEFAULT_COLOR, getAvatarURL, getClosetColor, PINK_COLOR } from './colorUtil';
 import MobileCarousel from './MobileCarousel';
 import RadiusPicker from './RadiusPicker';
 import type { THEME } from './ThemePicker';
 import ThemePicker from './ThemePicker';
-import { DEFAULT_COLOR, PINK_COLOR, getAvatarURL, getClosetColor } from './colorUtil';
-import Link from '../../../../theme/common/Link';
 
 const { Header, Content, Sider } = Layout;
 
@@ -354,6 +356,15 @@ export default function Theme() {
     setThemeData(mergedData);
     form.setFieldsValue(mergedData);
   }, [themeType]);
+
+  const isRootDark = useDark();
+
+  React.useEffect(() => {
+    onThemeChange(null, {
+      ...themeData,
+      themeType: isRootDark ? 'dark' : 'default',
+    });
+  }, [isRootDark]);
 
   // ================================ Tokens ================================
   const closestColor = getClosetColor(colorPrimaryValue);

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -1,12 +1,13 @@
-import { createStyles, css } from 'antd-style';
 import React, { Suspense } from 'react';
 import { ConfigProvider } from 'antd';
+import { createStyles, css } from 'antd-style';
+
 import useLocale from '../../hooks/useLocale';
-import Banner from './components/Banner';
 import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
 import ComponentsList from './components/ComponentsList';
 import DesignFramework from './components/DesignFramework';
 import Group from './components/Group';
+import PreviewBanner from './components/PreviewBanner';
 import Theme from './components/Theme';
 
 const useStyle = createStyles(() => ({
@@ -38,41 +39,40 @@ const Homepage: React.FC = () => {
   const { styles } = useStyle();
 
   return (
-    <ConfigProvider theme={{ algorithm: undefined }}>
-      <section>
-        <Banner>
-          <Suspense fallback={<BannerRecommendsFallback />}>
-            <BannerRecommends />
-          </Suspense>
-        </Banner>
-        <div>
-          <Theme />
-          <Group
-            background="#fff"
-            collapse
-            title={locale.assetsTitle}
-            description={locale.assetsDesc}
-            id="design"
-          >
-            <ComponentsList />
-          </Group>
-          <Group
-            title={locale.designTitle}
-            description={locale.designDesc}
-            background="#F5F8FF"
-            decoration={
-              <img
-                className={styles.image}
-                src="https://gw.alipayobjects.com/zos/bmw-prod/ba37a413-28e6-4be4-b1c5-01be1a0ebb1c.svg"
-                alt=""
-              />
-            }
-          >
-            <DesignFramework />
-          </Group>
-        </div>
-      </section>
-    </ConfigProvider>
+    <section>
+      <PreviewBanner>
+        {/* <Suspense fallback={<BannerRecommendsFallback />}>
+          <BannerRecommends />
+        </Suspense> */}
+      </PreviewBanner>
+
+      <div>
+        <Theme />
+        <Group
+          background="#fff"
+          collapse
+          title={locale.assetsTitle}
+          description={locale.assetsDesc}
+          id="design"
+        >
+          <ComponentsList />
+        </Group>
+        <Group
+          title={locale.designTitle}
+          description={locale.designDesc}
+          background="#F5F8FF"
+          decoration={
+            <img
+              className={styles.image}
+              src="https://gw.alipayobjects.com/zos/bmw-prod/ba37a413-28e6-4be4-b1c5-01be1a0ebb1c.svg"
+              alt=""
+            />
+          }
+        >
+          <DesignFramework />
+        </Group>
+      </div>
+    </section>
   );
 };
 

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -1,9 +1,10 @@
-import React, { Suspense } from 'react';
-import { ConfigProvider } from 'antd';
+import React from 'react';
+import { ConfigProvider, theme } from 'antd';
 import { createStyles, css } from 'antd-style';
 
+import useDark from '../../hooks/useDark';
 import useLocale from '../../hooks/useLocale';
-import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
+// import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
 import ComponentsList from './components/ComponentsList';
 import DesignFramework from './components/DesignFramework';
 import Group from './components/Group';
@@ -37,19 +38,32 @@ const locales = {
 const Homepage: React.FC = () => {
   const [locale] = useLocale(locales);
   const { styles } = useStyle();
+  const { token } = theme.useToken();
+
+  const isRootDark = useDark();
 
   return (
     <section>
       <PreviewBanner>
+        {/* 文档很久没更新了，先藏起来 */}
         {/* <Suspense fallback={<BannerRecommendsFallback />}>
           <BannerRecommends />
         </Suspense> */}
       </PreviewBanner>
 
       <div>
-        <Theme />
+        {/* 定制主题 */}
+        <ConfigProvider
+          theme={{
+            algorithm: theme.defaultAlgorithm,
+          }}
+        >
+          <Theme />
+        </ConfigProvider>
+
+        {/* 组件列表 */}
         <Group
-          background="#fff"
+          background={token.colorBgElevated}
           collapse
           title={locale.assetsTitle}
           description={locale.assetsDesc}
@@ -57,10 +71,12 @@ const Homepage: React.FC = () => {
         >
           <ComponentsList />
         </Group>
+
+        {/* 设计语言 */}
         <Group
           title={locale.designTitle}
           description={locale.designDesc}
-          background="#F5F8FF"
+          background={isRootDark ? 'rgb(57, 63, 74)' : '#F5F8FF'}
           decoration={
             <img
               className={styles.image}

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -1,22 +1,24 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   createCache,
+  extractStyle,
   legacyNotSelectorLinter,
   logicalPropertiesLinter,
   parentSelectorLinter,
   StyleProvider,
-  extractStyle,
 } from '@ant-design/cssinjs';
 import { HappyProvider } from '@ant-design/happy-work-theme';
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { createSearchParams, useOutlet, useSearchParams, useServerInsertedHTML } from 'dumi';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
-import { App, theme as antdTheme } from 'antd';
+import { theme as antdTheme, App } from 'antd';
 import type { DirectionType } from 'antd/es/config-provider';
+import { createSearchParams, useOutlet, useSearchParams, useServerInsertedHTML } from 'dumi';
+
+import { DarkContext } from '../../hooks/useDark';
 import useLayoutState from '../../hooks/useLayoutState';
-import SiteThemeProvider from '../SiteThemeProvider';
 import useLocation from '../../hooks/useLocation';
 import type { ThemeName } from '../common/ThemeSwitch';
 import ThemeSwitch from '../common/ThemeSwitch';
+import SiteThemeProvider from '../SiteThemeProvider';
 import type { SiteContextProps } from '../slots/SiteContext';
 import SiteContext from '../slots/SiteContext';
 
@@ -144,23 +146,25 @@ const GlobalLayout: React.FC = () => {
   }
 
   return (
-    <StyleProvider
-      cache={styleCache}
-      linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
-    >
-      <SiteContext.Provider value={siteContextValue}>
-        <SiteThemeProvider
-          theme={{
-            algorithm: getAlgorithm(theme),
-            token: {
-              motion: !theme.includes('motion-off'),
-            },
-          }}
-        >
-          <HappyProvider disabled={!theme.includes('happy-work')}>{content}</HappyProvider>
-        </SiteThemeProvider>
-      </SiteContext.Provider>
-    </StyleProvider>
+    <DarkContext.Provider value={theme.includes('dark')}>
+      <StyleProvider
+        cache={styleCache}
+        linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
+      >
+        <SiteContext.Provider value={siteContextValue}>
+          <SiteThemeProvider
+            theme={{
+              algorithm: getAlgorithm(theme),
+              token: {
+                motion: !theme.includes('motion-off'),
+              },
+            }}
+          >
+            <HappyProvider disabled={!theme.includes('happy-work')}>{content}</HappyProvider>
+          </SiteThemeProvider>
+        </SiteContext.Provider>
+      </StyleProvider>
+    </DarkContext.Provider>
   );
 };
 

--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -1,4 +1,5 @@
 import { TinyColor } from '@ctrl/tinycolor';
+
 import { resetComponent } from '../../style';
 import getArrowStyle, { MAX_VERTICAL_CONTENT_RADIUS } from '../../style/placementArrow';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
@@ -31,7 +32,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
     boxShadowTertiary,
     tourZIndexPopup,
     fontSize,
-    colorBgContainer,
+    colorBgElevated,
     fontWeightStrong,
     marginXS,
     colorTextLightSolid,
@@ -56,7 +57,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
         fontSize,
         lineHeight,
         width: 520,
-        '--antd-arrow-background-color': colorBgContainer,
+        '--antd-arrow-background-color': colorBgElevated,
 
         '&-pure': {
           maxWidth: '100%',
@@ -77,7 +78,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
           borderRadius: tourBorderRadius,
           boxShadow: boxShadowTertiary,
           position: 'relative',
-          backgroundColor: colorBgContainer,
+          backgroundColor: colorBgElevated,
           border: 'none',
           backgroundClip: 'padding-box',
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Home page support dark mode and show the components on the right

<img width="1424" alt="截屏2023-08-25 17 17 30" src="https://github.com/ant-design/ant-design/assets/5378891/f2352902-1707-4be7-b755-4a0de71c4c12">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Tour panel use wrong design token.      |
| 🇨🇳 Chinese |    修复 Tour 面板使用的 design token 错误的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6aa120</samp>

This pull request refactors and updates the documentation site of antd to support a dark theme feature. It adds a custom hook `useDark` and a context `DarkContext` to detect and provide the theme type, and modifies the homepage and layout components to use them. It also improves the code organization and readability of several files by grouping imports and using custom hooks for styles. Additionally, it changes the background color of the tour popup component and adds a new `PreviewBanner` component to showcase antd components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6aa120</samp>

*  Add a custom hook `useDark` and a context `DarkContext` to get and provide the root theme value ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-374ac283d811648736e29830c45ab9b5e70c14cb2191493f858974d6a19e6f24R1-R7))
*  Use the `useDark` hook to conditionally set the styles for the components list and the design framework cards ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L58-R99), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL63-R75))
*  Add a new component `ComponentsBlock` that renders a preview of various antd components ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-e7b678382f0c632748d793d3cdbd2207a645522f3a84911e91598381adb6b8d5R1-R226))
*  Add a new component `PreviewBanner` that renders a banner with a title, a slogan, a modal panel, and a components block ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beR1-R133))
*  Replace the `Banner` component with `PreviewBanner` and remove the `ConfigProvider` wrapper in the index page ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L39-R91))
*  Add a `DarkContext.Provider` wrapper that sets the value based on the theme in the global layout ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L147-R167))
*  Reorder the import statements and remove unused or add missing imports in several files ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L3-R20), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL2-R9), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL1-R2), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL8-R9), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL24-R43), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L1-R11), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L1-R21))
*  Replace the `colorBgContainer` token with `colorBgElevated` token for the tour popup styles ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L34-R35), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L59-R60), [link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L80-R81))
*  Add an empty line at the beginning of the `components/tour/style/index.ts` file ([link](https://github.com/ant-design/ant-design/pull/44428/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20R2))
