### PR TITLE
chore: merge master into feature

### DIFF
--- a/.dumi/hooks/useDark.tsx
+++ b/.dumi/hooks/useDark.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const DarkContext = React.createContext(false);
+
+export default function useDark() {
+  return React.useContext(DarkContext);
+}

--- a/.dumi/pages/index/components/ComponentsList.tsx
+++ b/.dumi/pages/index/components/ComponentsList.tsx
@@ -1,21 +1,23 @@
 /* eslint-disable react/jsx-pascal-case */
 import React, { useContext } from 'react';
-import dayjs from 'dayjs';
 import { CustomerServiceOutlined, QuestionCircleOutlined, SyncOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Carousel,
+  DatePicker,
+  FloatButton,
+  Modal,
+  Progress,
+  Space,
+  Tag,
+  Tour,
+  Typography,
+} from 'antd';
 import { createStyles, css, useTheme } from 'antd-style';
 import classNames from 'classnames';
-import {
-  Space,
-  Typography,
-  Tour,
-  Tag,
-  DatePicker,
-  Alert,
-  Modal,
-  FloatButton,
-  Progress,
-  Carousel,
-} from 'antd';
+import dayjs from 'dayjs';
+
+import useDark from '../../../hooks/useDark';
 import useLocale from '../../../hooks/useLocale';
 import SiteContext from '../../../theme/slots/SiteContext';
 import { getCarouselStyle } from './util';
@@ -55,40 +57,45 @@ const locales = {
   },
 };
 
-const useStyle = createStyles(({ token }) => {
-  const { carousel } = getCarouselStyle();
+const useStyle = () => {
+  const isRootDark = useDark();
 
-  return {
-    card: css`
-      border-radius: ${token.borderRadius}px;
-      background: #f5f8ff;
-      padding: ${token.paddingXL}px;
-      flex: none;
-      overflow: hidden;
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
+  return createStyles(({ token }) => {
+    const { carousel } = getCarouselStyle();
 
-      > * {
+    return {
+      card: css`
+        border-radius: ${token.borderRadius}px;
+        border: 1px solid ${isRootDark ? token.colorBorder : 'transparent'};
+        background: ${isRootDark ? token.colorBgContainer : '#f5f8ff'};
+        padding: ${token.paddingXL}px;
         flex: none;
-      }
-    `,
-    cardCircle: css`
-      position: absolute;
-      width: 120px;
-      height: 120px;
-      background: #1677ff;
-      border-radius: 50%;
-      filter: blur(40px);
-      opacity: 0.1;
-    `,
-    mobileCard: css`
-      height: 395px;
-    `,
-    carousel,
-  };
-});
+        overflow: hidden;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+
+        > * {
+          flex: none;
+        }
+      `,
+      cardCircle: css`
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        background: #1677ff;
+        border-radius: 50%;
+        filter: blur(40px);
+        opacity: 0.1;
+      `,
+      mobileCard: css`
+        height: 395px;
+      `,
+      carousel,
+    };
+  })();
+};
 
 const ComponentItem: React.FC<ComponentItemProps> = ({ title, node, type, index }) => {
   const tagColor = type === 'new' ? 'processing' : 'warning';

--- a/.dumi/pages/index/components/DesignFramework.tsx
+++ b/.dumi/pages/index/components/DesignFramework.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
+import { Col, Row, Typography } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { Link, useLocation } from 'dumi';
-import { Col, Row, Typography } from 'antd';
+
+import useDark from '../../../hooks/useDark';
 import useLocale from '../../../hooks/useLocale';
-import * as utils from '../../../theme/utils';
 import SiteContext from '../../../theme/slots/SiteContext';
+import * as utils from '../../../theme/utils';
 
 const SECONDARY_LIST = [
   {
@@ -60,12 +62,17 @@ const locales = {
   },
 };
 
-const useStyle = createStyles(({ token, css }) => ({
-  card: css`
+const useStyle = () => {
+  const isRootDark = useDark();
+
+  return createStyles(({ token, css }) => ({
+    card: css`
       padding: ${token.paddingSM}px;
       border-radius: ${token.borderRadius * 2}px;
-      background: #fff;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 1px 6px -1px rgba(0, 0, 0, 0.02),
+      background: ${isRootDark ? 'rgba(0,0,0,0.45)' : token.colorBgElevated};
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.03),
+        0 1px 6px -1px rgba(0, 0, 0, 0.02),
         0 2px 4px rgba(0, 0, 0, 0.02);
 
       img {
@@ -75,18 +82,19 @@ const useStyle = createStyles(({ token, css }) => ({
       }
     `,
 
-  cardMini: css`
+    cardMini: css`
       display: block;
       border-radius: ${token.borderRadius * 2}px;
       padding: ${token.paddingMD}px ${token.paddingLG}px;
-      background: rgba(0, 0, 0, 0.02);
-      border: 1px solid rgba(0, 0, 0, 0.06);
+      background: ${isRootDark ? 'rgba(0,0,0,0.25)' : 'rgba(0, 0, 0, 0.02)'};
+      border: 1px solid ${isRootDark ? 'rgba(255,255,255, 0.45)' : 'rgba(0, 0, 0, 0.06)'};
 
       img {
         height: 48px;
       }
     `,
-}));
+  }))();
+};
 
 export default function DesignFramework() {
   const [locale] = useLocale(locales);

--- a/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/ComponentsBlock.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import { AntDesignOutlined, CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Checkbox,
+  ColorPicker,
+  Dropdown,
+  Input,
+  message,
+  Modal,
+  Progress,
+  Select,
+  Slider,
+  Steps,
+  Switch,
+  Tooltip,
+} from 'antd';
+import { createStyles } from 'antd-style';
+import classNames from 'classnames';
+
+import useLocale from '../../../../hooks/useLocale';
+
+const { _InternalPanelDoNotUseOrYouWillBeFired: ModalPanel } = Modal;
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalTooltip } = Tooltip;
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalMessage } = message;
+
+const locales = {
+  cn: {
+    range: '设置范围',
+    text: 'Ant Design 5.0 使用 CSS-in-JS 技术以提供动态与混合主题的能力。与此同时，我们使用组件级别的 CSS-in-JS 解决方案，让你的应用获得更好的性能。',
+    infoText: '信息内容展示',
+    dropdown: '下拉菜单',
+    finished: '已完成',
+    inProgress: '进行中',
+    waiting: '等待中',
+    option: '选项',
+    apple: '苹果',
+    banana: '香蕉',
+    orange: '橘子',
+    watermelon: '西瓜',
+    primary: '主要按钮',
+    danger: '危险按钮',
+    default: '默认按钮',
+    dashed: '虚线按钮',
+    icon: '图标按钮',
+    hello: '你好，Ant Design!',
+    release: 'Ant Design 5.0 正式发布！',
+  },
+  en: {
+    range: 'Set Range',
+    text: 'Ant Design 5.0 use CSS-in-JS technology to provide dynamic & mix theme ability. And which use component level CSS-in-JS solution get your application a better performance.',
+    infoText: 'Info Text',
+    dropdown: 'Dropdown',
+    finished: 'Finished',
+    inProgress: 'In Progress',
+    waiting: 'Waiting',
+    option: 'Option',
+    apple: 'Apple',
+    banana: 'Banana',
+    orange: 'Orange',
+    watermelon: 'Watermelon',
+    primary: 'Primary',
+    danger: 'Danger',
+    default: 'Default',
+    dashed: 'Dashed',
+    icon: 'Icon',
+    hello: 'Hello, Ant Design!',
+    release: 'Ant Design 5.0 is released!',
+  },
+};
+
+const useStyle = createStyles(({ token, css }) => {
+  const gap = token.padding;
+
+  return {
+    holder: css`
+      width: 500px;
+      display: flex;
+      flex-direction: column;
+      row-gap: ${gap}px;
+      opacity: 0.65;
+    `,
+
+    flex: css`
+      display: flex;
+      flex-wrap: nowrap;
+      column-gap: ${gap}px;
+    `,
+    ptg_20: css`
+      flex: 0 1 20%;
+    `,
+    ptg_none: css`
+      flex: none;
+    `,
+    block: css`
+      background-color: ${token.colorBgContainer};
+      padding: ${token.paddingXS}px ${token.paddingSM}px;
+      border-radius: ${token.borderRadius}px;
+      border: 1px solid ${token.colorBorder};
+    `,
+    noMargin: css`
+      margin: 0;
+    `,
+  };
+});
+
+export interface ComponentsBlockProps {
+  className?: string;
+}
+
+export default function ComponentsBlock(props: ComponentsBlockProps) {
+  const { className } = props;
+
+  const [locale] = useLocale(locales);
+  const { styles } = useStyle();
+
+  return (
+    <div className={classNames(className, styles.holder)}>
+      <ModalPanel title="Ant Design 5.0" width="100%">
+        {locale.text}
+      </ModalPanel>
+
+      <Alert message={locale.infoText} type="info" />
+
+      {/* Line */}
+      <div className={styles.flex}>
+        <ColorPicker style={{ flex: 'none' }} />
+        <div style={{ flex: 'none' }}>
+          <Dropdown.Button
+            menu={{
+              items: new Array(5).fill(null).map((_, index) => ({
+                key: `opt${index}`,
+                label: `${locale.option} ${index}`,
+              })),
+            }}
+          >
+            {locale.dropdown}
+          </Dropdown.Button>
+        </div>
+
+        <Select
+          style={{ flex: 'auto' }}
+          mode="multiple"
+          maxTagCount="responsive"
+          defaultValue={[{ value: 'apple' }, { value: 'banana' }]}
+          options={[
+            {
+              value: 'apple',
+              label: locale.apple,
+            },
+            {
+              value: 'banana',
+              label: locale.banana,
+            },
+            {
+              value: 'orange',
+              label: locale.orange,
+            },
+            {
+              value: 'watermelon',
+              label: locale.watermelon,
+            },
+          ]}
+        />
+
+        <Input style={{ flex: 'none', width: 120 }} />
+      </div>
+
+      <Progress
+        style={{ margin: 0 }}
+        percent={100}
+        strokeColor={{ '0%': '#108ee9', '100%': '#87d068' }}
+      />
+      <Progress style={{ margin: 0 }} percent={33} status="exception" />
+
+      <Steps
+        current={1}
+        items={[
+          {
+            title: locale.finished,
+          },
+          {
+            title: locale.inProgress,
+          },
+          {
+            title: locale.waiting,
+          },
+        ]}
+      />
+
+      {/* Line */}
+      <div className={styles.block}>
+        <Slider
+          style={{ marginInline: 20 }}
+          range
+          marks={{
+            0: '0°C',
+            26: '26°C',
+            37: '37°C',
+            100: {
+              style: {
+                color: '#f50',
+              },
+              label: <strong>100°C</strong>,
+            },
+          }}
+          defaultValue={[26, 37]}
+        />
+      </div>
+
+      {/* Line */}
+      <div className={styles.flex}>
+        <Button className={styles.ptg_20} type="primary">
+          {locale.primary}
+        </Button>
+        <Button className={styles.ptg_20} type="primary" danger>
+          {locale.danger}
+        </Button>
+        <Button className={styles.ptg_20}>{locale.default}</Button>
+        <Button className={styles.ptg_20} type="dashed">
+          {locale.dashed}
+        </Button>
+        <Button className={styles.ptg_20} icon={<AntDesignOutlined />}>
+          {locale.icon}
+        </Button>
+      </div>
+
+      {/* Line */}
+      <div className={styles.block}>
+        <div className={styles.flex}>
+          <Switch
+            className={styles.ptg_none}
+            defaultChecked
+            checkedChildren={<CheckOutlined />}
+            unCheckedChildren={<CloseOutlined />}
+          />
+
+          <Checkbox.Group
+            className={styles.ptg_none}
+            options={[locale.apple, locale.banana, locale.orange]}
+            defaultValue={[locale.apple]}
+          />
+        </div>
+      </div>
+
+      <div>
+        <InternalMessage content={locale.release} type="success" />
+      </div>
+
+      <InternalTooltip title={locale.hello} placement="topLeft" className={styles.noMargin} />
+
+      <Alert message="Ant Design love you!" type="success" />
+    </div>
+  );
+}

--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Button, ConfigProvider, Space, Typography } from 'antd';
+import { createStyles, useTheme } from 'antd-style';
+import { Link, useLocation } from 'dumi';
+
+import useLocale from '../../../../hooks/useLocale';
+import SiteContext from '../../../../theme/slots/SiteContext';
+import * as utils from '../../../../theme/utils';
+import { GroupMask } from '../Group';
+import ComponentsBlock from './ComponentsBlock';
+
+const locales = {
+  cn: {
+    slogan: '助力设计开发者「更灵活」地搭建出「更美」的产品，让用户「快乐工作」～',
+    start: '开始使用',
+    designLanguage: '设计语言',
+  },
+  en: {
+    slogan:
+      'Help designers/developers building beautiful products more flexible and working with happiness',
+    start: 'Getting Started',
+    designLanguage: 'Design Language',
+  },
+};
+
+const useStyle = createStyles(({ token, css }) => {
+  const textShadow = `0 0 3px ${token.colorBgContainer}`;
+  const { direction } = React.useContext(ConfigProvider.ConfigContext);
+  const isRTL = direction === 'rtl';
+
+  return {
+    holder: css`
+      height: 520px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      overflow: hidden;
+      perspective: 800px;
+      row-gap: ${token.marginXL}px;
+    `,
+
+    typography: css`
+      text-align: center;
+      position: relative;
+      z-index: 1;
+      padding-inline: ${token.paddingXL}px;
+      text-shadow: ${new Array(5)
+        .fill(null)
+        .map(() => textShadow)
+        .join(', ')};
+
+      h1 {
+        font-family: AliPuHui, ${token.fontFamily} !important;
+        font-weight: 900 !important;
+        font-size: ${token.fontSizeHeading2 * 2}px !important;
+        line-height: ${token.lineHeightHeading2} !important;
+      }
+
+      p {
+        font-size: ${token.fontSizeLG}px !important;
+        font-weight: normal !important;
+        margin-bottom: 0;
+      }
+    `,
+
+    block: css`
+      position: absolute;
+      inset-inline-end: 0;
+      top: -38px;
+      transform: ${isRTL ? 'rotate3d(24, 83, -45, 57deg)' : 'rotate3d(24, -83, 45, 57deg)'};
+    `,
+
+    child: css`
+      position: relative;
+      z-index: 1;
+    `,
+  };
+});
+
+export interface PreviewBannerProps {
+  children?: React.ReactNode;
+}
+
+export default function PreviewBanner(props: PreviewBannerProps) {
+  const { children } = props;
+
+  const [locale] = useLocale(locales);
+  const { styles } = useStyle();
+  const { isMobile } = React.useContext(SiteContext);
+  const token = useTheme();
+  const { pathname, search } = useLocation();
+  const isZhCN = utils.isZhCN(pathname);
+
+  return (
+    <GroupMask>
+      {/* Image Left Top */}
+      <img
+        style={{ position: 'absolute', left: isMobile ? -120 : 0, top: 0, width: 240 }}
+        src="https://gw.alipayobjects.com/zos/bmw-prod/49f963db-b2a8-4f15-857a-270d771a1204.svg"
+        alt="bg"
+      />
+      {/* Image Right Top */}
+      <img
+        style={{ position: 'absolute', right: isMobile ? 0 : '40%', bottom: 120, width: 240 }}
+        src="https://gw.alipayobjects.com/zos/bmw-prod/e152223c-bcae-4913-8938-54fda9efe330.svg"
+        alt="bg"
+      />
+
+      <div className={styles.holder}>
+        {/* Mobile not show the component preview */}
+        {!isMobile && <ComponentsBlock className={styles.block} />}
+
+        <Typography className={styles.typography}>
+          <h1>Ant Design 5.0</h1>
+          <p>{locale.slogan}</p>
+        </Typography>
+
+        <Space size="middle" style={{ marginBottom: token.marginXL }}>
+          <Link to={utils.getLocalizedPathname('/components/overview/', isZhCN, search)}>
+            <Button size="large" type="primary">
+              {locale.start}
+            </Button>
+          </Link>
+          <Link to={utils.getLocalizedPathname('/docs/spec/introduce/', isZhCN, search)}>
+            <Button size="large">{locale.designLanguage}</Button>
+          </Link>
+        </Space>
+
+        <div className={styles.child}>{children}</div>
+      </div>
+    </GroupMask>
+  );
+}

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -1,15 +1,12 @@
-import { TinyColor } from '@ctrl/tinycolor';
+import * as React from 'react';
+import { defaultAlgorithm, defaultTheme } from '@ant-design/compatible';
 import {
   BellOutlined,
   FolderOutlined,
   HomeOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons';
-import { createStyles, css, useTheme } from 'antd-style';
-import * as React from 'react';
-import classNames from 'classnames';
-import { defaultTheme, defaultAlgorithm } from '@ant-design/compatible';
-import { useLocation } from 'dumi';
+import { TinyColor } from '@ctrl/tinycolor';
 import type { MenuProps } from 'antd';
 import {
   Breadcrumb,
@@ -21,24 +18,29 @@ import {
   Menu,
   Radio,
   Space,
-  Typography,
   theme,
+  Typography,
 } from 'antd';
+import { createStyles, css, useTheme } from 'antd-style';
 import type { Color } from 'antd/es/color-picker';
 import { generateColor } from 'antd/es/color-picker/util';
-import * as utils from '../../../../theme/utils';
+import classNames from 'classnames';
+import { useLocation } from 'dumi';
+
+import useDark from '../../../../hooks/useDark';
 import useLocale from '../../../../hooks/useLocale';
+import Link from '../../../../theme/common/Link';
 import SiteContext from '../../../../theme/slots/SiteContext';
+import * as utils from '../../../../theme/utils';
 import Group from '../Group';
 import { getCarouselStyle } from '../util';
 import BackgroundImage from './BackgroundImage';
 import ColorPicker from './ColorPicker';
+import { DEFAULT_COLOR, getAvatarURL, getClosetColor, PINK_COLOR } from './colorUtil';
 import MobileCarousel from './MobileCarousel';
 import RadiusPicker from './RadiusPicker';
 import type { THEME } from './ThemePicker';
 import ThemePicker from './ThemePicker';
-import { DEFAULT_COLOR, PINK_COLOR, getAvatarURL, getClosetColor } from './colorUtil';
-import Link from '../../../../theme/common/Link';
 
 const { Header, Content, Sider } = Layout;
 
@@ -354,6 +356,15 @@ export default function Theme() {
     setThemeData(mergedData);
     form.setFieldsValue(mergedData);
   }, [themeType]);
+
+  const isRootDark = useDark();
+
+  React.useEffect(() => {
+    onThemeChange(null, {
+      ...themeData,
+      themeType: isRootDark ? 'dark' : 'default',
+    });
+  }, [isRootDark]);
 
   // ================================ Tokens ================================
   const closestColor = getClosetColor(colorPrimaryValue);

--- a/.dumi/pages/index/index.tsx
+++ b/.dumi/pages/index/index.tsx
@@ -1,12 +1,14 @@
+import React from 'react';
+import { ConfigProvider, theme } from 'antd';
 import { createStyles, css } from 'antd-style';
-import React, { Suspense } from 'react';
-import { ConfigProvider } from 'antd';
+
+import useDark from '../../hooks/useDark';
 import useLocale from '../../hooks/useLocale';
-import Banner from './components/Banner';
-import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
+// import BannerRecommends, { BannerRecommendsFallback } from './components/BannerRecommends';
 import ComponentsList from './components/ComponentsList';
 import DesignFramework from './components/DesignFramework';
 import Group from './components/Group';
+import PreviewBanner from './components/PreviewBanner';
 import Theme from './components/Theme';
 
 const useStyle = createStyles(() => ({
@@ -36,43 +38,57 @@ const locales = {
 const Homepage: React.FC = () => {
   const [locale] = useLocale(locales);
   const { styles } = useStyle();
+  const { token } = theme.useToken();
+
+  const isRootDark = useDark();
 
   return (
-    <ConfigProvider theme={{ algorithm: undefined }}>
-      <section>
-        <Banner>
-          <Suspense fallback={<BannerRecommendsFallback />}>
-            <BannerRecommends />
-          </Suspense>
-        </Banner>
-        <div>
+    <section>
+      <PreviewBanner>
+        {/* 文档很久没更新了，先藏起来 */}
+        {/* <Suspense fallback={<BannerRecommendsFallback />}>
+          <BannerRecommends />
+        </Suspense> */}
+      </PreviewBanner>
+
+      <div>
+        {/* 定制主题 */}
+        <ConfigProvider
+          theme={{
+            algorithm: theme.defaultAlgorithm,
+          }}
+        >
           <Theme />
-          <Group
-            background="#fff"
-            collapse
-            title={locale.assetsTitle}
-            description={locale.assetsDesc}
-            id="design"
-          >
-            <ComponentsList />
-          </Group>
-          <Group
-            title={locale.designTitle}
-            description={locale.designDesc}
-            background="#F5F8FF"
-            decoration={
-              <img
-                className={styles.image}
-                src="https://gw.alipayobjects.com/zos/bmw-prod/ba37a413-28e6-4be4-b1c5-01be1a0ebb1c.svg"
-                alt=""
-              />
-            }
-          >
-            <DesignFramework />
-          </Group>
-        </div>
-      </section>
-    </ConfigProvider>
+        </ConfigProvider>
+
+        {/* 组件列表 */}
+        <Group
+          background={token.colorBgElevated}
+          collapse
+          title={locale.assetsTitle}
+          description={locale.assetsDesc}
+          id="design"
+        >
+          <ComponentsList />
+        </Group>
+
+        {/* 设计语言 */}
+        <Group
+          title={locale.designTitle}
+          description={locale.designDesc}
+          background={isRootDark ? 'rgb(57, 63, 74)' : '#F5F8FF'}
+          decoration={
+            <img
+              className={styles.image}
+              src="https://gw.alipayobjects.com/zos/bmw-prod/ba37a413-28e6-4be4-b1c5-01be1a0ebb1c.svg"
+              alt=""
+            />
+          }
+        >
+          <DesignFramework />
+        </Group>
+      </div>
+    </section>
   );
 };
 

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -1,22 +1,24 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   createCache,
+  extractStyle,
   legacyNotSelectorLinter,
   logicalPropertiesLinter,
   parentSelectorLinter,
   StyleProvider,
-  extractStyle,
 } from '@ant-design/cssinjs';
 import { HappyProvider } from '@ant-design/happy-work-theme';
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { createSearchParams, useOutlet, useSearchParams, useServerInsertedHTML } from 'dumi';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
-import { App, theme as antdTheme } from 'antd';
+import { theme as antdTheme, App } from 'antd';
 import type { DirectionType } from 'antd/es/config-provider';
+import { createSearchParams, useOutlet, useSearchParams, useServerInsertedHTML } from 'dumi';
+
+import { DarkContext } from '../../hooks/useDark';
 import useLayoutState from '../../hooks/useLayoutState';
-import SiteThemeProvider from '../SiteThemeProvider';
 import useLocation from '../../hooks/useLocation';
 import type { ThemeName } from '../common/ThemeSwitch';
 import ThemeSwitch from '../common/ThemeSwitch';
+import SiteThemeProvider from '../SiteThemeProvider';
 import type { SiteContextProps } from '../slots/SiteContext';
 import SiteContext from '../slots/SiteContext';
 
@@ -144,23 +146,25 @@ const GlobalLayout: React.FC = () => {
   }
 
   return (
-    <StyleProvider
-      cache={styleCache}
-      linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
-    >
-      <SiteContext.Provider value={siteContextValue}>
-        <SiteThemeProvider
-          theme={{
-            algorithm: getAlgorithm(theme),
-            token: {
-              motion: !theme.includes('motion-off'),
-            },
-          }}
-        >
-          <HappyProvider disabled={!theme.includes('happy-work')}>{content}</HappyProvider>
-        </SiteThemeProvider>
-      </SiteContext.Provider>
-    </StyleProvider>
+    <DarkContext.Provider value={theme.includes('dark')}>
+      <StyleProvider
+        cache={styleCache}
+        linters={[logicalPropertiesLinter, legacyNotSelectorLinter, parentSelectorLinter]}
+      >
+        <SiteContext.Provider value={siteContextValue}>
+          <SiteThemeProvider
+            theme={{
+              algorithm: getAlgorithm(theme),
+              token: {
+                motion: !theme.includes('motion-off'),
+              },
+            }}
+          >
+            <HappyProvider disabled={!theme.includes('happy-work')}>{content}</HappyProvider>
+          </SiteThemeProvider>
+        </SiteContext.Provider>
+      </StyleProvider>
+    </DarkContext.Provider>
   );
 };
 

--- a/components/calendar/demo/lunar.tsx
+++ b/components/calendar/demo/lunar.tsx
@@ -1,13 +1,10 @@
 import dayjs, { type Dayjs } from 'dayjs';
 import React from 'react';
-import lunisolar from 'lunisolar';
-import zhCn from 'lunisolar/locale/zh-cn';
+import { Lunar, HolidayUtil } from 'lunar-typescript';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';
 import { Calendar, Col, Radio, Row, Select } from 'antd';
 import type { CalendarProps } from 'antd';
-
-lunisolar.locale(zhCn);
 
 const useStyle = createStyles(({ token, css, cx }) => {
   const lunar = css`
@@ -16,7 +13,7 @@ const useStyle = createStyles(({ token, css, cx }) => {
   `;
   return {
     wrapper: css`
-      width: 400px;
+      width: 450px;
       border: 1px solid ${token.colorBorderSecondary};
       border-radius: ${token.borderRadiusOuter};
       padding: 5px;
@@ -94,17 +91,20 @@ const App: React.FC = () => {
 
   const onPanelChange = (value: Dayjs, mode: CalendarProps<Dayjs>['mode']) => {
     console.log(value.format('YYYY-MM-DD'), mode);
-    setSelectDate(value);
   };
 
-  const onDateChange = (value: Dayjs) => {
-    setSelectDate(value);
+  const onDateChange: CalendarProps<Dayjs>['onSelect'] = (value, selectInfo) => {
+    if (selectInfo.source === 'date') {
+      setSelectDate(value);
+    }
   };
 
   const cellRender: CalendarProps<Dayjs>['fullCellRender'] = (date, info) => {
-    const d = lunisolar(date.toDate());
-    const lunar = d.lunar.getDayName();
-    const solarTerm = d.solarTerm?.name;
+    const d = Lunar.fromDate(date.toDate());
+    const lunar = d.getDayInChinese();
+    const solarTerm = d.getJieQi();
+    const h = HolidayUtil.getHoliday(date.get('year'), date.get('month') + 1, date.get('date'));
+    const displayHoliday = h?.getTarget() === h?.getDay() ? h?.getName() : undefined;
     if (info.type === 'date') {
       return React.cloneElement(info.originNode, {
         ...info.originNode.props,
@@ -115,7 +115,9 @@ const App: React.FC = () => {
         children: (
           <div className={styles.text}>
             {date.get('date')}
-            {info.type === 'date' && <div className={styles.lunar}>{solarTerm || lunar}</div>}
+            {info.type === 'date' && (
+              <div className={styles.lunar}>{displayHoliday || solarTerm || lunar}</div>
+            )}
           </div>
         ),
       });
@@ -124,29 +126,29 @@ const App: React.FC = () => {
     if (info.type === 'month') {
       // Due to the fact that a solar month is part of the lunar month X and part of the lunar month X+1,
       // when rendering a month, always take X as the lunar month of the month
-      const d2 = lunisolar(new Date(date.get('year'), date.get('month')));
-      const month = d2.lunar.getMonthName();
+      const d2 = Lunar.fromDate(new Date(date.get('year'), date.get('month')));
+      const month = d2.getMonthInChinese();
       return (
         <div
           className={classNames(styles.monthCell, {
             [styles.monthCellCurrent]: selectDate.isSame(date, 'month'),
           })}
         >
-          {date.get('month') + 1}月（{month}）
+          {date.get('month') + 1}月（{month}月）
         </div>
       );
     }
   };
 
   const getYearLabel = (year: number) => {
-    const d = lunisolar(new Date(year + 1, 0));
-    return `${year}年（${d.format('cYcZ年')}）`;
+    const d = Lunar.fromDate(new Date(year + 1, 0));
+    return `${d.getYearInChinese()}年（${d.getYearInGanZhi()}${d.getYearShengXiao()}年）`;
   };
 
   const getMonthLabel = (month: number, value: Dayjs) => {
-    const d = lunisolar(new Date(value.year(), month));
-    const lunar = d.lunar.getMonthName();
-    return `${month + 1}月（${lunar}）`;
+    const d = Lunar.fromDate(new Date(value.year(), month));
+    const lunar = d.getMonthInChinese();
+    return `${month + 1}月（${lunar}月）`;
   };
 
   return (
@@ -155,7 +157,7 @@ const App: React.FC = () => {
         fullCellRender={cellRender}
         fullscreen={false}
         onPanelChange={onPanelChange}
-        onChange={onDateChange}
+        onSelect={onDateChange}
         headerRender={({ value, type, onChange, onTypeChange }) => {
           const start = 0;
           const end = 12;

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -4,6 +4,7 @@ import RcDropdown from 'rc-dropdown';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
+import type { AlignType } from '@rc-component/trigger';
 import * as React from 'react';
 import genPurePanel from '../_util/PurePanel';
 import type { AdjustOverflow } from '../_util/placements';
@@ -28,23 +29,10 @@ const Placements = [
   'bottom',
 ] as const;
 
-type Placement = (typeof Placements)[number];
+type Placement = typeof Placements[number];
 type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter'>;
 
 type OverlayFunc = () => React.ReactElement;
-
-type Align = {
-  points?: [string, string];
-  offset?: [number, number];
-  targetOffset?: [number, number];
-  overflow?: {
-    adjustX?: boolean;
-    adjustY?: boolean;
-  };
-  useCssRight?: boolean;
-  useCssBottom?: boolean;
-  useCssTransform?: boolean;
-};
 
 export type DropdownArrowOptions = {
   pointAtCenter?: boolean;
@@ -60,7 +48,7 @@ export interface DropdownProps {
   open?: boolean;
   disabled?: boolean;
   destroyPopupOnHide?: boolean;
-  align?: Align;
+  align?: AlignType;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   prefixCls?: string;
   className?: string;

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -1,4 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+
 import { resetComponent } from '../../style';
 import { genCollapseMotion, zoomIn } from '../../style/motion';
 import type { AliasToken, FullToken, GenerateStyle } from '../../theme/internal';
@@ -400,7 +401,7 @@ const makeVerticalLayoutLabel = (token: FormToken): CSSObject => ({
 });
 
 const makeVerticalLayout = (token: FormToken): CSSObject => {
-  const { componentCls, formItemCls } = token;
+  const { componentCls, formItemCls, rootPrefixCls } = token;
 
   return {
     [`${formItemCls} ${formItemCls}-label`]: makeVerticalLayoutLabel(token),
@@ -408,10 +409,14 @@ const makeVerticalLayout = (token: FormToken): CSSObject => {
       [formItemCls]: {
         flexWrap: 'wrap',
 
-        [`${formItemCls}-label,
-          ${formItemCls}-control`]: {
-          flex: '0 0 100%',
-          maxWidth: '100%',
+        [`${formItemCls}-label, ${formItemCls}-control`]: {
+          // When developer pass `xs: { span }`,
+          // It should follow the `xs` screen config
+          // ref: https://github.com/ant-design/ant-design/issues/44386
+          [`&:not([class*=" ${rootPrefixCls}-col-xs"])`]: {
+            flex: '0 0 100%',
+            maxWidth: '100%',
+          },
         },
       },
     },

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { render } from 'rc-util/lib/React/render';
 import * as React from 'react';
+import { render } from 'rc-util/lib/React/render';
+
 import ConfigProvider, { globalConfig, warnContext } from '../config-provider';
-import PurePanel from './PurePanel';
 import type {
   ArgsProps,
   ConfigOptions,
@@ -12,6 +12,7 @@ import type {
   NoticeType,
   TypeOpen,
 } from './interface';
+import PurePanel from './PurePanel';
 import useMessage, { useInternalMessage } from './useMessage';
 import { wrapPromiseFn } from './util';
 
@@ -70,7 +71,7 @@ function getGlobalContext() {
 
   return {
     prefixCls: mergedPrefixCls,
-    container: mergedContainer,
+    getContainer: () => mergedContainer!,
     duration,
     rtl,
     maxCount,
@@ -84,20 +85,7 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const initializeMessageConfig: () => ConfigOptions = () => {
-    const { prefixCls, container, maxCount, duration, rtl, top } = getGlobalContext();
-
-    return {
-      prefixCls,
-      getContainer: () => container!,
-      maxCount,
-      duration,
-      rtl,
-      top,
-    };
-  };
-
-  const [messageConfig, setMessageConfig] = React.useState<ConfigOptions>(initializeMessageConfig);
+  const [messageConfig, setMessageConfig] = React.useState<ConfigOptions>(getGlobalContext);
 
   const [api, holder] = useInternalMessage(messageConfig);
 
@@ -107,7 +95,7 @@ const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
   const theme = global.getTheme();
 
   const sync = () => {
-    setMessageConfig(initializeMessageConfig);
+    setMessageConfig(getGlobalContext);
   };
 
   React.useEffect(sync, []);

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { render } from 'rc-util/lib/React/render';
 import * as React from 'react';
+import { render } from 'rc-util/lib/React/render';
+
 import ConfigProvider, { globalConfig, warnContext } from '../config-provider';
-import PurePanel from './PurePanel';
 import type { ArgsProps, GlobalConfigProps, NotificationInstance } from './interface';
+import PurePanel from './PurePanel';
 import useNotification, { useInternalNotification } from './useNotification';
 
 let notification: GlobalNotification | null = null;
@@ -45,7 +46,7 @@ function getGlobalContext() {
 
   return {
     prefixCls: mergedPrefixCls,
-    container: mergedContainer,
+    getContainer: () => mergedContainer!,
     rtl,
     maxCount,
     top,
@@ -59,21 +60,10 @@ interface GlobalHolderRef {
 }
 
 const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
-  const [prefixCls, setPrefixCls] = React.useState<string>();
-  const [container, setContainer] = React.useState<HTMLElement | ShadowRoot>();
-  const [maxCount, setMaxCount] = React.useState<number>();
-  const [rtl, setRTL] = React.useState<boolean>();
-  const [top, setTop] = React.useState<number>();
-  const [bottom, setBottom] = React.useState<number>();
+  const [notificationConfig, setNotificationConfig] =
+    React.useState<GlobalConfigProps>(getGlobalContext);
 
-  const [api, holder] = useInternalNotification({
-    prefixCls,
-    getContainer: () => container!,
-    maxCount,
-    rtl,
-    top,
-    bottom,
-  });
+  const [api, holder] = useInternalNotification(notificationConfig);
 
   const global = globalConfig();
   const rootPrefixCls = global.getRootPrefixCls();
@@ -81,21 +71,7 @@ const GlobalHolder = React.forwardRef<GlobalHolderRef, {}>((_, ref) => {
   const theme = global.getTheme();
 
   const sync = () => {
-    const {
-      prefixCls: nextGlobalPrefixCls,
-      container: nextGlobalContainer,
-      maxCount: nextGlobalMaxCount,
-      rtl: nextGlobalRTL,
-      top: nextTop,
-      bottom: nextBottom,
-    } = getGlobalContext();
-
-    setPrefixCls(nextGlobalPrefixCls);
-    setContainer(nextGlobalContainer);
-    setMaxCount(nextGlobalMaxCount);
-    setRTL(nextGlobalRTL);
-    setTop(nextTop);
-    setBottom(nextBottom);
+    setNotificationConfig(getGlobalContext);
   };
 
   React.useEffect(sync, []);

--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -1,4 +1,5 @@
 import { TinyColor } from '@ctrl/tinycolor';
+
 import { resetComponent } from '../../style';
 import getArrowStyle, { MAX_VERTICAL_CONTENT_RADIUS } from '../../style/placementArrow';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
@@ -31,7 +32,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
     boxShadowTertiary,
     tourZIndexPopup,
     fontSize,
-    colorBgContainer,
+    colorBgElevated,
     fontWeightStrong,
     marginXS,
     colorTextLightSolid,
@@ -56,7 +57,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
         fontSize,
         lineHeight,
         width: 520,
-        '--antd-arrow-background-color': colorBgContainer,
+        '--antd-arrow-background-color': colorBgElevated,
 
         '&-pure': {
           maxWidth: '100%',
@@ -77,7 +78,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
           borderRadius: tourBorderRadius,
           boxShadow: boxShadowTertiary,
           position: 'relative',
-          backgroundColor: colorBgContainer,
+          backgroundColor: colorBgElevated,
           border: 'none',
           backgroundClip: 'padding-box',
 

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -171,9 +171,10 @@ If you are using the App Router in Next.js and using antd as your component libr
 import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import { useServerInsertedHTML } from 'next/navigation';
+import type Entity from '@ant-design/cssinjs/es/Cache';
 
 const StyledComponentsRegistry = ({ children }: { children: React.ReactNode }) => {
-  const cache = createCache();
+  const cache = React.useMemo<Entity>(() => createCache(), [createCache]);
   useServerInsertedHTML(() => (
     <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
   ));

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -171,9 +171,10 @@ export default Home;
 import React from 'react';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import { useServerInsertedHTML } from 'next/navigation';
+import type Entity from '@ant-design/cssinjs/es/Cache';
 
 const StyledComponentsRegistry = ({ children }: { children: React.ReactNode }) => {
-  const cache = createCache();
+  const cache = React.useMemo<Entity>(() => createCache(), [createCache]);
   useServerInsertedHTML(() => (
     <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
   ));

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "jsonml.js": "^0.1.0",
     "lint-staged": "^14.0.0",
     "lodash": "^4.17.21",
-    "lunisolar": "^2.2.2",
+    "lunar-typescript": "^1.6.9",
     "lz-string": "^1.4.4",
     "mockdate": "^3.0.0",
     "node-notifier": "^10.0.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: merge master into feature |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc2c26b</samp>

This pull request adds a new banner for Ant Design 5.0, improves the dark mode support and the styling of the documentation site and some components, refactors the state and props management of the message and notification components, updates the lunar calendar demo to use a different library, and fixes some minor bugs and type issues.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc2c26b</samp>

*  Add `PreviewBanner` and `ComponentsBlock` components to show the new features and styles of Ant Design 5.0 ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-e7b678382f0c632748d793d3cdbd2207a645522f3a84911e91598381adb6b8d5R1-R256), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beR1-R135), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L39-R91))
*  Replace `lunisolar` library with `lunar-typescript` library for the lunar calendar demo and adjust the code accordingly ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L3-R3), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L10-L11), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L19-R16), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L97-R107), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L118-R120), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L127-R130), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L135-R137), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L142-R151), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ca070ff551f2a8ae4ae9890edcc6a88a39335d0d2f72648cca683e51e9923336L158-R160), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L262-R262))
*  Add `useDark` hook and `DarkContext` to provide and consume the dark mode state for the components and apply different styles based on the state ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-374ac283d811648736e29830c45ab9b5e70c14cb2191493f858974d6a19e6f24R1-R7), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L58-R99), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL2-R9), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL63-R75), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL78-R90), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL89-R97), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL1-R2), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedR360-R368), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L1-R21), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L147-R167), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L34-R35), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L59-R60), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L80-R81))
*  Replace `Align` type with `AlignType` type imported from `@rc-component/trigger` package for the dropdown component ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR7), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL31-R36), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL63-R51))
*  Replace individual state variables and setters with a single state object and setter for the message and notification components, to simplify the state management and avoid unnecessary re-renders ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L87-R89), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L110-R98), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L62-R66), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L84-R74))
*  Replace `container` property with `getContainer` property for the message and notification components, to match the expected type of the config options ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L73-R74), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L48-R49))
*  Add `PurePanel` component to render a message panel without any context or config dependencies ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499R15))
*  Add a condition to the `flex` and `maxWidth` styles in the `makeVerticalLayout` function for the form component, to fix a bug where the `xs` screen config was overridden by the default styles ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L403-R404), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L411-R419))
*  Replace `createCache` function call with a `useMemo` hook in the `StyledComponentsRegistry` component for the Next.js integration, to memoize the cache object and avoid recreating it on every render ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L174-R177), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L174-R177))
*  Reorder the imports in several files to group the React and antd imports together, and the custom hooks and components imports together ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-12f648feaf3caa0382edb3b014fdd7dbedcad48bee322535d7cd01c5d210c9e6L3-R20), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-78d917ce86078797614d11e0c46bdd7f0f15ff00b3ebc25bca413370f07be21aL2-R9), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL1-R2), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-30afbf329ccd8dcb6bf69a0c2b4464e6ef851c61ed0d4c133113aa6afd4b8f28L1-R11), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L1-R21), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-afb9eb50b70d2e8a149079009b7e3150485edaa7d56dec15d54e6f64da530499L3-R6), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-ec815250b7c2f7267ba9b8a93ea48315da09b7060dc31f38646dd7db8964a965L3-R8))
*  Remove unused imports and type definitions from several files ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL8-R9), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL24-R43), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL63-R51))
*  Add empty lines to separate the imports from the code in some files ([link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5R2), [link](https://github.com/ant-design/ant-design/pull/44448/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20R2))
