### PR TITLE
refactor: abstract ribbon style

### DIFF
--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -1,10 +1,11 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
+
 import type { PresetColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import type { LiteralUnion } from '../_util/type';
 import { ConfigContext } from '../config-provider';
-import useStyle from './style';
+import useStyle from './style/ribbon';
 
 type RibbonPlacement = 'start' | 'end';
 

--- a/components/badge/index.en-US.md
+++ b/components/badge/index.en-US.md
@@ -48,13 +48,13 @@ Common props ref：[Common props](/docs/react/common-props)
 | offset | Set offset of the badge dot | \[number, number] | - |  |
 | overflowCount | Max count to show | number | 99 |  |
 | showZero | Whether to show badge when `count` is zero | boolean | false |  |
-| size | If `count` is set, `size` sets the size of badge | `default` \| `small` | - | 4.6.0 |
+| size | If `count` is set, `size` sets the size of badge | `default` \| `small` | - | - |
 | status | Set Badge as a status dot | `success` \| `processing` \| `default` \| `error` \| `warning` | - |  |
 | styles | Semantic DOM style | Record<SemanticDOM, CSSProperties> | - | 5.7.0 |
 | text | If `status` is set, `text` sets the display text of the status `dot` | ReactNode | - |  |
 | title | Text to show when hovering over the badge | string | - |  |
 
-### Badge.Ribbon (4.5.0+)
+### Badge.Ribbon
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |

--- a/components/badge/index.zh-CN.md
+++ b/components/badge/index.zh-CN.md
@@ -49,13 +49,13 @@ group: 数据展示
 | offset | 设置状态点的位置偏移 | \[number, number] | - |  |
 | overflowCount | 展示封顶的数字值 | number | 99 |  |
 | showZero | 当数值为 0 时，是否展示 Badge | boolean | false |  |
-| size | 在设置了 `count` 的前提下有效，设置小圆点的大小 | `default` \| `small` | - | 4.6.0 |
+| size | 在设置了 `count` 的前提下有效，设置小圆点的大小 | `default` \| `small` | - | - |
 | status | 设置 Badge 为状态点 | `success` \| `processing` \| `default` \| `error` \| `warning` | - |  |
 | styles | 语义化结构 style | Record<SemanticDOM, CSSProperties> | - | 5.7.0 |
 | text | 在设置了 `status` 的前提下有效，设置状态点的文本 | ReactNode | - |  |
 | title | 设置鼠标放在状态点上时显示的文字 | string | - |  |
 
-### Badge.Ribbon (4.5.0+)
+### Badge.Ribbon
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -1,10 +1,12 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { Keyframes } from '@ant-design/cssinjs';
+
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, genPresetColor, mergeToken } from '../../theme/internal';
+import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 
-interface BadgeToken extends FullToken<'Badge'> {
+export interface BadgeToken extends FullToken<'Badge'> {
   badgeFontHeight: number;
   badgeZIndex: number | string;
   badgeHeight: number;
@@ -61,17 +63,13 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
     componentCls,
     iconCls,
     antCls,
-    badgeFontHeight,
     badgeShadowSize,
     badgeHeightSm,
     motionDurationSlow,
     badgeStatusSize,
     marginXS,
-    badgeRibbonOffset,
   } = token;
   const numberPrefixCls = `${antCls}-scroll-number`;
-  const ribbonPrefixCls = `${antCls}-ribbon`;
-  const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
 
   const colorPreset = genPresetColor(token, (colorKey, { darkColor }) => ({
     [`&${componentCls} ${componentCls}-color-${colorKey}`]: {
@@ -79,13 +77,6 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
       [`&:not(${componentCls}-count)`]: {
         color: darkColor,
       },
-    },
-  }));
-
-  const statusRibbonPreset = genPresetColor(token, (colorKey, { darkColor }) => ({
-    [`&${ribbonPrefixCls}-color-${colorKey}`]: {
-      background: darkColor,
-      color: darkColor,
     },
   }));
 
@@ -286,59 +277,11 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
         },
       },
     },
-    [`${ribbonWrapperPrefixCls}`]: { position: 'relative' },
-    [`${ribbonPrefixCls}`]: {
-      ...resetComponent(token),
-      position: 'absolute',
-      top: marginXS,
-      padding: `0 ${token.paddingXS}px`,
-      color: token.colorPrimary,
-      lineHeight: `${badgeFontHeight}px`,
-      whiteSpace: 'nowrap',
-      backgroundColor: token.colorPrimary,
-      borderRadius: token.borderRadiusSM,
-      [`${ribbonPrefixCls}-text`]: { color: token.colorTextLightSolid },
-      [`${ribbonPrefixCls}-corner`]: {
-        position: 'absolute',
-        top: '100%',
-        width: badgeRibbonOffset,
-        height: badgeRibbonOffset,
-        color: 'currentcolor',
-        border: `${badgeRibbonOffset / 2}px solid`,
-        transform: token.badgeRibbonCornerTransform,
-        transformOrigin: 'top',
-        filter: token.badgeRibbonCornerFilter,
-      },
-      ...statusRibbonPreset,
-      [`&${ribbonPrefixCls}-placement-end`]: {
-        insetInlineEnd: -badgeRibbonOffset,
-        borderEndEndRadius: 0,
-        [`${ribbonPrefixCls}-corner`]: {
-          insetInlineEnd: 0,
-          borderInlineEndColor: 'transparent',
-          borderBlockEndColor: 'transparent',
-        },
-      },
-      [`&${ribbonPrefixCls}-placement-start`]: {
-        insetInlineStart: -badgeRibbonOffset,
-        borderEndStartRadius: 0,
-        [`${ribbonPrefixCls}-corner`]: {
-          insetInlineStart: 0,
-          borderBlockEndColor: 'transparent',
-          borderInlineStartColor: 'transparent',
-        },
-      },
-
-      // ====================== RTL =======================
-      '&-rtl': {
-        direction: 'rtl',
-      },
-    },
   };
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Badge', (token) => {
+export const prepareToken: (token: Parameters<GenStyleFn<'Badge'>>[0]) => BadgeToken = (token) => {
   const { fontSize, lineHeight, fontSizeSM, lineWidth, marginXS, colorBorderBg } = token;
 
   const badgeFontHeight = Math.round(fontSize * lineHeight);
@@ -377,6 +320,12 @@ export default genComponentStyleHook('Badge', (token) => {
     badgeRibbonCornerTransform: 'scaleY(0.75)',
     badgeRibbonCornerFilter: `brightness(75%)`,
   });
+
+  return badgeToken;
+};
+
+export default genComponentStyleHook('Badge', (token) => {
+  const badgeToken = prepareToken(token);
 
   return [genSharedBadgeStyle(badgeToken)];
 });

--- a/components/badge/style/ribbon.ts
+++ b/components/badge/style/ribbon.ts
@@ -1,0 +1,78 @@
+import type { CSSObject } from '@ant-design/cssinjs';
+
+import { prepareToken, type BadgeToken } from '.';
+import { resetComponent } from '../../style';
+import type { GenerateStyle } from '../../theme/internal';
+import { genComponentStyleHook, genPresetColor } from '../../theme/internal';
+
+// ============================== Ribbon ==============================
+const genRibbonStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSObject => {
+  const { antCls, badgeFontHeight, marginXS, badgeRibbonOffset } = token;
+  const ribbonPrefixCls = `${antCls}-ribbon`;
+  const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
+
+  const statusRibbonPreset = genPresetColor(token, (colorKey, { darkColor }) => ({
+    [`&${ribbonPrefixCls}-color-${colorKey}`]: {
+      background: darkColor,
+      color: darkColor,
+    },
+  }));
+
+  return {
+    [`${ribbonWrapperPrefixCls}`]: { position: 'relative' },
+    [`${ribbonPrefixCls}`]: {
+      ...resetComponent(token),
+      position: 'absolute',
+      top: marginXS,
+      padding: `0 ${token.paddingXS}px`,
+      color: token.colorPrimary,
+      lineHeight: `${badgeFontHeight}px`,
+      whiteSpace: 'nowrap',
+      backgroundColor: token.colorPrimary,
+      borderRadius: token.borderRadiusSM,
+      [`${ribbonPrefixCls}-text`]: { color: token.colorTextLightSolid },
+      [`${ribbonPrefixCls}-corner`]: {
+        position: 'absolute',
+        top: '100%',
+        width: badgeRibbonOffset,
+        height: badgeRibbonOffset,
+        color: 'currentcolor',
+        border: `${badgeRibbonOffset / 2}px solid`,
+        transform: token.badgeRibbonCornerTransform,
+        transformOrigin: 'top',
+        filter: token.badgeRibbonCornerFilter,
+      },
+      ...statusRibbonPreset,
+      [`&${ribbonPrefixCls}-placement-end`]: {
+        insetInlineEnd: -badgeRibbonOffset,
+        borderEndEndRadius: 0,
+        [`${ribbonPrefixCls}-corner`]: {
+          insetInlineEnd: 0,
+          borderInlineEndColor: 'transparent',
+          borderBlockEndColor: 'transparent',
+        },
+      },
+      [`&${ribbonPrefixCls}-placement-start`]: {
+        insetInlineStart: -badgeRibbonOffset,
+        borderEndStartRadius: 0,
+        [`${ribbonPrefixCls}-corner`]: {
+          insetInlineStart: 0,
+          borderBlockEndColor: 'transparent',
+          borderInlineStartColor: 'transparent',
+        },
+      },
+
+      // ====================== RTL =======================
+      '&-rtl': {
+        direction: 'rtl',
+      },
+    },
+  };
+};
+
+// ============================== Export ==============================
+export default genComponentStyleHook(['Badge', 'Ribbon'], (token) => {
+  const badgeToken = prepareToken(token);
+
+  return [genRibbonStyle(badgeToken)];
+});

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-redeclare */
+import { useContext } from 'react';
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { useStyleRegister } from '@ant-design/cssinjs';
 import { warning } from 'rc-util';
-import { useContext } from 'react';
+
 import { ConfigContext } from '../../config-provider/context';
 import { genCommonStyle, genLinkStyle } from '../../style';
 import type {
@@ -48,9 +49,14 @@ export type FullToken<ComponentName extends OverrideComponent> = TokenWithCommon
   GlobalTokenWithComponent<ComponentName>
 >;
 
+export type GenStyleFn<ComponentName extends OverrideComponent> = (
+  token: FullToken<ComponentName>,
+  info: StyleInfo<ComponentName>,
+) => CSSInterpolation;
+
 export default function genComponentStyleHook<ComponentName extends OverrideComponent>(
-  component: ComponentName,
-  styleFn: (token: FullToken<ComponentName>, info: StyleInfo<ComponentName>) => CSSInterpolation,
+  componentName: ComponentName | [ComponentName, string],
+  styleFn: GenStyleFn<ComponentName>,
   getDefaultToken?:
     | OverrideTokenWithoutDerivative[ComponentName]
     | ((token: GlobalToken) => OverrideTokenWithoutDerivative[ComponentName]),
@@ -64,6 +70,14 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
     clientOnly?: boolean;
   },
 ) {
+  const cells = (Array.isArray(componentName) ? componentName : [componentName, componentName]) as [
+    ComponentName,
+    string,
+  ];
+
+  const [component] = cells;
+  const concatComponent = cells.join('-');
+
   return (prefixCls: string): UseComponentStyleResult => {
     const [theme, token, hashId] = useToken();
     const { getPrefixCls, iconPrefixCls, csp } = useContext(ConfigContext);
@@ -93,62 +107,65 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
     );
 
     return [
-      useStyleRegister({ ...sharedConfig, path: [component, prefixCls, iconPrefixCls] }, () => {
-        const { token: proxyToken, flush } = statisticToken(token);
+      useStyleRegister(
+        { ...sharedConfig, path: [concatComponent, prefixCls, iconPrefixCls] },
+        () => {
+          const { token: proxyToken, flush } = statisticToken(token);
 
-        const customComponentToken = { ...(token[component] as ComponentToken<ComponentName>) };
-        if (options?.deprecatedTokens) {
-          const { deprecatedTokens } = options;
-          deprecatedTokens.forEach(([oldTokenKey, newTokenKey]) => {
-            if (process.env.NODE_ENV !== 'production') {
-              warning(
-                !customComponentToken?.[oldTokenKey],
-                `The token '${String(oldTokenKey)}' of ${component} had deprecated, use '${String(
-                  newTokenKey,
-                )}' instead.`,
-              );
-            }
+          const customComponentToken = { ...(token[component] as ComponentToken<ComponentName>) };
+          if (options?.deprecatedTokens) {
+            const { deprecatedTokens } = options;
+            deprecatedTokens.forEach(([oldTokenKey, newTokenKey]) => {
+              if (process.env.NODE_ENV !== 'production') {
+                warning(
+                  !customComponentToken?.[oldTokenKey],
+                  `The token '${String(oldTokenKey)}' of ${component} had deprecated, use '${String(
+                    newTokenKey,
+                  )}' instead.`,
+                );
+              }
 
-            // Should wrap with `if` clause, or there will be `undefined` in object.
-            if (customComponentToken?.[oldTokenKey] || customComponentToken?.[newTokenKey]) {
-              customComponentToken[newTokenKey] ??= customComponentToken?.[oldTokenKey];
-            }
-          });
-        }
-        const defaultComponentToken =
-          typeof getDefaultToken === 'function'
-            ? getDefaultToken(mergeToken(proxyToken, customComponentToken ?? {}))
-            : getDefaultToken;
+              // Should wrap with `if` clause, or there will be `undefined` in object.
+              if (customComponentToken?.[oldTokenKey] || customComponentToken?.[newTokenKey]) {
+                customComponentToken[newTokenKey] ??= customComponentToken?.[oldTokenKey];
+              }
+            });
+          }
+          const defaultComponentToken =
+            typeof getDefaultToken === 'function'
+              ? getDefaultToken(mergeToken(proxyToken, customComponentToken ?? {}))
+              : getDefaultToken;
 
-        const mergedComponentToken = { ...defaultComponentToken, ...customComponentToken };
+          const mergedComponentToken = { ...defaultComponentToken, ...customComponentToken };
 
-        const componentCls = `.${prefixCls}`;
-        const mergedToken = mergeToken<
-          TokenWithCommonCls<GlobalTokenWithComponent<OverrideComponent>>
-        >(
-          proxyToken,
-          {
-            componentCls,
+          const componentCls = `.${prefixCls}`;
+          const mergedToken = mergeToken<
+            TokenWithCommonCls<GlobalTokenWithComponent<OverrideComponent>>
+          >(
+            proxyToken,
+            {
+              componentCls,
+              prefixCls,
+              iconCls: `.${iconPrefixCls}`,
+              antCls: `.${rootPrefixCls}`,
+            },
+            mergedComponentToken,
+          );
+
+          const styleInterpolation = styleFn(mergedToken as unknown as FullToken<ComponentName>, {
+            hashId,
             prefixCls,
-            iconCls: `.${iconPrefixCls}`,
-            antCls: `.${rootPrefixCls}`,
-          },
-          mergedComponentToken,
-        );
-
-        const styleInterpolation = styleFn(mergedToken as unknown as FullToken<ComponentName>, {
-          hashId,
-          prefixCls,
-          rootPrefixCls,
-          iconPrefixCls,
-          overrideComponentToken: customComponentToken as any,
-        });
-        flush(component, mergedComponentToken);
-        return [
-          options?.resetStyle === false ? null : genCommonStyle(token, prefixCls),
-          styleInterpolation,
-        ];
-      }),
+            rootPrefixCls,
+            iconPrefixCls,
+            overrideComponentToken: customComponentToken as any,
+          });
+          flush(component, mergedComponentToken);
+          return [
+            options?.resetStyle === false ? null : genCommonStyle(token, prefixCls),
+            styleInterpolation,
+          ];
+        },
+      ),
       hashId,
     ];
   };

--- a/components/theme/util/statistic.ts
+++ b/components/theme/util/statistic.ts
@@ -67,7 +67,13 @@ export default function statisticToken<T extends object>(token: T) {
     });
 
     flush = (componentName, componentToken) => {
-      statistic[componentName] = { global: Array.from(tokenKeys!), component: componentToken };
+      statistic[componentName] = {
+        global: Array.from(tokenKeys!),
+        component: {
+          ...statistic[componentName]?.component,
+          ...componentToken,
+        },
+      };
     };
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Refactor Badge style logic and take Ribbon style out to reduce SSR inline style size.         |
| 🇨🇳 Chinese |   重构 Badge 样式逻辑将 Ribbon 样式抽离以降低 SSR 内联样式尺寸。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 054edc1</samp>

This pull request improves the documentation, style, and functionality of the `Badge` component and its sub-component `Badge.Ribbon`. It fixes some errors and inconsistencies in the English and Chinese docs, refactors the style code to separate the common and ribbon-specific logic, and adds support for the `showZero` prop and the default hiding behavior of the badge. It also modifies the `genComponentStyleHook` function to handle components with sub-components, and updates the import paths and order accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 054edc1</samp>

*  Refactor `Badge.Ribbon` to use a separate style hook and function from `Badge` ([link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-14f85870e2c911caa9b080f35767efa029c02b5ecf4118b487c75145b7554f09L1-R8), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L3-R9), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L64), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L70-R72), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L85-L91), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L289-R284), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809R324-R329), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0R1-R78), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL2-R6), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL51-R59), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacR73-R80), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL96-R168), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-0dc90a406b302dfe27fbf4738fdb36cdef989d720ee19295495254f2d8a2115dL70-R76))
* Remove unsupported `size` prop from `Badge.Ribbon` documentation ([link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-c8fdf756230cf3ebcb4f347ba42136a13694db1ab8c7f95bb30bbfa27fa2ca82L51-R51), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-46d43a0f65a205837cc26cbbec241f700f5a5a74712c02922f11584de845bed4L52-R52))
* Remove outdated version number from `Badge.Ribbon` documentation ([link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-c8fdf756230cf3ebcb4f347ba42136a13694db1ab8c7f95bb30bbfa27fa2ca82L57-R57), [link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-46d43a0f65a205837cc26cbbec241f700f5a5a74712c02922f11584de845bed4L58-R58))
* Fix import order of `react` and `classnames` in `components/badge/Ribbon.tsx` ([link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-14f85870e2c911caa9b080f35767efa029c02b5ecf4118b487c75145b7554f09L1-R8))
* Fix import order of `react` and `@ant-design/cssinjs` in `components/theme/util/genComponentStyleHook.ts` ([link](https://github.com/ant-design/ant-design/pull/44451/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL2-R6))
