### PR TITLE
fix: rm useless ts def of upload

### DIFF
--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -87,7 +87,7 @@ Extends File with additional props.
 | crossOrigin | CORS settings attributes | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.20.0 |
 | name | File name | string | - | - |
 | percent | Upload progress percent | number | - | - |
-| status | Upload status. Show different style when configured | `error` \| `success` \| `done` \| `uploading` \| `removed` | - | - |
+| status | Upload status. Show different style when configured | `error` \| `done` \| `uploading` \| `removed` | - | - |
 | thumbUrl | Thumb image url | string | - | - |
 | uid | unique id. Will auto-generate when not provided | string | - | - |
 | url | Download url | string | - | - |

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -88,7 +88,7 @@ demo:
 | crossOrigin | CORS 属性设置 | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.20.0 |
 | name | 文件名 | string | - | - |
 | percent | 上传进度 | number | - | - |
-| status | 上传状态，不同状态展示颜色也会有所不同 | `error` \| `success` \| `done` \| `uploading` \| `removed` | - | - |
+| status | 上传状态，不同状态展示颜色也会有所不同 | `error` \| `done` \| `uploading` \| `removed` | - | - |
 | thumbUrl | 缩略图地址 | string | - | - |
 | uid | 唯一标识符，不设置时会自动生成 | string | - | - |
 | url | 下载地址 | string | - | - |

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -1,16 +1,17 @@
+import type * as React from 'react';
 import type {
   RcFile as OriRcFile,
   UploadRequestOption as RcCustomRequestOptions,
   UploadProps as RcUploadProps,
 } from 'rc-upload/lib/interface';
-import type * as React from 'react';
+
 import type { ProgressAriaProps, ProgressProps } from '../progress';
 
 export interface RcFile extends OriRcFile {
   readonly lastModifiedDate: Date;
 }
 
-export type UploadFileStatus = 'error' | 'success' | 'done' | 'uploading' | 'removed';
+export type UploadFileStatus = 'error' | 'done' | 'uploading' | 'removed';
 
 export interface HttpRequestHeader {
   [key: string]: string;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #44467

### 💡 Background and solution

应该是以前写错了，有 `done` 然后额外写了一个 `success`，代码里其实不会填充 `success`。

ref https://github.com/ant-design/ant-design/blame/cda671fead899a6c13b22e89b7c6fd56da674e70/components/upload/interface.tsx#L3

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Upload file status definition to remove unused `success`.     |
| 🇨🇳 Chinese |      修复 Upload 文件状态定义，移除未使用过的 `success`。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a920527</samp>

The pull request removes the unused `success` status from the `UploadFile` interface and the `Upload` component, and updates the English and Chinese documentation accordingly. This improves the code quality and clarity of the `Upload` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a920527</samp>

*  Remove the `success` status from the `UploadFile` interface and the `UploadFileStatus` type, as it is no longer used by the `Upload` component ([link](https://github.com/ant-design/ant-design/pull/44468/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9L90-R90), [link](https://github.com/ant-design/ant-design/pull/44468/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390L91-R91), [link](https://github.com/ant-design/ant-design/pull/44468/files?diff=unified&w=0#diff-160ee6918ffebe6609f946497b4f3cb4dac8d6676f9c1eea3ba82e5ddc42aea8L13-R14))
*  Import the `React` type in the `interface.ts` file, to enable the use of `React.ReactNode` and other types from the React library ([link](https://github.com/ant-design/ant-design/pull/44468/files?diff=unified&w=0#diff-160ee6918ffebe6609f946497b4f3cb4dac8d6676f9c1eea3ba82e5ddc42aea8R1))
*  Add a blank line between the imports from `rc-upload` and `progress` in the `interface.ts` file, to improve the readability and style of the code ([link](https://github.com/ant-design/ant-design/pull/44468/files?diff=unified&w=0#diff-160ee6918ffebe6609f946497b4f3cb4dac8d6676f9c1eea3ba82e5ddc42aea8L6-R7))
