### PR TITLE
fix: transfer label height

### DIFF
--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -305,6 +305,11 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     '&-footer': {
       borderTop: `${lineWidth}px ${lineType} ${colorSplit}`,
     },
+
+    // fix: https://github.com/ant-design/ant-design/issues/44489
+    '&-checkbox': {
+      lineHeight: 1,
+    },
   };
 };
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/vueComponent/ant-design-vue/issues/6010
antd 同样存在这个问题

### 💡 Background and solution

fix: #44489

![1](https://github.com/ant-design/ant-design/assets/82451257/28043a80-42f7-4770-aef8-aea541adaa8a)

正常应该只是触发一次，但是触发了两次

修复：
<img width="45%" src="https://github.com/ant-design/ant-design/assets/82451257/5392805b-9075-4f2c-9721-788db1b244c1" />
->
<img width="45%" src="https://github.com/ant-design/ant-design/assets/82451257/59abd991-3ac8-4edb-b0e0-fa6767ee623d" />

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Keep the height of `label` tag with the height of the child `span` tag. Otherwise, when clicking on the area inside the label and outside the checkbox, the `onSelectChange` event will be triggered twice       |
| 🇨🇳 Chinese |  让 label 的高度与子标签 span 的高度保持一致，否则当点击到 label内，checkbox外的区域时，会触发两次 `onSelectChange` 事件     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30b9576</samp>

Fix checkbox label alignment and improve transfer component usability. Add a CSS rule to `&-checkbox` in `components/transfer/style/index.ts` and make other changes related to accessibility, keyboard navigation, and style consistency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30b9576</samp>

* Fix checkbox label alignment in transfer list (`[link](https://github.com/ant-design/ant-design/pull/44471/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbR308-R311)`)
