### PR TITLE
refactor: button default not use compact style

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,7 +1,4 @@
 /* eslint-disable react/button-has-type */
-import classNames from 'classnames';
-import omit from 'rc-util/lib/omit';
-import { composeRef } from 'rc-util/lib/ref';
 import React, {
   Children,
   createRef,
@@ -11,19 +8,24 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import classNames from 'classnames';
+import omit from 'rc-util/lib/omit';
+import { composeRef } from 'rc-util/lib/ref';
+
 import warning from '../_util/warning';
 import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
-import type { SizeType } from '../config-provider/SizeContext';
 import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import { useCompactItemContext } from '../space/Compact';
-import IconWrapper from './IconWrapper';
-import LoadingIcon from './LoadingIcon';
 import Group, { GroupSizeContext } from './button-group';
 import type { ButtonHTMLType, ButtonShape, ButtonType } from './buttonHelpers';
 import { isTwoCNChar, isUnBorderedButtonType, spaceChildren } from './buttonHelpers';
+import IconWrapper from './IconWrapper';
+import LoadingIcon from './LoadingIcon';
 import useStyle from './style';
+import CompactStyle from './style/compactCmp';
 
 export type LegacyButtonType = ButtonType | 'danger';
 
@@ -285,6 +287,9 @@ const InternalButton: React.ForwardRefRenderFunction<
     >
       {iconNode}
       {kids}
+
+      {/* Styles: compact */}
+      {compactItemClassnames && <CompactStyle prefixCls={prefixCls} />}
     </button>
   );
 

--- a/components/button/style/compactCmp.ts
+++ b/components/button/style/compactCmp.ts
@@ -1,0 +1,16 @@
+// Style as inline component
+import { prepareToken } from '.';
+import { genCompactItemStyle } from '../../style/compact-item';
+import { genCompactItemVerticalStyle } from '../../style/compact-item-vertical';
+import { genSubStyleComponent } from '../../theme/internal';
+
+// ============================== Export ==============================
+export default genSubStyleComponent(['Button', 'compact'], (token) => {
+  const buttonToken = prepareToken(token);
+
+  return [
+    // Space Compact
+    genCompactItemStyle(buttonToken),
+    genCompactItemVerticalStyle(buttonToken),
+  ];
+});

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -1,8 +1,6 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 
 import { genFocusStyle } from '../../style';
-import { genCompactItemStyle } from '../../style/compact-item';
-import { genCompactItemVerticalStyle } from '../../style/compact-item-vertical';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -1,9 +1,11 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+
 import { genFocusStyle } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import { genCompactItemVerticalStyle } from '../../style/compact-item-vertical';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 import genGroupStyle from './group';
 
 /** Component only token. Which will handle additional calculation of alias token */
@@ -517,7 +519,7 @@ const genBlockButtonStyle: GenerateStyle<ButtonToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Button', (token) => {
+export const prepareToken: (token: Parameters<GenStyleFn<'Badge'>>[0]) => ButtonToken = (token) => {
   const { controlTmpOutline, paddingContentHorizontal } = token;
 
   const buttonToken = mergeToken<ButtonToken>(token, {
@@ -526,6 +528,12 @@ export default genComponentStyleHook('Button', (token) => {
     buttonIconOnlyFontSize: token.fontSizeLG,
     buttonFontWeight: 400,
   });
+
+  return buttonToken;
+};
+
+export default genComponentStyleHook('Button', (token) => {
+  const buttonToken = prepareToken(token);
 
   return [
     // Shared
@@ -544,9 +552,5 @@ export default genComponentStyleHook('Button', (token) => {
 
     // Button Group
     genGroupStyle(buttonToken),
-
-    // Space Compact
-    genCompactItemStyle(token),
-    genCompactItemVerticalStyle(token),
   ];
 });

--- a/components/theme/internal.ts
+++ b/components/theme/internal.ts
@@ -1,4 +1,5 @@
 import { useStyleRegister } from '@ant-design/cssinjs';
+
 import type {
   AliasToken,
   GenerateStyle,
@@ -10,7 +11,7 @@ import type {
 import { PresetColors } from './interface';
 import useToken from './useToken';
 import type { FullToken } from './util/genComponentStyleHook';
-import genComponentStyleHook from './util/genComponentStyleHook';
+import genComponentStyleHook, { genSubStyleComponent } from './util/genComponentStyleHook';
 import genPresetColor from './util/genPresetColor';
 import statisticToken, { merge as mergeToken } from './util/statistic';
 import useResetIconStyle from './util/useResetIconStyle';
@@ -19,6 +20,7 @@ export { DesignTokenContext, defaultConfig } from './context';
 export {
   PresetColors,
   genComponentStyleHook,
+  genSubStyleComponent,
   genPresetColor,
   mergeToken,
   statisticToken,

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-redeclare */
-import { useContext } from 'react';
+import { useContext, type ComponentType } from 'react';
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { useStyleRegister } from '@ant-design/cssinjs';
 import { warning } from 'rc-util';
@@ -172,5 +172,20 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
       ),
       hashId,
     ];
+  };
+}
+
+export interface SubStyleComponentProps {
+  prefixCls: string;
+}
+
+export function genSubStyleComponent<ComponentName extends OverrideComponent>(
+  ...args: Parameters<typeof genComponentStyleHook<ComponentName>>
+): ComponentType<SubStyleComponentProps> {
+  const useStyle = genComponentStyleHook(...args);
+
+  return ({ prefixCls }: SubStyleComponentProps) => {
+    useStyle(prefixCls);
+    return null;
   };
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Extract Button compact style, now only the corresponding style will be generated when Space.Compact is used.        |
| 🇨🇳 Chinese |     剥离 Button 紧凑模式样式，现在只有当使用了 Space.Compact 才会生成对应样式。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 687d1c7</samp>

Added a new compact style option for the button component, and refactored some code to simplify the style generation and improve the code quality. Created a new utility function `genSubStyleComponent` to create sub-style components from style hooks, and used it in `components/button/style/compactCmp.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 687d1c7</samp>

*  Render `CompactStyle` component inside `Button` component to apply compact style in `Space` component ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140R290-R292))
* Define `CompactStyle` component in `components/button/style/compactCmp.ts` using `genSubStyleComponent` function ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-f59509a3fc4a96a99d390ab3e802d186dda6513e315fa028c25310541548ecb6R1-R16))
* Move imports of `classNames`, `omit`, and `composeRef` from `rc-util` library to line 12 in `components/button/button.tsx` ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L2-L4), [link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L14-R28))
* Add empty line to top of `components/button/style/index.ts` and `components/theme/internal.ts` ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R2), [link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-34415735daeac3a403575c234bd2a124b11f85d555ec72fe8d345b53f471016fR2))
* Import `GenStyleFn` type from `components/theme/util/genComponentStyleHook` in `components/button/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R8))
* Define and export `prepareToken` function in `components/button/style/index.ts` to prepare button token from input token ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L520-R522))
* Call `prepareToken` function inside `genComponentStyleHook` function in `components/button/style/index.ts` to use prepared button token ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R532-R537))
* Remove `genCompactItemStyle` and `genCompactItemVerticalStyle` functions from `genComponentStyleHook` function in `components/button/style/index.ts` to avoid duplication ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693L547-L550))
* Import and export `genSubStyleComponent` function from `components/theme/util/genComponentStyleHook` in `components/theme/internal.ts` ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-34415735daeac3a403575c234bd2a124b11f85d555ec72fe8d345b53f471016fL13-R14), [link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-34415735daeac3a403575c234bd2a124b11f85d555ec72fe8d345b53f471016fR23))
* Define and export `genSubStyleComponent` function in `components/theme/util/genComponentStyleHook` to generate sub-style component from style hook function ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL2-R2), [link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacR177-R191))
* Import `ComponentType` type from `react` in `components/theme/util/genComponentStyleHook` to use as return type for `genSubStyleComponent` function ([link](https://github.com/ant-design/ant-design/pull/44475/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL2-R2))
