### PR TITLE
refactor: Form style should always before Grid

### DIFF
--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -1,10 +1,12 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
+
 import type { ColProps } from '../grid/col';
 import Col from '../grid/col';
 import { FormContext, FormItemPrefixContext } from './context';
 import ErrorList from './ErrorList';
 import type { ValidateStatus } from './FormItem';
+import FallbackCmp from './style/fallbackCmp';
 
 interface FormItemInputMiscProps {
   prefixCls: string;
@@ -116,6 +118,7 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
       <Col {...mergedWrapperCol} className={className}>
         {dom}
       </Col>
+      <FallbackCmp prefixCls={prefixCls} />
     </FormContext.Provider>
   );
 };

--- a/components/form/style/fallbackCmp.ts
+++ b/components/form/style/fallbackCmp.ts
@@ -1,0 +1,29 @@
+/**
+ * Fallback of IE.
+ * Safe to remove.
+ */
+
+// Style as inline component
+import { prepareToken, type FormToken } from '.';
+import { genSubStyleComponent, type GenerateStyle } from '../../theme/internal';
+
+// ============================= Fallback =============================
+const genFallbackStyle: GenerateStyle<FormToken> = (token) => {
+  const { formItemCls } = token;
+
+  return {
+    '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
+      // Fallback for IE, safe to remove we not support it anymore
+      [`${formItemCls}-control`]: {
+        display: 'flex',
+      },
+    },
+  };
+};
+
+// ============================== Export ==============================
+export default genSubStyleComponent(['Form', 'item-item'], (token, { rootPrefixCls }) => {
+  const formToken = prepareToken(token, rootPrefixCls);
+
+  return [genFallbackStyle(formToken)];
+});

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -117,6 +117,11 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
   const { formItemCls, iconCls, componentCls, rootPrefixCls } = token;
 
   return {
+    // Fallback for IE, safe to remove we not support it anymore
+    [`${formItemCls}-control`]: {
+      display: 'flex',
+    },
+
     [formItemCls]: {
       ...resetComponent(token),
 
@@ -477,20 +482,29 @@ const genVerticalStyle: GenerateStyle<FormToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook('Form', (token, { rootPrefixCls }) => {
-  const formToken = mergeToken<FormToken>(token, {
-    formItemCls: `${token.componentCls}-item`,
-    rootPrefixCls,
-  });
+export default genComponentStyleHook(
+  'Form',
+  (token, { rootPrefixCls }) => {
+    const formToken = mergeToken<FormToken>(token, {
+      formItemCls: `${token.componentCls}-item`,
+      rootPrefixCls,
+    });
 
-  return [
-    genFormStyle(formToken),
-    genFormItemStyle(formToken),
-    genFormValidateMotionStyle(formToken),
-    genHorizontalStyle(formToken),
-    genInlineStyle(formToken),
-    genVerticalStyle(formToken),
-    genCollapseMotion(formToken),
-    zoomIn,
-  ];
-});
+    return [
+      genFormStyle(formToken),
+      genFormItemStyle(formToken),
+      genFormValidateMotionStyle(formToken),
+      genHorizontalStyle(formToken),
+      genInlineStyle(formToken),
+      genVerticalStyle(formToken),
+      genCollapseMotion(formToken),
+      zoomIn,
+    ];
+  },
+  null,
+  {
+    // Let From style before the Grid
+    // ref https://github.com/ant-design/ant-design/issues/44386
+    order: -1000,
+  },
+);

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -118,11 +118,6 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
   const { formItemCls, iconCls, componentCls, rootPrefixCls } = token;
 
   return {
-    // Fallback for IE, safe to remove we not support it anymore
-    [`${formItemCls}-control`]: {
-      display: 'flex',
-    },
-
     [formItemCls]: {
       ...resetComponent(token),
 

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -4,6 +4,7 @@ import { resetComponent } from '../../style';
 import { genCollapseMotion, zoomIn } from '../../style/motion';
 import type { AliasToken, FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 import genFormValidateMotionStyle from './explain';
 
 export interface FormToken extends FullToken<'Form'> {
@@ -154,7 +155,6 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
       // =                            Label                           =
       // ==============================================================
       [`${formItemCls}-label`]: {
-        display: 'inline-block',
         flexGrow: 0,
         overflow: 'hidden',
         whiteSpace: 'nowrap',
@@ -482,13 +482,22 @@ const genVerticalStyle: GenerateStyle<FormToken> = (token) => {
 };
 
 // ============================== Export ==============================
+export const prepareToken: (
+  token: Parameters<GenStyleFn<'Form'>>[0],
+  rootPrefixCls: string,
+) => FormToken = (token, rootPrefixCls) => {
+  const formToken = mergeToken<FormToken>(token, {
+    formItemCls: `${token.componentCls}-item`,
+    rootPrefixCls,
+  });
+
+  return formToken;
+};
+
 export default genComponentStyleHook(
   'Form',
   (token, { rootPrefixCls }) => {
-    const formToken = mergeToken<FormToken>(token, {
-      formItemCls: `${token.componentCls}-item`,
-      rootPrefixCls,
-    });
+    const formToken = prepareToken(token, rootPrefixCls);
 
     return [
       genFormStyle(formToken),

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -232,7 +232,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
       // =                            Input                           =
       // ==============================================================
       [`${formItemCls}-control`]: {
-        display: 'flex',
+        ['--ant-display' as any]: 'flex',
         flexDirection: 'column',
         flexGrow: 1,
 

--- a/components/grid/style/index.ts
+++ b/components/grid/style/index.ts
@@ -93,8 +93,7 @@ const genLoopGridColumnsStyle = (token: GridColToken, sizeCls: string): CSSObjec
   const gridColumnsStyle: CSSObject = {};
   for (let i = gridColumns; i >= 0; i--) {
     if (i === 0) {
-      // ref: https://github.com/ant-design/ant-design/issues/44456
-      gridColumnsStyle[`${componentCls}${componentCls}${componentCls}${sizeCls}-${i}`] = {
+      gridColumnsStyle[`${componentCls}${sizeCls}-${i}`] = {
         display: 'none',
       };
       gridColumnsStyle[`${componentCls}-push-${i}`] = {
@@ -116,11 +115,21 @@ const genLoopGridColumnsStyle = (token: GridColToken, sizeCls: string): CSSObjec
         order: 0,
       };
     } else {
-      gridColumnsStyle[`${componentCls}${sizeCls}-${i}`] = {
-        display: 'block',
-        flex: `0 0 ${(i / gridColumns) * 100}%`,
-        maxWidth: `${(i / gridColumns) * 100}%`,
-      };
+      gridColumnsStyle[`${componentCls}${sizeCls}-${i}`] = [
+        // https://github.com/ant-design/ant-design/issues/44456
+        // Form set `display: flex` on Col which will override `display: block`.
+        // Let's get it from css variable to support override.
+        {
+          ['--ant-display' as any]: 'block',
+          // Fallback to display if variable not support
+          display: 'block',
+        },
+        {
+          display: 'var(--ant-display)',
+          flex: `0 0 ${(i / gridColumns) * 100}%`,
+          maxWidth: `${(i / gridColumns) * 100}%`,
+        },
+      ];
       gridColumnsStyle[`${componentCls}${sizeCls}-push-${i}`] = {
         insetInlineStart: `${(i / gridColumns) * 100}%`,
       };

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -59,9 +59,10 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
   componentName: ComponentName | [ComponentName, string],
   styleFn: GenStyleFn<ComponentName>,
   getDefaultToken?:
+    | null
     | OverrideTokenWithoutDerivative[ComponentName]
     | ((token: GlobalToken) => OverrideTokenWithoutDerivative[ComponentName]),
-  options?: {
+  options: {
     resetStyle?: boolean;
     // Deprecated token key map [["oldTokenKey", "newTokenKey"], ["oldTokenKey", "newTokenKey"]]
     deprecatedTokens?: [ComponentTokenKey<ComponentName>, ComponentTokenKey<ComponentName>][];
@@ -69,7 +70,11 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
      * Only use component style in client side. Ignore in SSR.
      */
     clientOnly?: boolean;
-  },
+    /**
+     * Set order of component style. Default is -999.
+     */
+    order?: number;
+  } = {},
 ) {
   const cells = (Array.isArray(componentName) ? componentName : [componentName, componentName]) as [
     ComponentName,
@@ -90,10 +95,10 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
       token,
       hashId,
       nonce: () => csp?.nonce!,
-      clientOnly: options?.clientOnly,
+      clientOnly: options.clientOnly,
 
       // antd is always at top of styles
-      order: -999,
+      order: options.order || -999,
     };
 
     // Generate style for all a tags in antd component.
@@ -117,7 +122,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
           const { token: proxyToken, flush } = statisticToken(token);
 
           const customComponentToken = { ...(token[component] as ComponentToken<ComponentName>) };
-          if (options?.deprecatedTokens) {
+          if (options.deprecatedTokens) {
             const { deprecatedTokens } = options;
             deprecatedTokens.forEach(([oldTokenKey, newTokenKey]) => {
               if (process.env.NODE_ENV !== 'production') {
@@ -165,7 +170,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
           });
           flush(component, mergedComponentToken);
           return [
-            options?.resetStyle === false ? null : genCommonStyle(token, prefixCls),
+            options.resetStyle === false ? null : genCommonStyle(token, prefixCls),
             styleInterpolation,
           ];
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

follow up #44472
close #44491
close #44495

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjust Form style order that will be insert before Grid style to ensure Grid style take effect when has same selector priority with Form.     |
| 🇨🇳 Chinese |   调整 From 样式插入顺序在 Grid 之前，确保相同 css 优先级下首选 Grid 样式以解决在响应式布局下 Grid 设置不生效的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d11b65</samp>

This pull request refactors and fixes the style generation for the form and grid components, and enhances the utility function for creating component style hooks. It extracts the input style to a separate function `genInputStyle`, adds an `order` option to the `genComponentStyleHook` function, and moves the grid style from `components/grid/style/index.ts` to `components/form/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d11b65</samp>

*  Refactor the form and grid style to improve readability and fix a bug ([link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L232-L257), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5R296-R321), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-c8d24dba3dd3cae5f0db517022a284eb2fdc7f70f00007f29af301cb358e5432L90-R90), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-c8d24dba3dd3cae5f0db517022a284eb2fdc7f70f00007f29af301cb358e5432L96-R96), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-c8d24dba3dd3cae5f0db517022a284eb2fdc7f70f00007f29af301cb358e5432L142-L144))
* Add the `order` option to the `genComponentStyleHook` function to customize the insertion order of the style ([link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L480-R504), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL64-R64), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL72-R74), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL93-R98), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL120-R122), [link](https://github.com/ant-design/ant-design/pull/44485/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL168-R170))
