### PR TITLE
perf: Notification style should be generated when shown

### DIFF
--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -201,7 +201,4 @@ export default genComponentStyleHook(
       token.paddingSM
     }px`,
   }),
-  {
-    clientOnly: true,
-  },
 );

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -15,7 +15,7 @@ import type {
   NoticeType,
   TypeOpen,
 } from './interface';
-import useStyle from './style';
+import useMessageStyle from './style';
 import { getMotion, wrapPromiseFn } from './util';
 
 const DEFAULT_OFFSET = 8;
@@ -30,9 +30,16 @@ type HolderProps = ConfigOptions & {
 
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
-  hashId: string;
   message?: ComponentStyleConfig;
 }
+
+const useStyle = (prefixCls: string) => {
+  const [, hashId] = useMessageStyle(prefixCls);
+  return {
+    notice: hashId,
+    list: hashId,
+  };
+};
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const {
@@ -49,8 +56,6 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
 
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
-  const [, hashId] = useStyle(prefixCls);
-
   // =============================== Style ===============================
   const getStyle = (): React.CSSProperties => ({
     left: '50%',
@@ -58,7 +63,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     top: top ?? DEFAULT_OFFSET,
   });
 
-  const getClassName = () => classNames(hashId, { [`${prefixCls}-rtl`]: rtl });
+  const getClassName = () => classNames({ [`${prefixCls}-rtl`]: rtl });
 
   // ============================== Motion ===============================
   const getNotificationMotion = () => getMotion(prefixCls, transitionName);
@@ -82,13 +87,13 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     getContainer: () => staticGetContainer?.() || getPopupContainer?.() || document.body,
     maxCount,
     onAllRemoved,
+    useStyle,
   });
 
   // ================================ Ref ================================
   React.useImperativeHandle(ref, () => ({
     ...api,
     prefixCls,
-    hashId,
     message,
   }));
 
@@ -128,7 +133,7 @@ export function useInternalMessage(
         return fakeResult;
       }
 
-      const { open: originOpen, prefixCls, hashId, message } = holderRef.current;
+      const { open: originOpen, prefixCls, message } = holderRef.current;
       const noticePrefixCls = `${prefixCls}-notice`;
 
       const { content, icon, type, key, className, style, onClose, ...restConfig } = config;
@@ -151,7 +156,6 @@ export function useInternalMessage(
           placement: 'top',
           className: classNames(
             type && `${noticePrefixCls}-${type}`,
-            hashId,
             className,
             message?.className,
           ),

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -1,6 +1,6 @@
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
-import { useNotification as useRcNotification } from 'rc-notification';
+import { NotificationProvider, useNotification as useRcNotification } from 'rc-notification';
 import type { NotificationAPI } from 'rc-notification/lib';
 import * as React from 'react';
 import warning from '../_util/warning';
@@ -15,8 +15,10 @@ import type {
   NoticeType,
   TypeOpen,
 } from './interface';
-import useMessageStyle from './style';
+import useStyle from './style';
 import { getMotion, wrapPromiseFn } from './util';
+import type { FC, PropsWithChildren } from 'react';
+import type { NotificationConfig as RcNotificationConfig } from 'rc-notification/lib/useNotification';
 
 const DEFAULT_OFFSET = 8;
 const DEFAULT_DURATION = 3;
@@ -33,13 +35,23 @@ interface HolderRef extends NotificationAPI {
   message?: ComponentStyleConfig;
 }
 
-const useStyle = (prefixCls: string) => {
-  const [, hashId] = useMessageStyle(prefixCls);
-  return {
-    notice: hashId,
-    list: hashId,
-  };
+const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
+  const [, hashId] = useStyle(prefixCls);
+  return (
+    <NotificationProvider classNames={{ list: hashId, notice: hashId }}>
+      {children}
+    </NotificationProvider>
+  );
 };
+
+const renderNotifications: RcNotificationConfig['renderNotifications'] = (
+  node,
+  { prefixCls, key },
+) => (
+  <Wrapper prefixCls={prefixCls} key={key}>
+    {node}
+  </Wrapper>
+);
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const {
@@ -87,7 +99,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     getContainer: () => staticGetContainer?.() || getPopupContainer?.() || document.body,
     maxCount,
     onAllRemoved,
-    useStyle,
+    renderNotifications,
   });
 
   // ================================ Ref ================================

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -300,7 +300,4 @@ export default genComponentStyleHook(
     zIndexPopup: token.zIndexPopupBase + 50,
     width: 384,
   }),
-  {
-    clientOnly: true,
-  },
 );

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -15,10 +15,9 @@ import type {
   NotificationPlacement,
 } from './interface';
 import { getCloseIcon, PureContent } from './PurePanel';
-import useNotificationStyle from './style';
+import useStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
 import type { FC, PropsWithChildren } from 'react';
-import { useEffect } from 'react';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -37,7 +36,7 @@ interface HolderRef extends NotificationAPI {
 }
 
 const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
-  const [, hashId] = useNotificationStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
   return (
     <NotificationProvider classNames={{ list: hashId, notice: hashId }}>
       {children}
@@ -45,8 +44,13 @@ const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefi
   );
 };
 
-const renderNotifications: RcNotificationConfig['renderNotifications'] = (node, { prefixCls }) => (
-  <Wrapper prefixCls={prefixCls}>{node}</Wrapper>
+const renderNotifications: RcNotificationConfig['renderNotifications'] = (
+  node,
+  { prefixCls, key },
+) => (
+  <Wrapper prefixCls={prefixCls} key={key}>
+    {node}
+  </Wrapper>
 );
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -12,7 +12,7 @@ import type {
   NotificationPlacement,
 } from './interface';
 import { getCloseIcon, PureContent } from './PurePanel';
-import useStyle from './style';
+import useNotificationStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
@@ -28,9 +28,16 @@ type HolderProps = NotificationConfig & {
 
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
-  hashId: string;
   notification?: ComponentStyleConfig;
 }
+
+const useStyle = (prefixCls: string) => {
+  const [, hashId] = useNotificationStyle(prefixCls);
+  return {
+    notice: hashId,
+    list: hashId,
+  };
+};
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const {
@@ -50,10 +57,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const getStyle = (placement: NotificationPlacement): React.CSSProperties =>
     getPlacementStyle(placement, top ?? DEFAULT_OFFSET, bottom ?? DEFAULT_OFFSET);
 
-  // Style
-  const [, hashId] = useStyle(prefixCls);
-
-  const getClassName = () => classNames(hashId, { [`${prefixCls}-rtl`]: rtl });
+  const getClassName = () => classNames({ [`${prefixCls}-rtl`]: rtl });
 
   // ============================== Motion ===============================
   const getNotificationMotion = () => getMotion(prefixCls);
@@ -70,13 +74,13 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     getContainer: () => staticGetContainer?.() || getPopupContainer?.() || document.body,
     maxCount,
     onAllRemoved,
+    useStyle,
   });
 
   // ================================ Ref ================================
   React.useImperativeHandle(ref, () => ({
     ...api,
     prefixCls,
-    hashId,
     notification,
   }));
 
@@ -106,7 +110,7 @@ export function useInternalNotification(
         return;
       }
 
-      const { open: originOpen, prefixCls, hashId, notification } = holderRef.current;
+      const { open: originOpen, prefixCls, notification } = holderRef.current;
 
       const noticePrefixCls = `${prefixCls}-notice`;
 
@@ -142,7 +146,6 @@ export function useInternalNotification(
         ),
         className: classNames(
           type && `${noticePrefixCls}-${type}`,
-          hashId,
           className,
           notification?.className,
         ),

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { useNotification as useRcNotification } from 'rc-notification';
-import type { NotificationAPI } from 'rc-notification/lib';
+import { NotificationProvider, useNotification as useRcNotification } from 'rc-notification';
+import type {
+  NotificationAPI,
+  NotificationConfig as RcNotificationConfig,
+} from 'rc-notification/lib';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { ComponentStyleConfig } from '../config-provider/context';
@@ -14,6 +17,8 @@ import type {
 import { getCloseIcon, PureContent } from './PurePanel';
 import useNotificationStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
+import type { FC, PropsWithChildren } from 'react';
+import { useEffect } from 'react';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -31,13 +36,18 @@ interface HolderRef extends NotificationAPI {
   notification?: ComponentStyleConfig;
 }
 
-const useStyle = (prefixCls: string) => {
+const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
   const [, hashId] = useNotificationStyle(prefixCls);
-  return {
-    notice: hashId,
-    list: hashId,
-  };
+  return (
+    <NotificationProvider classNames={{ list: hashId, notice: hashId }}>
+      {children}
+    </NotificationProvider>
+  );
 };
+
+const renderNotifications: RcNotificationConfig['renderNotifications'] = (node, { prefixCls }) => (
+  <Wrapper prefixCls={prefixCls}>{node}</Wrapper>
+);
 
 const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   const {
@@ -74,7 +84,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     getContainer: () => staticGetContainer?.() || getPopupContainer?.() || document.body,
     maxCount,
     onAllRemoved,
-    useStyle,
+    renderNotifications,
   });
 
   // ================================ Ref ================================

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "rc-mentions": "~2.5.0",
     "rc-menu": "~9.10.0",
     "rc-motion": "^2.7.3",
-    "rc-notification": "~5.1.0",
+    "rc-notification": "~5.1.1",
     "rc-pagination": "~3.6.0",
     "rc-picker": "~3.13.0",
     "rc-progress": "~3.4.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "rc-mentions": "~2.5.0",
     "rc-menu": "~9.10.0",
     "rc-motion": "^2.7.3",
-    "rc-notification": "~5.1.0-1",
+    "rc-notification": "~5.1.0",
     "rc-pagination": "~3.6.0",
     "rc-picker": "~3.13.0",
     "rc-progress": "~3.4.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "rc-mentions": "~2.5.0",
     "rc-menu": "~9.10.0",
     "rc-motion": "^2.7.3",
-    "rc-notification": "~5.0.4",
+    "rc-notification": "~5.1.0-1",
     "rc-pagination": "~3.6.0",
     "rc-picker": "~3.13.0",
     "rc-progress": "~3.4.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
修复 Notification 和 Message 的 PureRender 没有 SSR 样式的问题，优化这两个组件的样式注入逻辑
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Notification and Message only generate styles when displayed.        |
| 🇨🇳 Chinese |   Notification 和 Message 组件只有在展示时才会插入对应样式。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72f55a5</samp>

This pull request simplifies the style class generation and usage for the `message` and `notification` components by refactoring the `useStyle` hook and removing the `hashId` property. It also updates the `rc-notification` dependency and removes the unnecessary `clientOnly` option from the `rc-notification` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72f55a5</samp>

*  Remove the `clientOnly` option from the `rc-notification` component and update the dependency to the latest version ([link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL204-L206), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-010d2fb0cf8202fc5bf9195acacedd5974befc60181c9b860c066fe6fcd5430fL303-L305), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L139-R139))
*  Refactor the `useStyle` hooks in `useMessage.tsx` and `useNotification.tsx` to return the `hashId` as part of the style object and append it to the `notice` and `list` style classes ([link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L33-R43), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL31-R41))
*  Pass the `useStyle` hooks as props to the `Notification` components in `useMessage.tsx` and `useNotification.tsx` and remove the `hashId` props and properties ([link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R90), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L91), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L131-R136), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L154), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfR77), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL79), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL109-R113), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL145))
*  Remove the calls to the `useStyle` hooks and the `hashId` from the `getClassName` functions in the `Holder` components in `useMessage.tsx` and `useNotification.tsx` ([link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L52-L53), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L61-R66), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL53-R61))
*  Rename the imported `useStyle` hooks to `useMessageStyle` and `useNotificationStyle` to avoid confusion with the local `useStyle` hooks ([link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L18-R18), [link](https://github.com/ant-design/ant-design/pull/44488/files?diff=unified&w=0#diff-fa8b6f08e906ed18759c056ccb358fb0b780b4ffbb0f00ed368b45c3b8efe5dfL15-R15))
