### PR TITLE
fix: Watermark should not crash if content is empty

### DIFF
--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -16,8 +16,16 @@ describe('Watermark', () => {
     });
   });
 
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterAll(() => {
     mockSrcSet.mockRestore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('The watermark should render successfully', () => {
@@ -93,5 +101,16 @@ describe('Watermark', () => {
     target?.setAttribute('style', '');
     await waitFor(() => expect(target).toBeTruthy());
     expect(container).toMatchSnapshot();
+  });
+
+  it('should not crash if content is empty string', async () => {
+    const spy = jest.spyOn(CanvasRenderingContext2D.prototype, 'drawImage');
+    render(<Watermark content="" className="watermark" />);
+    await waitFakeTimer();
+    expect(spy).not.toHaveBeenCalledWith(expect.anything(), 0, 0);
+    expect(spy).not.toHaveBeenCalledWith(expect.anything(), -0, 0);
+    expect(spy).not.toHaveBeenCalledWith(expect.anything(), -0, -0);
+    expect(spy).not.toHaveBeenCalledWith(expect.anything(), 0, -0);
+    spy.mockRestore();
   });
 });

--- a/components/watermark/useClips.ts
+++ b/components/watermark/useClips.ts
@@ -69,7 +69,9 @@ export default function useClips() {
     // Copy from `ctx` and rotate
     rCtx.translate(realMaxSize / 2, realMaxSize / 2);
     rCtx.rotate(angle);
-    rCtx.drawImage(canvas, -contentWidth / 2, -contentHeight / 2);
+    if (contentWidth > 0 && contentHeight > 0) {
+      rCtx.drawImage(canvas, -contentWidth / 2, -contentHeight / 2);
+    }
 
     // Get boundary of rotated text
     function getRotatePos(x: number, y: number) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
close https://github.com/ant-design/ant-design/issues/44486
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Watermark that would crash if `content` is empty string.        |
| 🇨🇳 Chinese |      修复 Watermark 组件在 `content` 是空字符串时报错的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd7b8b4</samp>

This pull request enhances the watermark component by improving its tests and fixing a bug. It uses `fakeTimers` in `components/watermark/__tests__/index.test.tsx` to avoid flaky tests and adds a test for empty content. It also adds a condition to `getClips` in `components/watermark/useClips.ts` to prevent drawing an empty canvas that would cause an error in some browsers.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd7b8b4</samp>

* Fix a bug that caused watermark component to crash with empty content ([link](https://github.com/ant-design/ant-design/pull/44501/files?diff=unified&w=0#diff-e74de8cfb7d6f9243c101cce673937f42777adc732547f8ef936d6ae1a92e001L72-R74), [link](https://github.com/ant-design/ant-design/pull/44501/files?diff=unified&w=0#diff-09e48387fb55cf0737e5d58290892068215dd51b1aa43558679d3ffed6dae497R105-R115))
* Use fake timers for watermark tests to avoid flaky results ([link](https://github.com/ant-design/ant-design/pull/44501/files?diff=unified&w=0#diff-09e48387fb55cf0737e5d58290892068215dd51b1aa43558679d3ffed6dae497L19-R30))
