### PR TITLE
docs: add note regarding considerations for using getContainer

### DIFF
--- a/components/drawer/demo/render-in-current.md
+++ b/components/drawer/demo/render-in-current.md
@@ -4,8 +4,12 @@
 
 > 注意：在 v5 中 `style` 与 `className` 迁移至 Drawer 面板上与 Modal 保持一致，原 `style` 与 `className` 替换为 `rootStyle` 与 `rootClassName`。
 
+> 如 [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152) 所述，如果 `getContainer` 以 callback 的形式返回了自定义容器，需要手动设置 `rootStyle` 为 `{ position: 'absolute' }`，否则会导致 `Drawer` 组件的表现不如预期。
+
 ## en-US
 
 Render in current dom. custom container, check `getContainer`.
 
 > Note: `style` and `className` props are moved to Drawer panel in v5 which is aligned with Modal component. Original `style` and `className` props are replaced by `rootStyle` and `rootClassName`.
+
+> As noted in [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152), if `getContainer` returns a custom container as a callback. The `rootStyle` needs to be set manually to `{ position: 'absolute' }`, otherwise the `Drawer` component will not behave as expected.

--- a/components/drawer/demo/render-in-current.md
+++ b/components/drawer/demo/render-in-current.md
@@ -4,7 +4,7 @@
 
 > 注意：在 v5 中 `style` 与 `className` 迁移至 Drawer 面板上与 Modal 保持一致，原 `style` 与 `className` 替换为 `rootStyle` 与 `rootClassName`。
 
-> 如 [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152) 所述，如果 `getContainer` 以 callback 的形式返回了自定义容器，需要手动设置 `rootStyle` 为 `{ position: 'absolute' }`，否则会导致 `Drawer` 组件的表现不如预期。
+> 当 `getContainer` 返回 DOM 节点时，需要手动设置 `rootStyle` 为 `{ position: 'absolute' }`，参考 [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152)。
 
 ## en-US
 
@@ -12,4 +12,4 @@ Render in current dom. custom container, check `getContainer`.
 
 > Note: `style` and `className` props are moved to Drawer panel in v5 which is aligned with Modal component. Original `style` and `className` props are replaced by `rootStyle` and `rootClassName`.
 
-> As noted in [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152), if `getContainer` returns a custom container as a callback. The `rootStyle` needs to be set manually to `{ position: 'absolute' }`, otherwise the `Drawer` component will not behave as expected.
+> When `getContainer` returns a DOM node, you need to manually set `rootStyle` to `{ position: 'absolute' }`, see [#41951](https://github.com/ant-design/ant-design/issues/41951#issuecomment-1521099152).


### PR DESCRIPTION
(cherry picked from commit fa6af984ee896f13b4f983f905092098f2f8689d)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      add note regarding considerations for using getContainer     |
| 🇨🇳 Chinese |    添加使用 getContainer 的注意事项说明       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a692289</samp>

Improve documentation of `Drawer` component's `render-in-current` demo. Add a note to `components/drawer/demo/render-in-current.md` explaining how to use the `rootStyle` prop with a custom container.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a692289</samp>

* Add a note to the documentation of the `render-in-current` demo of the `Drawer` component, explaining how to set the `rootStyle` prop to avoid unexpected behavior when using a custom container ([link](https://github.com/ant-design/ant-design/pull/44504/files?diff=unified&w=0#diff-ffad735264566b5fc7fae5759af783eeb153d6b640096ef27fb53523680a7411R7-R8), [link](https://github.com/ant-design/ant-design/pull/44504/files?diff=unified&w=0#diff-ffad735264566b5fc7fae5759af783eeb153d6b640096ef27fb53523680a7411R14-R15))
