### PR TITLE
refactor: Extract Tag unused style

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -25,7 +25,7 @@ import { isTwoCNChar, isUnBorderedButtonType, spaceChildren } from './buttonHelp
 import IconWrapper from './IconWrapper';
 import LoadingIcon from './LoadingIcon';
 import useStyle from './style';
-import CompactStyle from './style/compactCmp';
+import CompactCmp from './style/compactCmp';
 
 export type LegacyButtonType = ButtonType | 'danger';
 
@@ -289,7 +289,7 @@ const InternalButton: React.ForwardRefRenderFunction<
       {kids}
 
       {/* Styles: compact */}
-      {compactItemClassnames && <CompactStyle prefixCls={prefixCls} />}
+      {compactItemClassnames && <CompactCmp key="compact" prefixCls={prefixCls} />}
     </button>
   );
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -13,6 +13,7 @@ import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
 import CheckableTag from './CheckableTag';
 import useStyle from './style';
+import PresetCmp from './style/presetCmp';
 import StatusCmp from './style/statusCmp';
 
 export type { CheckableTagProps } from './CheckableTag';
@@ -71,8 +72,9 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     }
   }, [props.visible]);
 
-  const isStatusColor = isPresetStatusColor(color);
-  const isInternalColor = isPresetColor(color) || isStatusColor;
+  const isPreset = isPresetColor(color);
+  const isStatus = isPresetStatusColor(color);
+  const isInternalColor = isPreset || isStatus;
 
   const tagStyle: React.CSSProperties = {
     backgroundColor: color && !isInternalColor ? color : undefined,
@@ -143,7 +145,8 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     <span {...props} ref={ref} className={tagClassName} style={tagStyle}>
       {kids}
       {mergedCloseIcon}
-      {isStatusColor && <StatusCmp key="status" prefixCls={prefixCls} />}
+      {isPreset && <PresetCmp key="preset" prefixCls={prefixCls} />}
+      {isStatus && <StatusCmp key="status" prefixCls={prefixCls} />}
     </span>
   );
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -143,7 +143,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     <span {...props} ref={ref} className={tagClassName} style={tagStyle}>
       {kids}
       {mergedCloseIcon}
-      {isStatusColor && <StatusCmp prefixCls={prefixCls} />}
+      {isStatusColor && <StatusCmp key="status" prefixCls={prefixCls} />}
     </span>
   );
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
-import * as React from 'react';
+
 import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
 import { isPresetColor, isPresetStatusColor } from '../_util/colors';
 import useClosable from '../_util/hooks/useClosable';
@@ -12,6 +13,7 @@ import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
 import CheckableTag from './CheckableTag';
 import useStyle from './style';
+import StatusCmp from './style/statusCmp';
 
 export type { CheckableTagProps } from './CheckableTag';
 
@@ -69,7 +71,8 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     }
   }, [props.visible]);
 
-  const isInternalColor = isPresetColor(color) || isPresetStatusColor(color);
+  const isStatusColor = isPresetStatusColor(color);
+  const isInternalColor = isPresetColor(color) || isStatusColor;
 
   const tagStyle: React.CSSProperties = {
     backgroundColor: color && !isInternalColor ? color : undefined,
@@ -140,6 +143,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     <span {...props} ref={ref} className={tagClassName} style={tagStyle}>
       {kids}
       {mergedCloseIcon}
+      {isStatusColor && <StatusCmp prefixCls={prefixCls} />}
     </span>
   );
 

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -1,9 +1,11 @@
-import type { CSSInterpolation } from '@ant-design/cssinjs';
 import type React from 'react';
-import capitalize from '../../_util/capitalize';
+import type { CSSInterpolation } from '@ant-design/cssinjs';
+
 import { resetComponent } from '../../style';
+import type { GlobalToken } from '../../theme';
 import type { FullToken } from '../../theme/internal';
 import { genComponentStyleHook, genPresetColor, mergeToken } from '../../theme/internal';
+import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 
 export interface ComponentToken {
   /**
@@ -18,7 +20,7 @@ export interface ComponentToken {
   defaultColor: string;
 }
 
-interface TagToken extends FullToken<'Tag'> {
+export interface TagToken extends FullToken<'Tag'> {
   tagFontSize: number;
   tagLineHeight: React.CSSProperties['lineHeight'];
   tagIconSize: number;
@@ -27,27 +29,6 @@ interface TagToken extends FullToken<'Tag'> {
 }
 
 // ============================== Styles ==============================
-
-type CssVariableType = 'Success' | 'Info' | 'Error' | 'Warning';
-
-const genTagStatusStyle = (
-  token: TagToken,
-  status: 'success' | 'processing' | 'error' | 'warning',
-  cssVariableType: CssVariableType,
-): CSSInterpolation => {
-  const capitalizedCssVariableType = capitalize<CssVariableType>(cssVariableType);
-  return {
-    [`${token.componentCls}-${status}`]: {
-      color: token[`color${cssVariableType}`],
-      background: token[`color${capitalizedCssVariableType}Bg`],
-      borderColor: token[`color${capitalizedCssVariableType}Border`],
-      [`&${token.componentCls}-borderless`]: {
-        borderColor: 'transparent',
-      },
-    },
-  };
-};
-
 const genPresetStyle = (token: TagToken) =>
   genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
     [`${token.componentCls}-${colorKey}`]: {
@@ -162,33 +143,33 @@ const genBaseStyle = (token: TagToken): CSSInterpolation => {
 };
 
 // ============================== Export ==============================
+export const prepareToken: (token: Parameters<GenStyleFn<'Tag'>>[0]) => TagToken = (token) => {
+  const { lineWidth, fontSizeIcon } = token;
+
+  const tagFontSize = token.fontSizeSM;
+  const tagLineHeight = `${token.lineHeightSM * tagFontSize}px`;
+
+  const tagToken = mergeToken<TagToken>(token, {
+    tagFontSize,
+    tagLineHeight,
+    tagIconSize: fontSizeIcon - 2 * lineWidth, // Tag icon is much smaller
+    tagPaddingHorizontal: 8, // Fixed padding.
+    tagBorderlessBg: token.colorFillTertiary,
+  });
+  return tagToken;
+};
+
+export const prepareCommonToken: (token: GlobalToken) => ComponentToken = (token) => ({
+  defaultBg: token.colorFillQuaternary,
+  defaultColor: token.colorText,
+});
+
 export default genComponentStyleHook(
   'Tag',
   (token) => {
-    const { lineWidth, fontSizeIcon } = token;
+    const tagToken = prepareToken(token);
 
-    const tagFontSize = token.fontSizeSM;
-    const tagLineHeight = `${token.lineHeightSM * tagFontSize}px`;
-
-    const tagToken = mergeToken<TagToken>(token, {
-      tagFontSize,
-      tagLineHeight,
-      tagIconSize: fontSizeIcon - 2 * lineWidth, // Tag icon is much smaller
-      tagPaddingHorizontal: 8, // Fixed padding.
-      tagBorderlessBg: token.colorFillTertiary,
-    });
-
-    return [
-      genBaseStyle(tagToken),
-      genPresetStyle(tagToken),
-      genTagStatusStyle(tagToken, 'success', 'Success'),
-      genTagStatusStyle(tagToken, 'processing', 'Info'),
-      genTagStatusStyle(tagToken, 'error', 'Error'),
-      genTagStatusStyle(tagToken, 'warning', 'Warning'),
-    ];
+    return [genBaseStyle(tagToken), genPresetStyle(tagToken)];
   },
-  (token) => ({
-    defaultBg: token.colorFillQuaternary,
-    defaultColor: token.colorText,
-  }),
+  prepareCommonToken,
 );

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -4,7 +4,7 @@ import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { GlobalToken } from '../../theme';
 import type { FullToken } from '../../theme/internal';
-import { genComponentStyleHook, genPresetColor, mergeToken } from '../../theme/internal';
+import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 
 export interface ComponentToken {
@@ -29,23 +29,6 @@ export interface TagToken extends FullToken<'Tag'> {
 }
 
 // ============================== Styles ==============================
-const genPresetStyle = (token: TagToken) =>
-  genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
-    [`${token.componentCls}-${colorKey}`]: {
-      color: textColor,
-      background: lightColor,
-      borderColor: lightBorderColor,
-      // Inverse color
-      '&-inverse': {
-        color: token.colorTextLightSolid,
-        background: darkColor,
-        borderColor: darkColor,
-      },
-      [`&${token.componentCls}-borderless`]: {
-        borderColor: 'transparent',
-      },
-    },
-  }));
 
 const genBaseStyle = (token: TagToken): CSSInterpolation => {
   const { paddingXXS, lineWidth, tagPaddingHorizontal, componentCls } = token;
@@ -169,7 +152,7 @@ export default genComponentStyleHook(
   (token) => {
     const tagToken = prepareToken(token);
 
-    return [genBaseStyle(tagToken), genPresetStyle(tagToken)];
+    return genBaseStyle(tagToken);
   },
   prepareCommonToken,
 );

--- a/components/tag/style/presetCmp.ts
+++ b/components/tag/style/presetCmp.ts
@@ -1,0 +1,33 @@
+// Style as status component
+import { prepareCommonToken, prepareToken, type TagToken } from '.';
+import { genPresetColor, genSubStyleComponent } from '../../theme/internal';
+
+// ============================== Preset ==============================
+const genPresetStyle = (token: TagToken) =>
+  genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
+    [`${token.componentCls}-${colorKey}`]: {
+      color: textColor,
+      background: lightColor,
+      borderColor: lightBorderColor,
+      // Inverse color
+      '&-inverse': {
+        color: token.colorTextLightSolid,
+        background: darkColor,
+        borderColor: darkColor,
+      },
+      [`&${token.componentCls}-borderless`]: {
+        borderColor: 'transparent',
+      },
+    },
+  }));
+
+// ============================== Export ==============================
+export default genSubStyleComponent(
+  ['Tag', 'preset'],
+  (token) => {
+    const tagToken = prepareToken(token);
+
+    return genPresetStyle(tagToken);
+  },
+  prepareCommonToken,
+);

--- a/components/tag/style/statusCmp.ts
+++ b/components/tag/style/statusCmp.ts
@@ -1,4 +1,4 @@
-// Style as inline component
+// Style as status component
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 
 import { prepareCommonToken, prepareToken, type TagToken } from '.';

--- a/components/tag/style/statusCmp.ts
+++ b/components/tag/style/statusCmp.ts
@@ -1,0 +1,43 @@
+// Style as inline component
+import type { CSSInterpolation } from '@ant-design/cssinjs';
+
+import { prepareCommonToken, prepareToken, type TagToken } from '.';
+import capitalize from '../../_util/capitalize';
+import { genSubStyleComponent } from '../../theme/internal';
+
+// ============================== Status ==============================
+type CssVariableType = 'Success' | 'Info' | 'Error' | 'Warning';
+
+const genTagStatusStyle = (
+  token: TagToken,
+  status: 'success' | 'processing' | 'error' | 'warning',
+  cssVariableType: CssVariableType,
+): CSSInterpolation => {
+  const capitalizedCssVariableType = capitalize<CssVariableType>(cssVariableType);
+  return {
+    [`${token.componentCls}-${status}`]: {
+      color: token[`color${cssVariableType}`],
+      background: token[`color${capitalizedCssVariableType}Bg`],
+      borderColor: token[`color${capitalizedCssVariableType}Border`],
+      [`&${token.componentCls}-borderless`]: {
+        borderColor: 'transparent',
+      },
+    },
+  };
+};
+
+// ============================== Export ==============================
+export default genSubStyleComponent(
+  ['Tag', 'status'],
+  (token) => {
+    const tagToken = prepareToken(token);
+
+    return [
+      genTagStatusStyle(tagToken, 'success', 'Success'),
+      genTagStatusStyle(tagToken, 'processing', 'Info'),
+      genTagStatusStyle(tagToken, 'error', 'Error'),
+      genTagStatusStyle(tagToken, 'warning', 'Warning'),
+    ];
+  },
+  prepareCommonToken,
+);

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -184,13 +184,19 @@ export interface SubStyleComponentProps {
   prefixCls: string;
 }
 
-export function genSubStyleComponent<ComponentName extends OverrideComponent>(
+export const genSubStyleComponent: <ComponentName extends OverrideComponent>(
   ...args: Parameters<typeof genComponentStyleHook<ComponentName>>
-): ComponentType<SubStyleComponentProps> {
-  const useStyle = genComponentStyleHook(...args);
+) => ComponentType<SubStyleComponentProps> = (componentName, styleFn, getDefaultToken, options) => {
+  const useStyle = genComponentStyleHook(componentName, styleFn, getDefaultToken, {
+    resetStyle: false,
+
+    // Sub Style should default after root one
+    order: -998,
+    ...options,
+  });
 
   return ({ prefixCls }: SubStyleComponentProps) => {
     useStyle(prefixCls);
     return null;
   };
-}
+};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Extract Tag status & preset color style which will only generate by needed.     |
| 🇨🇳 Chinese |      剥离 Tag 状态与预设颜色样式，现在只有当使用的使用才会生成它们。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65a8e96</samp>

Refactored the tag component and its style logic to use sub-style components for preset and status colors, and fixed some issues with the button component. Renamed `CompactStyle` to `CompactCmp` and added a `key` prop in `components/button/button.tsx`. Extracted the preset and status styles into separate files and functions in `components/tag/style/`. Updated the `genSubStyleComponent` function in `components/theme/util/genComponentStyleHook.ts` to accept more parameters and set default options.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65a8e96</samp>

*  Rename `CompactStyle` to `CompactCmp` and add `key` prop to avoid confusion and warning ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L28-R28), [link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L292-R292))
*  Reorder imports of `React`, `CloseOutlined` and `classNames` to match `components/button/button.tsx` ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L3-R6), [link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L1-R8))
*  Import `PresetCmp` and `StatusCmp` from sub-style files to render preset and status styles of tag component ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R16-R17))
*  Add `isPreset` and `isStatus` variables to store results of color check functions and improve readability ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L72-R77))
*  Add `PresetCmp` and `StatusCmp` to tag component's children based on `color` prop ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R148-R149))
*  Export `TagToken` interface to be used by sub-style components and files ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L21-R23))
*  Move `genTagStatusStyle` and `genPresetStyle` functions to sub-style files to modularize tag style logic ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L31-L68), [link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-79f09cde60f663f18ad398ac97f9dffdd51e3ff6c851cfc508e5cfdb51cc11d9R1-R33), [link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-b41be4b94be27b2254289f98a0514add547f0e2c93ec2ebb3236111832a702c4R1-R43))
*  Add `prepareToken` and `prepareCommonToken` functions to extract common logic of merging and preparing tag token ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L165-R157))
*  Update `genComponentStyleHook` call to use `prepareToken` and `prepareCommonToken` functions and to only generate base style ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L165-R157))
*  Update `genSubStyleComponent` function to accept same parameters as `genComponentStyleHook` and to set default options for sub-style components ([link](https://github.com/ant-design/ant-design/pull/44512/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL187-R202))
