### PR TITLE
fix: Remove Segmented redundant styles when the item is selected

### DIFF
--- a/components/segmented/demo/componentToken.tsx
+++ b/components/segmented/demo/componentToken.tsx
@@ -9,6 +9,7 @@ export default () => (
           itemColor: '#222',
           itemHoverColor: '#333',
           itemHoverBg: 'rgba(0, 0, 0, 0.06)',
+          itemSelectedColor: '#444',
           itemSelectedBg: '#aaa',
           itemActiveBg: '#ccc',
         },

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -25,6 +25,11 @@ export interface ComponentToken {
    */
   itemActiveBg: string;
   /**
+   * @desc 选项选中时文本颜色
+   * @descEN Text color of item when selected
+   */
+  itemSelectedColor: string;
+  /**
    * @desc 选项选中时背景颜色
    * @descEN Background color of item when selected
    */
@@ -109,6 +114,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 
         '&-selected': {
           ...getItemSelectedStyle(token),
+          color: token.itemSelectedColor,
         },
 
         '&::after': {
@@ -238,6 +244,7 @@ export default genComponentStyleHook(
       itemColor: colorTextLabel,
       itemHoverColor: colorText,
       itemHoverBg: colorFillSecondary,
+      itemSelectedColor: colorText,
       itemSelectedBg: colorBgElevated,
       itemActiveBg: colorFill,
     };

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -109,7 +109,6 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 
         '&-selected': {
           ...getItemSelectedStyle(token),
-          color: token.itemHoverColor,
         },
 
         '&::after': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #44513 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

选项被选中时，文字不应该使用 hover 时的颜色，而是默认的即可。

或者增加一个 `itemSelectedColor` 属性单独控制

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Remove Segmented font color when the item is selected, keep same with `itemColor`      |
| 🇨🇳 Chinese |   移除 Segmented 被选中项的文字颜色，保持跟 `itemColor` 一致        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21f20f7</samp>

Remove `color` property from `itemHover` style in `components/segmented/style/index.tsx` to fix text color bug. This change is part of a pull request to improve the segmented control component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21f20f7</samp>

* Remove `color` property from `itemHover` style to fix text color bug on hover ([link](https://github.com/ant-design/ant-design/pull/44519/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL112))
