### PR TITLE
feat: Descriptions `items.span` support responsive config

### DIFF
--- a/components/_util/responsiveObserver.ts
+++ b/components/_util/responsiveObserver.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import type { GlobalToken } from '../theme/interface';
 import { useToken } from '../theme/internal';
 
@@ -124,3 +125,14 @@ export default function useResponsiveObserver() {
     };
   }, [token]);
 }
+
+export const matchScreen = (screens: ScreenMap, screenSizes?: ScreenSizeMap) => {
+  if (screenSizes && typeof screenSizes === 'object') {
+    for (let i = 0; i < responsiveArray.length; i++) {
+      const breakpoint: Breakpoint = responsiveArray[i];
+      if (screens[breakpoint] && screenSizes[breakpoint] !== undefined) {
+        return screenSizes[breakpoint];
+      }
+    }
+  }
+};

--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import type { DescriptionsItemType } from '.';
+
+import type { InternalDescriptionsItemType } from '.';
 import Cell from './Cell';
 import type { DescriptionsContextProps } from './DescriptionsContext';
 import DescriptionsContext from './DescriptionsContext';
@@ -12,7 +13,7 @@ interface CellConfig {
 }
 
 function renderCells(
-  items: DescriptionsItemType[],
+  items: InternalDescriptionsItemType[],
   { colon, prefixCls, bordered }: RowProps,
   {
     component,
@@ -87,7 +88,7 @@ function renderCells(
 export interface RowProps {
   prefixCls: string;
   vertical: boolean;
-  row: DescriptionsItemType[];
+  row: InternalDescriptionsItemType[];
   bordered?: boolean;
   colon: boolean;
   index: number;

--- a/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1116,13 +1116,32 @@ exports[`renders components/descriptions/demo/responsive.tsx extend context corr
               Database version: 3.4
               <br />
               Package: dds.mongo.mid
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="ant-descriptions-row"
+        >
+          <th
+            class="ant-descriptions-item-label"
+            colspan="1"
+          >
+            <span>
+              Hardware Info
+            </span>
+          </th>
+          <td
+            class="ant-descriptions-item-content"
+            colspan="1"
+          >
+            <span>
+              CPU: 6 Core 3.5 GHz
               <br />
               Storage space: 10 GB
               <br />
               Replication factor: 3
               <br />
               Region: East China 1
-              <br />
             </span>
           </td>
         </tr>

--- a/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
@@ -1004,7 +1004,7 @@ exports[`renders components/descriptions/demo/responsive.tsx correctly 1`] = `
           </th>
           <td
             class="ant-descriptions-item-content"
-            colspan="5"
+            colspan="1"
           >
             <span>
               Data disk type: MongoDB
@@ -1012,13 +1012,28 @@ exports[`renders components/descriptions/demo/responsive.tsx correctly 1`] = `
               Database version: 3.4
               <br />
               Package: dds.mongo.mid
+            </span>
+          </td>
+          <th
+            class="ant-descriptions-item-label"
+            colspan="1"
+          >
+            <span>
+              Hardware Info
+            </span>
+          </th>
+          <td
+            class="ant-descriptions-item-content"
+            colspan="3"
+          >
+            <span>
+              CPU: 6 Core 3.5 GHz
               <br />
               Storage space: 10 GB
               <br />
               Replication factor: 3
               <br />
               Region: East China 1
-              <br />
             </span>
           </td>
         </tr>

--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -1,9 +1,10 @@
-import MockDate from 'mockdate';
 import React from 'react';
+import MockDate from 'mockdate';
+
 import Descriptions from '..';
+import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import { render } from '../../../tests/utils';
-import { resetWarned } from '../../_util/warning';
 import ConfigProvider from '../../config-provider';
 
 describe('Descriptions', () => {
@@ -20,7 +21,7 @@ describe('Descriptions', () => {
     errorSpy.mockRestore();
   });
 
-  it('when max-width: 575px，column=1', () => {
+  it('when max-width: 575px, column=1', () => {
     const wrapper = render(
       <Descriptions>
         <Descriptions.Item label="Product">Cloud Database</Descriptions.Item>
@@ -35,7 +36,7 @@ describe('Descriptions', () => {
     wrapper.unmount();
   });
 
-  it('when max-width: 575px，column=2', () => {
+  it('when max-width: 575px, column=2', () => {
     // eslint-disable-next-line global-require
     const wrapper = render(
       <Descriptions column={{ xs: 2 }}>
@@ -47,6 +48,36 @@ describe('Descriptions', () => {
     );
     expect(wrapper.container.querySelectorAll('tr')).toHaveLength(2);
     wrapper.unmount();
+  });
+
+  it('when max-width: 575px, column=2, span=2', () => {
+    // eslint-disable-next-line global-require
+    const { container } = render(
+      <Descriptions
+        column={{ xs: 2 }}
+        items={[
+          {
+            label: 'Product',
+            children: 'Cloud Database',
+            span: { xs: 2 },
+          },
+          {
+            label: 'Billing',
+            children: 'Prepaid',
+            span: { xs: 1 },
+          },
+          {
+            label: 'Time',
+            children: '18:00:00',
+            span: { xs: 1 },
+          },
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('.ant-descriptions-item')[0]).toHaveAttribute('colSpan', '2');
+    expect(container.querySelectorAll('.ant-descriptions-item')[1]).toHaveAttribute('colSpan', '1');
+    expect(container.querySelectorAll('.ant-descriptions-item')[2]).toHaveAttribute('colSpan', '1');
   });
 
   it('column is number', () => {

--- a/components/descriptions/constant.ts
+++ b/components/descriptions/constant.ts
@@ -1,0 +1,12 @@
+import type { Breakpoint } from '../_util/responsiveObserver';
+
+const DEFAULT_COLUMN_MAP: Record<Breakpoint, number> = {
+  xxl: 3,
+  xl: 3,
+  lg: 3,
+  md: 3,
+  sm: 2,
+  xs: 1,
+};
+
+export default DEFAULT_COLUMN_MAP;

--- a/components/descriptions/demo/responsive.tsx
+++ b/components/descriptions/demo/responsive.tsx
@@ -4,38 +4,34 @@ import type { DescriptionsProps } from 'antd';
 
 const items: DescriptionsProps['items'] = [
   {
-    key: '1',
     label: 'Product',
     children: 'Cloud Database',
   },
   {
-    key: '2',
     label: 'Billing',
     children: 'Prepaid',
   },
   {
-    key: '3',
     label: 'Time',
     children: '18:00:00',
   },
   {
-    key: '4',
     label: 'Amount',
     children: '$80.00',
   },
   {
-    key: '5',
     label: 'Discount',
+    span: { xl: 2, xxl: 2 },
     children: '$20.00',
   },
   {
-    key: '6',
     label: 'Official',
+    span: { xl: 2, xxl: 2 },
     children: '$60.00',
   },
   {
-    key: '7',
     label: 'Config Info',
+    span: { xs: 1, sm: 2, md: 3, lg: 3, xl: 2, xxl: 2 },
     children: (
       <>
         Data disk type: MongoDB
@@ -43,13 +39,21 @@ const items: DescriptionsProps['items'] = [
         Database version: 3.4
         <br />
         Package: dds.mongo.mid
+      </>
+    ),
+  },
+  {
+    label: 'Hardware Info',
+    span: { xs: 1, sm: 2, md: 3, lg: 3, xl: 2, xxl: 2 },
+    children: (
+      <>
+        CPU: 6 Core 3.5 GHz
         <br />
         Storage space: 10 GB
         <br />
         Replication factor: 3
         <br />
         Region: East China 1
-        <br />
       </>
     ),
   },
@@ -59,7 +63,7 @@ const App: React.FC = () => (
   <Descriptions
     title="Responsive Descriptions"
     bordered
-    column={{ xxl: 4, xl: 3, lg: 3, md: 3, sm: 2, xs: 1 }}
+    column={{ xs: 1, sm: 2, md: 3, lg: 3, xl: 4, xxl: 4 }}
     items={items}
   />
 );

--- a/components/descriptions/hooks/useItems.ts
+++ b/components/descriptions/hooks/useItems.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import toArray from 'rc-util/lib/Children/toArray';
+
+import type { DescriptionsItemType } from '..';
+import { matchScreen, type ScreenMap } from '../../_util/responsiveObserver';
+
+// Convert children into items
+const transChildren2Items = (childNodes?: React.ReactNode) =>
+  toArray(childNodes).map((node) => ({ ...node?.props }));
+
+export default function useItems(
+  screens: ScreenMap,
+  items?: DescriptionsItemType[],
+  children?: React.ReactNode,
+) {
+  const mergedItems = React.useMemo(
+    () =>
+      // Take `items` first or convert `children` into items
+      items || transChildren2Items(children),
+    [items, children],
+  );
+
+  const responsiveItems = React.useMemo(
+    () =>
+      mergedItems.map(({ span, ...restItem }) => ({
+        ...restItem,
+        span: typeof span === 'number' ? span : matchScreen(screens, span),
+      })),
+    [mergedItems, screens],
+  );
+
+  return responsiveItems;
+}

--- a/components/descriptions/hooks/useItems.ts
+++ b/components/descriptions/hooks/useItems.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import toArray from 'rc-util/lib/Children/toArray';
 
-import type { DescriptionsItemType } from '..';
+import type { DescriptionsItemType, InternalDescriptionsItemType } from '..';
 import { matchScreen, type ScreenMap } from '../../_util/responsiveObserver';
 
 // Convert children into items
@@ -13,14 +13,14 @@ export default function useItems(
   items?: DescriptionsItemType[],
   children?: React.ReactNode,
 ) {
-  const mergedItems = React.useMemo(
+  const mergedItems = React.useMemo<DescriptionsItemType[]>(
     () =>
       // Take `items` first or convert `children` into items
       items || transChildren2Items(children),
     [items, children],
   );
 
-  const responsiveItems = React.useMemo(
+  const responsiveItems = React.useMemo<InternalDescriptionsItemType[]>(
     () =>
       mergedItems.map(({ span, ...restItem }) => ({
         ...restItem,

--- a/components/descriptions/hooks/useRow.ts
+++ b/components/descriptions/hooks/useRow.ts
@@ -1,13 +1,13 @@
 import { useMemo } from 'react';
 
-import type { DescriptionsItemType, InternalDescriptionsItemType } from '..';
+import type { InternalDescriptionsItemType } from '..';
 import warning from '../../_util/warning';
 
 function getFilledItem(
-  rowItem: DescriptionsItemType,
+  rowItem: InternalDescriptionsItemType,
   rowRestCol: number,
   span?: number,
-): DescriptionsItemType {
+): InternalDescriptionsItemType {
   let clone = rowItem;
 
   if (span === undefined || span > rowRestCol) {
@@ -26,8 +26,8 @@ function getFilledItem(
 
 // Calculate the sum of span in a row
 function getCalcRows(rowItems: InternalDescriptionsItemType[], mergedColumn: number) {
-  const rows: DescriptionsItemType[][] = [];
-  let tmpRow: DescriptionsItemType[] = [];
+  const rows: InternalDescriptionsItemType[][] = [];
+  let tmpRow: InternalDescriptionsItemType[] = [];
   let rowRestCol = mergedColumn;
 
   rowItems

--- a/components/descriptions/hooks/useRow.ts
+++ b/components/descriptions/hooks/useRow.ts
@@ -1,6 +1,7 @@
-import toArray from 'rc-util/lib/Children/toArray';
 import type React from 'react';
 import { useMemo } from 'react';
+import toArray from 'rc-util/lib/Children/toArray';
+
 import type { DescriptionsItemType } from '..';
 import warning from '../../_util/warning';
 
@@ -24,10 +25,6 @@ function getFilledItem(
   }
   return clone;
 }
-
-// Convert children into items
-const transChildren2Items = (childNodes?: React.ReactNode) =>
-  toArray(childNodes).map((node) => ({ ...node?.props }));
 
 // Calculate the sum of span in a row
 function getCalcRows(rowItems: DescriptionsItemType[], mergedColumn: number) {
@@ -62,17 +59,8 @@ function getCalcRows(rowItems: DescriptionsItemType[], mergedColumn: number) {
   return rows;
 }
 
-const useRow = (
-  mergedColumn: number,
-  items?: DescriptionsItemType[],
-  children?: React.ReactNode,
-) => {
-  const rows = useMemo(() => {
-    if (Array.isArray(items)) {
-      return getCalcRows(items, mergedColumn);
-    }
-    return getCalcRows(transChildren2Items(children), mergedColumn);
-  }, [items, children, mergedColumn]);
+const useRow = (mergedColumn: number, items: DescriptionsItemType[]) => {
+  const rows = useMemo(() => getCalcRows(items, mergedColumn), [items, mergedColumn]);
 
   return rows;
 };

--- a/components/descriptions/hooks/useRow.ts
+++ b/components/descriptions/hooks/useRow.ts
@@ -1,8 +1,6 @@
-import type React from 'react';
 import { useMemo } from 'react';
-import toArray from 'rc-util/lib/Children/toArray';
 
-import type { DescriptionsItemType } from '..';
+import type { DescriptionsItemType, InternalDescriptionsItemType } from '..';
 import warning from '../../_util/warning';
 
 function getFilledItem(
@@ -27,7 +25,7 @@ function getFilledItem(
 }
 
 // Calculate the sum of span in a row
-function getCalcRows(rowItems: DescriptionsItemType[], mergedColumn: number) {
+function getCalcRows(rowItems: InternalDescriptionsItemType[], mergedColumn: number) {
   const rows: DescriptionsItemType[][] = [];
   let tmpRow: DescriptionsItemType[] = [];
   let rowRestCol = mergedColumn;
@@ -59,7 +57,7 @@ function getCalcRows(rowItems: DescriptionsItemType[], mergedColumn: number) {
   return rows;
 }
 
-const useRow = (mergedColumn: number, items: DescriptionsItemType[]) => {
+const useRow = (mergedColumn: number, items: InternalDescriptionsItemType[]) => {
   const rows = useMemo(() => getCalcRows(items, mergedColumn), [items, mergedColumn]);
 
   return rows;

--- a/components/descriptions/index.en-US.md
+++ b/components/descriptions/index.en-US.md
@@ -93,12 +93,12 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### DescriptionItem
 
-| Property     | Description                    | Type          | Default | Version |
-| ------------ | ------------------------------ | ------------- | ------- | ------- |
-| contentStyle | Customize content style        | CSSProperties | -       | 4.9.0   |
-| label        | The description of the content | ReactNode     | -       |         |
-| labelStyle   | Customize label style          | CSSProperties | -       | 4.9.0   |
-| span         | The number of columns included | number        | 1       |         |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| contentStyle | Customize content style | CSSProperties | - | 4.9.0 |
+| label | The description of the content | ReactNode | - |  |
+| labelStyle | Customize label style | CSSProperties | - | 4.9.0 |
+| span | The number of columns included | number \| [Screens](/components/grid#col) | 1 | `screens: 5.9.0` |
 
 > The number of span Description.Item. Span={2} takes up the width of two DescriptionItems. When both `style` and `labelStyle`(or `contentStyle`) configured, both of them will work. And next one will overwrite first when conflict.
 

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -4,10 +4,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import type { Breakpoint, ScreenMap } from '../_util/responsiveObserver';
-import useResponsiveObserver, { matchScreen } from '../_util/responsiveObserver';
+import type { Breakpoint } from '../_util/responsiveObserver';
+import { matchScreen } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
 import useSize from '../config-provider/hooks/useSize';
+import useBreakpoint from '../grid/hooks/useBreakpoint';
 import DEFAULT_COLUMN_MAP from './constant';
 import DescriptionsContext from './DescriptionsContext';
 import useItems from './hooks/useItems';
@@ -68,7 +69,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
   } = props;
   const { getPrefixCls, direction, descriptions } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('descriptions', customizePrefixCls);
-  const [screens, setScreens] = React.useState<ScreenMap>({});
+  const screens = useBreakpoint();
 
   // Column count
   const mergedColumn = React.useMemo(() => {
@@ -91,21 +92,6 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
   const rows = useRow(mergedColumn, mergedItems);
 
   const [wrapSSR, hashId] = useStyle(prefixCls);
-  const responsiveObserver = useResponsiveObserver();
-
-  // Responsive
-  React.useEffect(() => {
-    const token = responsiveObserver.subscribe((newScreens) => {
-      if (typeof column !== 'object') {
-        return;
-      }
-      setScreens(newScreens);
-    });
-
-    return () => {
-      responsiveObserver.unsubscribe(token);
-    };
-  }, []);
 
   // ======================== Render ========================
   const contextValue = React.useMemo(

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -22,8 +22,11 @@ interface CompoundedComponent {
   Item: typeof DescriptionsItem;
 }
 
-export interface DescriptionsItemType extends Omit<DescriptionsItemProps, 'span'> {
+export interface InternalDescriptionsItemType extends DescriptionsItemProps {
   key?: React.Key;
+}
+
+export interface DescriptionsItemType extends Omit<InternalDescriptionsItemType, 'span'> {
   span?: number | { [key in Breakpoint]?: number };
 }
 

--- a/components/descriptions/index.zh-CN.md
+++ b/components/descriptions/index.zh-CN.md
@@ -94,12 +94,12 @@ const items: DescriptionsProps['items'] = [
 
 ### DescriptionItem
 
-| 参数         | 说明           | 类型          | 默认值 | 版本  |
-| ------------ | -------------- | ------------- | ------ | ----- |
-| contentStyle | 自定义内容样式 | CSSProperties | -      | 4.9.0 |
-| label        | 内容的描述     | ReactNode     | -      |       |
-| labelStyle   | 自定义标签样式 | CSSProperties | -      | 4.9.0 |
-| span         | 包含列的数量   | number        | 1      |       |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| contentStyle | 自定义内容样式 | CSSProperties | - | 4.9.0 |
+| label | 内容的描述 | ReactNode | - |  |
+| labelStyle | 自定义标签样式 | CSSProperties | - | 4.9.0 |
+| span | 包含列的数量 | number \| [Screens](/components/grid#col) | 1 | `screens: 5.9.0` |
 
 > span 是 Description.Item 的数量。 span={2} 会占用两个 DescriptionItem 的宽度。当同时配置 `style` 和 `labelStyle`（或 `contentStyle`）时，两者会同时作用。样式冲突时，后者会覆盖前者。
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #44442

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Descriptions `items.span` support responsive config.     |
| 🇨🇳 Chinese |     Descriptions 的 `items.span` 支持响应式设置。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aae85dc</samp>

This pull request adds a new feature to `DescriptionsItem` that allows specifying responsive `span` values based on breakpoints. It also refactors and improves the code and documentation of the `Descriptions` component and its related files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aae85dc</samp>

*  Add responsive `span` feature for `DescriptionsItem` component ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-1cd1627a602528d79cb6ef420545e6efe1b84829291921f70f2b92486c98a6acR128-R138), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0R53-R82), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45L7-R34), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45R42-R50), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-753321f9ada9303e96dd54c0eb16876870bc246cdfd280037108d10d4aeceddbR1-R33), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL28-R28), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-3f64513cdfc6dee19c44c75fedca6e3210024ee4645913d233bb40983c60ed40L96-R101), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL93-R98), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-5c5342a18baa457033c47a80bdb51dae359f54fbe82bf13867b588e20a9ecec6L97-R102))
  - Extract `DEFAULT_COLUMN_MAP` object to `./constant.ts` file ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-75eca06c8896a1418148496d64bdf91139eeca83fc7180707e126e71628c86dfR1-R12), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL4-R32), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL77-R59))
  - Use `matchScreen` function from `./_util/responsiveObserver.ts` file to get the value that matches the current screen size ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-1cd1627a602528d79cb6ef420545e6efe1b84829291921f70f2b92486c98a6acR128-R138), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-753321f9ada9303e96dd54c0eb16876870bc246cdfd280037108d10d4aeceddbR1-R33), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL4-R32), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL93-R98))
  - Use `useBreakpoint` hook from `antd` to get the current responsive breakpoints ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL4-R32), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL93-R98))
  - Extract `useItems` hook to `./hooks/useItems.ts` file to get the array of items with responsive `span` value ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-753321f9ada9303e96dd54c0eb16876870bc246cdfd280037108d10d4aeceddbR1-R33), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL1-R3), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL65-R61), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL4-R32), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL93-R98))
  - Modify `useRow` hook in `./hooks/useRow.ts` file to expect items with responsive `span` value ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL1-R3), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL28-R28), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-e9f3cd5d3771f55318016ed9a79429cc2c60433b9c0f7605abe9db0b405f82dfL65-R61))
  - Modify `Descriptions` component in `./index.tsx` file to use the new hooks and functions and simplify the logic ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL4-R32), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL77-R59), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL93-R98))
  - Modify documentation and demo files to reflect the new feature and type of `span` property ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45L7-R34), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45R42-R50), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-3f64513cdfc6dee19c44c75fedca6e3210024ee4645913d233bb40983c60ed40L96-R101), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-5c5342a18baa457033c47a80bdb51dae359f54fbe82bf13867b588e20a9ecec6L97-R102))
* Fix typos and formatting issues in various files ([link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-1cd1627a602528d79cb6ef420545e6efe1b84829291921f70f2b92486c98a6acR2), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0L1-R7), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0L23-R24), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-12b6ba8cb14a965604bc8d300d6519622043ad3cf7dee78356a3305af26831e0L38-R39), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45L52), [link](https://github.com/ant-design/ant-design/pull/44534/files?diff=unified&w=0#diff-2319617cffdda0c8855519d4a5da4a968f3e33df81ef20ee49fbde62e98eea45L62-R66))
