### PR TITLE
docs: add help text for token customization

### DIFF
--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -52,7 +52,7 @@ const useStyle = createStyles(() => ({
     }
   `,
   help: css`
-    margin-left: 6px;
+    margin-left: 8px;
     font-size: 12px;
     font-weight: normal;
     color: #999;
@@ -170,7 +170,7 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({
             }
           >
             <span className={styles.help}>
-              <QuestionCircleOutlined style={{ marginRight: 2 }} />
+              <QuestionCircleOutlined style={{ marginRight: 3 }} />
               {helpText}
             </span>
           </Popover>

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -29,7 +29,7 @@ const locales = {
     value: 'Default Value',
     componentToken: 'Component Token',
     globalToken: 'Global Token',
-    help: 'How to customize?',
+    help: 'How to use?',
     customizeTokenLink: '/docs/react/customize-theme#customize-design-token',
     customizeComponentTokenLink: 'docs/react/customize-theme#customize-component-token',
   },

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -1,11 +1,11 @@
-import { RightOutlined } from '@ant-design/icons';
+import { RightOutlined, LinkOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { createStyles, css, useTheme } from 'antd-style';
 import Link from '../../common/Link';
 import { getDesignToken } from 'antd-token-previewer';
 import React, { useMemo, useState } from 'react';
 import tokenMeta from 'antd/es/version/token-meta.json';
 import tokenData from 'antd/es/version/token.json';
-import { ConfigProvider, Table } from 'antd';
+import { ConfigProvider, Table, Popover, Typography } from 'antd';
 import useLocale from '../../../hooks/useLocale';
 import { useColumns } from '../TokenTable';
 
@@ -21,7 +21,7 @@ const locales = {
     globalToken: '全局 Token',
     help: '如何定制？',
     customizeTokenLink: '/docs/react/customize-theme-cn#修改主题变量',
-    customizeComponentTokenLink: '/docs/react/customize-theme-cn#修改主题变量',
+    customizeComponentTokenLink: '/docs/react/customize-theme-cn#修改组件变量',
   },
   en: {
     token: 'Token Name',
@@ -54,7 +54,11 @@ const useStyle = createStyles(() => ({
   `,
   help: css`
     margin-left: 6px;
+<<<<<<< HEAD
     font-size: 13px;
+=======
+    font-size: 12px;
+>>>>>>> bcbc52141 (docs: add help text for token customization)
     font-weight: normal;
     color: #999;
     a {
@@ -66,16 +70,18 @@ const useStyle = createStyles(() => ({
 interface SubTokenTableProps {
   defaultOpen?: boolean;
   title: string;
-  help: React.ReactNode;
+  helpText: React.ReactNode;
+  helpLink: string;
   tokens: string[];
   component?: string;
 }
 
 const SubTokenTable: React.FC<SubTokenTableProps> = ({
   defaultOpen,
-  help,
   tokens,
   title,
+  helpText,
+  helpLink,
   component,
 }) => {
   const [, lang] = useLocale(locales);
@@ -127,13 +133,52 @@ const SubTokenTable: React.FC<SubTokenTableProps> = ({
     })
     .filter(Boolean);
 
+  const code = component
+    ? `<ConfigProvider
+  theme={{
+    components: {
+      ${component}: {
+        /* here is your component tokens */
+      },
+    },
+  }}
+>
+  ...
+</ConfigProvider>`
+    : `<ConfigProvider
+  theme={{
+    token: {
+      /* here is your global tokens */
+    },
+  }}
+>
+  ...
+</ConfigProvider>`;
+
   return (
     <>
       <div className={styles.tableTitle} onClick={() => setOpen(!open)}>
         <RightOutlined className={styles.arrowIcon} rotate={open ? 90 : 0} />
         <h3>
           {title}
-          <span className={styles.help}>({help})</span>
+          <Popover
+            title={null}
+            popupStyle={{ width: 400 }}
+            content={
+              <Typography>
+                <pre style={{ fontSize: 12 }}>{code}</pre>
+                <a href={helpLink} target="_blank" rel="noreferrer">
+                  <LinkOutlined style={{ marginRight: 4 }} />
+                  {helpText}
+                </a>
+              </Typography>
+            }
+          >
+            <span className={styles.help}>
+              <QuestionCircleOutlined style={{ marginRight: 2 }} />
+              {helpText}
+            </span>
+          </Popover>
         </h3>
       </div>
       {open && (
@@ -178,7 +223,8 @@ const ComponentTokenTable: React.FC<ComponentTokenTableProps> = ({ component }) 
       {tokenMeta.components[component] && (
         <SubTokenTable
           title={locale.componentToken}
-          help={<Link to={locale.customizeTokenLink}>{locale.help}</Link>}
+          helpText={<Link to={locale.customizeTokenLink}>{locale.help}</Link>}
+          helpLink={locale.customizeTokenLink}
           tokens={tokenMeta.components[component].map((item) => item.token)}
           component={component}
           defaultOpen
@@ -186,7 +232,8 @@ const ComponentTokenTable: React.FC<ComponentTokenTableProps> = ({ component }) 
       )}
       <SubTokenTable
         title={locale.globalToken}
-        help={<Link to={locale.customizeComponentTokenLink}>{locale.help}</Link>}
+        helpText={locale.help}
+        helpLink={locale.customizeComponentTokenLink}
         tokens={mergedGlobalTokens}
       />
     </>

--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -1,6 +1,5 @@
 import { RightOutlined, LinkOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { createStyles, css, useTheme } from 'antd-style';
-import Link from '../../common/Link';
 import { getDesignToken } from 'antd-token-previewer';
 import React, { useMemo, useState } from 'react';
 import tokenMeta from 'antd/es/version/token-meta.json';
@@ -54,11 +53,7 @@ const useStyle = createStyles(() => ({
   `,
   help: css`
     margin-left: 6px;
-<<<<<<< HEAD
-    font-size: 13px;
-=======
     font-size: 12px;
->>>>>>> bcbc52141 (docs: add help text for token customization)
     font-weight: normal;
     color: #999;
     a {
@@ -223,7 +218,7 @@ const ComponentTokenTable: React.FC<ComponentTokenTableProps> = ({ component }) 
       {tokenMeta.components[component] && (
         <SubTokenTable
           title={locale.componentToken}
-          helpText={<Link to={locale.customizeTokenLink}>{locale.help}</Link>}
+          helpText={locale.help}
           helpLink={locale.customizeTokenLink}
           tokens={tokenMeta.components[component].map((item) => item.token)}
           component={component}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
给一个如何定制变量的提示。

<img width="528" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/b758667d-6f15-423f-b471-85c2753f6389">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     --      |
| 🇨🇳 Chinese |     --      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a59df4f</samp>

Add popover feature and fix typo in component token table. The popover shows how to use `ConfigProvider` to customize tokens and provides a link for more details. The code also corrects a spelling error in the Chinese locale and refactors some styles and imports.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a59df4f</samp>

*  Add popover with code example and link for token customization ([link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L1-R1), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L8-R8), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L57-R61), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L69-R74), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L76-R84), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93R136-R157), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L136-R181), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L181-R227), [link](https://github.com/ant-design/ant-design/pull/44540/files?diff=unified&w=0#diff-377ed68f4e882f6438c31331026bdb11548e6b62be65727a5793cda37badfa93L189-R236))
