### PR TITLE
fix: Form sm 24 not working

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -338,8 +338,10 @@ const genHorizontalStyle: GenerateStyle<FormToken> = (token) => {
         minWidth: 0,
       },
 
+      // Do not change this to `ant-col-24`! `-24` match all the responsive rules
       // https://github.com/ant-design/ant-design/issues/32980
       // https://github.com/ant-design/ant-design/issues/34903
+      // https://github.com/ant-design/ant-design/issues/44538
       [`${formItemCls}-label[class$='-24'], ${formItemCls}-label[class*='-24 ']`]: {
         [`& + ${formItemCls}-control`]: {
           minWidth: 'unset',

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -323,7 +323,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 };
 
 const genHorizontalStyle: GenerateStyle<FormToken> = (token) => {
-  const { componentCls, formItemCls, rootPrefixCls } = token;
+  const { componentCls, formItemCls } = token;
 
   return {
     [`${componentCls}-horizontal`]: {
@@ -339,8 +339,11 @@ const genHorizontalStyle: GenerateStyle<FormToken> = (token) => {
       },
 
       // https://github.com/ant-design/ant-design/issues/32980
-      [`${formItemCls}-label.${rootPrefixCls}-col-24 + ${formItemCls}-control`]: {
-        minWidth: 'unset',
+      // https://github.com/ant-design/ant-design/issues/34903
+      [`${formItemCls}-label[class$='-24'], ${formItemCls}-label[class*='-24 ']`]: {
+        [`& + ${formItemCls}-control`]: {
+          minWidth: 'unset',
+        },
       },
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #44538

### 💡 Background and solution

v4 is correct https://github.com/ant-design/ant-design/blob/4.x-stable/components/form/style/horizontal.less#L18


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form `wrapperCol` to be `24` not working when `labelCol` is set to `24`.      |
| 🇨🇳 Chinese |    修复 Form `labelCol` 设置为 `24` 时，会使 `wrapperCol` 设置 `24` 失效的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 609c5d0</samp>

Fixed a form style bug and removed unused code in `components/form/style/index.ts`. The bug caused incorrect label alignment for some custom classes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 609c5d0</samp>

* Fix form item control style for custom label class names that end with or contain `-24` ([link](https://github.com/ant-design/ant-design/pull/44541/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L342-R346))
* Remove unused `rootPrefixCls` variable from `genHorizontalStyle` function ([link](https://github.com/ant-design/ant-design/pull/44541/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L326-R326))
