### PR TITLE
feature: add itemSelectedFontColor token in Segemented Component 

### DIFF
--- a/components/segmented/demo/componentToken.tsx
+++ b/components/segmented/demo/componentToken.tsx
@@ -11,7 +11,7 @@ export default () => (
           itemHoverBg: 'rgba(0, 0, 0, 0.06)',
           itemSelectedBg: '#aaa',
           itemActiveBg: '#ccc',
-          itemSelectedFontColor: '#fff'
+          itemSelectedFontColor: '#fff',
         },
       },
     }}

--- a/components/segmented/demo/componentToken.tsx
+++ b/components/segmented/demo/componentToken.tsx
@@ -11,7 +11,7 @@ export default () => (
           itemHoverBg: 'rgba(0, 0, 0, 0.06)',
           itemSelectedBg: '#aaa',
           itemActiveBg: '#ccc',
-          itemSelectedFontColor: '#fff',
+          itemSelectedColor: '#fff',
         },
       },
     }}

--- a/components/segmented/demo/componentToken.tsx
+++ b/components/segmented/demo/componentToken.tsx
@@ -11,6 +11,7 @@ export default () => (
           itemHoverBg: 'rgba(0, 0, 0, 0.06)',
           itemSelectedBg: '#aaa',
           itemActiveBg: '#ccc',
+          itemSelectedFontColor: '#fff'
         },
       },
     }}

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -246,7 +246,7 @@ export default genComponentStyleHook(
       itemHoverBg: colorFillSecondary,
       itemSelectedBg: colorBgElevated,
       itemActiveBg: colorFill,
-      itemSelectedFontColor: colorTextLabel
+      itemSelectedFontColor: colorTextLabel,
     };
   },
 );

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -29,6 +29,11 @@ export interface ComponentToken {
    * @descEN Background color of item when selected
    */
   itemSelectedBg: string;
+  /**
+   * @desc 选项选中时文字颜色
+   * @descEN Text color of item when selected
+   */
+  itemSelectedFontColor: string;
 }
 
 interface SegmentedToken extends FullToken<'Segmented'> {
@@ -109,7 +114,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 
         '&-selected': {
           ...getItemSelectedStyle(token),
-          color: token.itemHoverColor,
+          color: token.itemSelectedFontColor,
         },
 
         '&::after': {
@@ -241,6 +246,7 @@ export default genComponentStyleHook(
       itemHoverBg: colorFillSecondary,
       itemSelectedBg: colorBgElevated,
       itemActiveBg: colorFill,
+      itemSelectedFontColor: colorTextLabel
     };
   },
 );

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -33,7 +33,7 @@ export interface ComponentToken {
    * @desc 选项选中时文字颜色
    * @descEN Text color of item when selected
    */
-  itemSelectedFontColor: string;
+  itemSelectedColor: string;
 }
 
 interface SegmentedToken extends FullToken<'Segmented'> {
@@ -114,7 +114,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 
         '&-selected': {
           ...getItemSelectedStyle(token),
-          color: token.itemSelectedFontColor,
+          color: token.itemSelectedColor,
         },
 
         '&::after': {
@@ -246,7 +246,7 @@ export default genComponentStyleHook(
       itemHoverBg: colorFillSecondary,
       itemSelectedBg: colorBgElevated,
       itemActiveBg: colorFill,
-      itemSelectedFontColor: colorTextLabel,
+      itemSelectedColor: colorText,
     };
   },
 );


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #44513 

### 💡 Background and solution


### 📝 Changelog

- 新增itemSelectedFontColor的token，默认与itemColor的token相同，可以自定义item被选中时的颜色

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add ```itemSelectedColor```  token in Segemented Component     |
| 🇨🇳 Chinese |   Segmented 组件新增 ```itemSelectedColor``` 的组件 Token      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5318af6</samp>

This pull request enhances the segmented component by adding a new style property `itemSelectedFontColor` that can be used to customize the text color of the selected item. It also updates the style file and the demo file to demonstrate this feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5318af6</samp>

* Add a new property `itemSelectedFontColor` to the custom token of the segmented component to customize the text color of the selected item ([link](https://github.com/ant-design/ant-design/pull/44555/files?diff=unified&w=0#diff-23d230bfddcd1aff67ccd960c918c66a3589e9bbe35d535d9629257a15a17f94R14), [link](https://github.com/ant-design/ant-design/pull/44555/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dR32-R36), [link](https://github.com/ant-design/ant-design/pull/44555/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dR249))
* Use the new property `itemSelectedFontColor` instead of the existing property `itemHoverColor` for the color of the selected item in the `genSegmentedStyle` function in `components/segmented/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/44555/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL112-R117))
* Add a console log statement to the `genSegmentedStyle` function for debugging purposes ([link](https://github.com/ant-design/ant-design/pull/44555/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL67-R72))
