### PR TITLE
fix(Breadcrumb): fix wrong overlay warning

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -48,8 +48,15 @@ const BreadcrumbItem: CompoundedComponent = (props) => {
   /** If overlay is have Wrap a Dropdown */
   const renderBreadcrumbNode = (breadcrumbItem: React.ReactNode) => {
     if (menu || overlay) {
+      const mergeDropDownProps: DropdownProps = {
+        ...dropdownProps,
+      };
+      if ('overlay' in props) {
+        mergeDropDownProps.overlay = overlay;
+      }
+
       return (
-        <Dropdown menu={menu} overlay={overlay} placement="bottom" {...dropdownProps}>
+        <Dropdown menu={menu} placement="bottom" {...mergeDropDownProps}>
           <span className={`${prefixCls}-overlay-link`}>
             {breadcrumbItem}
             <DownOutlined />

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -46,6 +46,30 @@ describe('Breadcrumb', () => {
     );
   });
 
+  // https://github.com/ant-design/ant-design/issues/40204
+  it('wrong overlay deprecation warning in Dropdown', () => {
+    const items = [
+      {
+        key: '1',
+        label: (
+          <a target="_blank" rel="noopener noreferrer" href="http://www.alipay.com/">
+            General
+          </a>
+        ),
+      },
+    ];
+    render(
+      <Breadcrumb>
+        <Breadcrumb.Item menu={{ items }}>
+          <a href="">General</a>
+        </Breadcrumb.Item>
+      </Breadcrumb>,
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      'Warning: [antd: Dropdown] `overlay` is deprecated. Please use `menu` instead.',
+    );
+  });
+
   // https://github.com/ant-design/ant-design/issues/5015
   it('should allow Breadcrumb.Item is null or undefined', () => {
     const { asFragment } = render(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #40204

### 💡 Background and solution
此问题在主版本上[已修复](https://github.com/ant-design/ant-design/pull/40211)，但在4.x最新版本仍能重现：
[官网重现用例](https://codesandbox.io/s/yfllh5?file=/index.tsx)
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix wrong overlay deprecation warning in Dropdown when use Breadcrumb with menu props    |
| 🇨🇳 Chinese |    修复4.x版本中，Breadcrumb组件使用menu属性，但是出现overlay deprecation警告的问题     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f513486</samp>

Fix a deprecation warning bug for `overlay` prop in `BreadcrumbItem` and add a test case. The bug caused a false warning when using `overlay` with `menu` in `BreadcrumbItem`. The test case verifies that the warning is not shown.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f513486</samp>

* Fix a bug where `overlay` prop of `Dropdown` was deprecated inside `BreadcrumbItem` ([link](https://github.com/ant-design/ant-design/pull/44578/files?diff=unified&w=0#diff-a6c84736ab41b111c92cd33d3ae19e5b651015b5d09876c4295859d2abc323d0L51-R59))
* Add a test case to verify that no deprecation warning is triggered when using `overlay` prop in `BreadcrumbItem` ([link](https://github.com/ant-design/ant-design/pull/44578/files?diff=unified&w=0#diff-1f5cb409ee338e77b70932aba3fbae743db453fb7446e329cfe52e021c654f5aR49-R72))
