### PR TITLE
fix: hide arrow for last item in vertical navigation Steps

### DIFF
--- a/components/steps/style/nav.ts
+++ b/components/steps/style/nav.ts
@@ -130,6 +130,13 @@ const genStepsNavStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
           textAlign: 'center',
           transform: 'translateY(-50%) translateX(-50%) rotate(135deg)',
         },
+
+        '&:last-child': {
+          '&::after': {
+            display: 'none',
+          },
+        },
+
         [`> ${componentCls}-item-container > ${componentCls}-item-tail`]: {
           visibility: 'hidden',
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #44536 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

The last item in the vertical navigation Steps component should hide the arrow.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix the issue that the last arrow of the vertical navigation Steps is not hidden      |
| 🇨🇳 Chinese |  修复垂直导航步骤条的最后一项箭头没隐藏的问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffcb8e6</samp>

Fix a visual bug in the steps component by hiding the unnecessary line after the last step. Modify the CSS file `components/steps/style/nav.ts` to achieve this.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffcb8e6</samp>

* Hide the line after the last step in horizontal and vertical navigation ([link](https://github.com/ant-design/ant-design/pull/44582/files?diff=unified&w=0#diff-e7d8c4a1a9b938afa3709335c6eece6df2ea56049221a1ae1bd3221bd050a04eR133-R139),    in `components/steps/style/nav.ts`)
