### PR TITLE
style(site): optimize site scroll bar dark mode style

### DIFF
--- a/.dumi/theme/common/styles/Common.tsx
+++ b/.dumi/theme/common/styles/Common.tsx
@@ -63,6 +63,10 @@ export default () => {
       html {
         scroll-padding-top: ${headerHeight + margin}px;
       }
+
+      [data-prefers-color='dark'] {
+        color-scheme: dark;
+      }
     `}
     />
   );

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -11,7 +11,13 @@ import { HappyProvider } from '@ant-design/happy-work-theme';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
 import { theme as antdTheme, App } from 'antd';
 import type { DirectionType } from 'antd/es/config-provider';
-import { createSearchParams, useOutlet, useSearchParams, useServerInsertedHTML } from 'dumi';
+import {
+  createSearchParams,
+  useOutlet,
+  useSearchParams,
+  useServerInsertedHTML,
+  usePrefersColor,
+} from 'dumi';
 
 import { DarkContext } from '../../hooks/useDark';
 import useLayoutState from '../../hooks/useLayoutState';
@@ -47,6 +53,7 @@ const GlobalLayout: React.FC = () => {
   const outlet = useOutlet();
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [, , setPrefersColor] = usePrefersColor();
   const [{ theme = [], direction, isMobile }, setSiteState] = useLayoutState<SiteState>({
     isMobile: false,
     direction: 'ltr',
@@ -74,6 +81,7 @@ const GlobalLayout: React.FC = () => {
             ...nextSearchParams,
             theme: value.filter((t) => t !== 'light'),
           });
+          setPrefersColor(theme.indexOf('dark') > -1 ? 'dark' : 'light');
         }
       });
 
@@ -95,6 +103,8 @@ const GlobalLayout: React.FC = () => {
     setSiteState({ theme: _theme, direction: _direction === 'rtl' ? 'rtl' : 'ltr' });
     // Handle isMobile
     updateMobileMode();
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
+    setPrefersColor(_theme.indexOf('dark') > -1 ? 'dark' : 'light');
 
     window.addEventListener('resize', updateMobileMode);
     return () => {

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -77,11 +77,12 @@ const GlobalLayout: React.FC = () => {
           }
         }
         if (key === 'theme') {
+          const _theme = value.filter((t) => t !== 'light');
           nextSearchParams = createSearchParams({
             ...nextSearchParams,
-            theme: value.filter((t) => t !== 'light'),
+            theme: _theme,
           });
-          setPrefersColor(theme.indexOf('dark') > -1 ? 'dark' : 'light');
+          setPrefersColor(_theme.includes('dark') ? 'dark' : 'light');
         }
       });
 
@@ -104,7 +105,7 @@ const GlobalLayout: React.FC = () => {
     // Handle isMobile
     updateMobileMode();
     // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
-    setPrefersColor(_theme.indexOf('dark') > -1 ? 'dark' : 'light');
+    setPrefersColor(_theme.includes('dark') ? 'dark' : 'light');
 
     window.addEventListener('resize', updateMobileMode);
     return () => {


### PR DESCRIPTION
…de style of the site scroll bar

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      set the `prefers-color-scheme` value to optimize the dark mode style of the site scroll bar.     |
| 🇨🇳 Chinese |    设置 `prefers-color-scheme `值优化站点滚动条暗黑模式样式       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec48d58</samp>

This pull request enhances the dark mode support for the documentation site of ant-design. It uses a custom hook from `dumi` to detect and update the `color-scheme` attribute of the global layout and the root element, improving the appearance and accessibility of the site.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec48d58</samp>

*  Add `color-scheme` attribute to the root element to support dark mode ([link](https://github.com/ant-design/ant-design/pull/44588/files?diff=unified&w=0#diff-47bec176af3312fe06e411808360623c0f260f173fda373db619c6a4bc4ef5f1R66-R69))
*  Import and use `usePrefersColor` hook from `dumi` to get and set the user's preferred color scheme ([link](https://github.com/ant-design/ant-design/pull/44588/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L14-R20), [link](https://github.com/ant-design/ant-design/pull/44588/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R56))
*  Update `color-scheme` attribute when the user switches the theme from the ant-design menu ([link](https://github.com/ant-design/ant-design/pull/44588/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R84))
*  Set `color-scheme` attribute on the first render based on the initial theme value ([link](https://github.com/ant-design/ant-design/pull/44588/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R106-R107))

* 优化暗黑模式下全局滚动条样式
* 优化暗黑模式下 markdown 代码块颜色

before
![dark-mode-site](https://github.com/ant-design/ant-design/assets/20694238/51708ad7-7c5b-4f5c-9aa0-cc38fd5b9c82)
after
![dark-mode](https://github.com/ant-design/ant-design/assets/20694238/398afcf3-44c9-4b0c-abdb-48a9e02b46db)


