### PR TITLE
fix: CheckableTag miss CP tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 jobs:
   test-argos-ci:
     docker:
-      - image: cimg/node:16.20-browsers
+      - image: cimg/node:18.17-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
   test-argos-ci:
     docker:
       - image: cimg/node:18.17-browsers
+    environment:
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - checkout
       - run:
@@ -15,7 +17,7 @@ jobs:
           command: yarn
       - run:
           name: Build dist file
-          command: npm --openssl-legacy-provider run dist:esbuild
+          command: npm run dist:esbuild
       - run:
           name: Run image screenshot tests
           command: npm run test-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: yarn
       - run:
           name: Build dist file
-          command: npm run dist:esbuild
+          command: npm --openssl-legacy-provider run dist:esbuild
       - run:
           name: Run image screenshot tests
           command: npm run test-image

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ConfigProvider from '..';
 import { fireEvent, render } from '../../../tests/utils';
 import Alert from '../../alert';
@@ -942,11 +943,16 @@ describe('ConfigProvider support style and className props', () => {
     const { container } = render(
       <ConfigProvider tag={{ className: 'cp-tag', style: { backgroundColor: 'blue' } }}>
         <Tag>Test</Tag>
+        <Tag.CheckableTag checked>CheckableTag</Tag.CheckableTag>
       </ConfigProvider>,
     );
     const element = container.querySelector<HTMLSpanElement>('.ant-tag');
     expect(element).toHaveClass('cp-tag');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
+
+    const checkableElement = container.querySelector<HTMLSpanElement>('.ant-tag-checkable');
+    expect(checkableElement).toHaveClass('cp-tag');
+    expect(checkableElement).toHaveStyle({ backgroundColor: 'blue' });
   });
 
   it('Should Table className & style works', () => {

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,5 +1,6 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
+
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
 
@@ -21,13 +22,14 @@ export interface CheckableTagProps {
 const CheckableTag: React.FC<CheckableTagProps> = (props) => {
   const {
     prefixCls: customizePrefixCls,
+    style,
     className,
     checked,
     onChange,
     onClick,
     ...restProps
   } = props;
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const { getPrefixCls, tag } = React.useContext(ConfigContext);
 
   const handleClick = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
     onChange?.(!checked);
@@ -44,11 +46,22 @@ const CheckableTag: React.FC<CheckableTagProps> = (props) => {
     {
       [`${prefixCls}-checkable-checked`]: checked,
     },
+    tag?.className,
     className,
     hashId,
   );
 
-  return wrapSSR(<span {...restProps} className={cls} onClick={handleClick} />);
+  return wrapSSR(
+    <span
+      {...restProps}
+      style={{
+        ...style,
+        ...tag?.style,
+      }}
+      className={cls}
+      onClick={handleClick}
+    />,
+  );
 };
 
 export default CheckableTag;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix ConfigProvider `tag.className` & `tag.style` not working on Tag.CheckableTag.     |
| 🇨🇳 Chinese |     修复 ConfigProvider `tag.className` 与 `tag.style` 无法作用于 Tag.CheckableTag 的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e21907a</samp>

This pull request adds support for custom style and class name of the `CheckableTag` component from the `ConfigProvider` component. It also adds a test case and improves the code formatting of the related files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e21907a</samp>

*  Add `style` prop to `CheckableTag` component and apply custom style and class name from `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0L1-R3), [link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0R25), [link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0L30-R32), [link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0L47-R64))
*  Add `Tag.CheckableTag` component and assertions to test case `should render style correctly` in `style.test.tsx` to verify custom style and class name from `ConfigProvider` component ([link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R2), [link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R946), [link](https://github.com/ant-design/ant-design/pull/44602/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R952-R955))
