### PR TITLE
site: mobile menu drawer

### DIFF
--- a/.dumi/theme/slots/Sidebar/index.tsx
+++ b/.dumi/theme/slots/Sidebar/index.tsx
@@ -1,10 +1,11 @@
 import { createStyles, useTheme } from 'antd-style';
 import { useSidebarData } from 'dumi';
-import MobileMenu from 'rc-drawer';
-import React, { useContext } from 'react';
-import { Col, ConfigProvider, Menu } from 'antd';
+import React, { useContext, useState } from 'react';
+import { Col, ConfigProvider, Menu, Drawer } from 'antd';
+import { DoubleRightOutlined } from '@ant-design/icons';
 import useMenu from '../../../hooks/useMenu';
 import SiteContext from '../SiteContext';
+import useLocale from '../../../hooks/useLocale';
 
 const useStyle = createStyles(({ token, css }) => {
   const { antCls, fontFamily, colorSplit } = token;
@@ -116,6 +117,19 @@ const useStyle = createStyles(({ token, css }) => {
         overflow-y: auto;
       }
     `,
+    drawerTrigger: css`
+      position: fixed;
+      top: 72px;
+      left: 0;
+      z-index: 10;
+      padding: 2px 6px;
+      color: #777;
+      font-size: 12px;
+      background: #fff;
+      border-radius: 0 4px 4px 0;
+      box-shadow: 0 1px 4px -2px #00000021, 0 2px 8px #00000014, 0 8px 16px 4px #0000000a;
+      transition: all .3s;
+    `,
   };
 });
 
@@ -127,6 +141,9 @@ const Sidebar: React.FC = () => {
   const [menuItems, selectedKey] = useMenu();
   const isDark = theme.includes('dark');
   const { colorBgContainer } = useTheme();
+
+  const [, lang] = useLocale();
+  const isZhCN = lang === 'cn';
 
   const menuChild = (
     <ConfigProvider
@@ -144,8 +161,25 @@ const Sidebar: React.FC = () => {
     </ConfigProvider>
   );
 
+  // fix: https://github.com/ant-design/ant-design/issues/44142
+  const [open, setOpen] = useState(false);
+  const showDrawer = () => {
+    setOpen(true);
+  };
+  const onClose = () => {
+    setOpen(false);
+  };
+
   return isMobile ? (
-    <MobileMenu key="Mobile-menu">{menuChild}</MobileMenu>
+    <>
+      <a onClick={showDrawer} className={styles.drawerTrigger}>
+        <DoubleRightOutlined />
+        {isZhCN ? '目录' : 'TOC'}
+      </a>
+      <Drawer key="Mobile-menu" placement="left" onClose={onClose} open={open}>
+        {menuChild}
+      </Drawer>
+    </>
   ) : (
     <Col xxl={4} xl={5} lg={6} md={6} sm={24} xs={24} className={styles.mainMenu}>
       <section className="main-menu-inner">{menuChild}</section>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

fix: #44142

<img height="500px" src="https://github.com/ant-design/ant-design/assets/82451257/e33a8ac9-569b-4171-83e4-feb090366ed7" />


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Enhance the document list structure for mobile browser access.    |
| 🇨🇳 Chinese |      增加手机浏览器访问时的文档列表结构      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 363f351</samp>

Add a sidebar drawer menu for mobile devices and fix a layout bug in `.dumi/theme/slots/Sidebar/index.tsx`. The menu uses Ant Design components and React hooks to provide a responsive and user-friendly navigation.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 363f351</samp>

*  Import React hooks and Ant Design components for sidebar drawer menu ([link](https://github.com/ant-design/ant-design/pull/44607/files?diff=unified&w=0#diff-df557d0ed53eb1710843e7fce2d294362941ec80e20a8bb0ed385299362e204bL3-R5))
*  Define CSS style for drawer trigger button ([link](https://github.com/ant-design/ant-design/pull/44607/files?diff=unified&w=0#diff-df557d0ed53eb1710843e7fce2d294362941ec80e20a8bb0ed385299362e204bR119-R131))
*  Replace `MobileMenu` with custom `Drawer` component to fix sidebar overlap bug ([link](https://github.com/ant-design/ant-design/pull/44607/files?diff=unified&w=0#diff-df557d0ed53eb1710843e7fce2d294362941ec80e20a8bb0ed385299362e204bL147-R178))
