### PR TITLE
site: add source code btn

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -15,6 +15,10 @@ const useStyle = createStyles(({ token, css }) => ({
   ref: css`
     margin-left: ${token.marginXS}px;
   `,
+
+  btn: css`
+    color: ${token.colorTextSecondary};
+  `,
 }));
 
 export interface ComponentChangelogProps {
@@ -152,6 +156,8 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
   return (
     <>
       <Button
+        size="small"
+        className={styles.btn}
         icon={<HistoryOutlined />}
         onClick={() => {
           setShow(true);

--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -8,12 +8,6 @@ import useLocale from '../../../hooks/useLocale';
 import useFetch from '../../../hooks/useFetch';
 
 const useStyle = createStyles(({ token, css }) => ({
-  history: css`
-    position: absolute;
-    top: 0;
-    inset-inline-end: 0;
-  `,
-
   li: css`
     // white-space: pre;
   `,
@@ -158,7 +152,6 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
   return (
     <>
       <Button
-        className={styles.history}
         icon={<HistoryOutlined />}
         onClick={() => {
           setShow(true);

--- a/.dumi/theme/common/ViewSourceCode.tsx
+++ b/.dumi/theme/common/ViewSourceCode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from 'antd';
+import { createStyles } from 'antd-style';
 import { GithubOutlined } from '@ant-design/icons';
 import useLocale from '../../hooks/useLocale';
 
@@ -7,10 +8,17 @@ interface SourceCodeProps {
   pathname: string;
 }
 
+const useStyle = createStyles(({ token, css }) => ({
+  btn: css`
+    color: ${token.colorTextSecondary};
+  `,
+}));
+
 const REPO_BASE = 'https://github.com/ant-design/ant-design/blob/master';
 const SOURCE_BASE = `${REPO_BASE}/components`;
 
 export default function ViewSourceCode(props: SourceCodeProps) {
+  const { styles } = useStyle();
   const { pathname = '' } = props;
   const [, lang] = useLocale();
   const isZhCN = lang === 'cn';
@@ -18,7 +26,13 @@ export default function ViewSourceCode(props: SourceCodeProps) {
   const componentPath = pathname.match(/\/components\/([^/]+)/)?.[1] || '';
 
   return (
-    <Button icon={<GithubOutlined />} href={`${SOURCE_BASE}/${componentPath}/index.ts`}>
+    <Button
+      size="small"
+      className={styles.btn}
+      icon={<GithubOutlined />}
+      href={`${SOURCE_BASE}/${componentPath}`}
+      target="_blank"
+    >
       {isZhCN ? '查看源码' : 'View Source Code'}
     </Button>
   );

--- a/.dumi/theme/common/ViewSourceCode.tsx
+++ b/.dumi/theme/common/ViewSourceCode.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button } from 'antd';
+import { GithubOutlined } from '@ant-design/icons';
+import useLocale from '../../hooks/useLocale';
+
+interface SourceCodeProps {
+  pathname: string;
+}
+
+const REPO_BASE = 'https://github.com/ant-design/ant-design/blob/master';
+const SOURCE_BASE = `${REPO_BASE}/components`;
+
+export default function ViewSourceCode(props: SourceCodeProps) {
+  const { pathname = '' } = props;
+  const [, lang] = useLocale();
+  const isZhCN = lang === 'cn';
+
+  const componentPath = pathname.match(/\/components\/([^/]+)/)?.[1] || '';
+
+  return (
+    <Button icon={<GithubOutlined />} href={`${SOURCE_BASE}/${componentPath}/index.ts`}>
+      {isZhCN ? '查看源码' : 'View Source Code'}
+    </Button>
+  );
+}

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -12,6 +12,7 @@ import useLocation from '../../../hooks/useLocation';
 import EditButton from '../../common/EditButton';
 import PrevAndNext from '../../common/PrevAndNext';
 import ComponentChangelog from '../../common/ComponentChangelog';
+import ViewSourceCode from '../../common/ViewSourceCode';
 import type { DemoContextProps } from '../DemoContext';
 import DemoContext from '../DemoContext';
 import Footer from '../Footer';
@@ -246,7 +247,6 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
                   />
                 )}
               </Space>
-              {pathname.startsWith('/components/') && <ComponentChangelog pathname={pathname} />}
             </Typography.Title>
           ) : null}
           {/* 添加作者、时间等信息 */}
@@ -275,6 +275,10 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
             </Typography.Paragraph>
           ) : null}
           {!meta.frontmatter.__autoDescription && meta.frontmatter.description}
+          <Space>
+            {pathname.startsWith('/components/') && <ComponentChangelog pathname={pathname} />}
+            {!pathname.startsWith('/components/overview') && <ViewSourceCode pathname={pathname} />}
+          </Space>
           <div style={{ minHeight: 'calc(100vh - 64px)' }}>{children}</div>
           {(meta.frontmatter?.zhihu_url ||
             meta.frontmatter?.yuque_url ||


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

close #44319

![image](https://github.com/ant-design/ant-design/assets/82451257/577d4d63-b63a-44df-aa11-dcb09c4c340d)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add a 'View Source Code' button and optimize the layout.    |
| 🇨🇳 Chinese |     添加查看源码按钮，并优化布局      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca522ad</samp>

Improved the documentation pages by adding a `ViewSourceCode` button and reorganizing the `ComponentChangelog` section. Simplified the code of `ComponentChangelog` and `Timeline` components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca522ad</samp>

*  Add `ViewSourceCode` component to render a button that links to the GitHub source code of the current component page ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-2c4f389cb4abf379d2eea689e3c81282328a5057624b3717b63c1f729986131cR1-R25))
* Import `ViewSourceCode` component in the `Content` slot component, which renders the main content of the documentation pages ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82R15))
* Move `ComponentChangelog` component from the top to the bottom of the `Content` slot component, after the `API` component, to improve the readability and usability of the documentation pages ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L249))
* Wrap `ComponentChangelog` and `ViewSourceCode` components in a `Space` component, which adds some margin between them, and conditionally render `ViewSourceCode` component only for component pages that are not the overview page ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82R278-R281))
* Remove `history` style from the `ComponentChangelog` component, as it was no longer needed after moving the changelog to the bottom of the page ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L11-L16))
* Remove `className` prop from the `Timeline` component, as it was using the `history` style that was removed ([link](https://github.com/ant-design/ant-design/pull/44610/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L161))
