### PR TITLE
fix: Modal hooks press esc can not trigger await

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -1,17 +1,18 @@
+import * as React from 'react';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import classNames from 'classnames';
-import * as React from 'react';
+
 import ActionButton from '../_util/ActionButton';
 import { getTransitionName } from '../_util/motion';
 import warning from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';
 import ConfigProvider from '../config-provider';
 import { useLocale } from '../locale';
-import Dialog from './Modal';
 import type { ModalFuncProps, ModalLocale } from './interface';
+import Dialog from './Modal';
 
 interface ConfirmDialogProps extends ModalFuncProps {
   afterClose?: () => void;
@@ -172,6 +173,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     closeIcon,
     modalRender,
     focusTriggerAfterClose,
+    onConfirm,
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -211,7 +213,10 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
           { [`${confirmPrefixCls}-centered`]: !!props.centered },
           wrapClassName,
         )}
-        onCancel={() => close?.({ triggerCancel: true })}
+        onCancel={() => {
+          close?.({ triggerCancel: true });
+          onConfirm?.(false);
+        }}
         open={open}
         title=""
         footer={null}

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -487,6 +487,6 @@ describe('Modal.hook', () => {
     });
     await waitFakeTimer();
 
-    expect(lastResult).toBeFalsy();
+    expect(lastResult).toBe(false);
   });
 });

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -1,15 +1,15 @@
+import React from 'react';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 import KeyCode from 'rc-util/lib/KeyCode';
-import React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import Modal from '..';
-import zhCN from '../../locale/zh_CN';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
 import Input from '../../input';
+import zhCN from '../../locale/zh_CN';
 import type { ModalFunc } from '../confirm';
 
 jest.mock('rc-util/lib/Portal');
@@ -410,10 +410,55 @@ describe('Modal.hook', () => {
     jest.useRealTimers();
   });
 
-  it('support await', async () => {
+  describe('support await', () => {
+    it('click', async () => {
+      jest.useFakeTimers();
+
+      let notReady = true;
+      let lastResult: boolean | null = null;
+
+      const Demo: React.FC = () => {
+        const [modal, contextHolder] = Modal.useModal();
+
+        React.useEffect(() => {
+          (async () => {
+            lastResult = await modal.confirm({
+              content: <Input />,
+              onOk: async () => {
+                if (notReady) {
+                  notReady = false;
+                  return Promise.reject();
+                }
+              },
+            });
+          })();
+        }, []);
+
+        return contextHolder;
+      };
+
+      render(<Demo />);
+
+      // Wait for modal show
+      await waitFakeTimer();
+
+      // First time click should not close
+      fireEvent.click(document.querySelector('.ant-btn-primary')!);
+      await waitFakeTimer();
+      expect(lastResult).toBeFalsy();
+
+      // Second time click to close
+      fireEvent.click(document.querySelector('.ant-btn-primary')!);
+      await waitFakeTimer();
+      expect(lastResult).toBeTruthy();
+
+      jest.useRealTimers();
+    });
+  });
+
+  it('esc', async () => {
     jest.useFakeTimers();
 
-    let notReady = true;
     let lastResult: boolean | null = null;
 
     const Demo: React.FC = () => {
@@ -423,12 +468,6 @@ describe('Modal.hook', () => {
         (async () => {
           lastResult = await modal.confirm({
             content: <Input />,
-            onOk: async () => {
-              if (notReady) {
-                notReady = false;
-                return Promise.reject();
-              }
-            },
           });
         })();
       }, []);
@@ -441,16 +480,13 @@ describe('Modal.hook', () => {
     // Wait for modal show
     await waitFakeTimer();
 
-    // First time click should not close
-    fireEvent.click(document.querySelector('.ant-btn-primary')!);
+    // ESC to close
+    fireEvent.keyDown(document.querySelector('.ant-modal')!, {
+      key: 'Esc',
+      keyCode: KeyCode.ESC,
+    });
     await waitFakeTimer();
+
     expect(lastResult).toBeFalsy();
-
-    // Second time click to close
-    fireEvent.click(document.querySelector('.ant-btn-primary')!);
-    await waitFakeTimer();
-    expect(lastResult).toBeTruthy();
-
-    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #44640

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Modal hooks function do not bypass await when press `esc` to close.       |
| 🇨🇳 Chinese |      修复 Modal 的 hooks 调用通过按键 `esc` 关闭时无法正确触发 await 的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7af2689</samp>

This pull request enhances the modal component and its tests. It adds a new `onConfirm` prop to the modal function for custom confirmation logic, and refactors the `hook.test.tsx` file to improve the test cases and code style.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7af2689</samp>

* Import React and reorder import statements in `hook.test.tsx` and `ConfirmDialog.tsx` to follow conventions and improve readability ([link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-5cc44c30b913e204e295b0eb9a14aae402674961ca7268e348e5157bbb2b208aL1-R12), [link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3R1), [link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L6-R7), [link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L13-R15))
* Add `onConfirm` prop to `ConfirmDialogProps` interface and invoke it with a boolean value when the user confirms or cancels the dialog in `ConfirmDialog.tsx` to allow the caller to handle the dialog result ([link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3R176), [link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L214-R219))
* Wrap the test case for supporting await with modal.confirm in a describe block and remove the `onOk` prop from the modal.confirm call in `hook.test.tsx` to simplify the test and add a clear description ([link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-5cc44c30b913e204e295b0eb9a14aae402674961ca7268e348e5157bbb2b208aL413-R461), [link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-5cc44c30b913e204e295b0eb9a14aae402674961ca7268e348e5157bbb2b208aL426-L431))
* Replace the test case for clicking the confirm button twice with the test case for pressing the ESC key to close the dialog in `hook.test.tsx` to cover a different scenario and check the `lastResult` value ([link](https://github.com/ant-design/ant-design/pull/44646/files?diff=unified&w=0#diff-5cc44c30b913e204e295b0eb9a14aae402674961ca7268e348e5157bbb2b208aL444-R490))
