### PR TITLE
docs(:sparkles:): release 4.24.14

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,14 @@ timeline: true
 
 ---
 
+## 4.24.14
+
+`2023-09-06`
+
+- 🐞 Fix Breadcrumb unexpected overlay deprecation warning message. [#43917](https://github.com/ant-design/ant-design/pull/44578) [@whalesink](https://github.com/whalesink)
+- 🐞 Fix Upload gif thumbnail not playing. [#44129](https://github.com/ant-design/ant-design/pull/44129) [@linxianxi](https://github.com/linxianxi)
+- 🐞 Fix ConfigProvider throws `rc-util/lib/utils/set` not existed. [#44630](https://github.com/ant-design/ant-design/pull/44630) [@varown](https://github.com/varown)
+
 ## 4.24.13
 
 `2023-08-03`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,14 @@ timeline: true
 
 ---
 
+## 4.24.14
+
+`2023-09-06`
+
+- 🐞 修复 Breadcrumb 使用 `menu` 属性时出现 `overlay` 废弃警告的问题。[#43917](https://github.com/ant-design/ant-design/pull/44578) [@whalesink](https://github.com/whalesink)
+- 🐞 修复 Upload gif 缩略图不会动的问题。[#44129](https://github.com/ant-design/ant-design/pull/44129) [@linxianxi](https://github.com/linxianxi)
+- 🐞 修复 ConfigProvider 抛出 `rc-util/lib/utils/set` 不存在的问题。[#44630](https://github.com/ant-design/ant-design/pull/44630) [@varown](https://github.com/varown)
+
 ## 4.24.13
 
 `2023-08-03`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.24.13",
+  "version": "4.24.14",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
- 🐞 修复 Breadcrumb 使用 `menu` 属性时出现 `overlay` 废弃警告的问题。[#43917](https://github.com/ant-design/ant-design/pull/44578) [@whalesink](https://github.com/whalesink)
- 🐞 修复 Upload gif 缩略图不会动的问题。[#44129](https://github.com/ant-design/ant-design/pull/44129) [@linxianxi](https://github.com/linxianxi)
- 🐞 修复 ConfigProvider 抛出 `rc-util/lib/utils/set` 不存在的问题。[#44630](https://github.com/ant-design/ant-design/pull/44630) [@varown](https://github.com/varown)

---

- 🐞 Fix Breadcrumb unexpected overlay deprecation warning message. [#43917](https://github.com/ant-design/ant-design/pull/44578) [@whalesink](https://github.com/whalesink)
- 🐞 Fix Upload gif thumbnail not playing. [#44129](https://github.com/ant-design/ant-design/pull/44129) [@linxianxi](https://github.com/linxianxi)
- 🐞 Fix ConfigProvider throws `rc-util/lib/utils/set` not existed. [#44630](https://github.com/ant-design/ant-design/pull/44630) [@varown](https://github.com/varown)