### PR TITLE
docs: add theme toggle animation

### DIFF
--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react';
+
+import theme from '../../components/theme';
+
+const viewTransitionStyle = `
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+    }
+
+    .dark::view-transition-old(root) {
+    z-index: 1;
+    }
+
+    .dark::view-transition-new(root) {
+    z-index: 999;
+    }
+
+    ::view-transition-old(root) {
+    z-index: 999;
+    }
+
+    ::view-transition-new(root) {
+    z-index: 1;
+    }
+`;
+
+const useThemeAnimation = () => {
+  const {
+    token: { colorBgElevated },
+  } = theme.useToken();
+  const animateRef = useRef<{
+    isDark: boolean;
+    event: MouseEvent | null;
+  }>({
+    isDark: false,
+    event: null,
+  });
+
+  const startAnimaTheme = () => {
+    const { isDark, event } = animateRef.current;
+    if (!event) return;
+    const x = event.clientX;
+    const y = event.clientY;
+    const endRadius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y));
+
+    document
+      // @ts-ignore
+      .startViewTransition(() => {
+        const root = document.documentElement;
+        root.classList.remove(isDark ? 'dark' : 'light');
+        root.classList.add(isDark ? 'light' : 'dark');
+      })
+      .ready.then(() => {
+        const clipPath = [
+          `circle(0px at ${x}px ${y}px)`,
+          `circle(${endRadius}px at ${x}px ${y}px)`,
+        ];
+        document.documentElement.animate(
+          {
+            clipPath: isDark ? [...clipPath].reverse() : clipPath,
+          },
+          {
+            duration: 500,
+            easing: 'ease-in',
+            pseudoElement: isDark ? '::view-transition-old(root)' : '::view-transition-new(root)',
+          },
+        );
+      });
+  };
+
+  const toggleAnimateTheme = (event: MouseEvent, isDark?: boolean) => {
+    animateRef.current.isDark = isDark;
+    animateRef.current.event = event;
+  };
+
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.innerHTML = viewTransitionStyle;
+    document.head.append(style);
+  }, []);
+
+  useEffect(() => {
+    startAnimaTheme();
+  }, [colorBgElevated]);
+
+  return toggleAnimateTheme;
+};
+
+export default useThemeAnimation;

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import theme from '../../components/theme';
 
@@ -37,10 +37,12 @@ const useThemeAnimation = () => {
     isDark: false,
     event: null,
   });
+  // @ts-ignore
+  const isApiAvailable = useMemo(() => typeof document.startViewTransition === 'function', []);
 
   const startAnimaTheme = () => {
     const { isDark, event } = animateRef.current;
-    if (!event) return;
+    if (!(event && isApiAvailable)) return;
     const x = event.clientX;
     const y = event.clientY;
     const endRadius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y));
@@ -75,10 +77,13 @@ const useThemeAnimation = () => {
     animateRef.current.event = event;
   };
 
+  // inject transition style
   useEffect(() => {
-    const style = document.createElement('style');
-    style.innerHTML = viewTransitionStyle;
-    document.head.append(style);
+    if (isApiAvailable) {
+      const style = document.createElement('style');
+      style.innerHTML = viewTransitionStyle;
+      document.head.append(style);
+    }
   }, []);
 
   useEffect(() => {

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -38,12 +38,11 @@ const useThemeAnimation = () => {
     isDark: false,
     event: null,
   });
-  // @ts-ignore
-  const isApiAvailable = typeof document.startViewTransition === 'function';
 
   const startAnimationTheme = () => {
     const { isDark, event } = animateRef.current;
-    if (!(event && isApiAvailable)) return;
+    // @ts-ignore
+    if (!(event && typeof document.startViewTransition === 'function')) return;
     const x = event.clientX;
     const y = event.clientY;
     const endRadius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y));
@@ -80,7 +79,8 @@ const useThemeAnimation = () => {
 
   // inject transition style
   useEffect(() => {
-    if (isApiAvailable) {
+    // @ts-ignore
+    if (typeof document.startViewTransition === 'function') {
       updateCSS(viewTransitionStyle, 'view-transition-style');
     }
   }, []);

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -1,29 +1,30 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import { updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 
 import theme from '../../components/theme';
 
 const viewTransitionStyle = `
-    ::view-transition-old(root),
-    ::view-transition-new(root) {
-    animation: none;
-    mix-blend-mode: normal;
-    }
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
 
-    .dark::view-transition-old(root) {
-    z-index: 1;
-    }
+.dark::view-transition-old(root) {
+  z-index: 1;
+}
 
-    .dark::view-transition-new(root) {
-    z-index: 999;
-    }
+.dark::view-transition-new(root) {
+  z-index: 999;
+}
 
-    ::view-transition-old(root) {
-    z-index: 999;
-    }
+::view-transition-old(root) {
+  z-index: 999;
+}
 
-    ::view-transition-new(root) {
-    z-index: 1;
-    }
+::view-transition-new(root) {
+  z-index: 1;
+}
 `;
 
 const useThemeAnimation = () => {
@@ -38,9 +39,9 @@ const useThemeAnimation = () => {
     event: null,
   });
   // @ts-ignore
-  const isApiAvailable = useMemo(() => typeof document.startViewTransition === 'function', []);
+  const isApiAvailable = typeof document.startViewTransition === 'function';
 
-  const startAnimaTheme = () => {
+  const startAnimationTheme = () => {
     const { isDark, event } = animateRef.current;
     if (!(event && isApiAvailable)) return;
     const x = event.clientX;
@@ -72,7 +73,7 @@ const useThemeAnimation = () => {
       });
   };
 
-  const toggleAnimateTheme = (event: MouseEvent, isDark?: boolean) => {
+  const toggleAnimationTheme = (event: MouseEvent, isDark?: boolean) => {
     animateRef.current.isDark = isDark;
     animateRef.current.event = event;
   };
@@ -80,17 +81,16 @@ const useThemeAnimation = () => {
   // inject transition style
   useEffect(() => {
     if (isApiAvailable) {
-      const style = document.createElement('style');
-      style.innerHTML = viewTransitionStyle;
-      document.head.append(style);
+      updateCSS(viewTransitionStyle, 'view-transition-style');
     }
   }, []);
 
+  // start animation by light/dark change
   useEffect(() => {
-    startAnimaTheme();
+    startAnimationTheme();
   }, [colorBgElevated]);
 
-  return toggleAnimateTheme;
+  return toggleAnimationTheme;
 };
 
 export default useThemeAnimation;

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -47,6 +47,7 @@ const useThemeAnimation = () => {
     `,
       'disable-transition',
     );
+
     document.documentElement
       .animate(
         {
@@ -69,7 +70,18 @@ const useThemeAnimation = () => {
     const x = event.clientX;
     const y = event.clientY;
     const endRadius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y));
-
+    updateCSS(
+      `
+    [data-prefers-color='dark'] {
+      color-scheme: light !important;
+    }
+    
+    [data-prefers-color='light'] {
+      color-scheme: dark !important;
+    }
+    `,
+      'color-scheme',
+    );
     document
       // @ts-ignore
       .startViewTransition(async () => {
@@ -89,6 +101,7 @@ const useThemeAnimation = () => {
           `circle(0px at ${x}px ${y}px)`,
           `circle(${endRadius}px at ${x}px ${y}px)`,
         ];
+        removeCSS('color-scheme');
         startAnimationTheme(clipPath, isDark);
       });
   };

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
+import { removeCSS, updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 
 import theme from '../../components/theme';
 
@@ -39,16 +39,28 @@ const useThemeAnimation = () => {
   });
 
   const startAnimationTheme = (clipPath: string[], isDark: boolean) => {
-    document.documentElement.animate(
-      {
-        clipPath: isDark ? [...clipPath].reverse() : clipPath,
-      },
-      {
-        duration: 500,
-        easing: 'ease-in',
-        pseudoElement: isDark ? '::view-transition-old(root)' : '::view-transition-new(root)',
-      },
+    updateCSS(
+      `
+    * {
+    transition: none !important;
+  }
+    `,
+      'disable-transition',
     );
+    document.documentElement
+      .animate(
+        {
+          clipPath: isDark ? [...clipPath].reverse() : clipPath,
+        },
+        {
+          duration: 500,
+          easing: 'ease-in',
+          pseudoElement: isDark ? '::view-transition-old(root)' : '::view-transition-new(root)',
+        },
+      )
+      .addEventListener('finish', () => {
+        removeCSS('disable-transition');
+      });
   };
 
   const toggleAnimationTheme = (event: MouseEvent, isDark: boolean) => {
@@ -89,7 +101,6 @@ const useThemeAnimation = () => {
     }
   }, []);
 
-  // // start animation by light/dark change
   useEffect(() => {
     if (colorBgElevated !== animateRef.current.colorBgElevated) {
       animateRef.current.colorBgElevated = colorBgElevated;

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
 import { BgColorsOutlined, SmileOutlined } from '@ant-design/icons';
+import { FloatButton } from 'antd';
+import { useTheme } from 'antd-style';
 import { CompactTheme, DarkTheme } from 'antd-token-previewer/es/icons';
 // import { Motion } from 'antd-token-previewer/es/icons';
 import { FormattedMessage, Link, useLocation } from 'dumi';
-import React from 'react';
-import { useTheme } from 'antd-style';
-import { FloatButton } from 'antd';
+
+import useThemeAnimation from '../../../hooks/useThemeAnimation';
 import { getLocalizedPathname, isZhCN } from '../../utils';
 import ThemeIcon from './ThemeIcon';
 
@@ -22,6 +24,9 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
 
   // const isMotionOff = value.includes('motion-off');
   const isHappyWork = value.includes('happy-work');
+  const isDark = value.includes('dark');
+
+  const toggleAnimateTheme = useThemeAnimation();
 
   return (
     <FloatButton.Group
@@ -42,9 +47,12 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
       </Link>
       <FloatButton
         icon={<DarkTheme />}
-        type={value.includes('dark') ? 'primary' : 'default'}
-        onClick={() => {
-          if (value.includes('dark')) {
+        type={isDark ? 'primary' : 'default'}
+        onClick={(e) => {
+          // Toggle animate when switch theme
+          toggleAnimateTheme(e, isDark);
+
+          if (isDark) {
             onChange(value.filter((theme) => theme !== 'dark'));
           } else {
             onChange([...value, 'dark']);

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -26,7 +26,7 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
   const isHappyWork = value.includes('happy-work');
   const isDark = value.includes('dark');
 
-  const toggleAnimateTheme = useThemeAnimation();
+  const toggleAnimationTheme = useThemeAnimation();
 
   return (
     <FloatButton.Group
@@ -49,8 +49,8 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = (props) => {
         icon={<DarkTheme />}
         type={isDark ? 'primary' : 'default'}
         onClick={(e) => {
-          // Toggle animate when switch theme
-          toggleAnimateTheme(e, isDark);
+          // Toggle animation when switch theme
+          toggleAnimationTheme(e, isDark);
 
           if (isDark) {
             onChange(value.filter((theme) => theme !== 'dark'));


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #44644
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![2023-09-08 12 51 14](https://github.com/ant-design/ant-design/assets/21119589/e4247756-9b39-42e7-a588-2e4aad008908)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add theme toggle animation     |
| 🇨🇳 Chinese |    添加主题切换动画       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49104ea</samp>

This pull request adds a circular clip-path animation for the theme switcher component in the documentation site. It uses a custom hook `useThemeAnimation` and the `startViewTransition` API to create a smooth and responsive transition between the light and dark themes. It also refactors the theme switcher component to use a boolean flag for the dark mode.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49104ea</samp>

*  Add a custom hook `useThemeAnimation` to implement a circular clip-path animation for the theme switcher ([link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-941fcbacf1a38746130e95a5c46349e59999f00997963e17e027e79e2840a2c0R1-R91))
*  Use the hook in the `ThemeSwitch` component to trigger the animation on button click, passing the mouse event and the theme mode ([link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L25-R30), [link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L45-R55))
*  Simplify the theme mode check by using a variable `isDark` instead of `value.includes('dark')` ([link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L25-R30), [link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L45-R55))
*  Reorder some imports in the `ThemeSwitch` component for consistency ([link](https://github.com/ant-design/ant-design/pull/44655/files?diff=unified&w=0#diff-8d8f58ae995a6180f1788f819583cf51b719b8d8ab1ae422b06a1e8d846f2447L1-R9))
