### PR TITLE
fix(SliderTooltipProps): Extedn SliderTooltipProps

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -7,7 +7,7 @@ import type { SliderRef } from 'rc-slider/lib/Slider';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
-import type { TooltipPlacement } from '../tooltip';
+import type { AbstractTooltipProps, TooltipPlacement } from '../tooltip';
 import SliderTooltip from './SliderTooltip';
 import useStyle from './style';
 
@@ -28,7 +28,7 @@ export type HandleGeneratorFn = (config: {
 export type Formatter = (value?: number) => React.ReactNode;
 const defaultFormatter: Formatter = (val) => (typeof val === 'number' ? val.toString() : '');
 
-export interface SliderTooltipProps {
+export interface SliderTooltipProps extends AbstractTooltipProps {
   prefixCls?: string;
   open?: boolean;
   placement?: TooltipPlacement;


### PR DESCRIPTION
Extend SliderTooltipProps with AbstractTooltipProps to have access to all props from Tooltip

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
No issue but can create one if needed.

### 💡 Background and solution

The problem is: I can't get access to all of the Tooltip props from the Slider component, and I need to do this to target the arrow color properly, by using the Tooltip prop "color" rather than using global css properties.

### 📝 Changelog

No user changes, just making it more developer friendly.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6864695</samp>

Enhance `SliderTooltip` component by supporting tooltip props. This enables more customization and consistency for the slider tooltips.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6864695</samp>

*  Extend `SliderTooltipProps` from `AbstractTooltipProps` to inherit common tooltip props ([link](https://github.com/ant-design/ant-design/pull/44656/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL9-R9), [link](https://github.com/ant-design/ant-design/pull/44656/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL30-R30))
