### PR TITLE
chore: replace theme.useToken with useInternalToken

### DIFF
--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -44,7 +44,7 @@ import ThemePicker from './ThemePicker';
 
 const { Header, Content, Sider } = Layout;
 
-const TokenChecker = () => {
+const TokenChecker: React.FC = () => {
   if (process.env.NODE_ENV !== 'production') {
     console.log('Demo Token:', theme.useToken());
   }

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -17,7 +17,7 @@ import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext, NoFormStyle } from '../form/context';
 import type { PopoverProps } from '../popover';
 import Popover from '../popover';
-import theme from '../theme';
+import { useToken } from '../theme/internal';
 import type { Color } from './color';
 import ColorPickerPanel from './ColorPickerPanel';
 import ColorTrigger from './components/ColorTrigger';
@@ -101,7 +101,7 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   const { getPrefixCls, direction, colorPicker } = useContext<ConfigConsumerProps>(ConfigContext);
 
-  const { token } = theme.useToken();
+  const [, token] = useToken();
 
   const [colorValue, setColorValue] = useColorState(token.colorPrimary, {
     value,

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -1,12 +1,13 @@
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
 import { ColorBlock, Color as RcColor } from '@rc-component/color-picker';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import type { FC } from 'react';
-import React, { useMemo } from 'react';
+
 import type { CollapseProps } from '../../collapse';
 import Collapse from '../../collapse';
 import { useLocale } from '../../locale';
-import theme from '../../theme';
+import { useToken } from '../../theme/internal';
 import type { Color } from '../color';
 import type { ColorPickerBaseProps, PresetsItem } from '../interface';
 import { generateColor } from '../util';
@@ -35,9 +36,7 @@ const isBright = (value: Color, bgColorToken: string) => {
 
 const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color, onChange }) => {
   const [locale] = useLocale('ColorPicker');
-  const {
-    token: { colorBgElevated },
-  } = theme.useToken();
+  const [, token] = useToken();
   const [presetsValue] = useMergedState(genPresetColor(presets), {
     value: genPresetColor(presets),
     postState: genPresetColor,
@@ -68,7 +67,10 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
               className={classNames(`${colorPresetsPrefixCls}-color`, {
                 [`${colorPresetsPrefixCls}-color-checked`]:
                   presetColor.toHexString() === color?.toHexString(),
-                [`${colorPresetsPrefixCls}-color-bright`]: isBright(presetColor, colorBgElevated),
+                [`${colorPresetsPrefixCls}-color-bright`]: isBright(
+                  presetColor,
+                  token.colorBgElevated,
+                ),
               })}
               onClick={() => handleClick(presetColor)}
             />

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,21 +1,22 @@
+import * as React from 'react';
 import RightOutlined from '@ant-design/icons/RightOutlined';
+import type { AlignType } from '@rc-component/trigger';
 import classNames from 'classnames';
 import RcDropdown from 'rc-dropdown';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
-import type { AlignType } from '@rc-component/trigger';
-import * as React from 'react';
-import genPurePanel from '../_util/PurePanel';
+
 import type { AdjustOverflow } from '../_util/placements';
 import getPlacements from '../_util/placements';
+import genPurePanel from '../_util/PurePanel';
 import { cloneElement } from '../_util/reactNode';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { MenuProps } from '../menu';
 import Menu from '../menu';
 import { OverrideProvider } from '../menu/OverrideContext';
-import theme from '../theme';
+import { useToken } from '../theme/internal';
 import useStyle from './style';
 
 const Placements = [
@@ -173,7 +174,7 @@ const Dropdown: CompoundedComponent = (props) => {
   const prefixCls = getPrefixCls('dropdown', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
-  const { token } = theme.useToken();
+  const [, token] = useToken();
 
   const child = React.Children.only(children) as React.ReactElement<any>;
 

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -1,21 +1,20 @@
+import React, { useContext } from 'react';
 import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 import classNames from 'classnames';
 import { QRCodeCanvas, QRCodeSVG } from 'qrcode.react';
-import React, { useContext } from 'react';
+
 import warning from '../_util/warning';
 import Button from '../button';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import { useLocale } from '../locale';
 import Spin from '../spin';
-import theme from '../theme';
+import { useToken } from '../theme/internal';
 import type { QRCodeProps, QRProps } from './interface';
 import useStyle from './style/index';
 
-const { useToken } = theme;
-
 const QRCode: React.FC<QRCodeProps> = (props) => {
-  const { token } = useToken();
+  const [, token] = useToken();
   const {
     value,
     type = 'canvas',

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -1,14 +1,15 @@
+import type { CSSProperties } from 'react';
+import * as React from 'react';
 import type { BuildInPlacements } from '@rc-component/trigger';
 import classNames from 'classnames';
 import RcTooltip from 'rc-tooltip';
+import type { placements as Placements } from 'rc-tooltip/lib/placements';
 import type {
   TooltipProps as RcTooltipProps,
   TooltipRef as RcTooltipRef,
 } from 'rc-tooltip/lib/Tooltip';
-import type { placements as Placements } from 'rc-tooltip/lib/placements';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import type { CSSProperties } from 'react';
-import * as React from 'react';
+
 import type { PresetColorType } from '../_util/colors';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
@@ -19,12 +20,10 @@ import type { LiteralUnion } from '../_util/type';
 import warning from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { NoCompactStyle } from '../space/Compact';
-import theme from '../theme';
+import { useToken } from '../theme/internal';
 import PurePanel from './PurePanel';
 import useStyle from './style';
 import { parseColor } from './util';
-
-const { useToken } = theme;
 
 export type { AdjustOverflow, PlacementsConfig };
 
@@ -208,7 +207,7 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
 
   const mergedShowArrow = !!arrow;
 
-  const { token } = useToken();
+  const [, token] = useToken();
 
   const {
     getPopupContainer: getContextPopupContainer,

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -1,13 +1,14 @@
+import React, { useContext } from 'react';
 import RCTour from '@rc-component/tour';
 import classNames from 'classnames';
-import React, { useContext } from 'react';
+
 import getPlacements from '../_util/placements';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
-import theme from '../theme';
-import PurePanel from './PurePanel';
+import { useToken } from '../theme/internal';
 import type { TourProps, TourStepProps } from './interface';
 import TourPanel from './panelRender';
+import PurePanel from './PurePanel';
 import useStyle from './style';
 import useMergedType from './useMergedType';
 
@@ -27,7 +28,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
   const { getPrefixCls, direction } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('tour', customizePrefixCls);
   const [wrapSSR, hashId] = useStyle(prefixCls);
-  const { token } = theme.useToken();
+  const [, token] = useToken();
 
   const { currentMergedType, updateInnerCurrent } = useMergedType({
     defaultType: type,

--- a/components/transfer/demo/tree-transfer.tsx
+++ b/components/transfer/demo/tree-transfer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Transfer, Tree, theme } from 'antd';
+import { theme, Transfer, Tree } from 'antd';
 import type { TransferDirection, TransferItem } from 'antd/es/transfer';
 import type { DataNode } from 'antd/es/tree';
 
@@ -20,7 +20,7 @@ const generateTree = (treeNodes: DataNode[] = [], checkedKeys: string[] = []): D
     children: generateTree(children, checkedKeys),
   }));
 
-const TreeTransfer = ({ dataSource, targetKeys, ...restProps }: TreeTransferProps) => {
+const TreeTransfer: React.FC<TreeTransferProps> = ({ dataSource, targetKeys, ...restProps }) => {
   const { token } = theme.useToken();
 
   const transferDataSource: TransferItem[] = [];

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef } from 'react';
-
 import MutateObserver from '@rc-component/mutate-observer';
 import classNames from 'classnames';
 
-import theme from '../theme';
+import { useToken } from '../theme/internal';
 import useClips, { FontGap } from './useClips';
 import { getPixelRatio, getStyleStr, reRendering } from './utils';
 
@@ -49,7 +48,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
     offset,
     children,
   } = props;
-  const { token } = theme.useToken();
+  const [, token] = useToken();
   const {
     color = token.colorFill,
     fontSize = token.fontSizeLG,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: replace `theme.useToken` with `useInternalToken` |
| 🇨🇳 Chinese | 把 `theme.useToken`  替换成内部的 `useInternalToken` |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a28a5d3</samp>

This pull request refactors several components and demo files to use the internal theme hook `useToken` more consistently and directly. It also improves the code style and readability by reordering imports, simplifying destructuring, and adding type annotations. The main files affected are `ColorPicker.tsx`, `Dropdown.tsx`, `QRCode.tsx`, `Tooltip.tsx`, `Tour.tsx`, `Watermark.tsx`, and `TreeTransfer.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a28a5d3</samp>

*  Annotate `TokenChecker` and `TreeTransfer` components with `React.FC` type to avoid implicit `any` type ([link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL47-R47), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-5d2a9fbb1586f5058bfd77d20e281f359ce068ed333ccc4375ee0ef1961342cbL23-R23))
* Import `useToken` hook from `../theme/internal` module instead of `../theme` module to avoid circular dependencies and follow internal convention ([link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL20-R20), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L38-R39), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL18-R19), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL11-R17), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966L22-R27), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-adad9b12865a3221e41486d220d744321efe428765a7ef91e2f5719dcd00a342L30-R31), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L52-R51))
* Destructure `token` object from `useToken` hook without the `token` property name, since the hook returns an array of `[setToken, token]` instead of an object ([link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL104-R104), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L71-R73), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL176-R177), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL11-R17), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966L211-R210), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-adad9b12865a3221e41486d220d744321efe428765a7ef91e2f5719dcd00a342L30-R31), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L52-R51))
* Access `token.colorBgElevated` property directly from `token` object instead of destructuring it, to make the code more concise and consistent ([link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L71-R73))
* Reorder imports to follow the convention of importing React and types first, then external dependencies, then internal modules, and then styles ([link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L1-R10), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL1-R3), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL7-R12), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL1-R5), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-15851db1188c7109b62716f8105c243911fa7473baa0436e6e0798e0c10b4966L1-R12), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-adad9b12865a3221e41486d220d744321efe428765a7ef91e2f5719dcd00a342L1-R11), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-5d2a9fbb1586f5058bfd77d20e281f359ce068ed333ccc4375ee0ef1961342cbL2-R2), [link](https://github.com/ant-design/ant-design/pull/44670/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19L2-R5))
