### PR TITLE
feat: add tokens in Descriptions component(#44674)

### DIFF
--- a/components/descriptions/demo/component-token.tsx
+++ b/components/descriptions/demo/component-token.tsx
@@ -101,10 +101,12 @@ const App: React.FC = () => {
         components: {
           Descriptions: {
             labelBg: 'red',
+            titleColor: 'red',
             titleMarginBottom: 2,
             itemPaddingBottom: 8,
             colonMarginRight: 10,
             colonMarginLeft: 20,
+            contentColor: 'green',
             extraColor: 'blue',
           },
         },

--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -1,4 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+
 import { resetComponent, textEllipsis } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -11,6 +12,16 @@ export interface ComponentToken {
    * @descEN Background color of label
    */
   labelBg: string;
+  /**
+   * @desc 标签文字颜色
+   * @descEN Text color of label
+   */
+  labelColor: string;
+  /**
+   * @desc 标题文字颜色
+   * @descEN Text color of title
+   */
+  titleColor: string;
   /**
    * @desc 标题下间距
    * @descEN Bottom margin of title
@@ -32,6 +43,11 @@ export interface ComponentToken {
    */
   colonMarginLeft: number;
   /**
+   * @desc 内容区域文字颜色
+   * @descEN Text color of content
+   */
+  contentColor: string;
+  /**
    * @desc 额外区域文字颜色
    * @descEN Text color of extra area
    */
@@ -41,7 +57,7 @@ export interface ComponentToken {
 interface DescriptionsToken extends FullToken<'Descriptions'> {}
 
 const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
-  const { componentCls, labelBg } = token;
+  const { componentCls, labelBg, labelColor } = token;
   return {
     [`&${componentCls}-bordered`]: {
       [`> ${componentCls}-view`]: {
@@ -63,7 +79,7 @@ const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
             },
           },
           [`> ${componentCls}-item-label`]: {
-            color: token.colorTextSecondary,
+            color: labelColor,
             backgroundColor: labelBg,
             '&::after': {
               display: 'none',
@@ -113,7 +129,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
       [`${componentCls}-title`]: {
         ...textEllipsis,
         flex: 'auto',
-        color: token.colorText,
+        color: token.titleColor,
         fontWeight: token.fontWeightStrong,
         fontSize: token.fontSizeLG,
         lineHeight: token.lineHeightLG,
@@ -140,7 +156,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
         },
       },
       [`${componentCls}-item-label`]: {
-        color: token.colorTextTertiary,
+        color: token.labelColor,
         fontWeight: 'normal',
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
@@ -166,7 +182,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
       [`${componentCls}-item-content`]: {
         display: 'table-cell',
         flex: 1,
-        color: token.colorText,
+        color: token.contentColor,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         wordBreak: 'break-word',
@@ -213,10 +229,13 @@ export default genComponentStyleHook(
   },
   (token) => ({
     labelBg: token.colorFillAlter,
+    labelColor: token.colorTextSecondary,
+    titleColor: token.colorText,
     titleMarginBottom: token.fontSizeSM * token.lineHeightSM,
     itemPaddingBottom: token.padding,
     colonMarginRight: token.marginXS,
     colonMarginLeft: token.marginXXS / 2,
+    contentColor: token.colorText,
     extraColor: token.colorText,
   }),
 );

--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -57,7 +57,7 @@ export interface ComponentToken {
 interface DescriptionsToken extends FullToken<'Descriptions'> {}
 
 const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
-  const { componentCls, labelBg, labelColor } = token;
+  const { componentCls, labelBg } = token;
   return {
     [`&${componentCls}-bordered`]: {
       [`> ${componentCls}-view`]: {
@@ -79,7 +79,7 @@ const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
             },
           },
           [`> ${componentCls}-item-label`]: {
-            color: labelColor,
+            color: token.colorTextSecondary,
             backgroundColor: labelBg,
             '&::after': {
               display: 'none',
@@ -229,7 +229,7 @@ export default genComponentStyleHook(
   },
   (token) => ({
     labelBg: token.colorFillAlter,
-    labelColor: token.colorTextSecondary,
+    labelColor: token.colorTextTertiary,
     titleColor: token.colorText,
     titleMarginBottom: token.fontSizeSM * token.lineHeightSM,
     itemPaddingBottom: token.padding,

--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -13,11 +13,6 @@ export interface ComponentToken {
    */
   labelBg: string;
   /**
-   * @desc 标签文字颜色
-   * @descEN Text color of label
-   */
-  labelColor: string;
-  /**
    * @desc 标题文字颜色
    * @descEN Text color of title
    */
@@ -156,7 +151,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
         },
       },
       [`${componentCls}-item-label`]: {
-        color: token.labelColor,
+        color: token.colorTextTertiary,
         fontWeight: 'normal',
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
@@ -229,7 +224,6 @@ export default genComponentStyleHook(
   },
   (token) => ({
     labelBg: token.colorFillAlter,
-    labelColor: token.colorTextTertiary,
     titleColor: token.colorText,
     titleMarginBottom: token.fontSizeSM * token.lineHeightSM,
     itemPaddingBottom: token.padding,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #44674 
### 💡 Background and solution

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add new component tokens for title, label and content colors |
| 🇨🇳 Chinese |   为title,label,content添加新的组件样式token      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---


### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13c3e82</samp>

This pull request enhances the description component with new style customization options. It adds `labelTextColor`, `titleTextColor`, and `contentTextColor` properties to the `ComponentToken` interface in `components/descriptions/style/index.ts` and applies them to the corresponding style rules and theme mapping.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13c3e82</samp>

*  Add new properties to `ComponentToken` interface to customize text colors of description items ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169R16-R25), [link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169R46-R50))
*  Use `labelColor` property in style rules for label elements in both bordered and default variants ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L44-R60), [link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L66-R82), [link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L143-R159))
*  Use `titleColor` property in style rule for title element in default variant ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L116-R132))
*  Use `contentColor` property in style rule for content element in default variant ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L169-R185))
*  Map global theme token to component token with new properties ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L216-R238))
*  Add empty line at the beginning of `components/descriptions/style/index.ts` for readability ([link](https://github.com/ant-design/ant-design/pull/44729/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169R2))
