### PR TITLE
fix: radioButton ref type

### DIFF
--- a/components/radio/__tests__/type.test.tsx
+++ b/components/radio/__tests__/type.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Radio from '..';
+import type { RadioRef } from '..';
+
+describe('Radio.typescript', () => {
+  it('Radio', () => {
+    const ref = React.createRef<RadioRef>();
+    const checkbox = <Radio value ref={ref} />;
+
+    expect(checkbox).toBeTruthy();
+  });
+
+  it('Radio.Group', () => {
+    const group = (
+      <Radio.Group>
+        <Radio />
+      </Radio.Group>
+    );
+
+    expect(group).toBeTruthy();
+  });
+});

--- a/components/radio/index.ts
+++ b/components/radio/index.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 import Group from './group';
-import type { RadioProps } from './interface';
+import type { RadioProps, RadioRef } from './interface';
 import InternalRadio from './radio';
 import Button from './radioButton';
 
@@ -12,11 +12,12 @@ export {
   RadioGroupOptionType,
   RadioGroupProps,
   RadioProps,
+  RadioRef,
 } from './interface';
 export { Button, Group };
 
 type CompoundedComponent = React.ForwardRefExoticComponent<
-  RadioProps & React.RefAttributes<HTMLElement>
+  RadioProps & React.RefAttributes<RadioRef>
 > & {
   Group: typeof Group;
   Button: typeof Button;

--- a/components/radio/interface.ts
+++ b/components/radio/interface.ts
@@ -4,6 +4,7 @@ import type { AbstractCheckboxGroupProps } from '../checkbox/Group';
 import type { DisabledType } from '../config-provider/DisabledContext';
 import type { SizeType } from '../config-provider/SizeContext';
 
+export type { CheckboxRef as RadioRef } from 'rc-checkbox';
 export type RadioGroupButtonStyle = 'outline' | 'solid';
 export type RadioGroupOptionType = 'default' | 'button';
 

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import type { CheckboxRef } from 'rc-checkbox';
 import RcCheckbox from 'rc-checkbox';
 import { composeRef } from 'rc-util/lib/ref';
 
@@ -11,15 +10,15 @@ import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import { FormItemInputContext } from '../form/context';
 import RadioGroupContext, { RadioOptionTypeContext } from './context';
-import type { RadioChangeEvent, RadioProps } from './interface';
+import type { RadioChangeEvent, RadioProps, RadioRef } from './interface';
 import useStyle from './style';
 
-const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (props, ref) => {
+const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (props, ref) => {
   const groupContext = React.useContext(RadioGroupContext);
   const radioOptionTypeContext = React.useContext(RadioOptionTypeContext);
 
   const { getPrefixCls, direction, radio } = React.useContext(ConfigContext);
-  const innerRef = React.useRef<CheckboxRef>(null);
+  const innerRef = React.useRef<RadioRef>(null);
   const mergedRef = composeRef(ref, innerRef);
   const { isFormItemInput } = React.useContext(FormItemInputContext);
 
@@ -104,7 +103,7 @@ const InternalRadio: React.ForwardRefRenderFunction<CheckboxRef, RadioProps> = (
   );
 };
 
-const Radio = React.forwardRef<CheckboxRef, RadioProps>(InternalRadio);
+const Radio = React.forwardRef<RadioRef, RadioProps>(InternalRadio);
 
 if (process.env.NODE_ENV !== 'production') {
   Radio.displayName = 'Radio';

--- a/components/radio/radioButton.tsx
+++ b/components/radio/radioButton.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
-import type { CheckboxRef } from '../checkbox';
 import type { AbstractCheckboxProps } from '../checkbox/Checkbox';
 import { ConfigContext } from '../config-provider';
 import { RadioOptionTypeContextProvider } from './context';
-import type { RadioChangeEvent } from './interface';
+import type { RadioChangeEvent, RadioRef } from './interface';
 import Radio from './radio';
 
 export type RadioButtonProps = AbstractCheckboxProps<RadioChangeEvent>;
 
-const RadioButton: React.ForwardRefRenderFunction<CheckboxRef, RadioButtonProps> = (props, ref) => {
+const RadioButton: React.ForwardRefRenderFunction<RadioRef, RadioButtonProps> = (props, ref) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const { prefixCls: customizePrefixCls, ...radioProps } = props;
   const prefixCls = getPrefixCls('radio', customizePrefixCls);
 
   return (
-    <RadioOptionTypeContextProvider value='button'>
-      <Radio prefixCls={prefixCls} {...radioProps} type='radio' ref={ref} />
+    <RadioOptionTypeContextProvider value="button">
+      <Radio prefixCls={prefixCls} {...radioProps} type="radio" ref={ref} />
     </RadioOptionTypeContextProvider>
   );
 };
 
-export default React.forwardRef<CheckboxRef, RadioButtonProps>(RadioButton);
+export default React.forwardRef<RadioRef, RadioButtonProps>(RadioButton);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link https://github.com/ant-design/ant-design/issues/44725

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
To reproduce please check related issue link, even its related to checkbox, it appears that radio has the same issue

1. Changed `CheckboxRef` to `RadioRef` to be more semantic and readable and reused it for radioButton component
2. Replaced the `HTMLElement` to `RadioRef` type for external export, so component would accept the right types
3. Added type export for `RadioRef` from index.ts

<!--
1. Describe the problem and the scenario.
4. GIF or snapshot should be provided if includes UI/interactive modification.
5. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8da3463</samp>

Improved the type definition of the `Radio` component and its variants by using the `RadioRef` type from `./interface`. This type is based on the `rc-checkbox` component's ref type, which is the underlying implementation of the `Radio` component. Removed unused and redundant types from `./radio` and `./radioButton`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8da3463</samp>

*  Replace `HTMLElement` with `RadioRef` as the generic parameter for `React.RefAttributes` in `CompoundedComponent` type definition ([link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-a99902c2d8eb787c3c4c81d2f747a521ac4bc125ec40d041f939ea3fd4881ce6L3-R3),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-a99902c2d8eb787c3c4c81d2f747a521ac4bc125ec40d041f939ea3fd4881ce6L15-R20))
* Export `RadioRef` type from `./interface` by re-exporting `CheckboxRef` type from `rc-checkbox` ([link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-bccd290233d5c814e43abf7bd1d1e8ab688b2364c63cdb646845db882fbc7c9cR7))
* Use `RadioRef` instead of `CheckboxRef` as the generic parameter for `React.ForwardRefRenderFunction` and `React.forwardRef` in `InternalRadio`, `Radio`, and `RadioButton` components ([link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL2),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL11-R10),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL17-R21),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL98-R97),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-e88afe9f7ed34bd0dd99d033def998aaeb46b1eb1393ad6e18489d2b225ab9efL2-R10),[link](https://github.com/ant-design/ant-design/pull/44747/files?diff=unified&w=0#diff-e88afe9f7ed34bd0dd99d033def998aaeb46b1eb1393ad6e18489d2b225ab9efL18-R23))
