### PR TITLE
refactor: rename Popover token `minWidth`  to `titleMinWidth`

### DIFF
--- a/components/popover/demo/component-token.tsx
+++ b/components/popover/demo/component-token.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => (
     theme={{
       components: {
         Popover: {
-          minWidth: 40,
+          titleMinWidth: 40,
         },
       },
     }}

--- a/components/popover/style/index.tsx
+++ b/components/popover/style/index.tsx
@@ -6,15 +6,22 @@ import { PresetColors, genComponentStyleHook, mergeToken } from '../../theme/int
 
 export interface ComponentToken {
   /**
+   * @deprecated Please use `titleMinWidth` instead
    * @desc 气泡卡片宽度
    * @descEN Width of Popover
    */
   width: number;
   /**
+   * @deprecated Please use `titleMinWidth` instead
    * @desc 气泡卡片最小宽度
    * @descEN Min width of Popover
    */
   minWidth: number;
+  /**
+   * @desc 气泡卡片标题最小宽度
+   * @descEN Min width of Popover title
+   */
+  titleMinWidth: number;
   /**
    * @desc 气泡卡片 z-index
    * @descEN z-index of Popover
@@ -197,6 +204,7 @@ export default genComponentStyleHook(
   (token) => ({
     width: 177,
     minWidth: 177,
+    titleMinWidth: 177,
     zIndexPopup: token.zIndexPopupBase + 30,
   }),
   {

--- a/components/popover/style/index.tsx
+++ b/components/popover/style/index.tsx
@@ -209,6 +209,9 @@ export default genComponentStyleHook(
   }),
   {
     resetStyle: false,
-    deprecatedTokens: [['width', 'minWidth']],
+    deprecatedTokens: [
+      ['width', 'titleMinWidth'],
+      ['minWidth', 'titleMinWidth'],
+    ],
   },
 );

--- a/components/popover/style/index.tsx
+++ b/components/popover/style/index.tsx
@@ -39,7 +39,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
   const {
     componentCls,
     popoverColor,
-    minWidth,
+    titleMinWidth,
     fontWeightStrong,
     popoverPadding,
     boxShadowSecondary,
@@ -92,7 +92,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         },
 
         [`${componentCls}-title`]: {
-          minWidth,
+          minWidth: titleMinWidth,
           marginBottom: marginXS,
           color: colorTextHeading,
           fontWeight: fontWeightStrong,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/44740
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Popover deprecate `minWidth` token, and add new token `titleMinWidth` instead.      |
| 🇨🇳 Chinese |     Popover 组件废弃 `minWidth` 组件 token，并添加 `titleMinWidth` 作为替代。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 199e679</samp>

Renamed `minWidth` property of `Popover` component token to `titleMinWidth` to avoid confusion and improve clarity. Updated style and demo files accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 199e679</samp>

*  Rename `minWidth` to `titleMinWidth` for the `Popover` component token to clarify its scope ([link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-092798382a4a8a891d32ef1d207ac143aa01577715c58e41f70292203bfc9517L18-R18), [link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR9), [link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR21-R25), [link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR207))
*  Mark `maxWidth` as deprecated for the `Popover` component token and suggest using `titleMinWidth` instead ([link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR15))
*  Add comments to document the new and deprecated properties of the `Popover` component token in both Chinese and English ([link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR9), [link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR15), [link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-f9107e2ff98d96f05f49b74223913c7382b375478e8f909fcd18679dc966302eR21-R25))
*  Update the demo file `components/popover/demo/component-token.tsx` to show the usage of the new `titleMinWidth` property ([link](https://github.com/ant-design/ant-design/pull/44750/files?diff=unified&w=0#diff-092798382a4a8a891d32ef1d207ac143aa01577715c58e41f70292203bfc9517L18-R18))
