### PR TITLE
fix: Select alignment issue when label is Typography

### DIFF
--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -217,7 +217,7 @@ const getSearchInputWithoutBorderStyle: GenerateStyle<SelectToken, CSSObject> = 
 
 // =============================== Base ===============================
 const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
-  const { componentCls, inputPaddingHorizontalBase, iconCls } = token;
+  const { antCls, componentCls, inputPaddingHorizontalBase, iconCls } = token;
 
   return {
     [componentCls]: {
@@ -239,7 +239,14 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
       [`${componentCls}-selection-item`]: {
         flex: 1,
         fontWeight: 'normal',
+        position: 'relative',
+        userSelect: 'none',
         ...textEllipsis,
+
+        // https://github.com/ant-design/ant-design/issues/40421
+        [`> ${antCls}-typography`]: {
+          display: 'inline',
+        },
       },
 
       // ======================= Placeholder =======================

--- a/components/select/style/multiple.tsx
+++ b/components/select/style/multiple.tsx
@@ -86,7 +86,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
 
       // ======================== Selections ========================
       [`${componentCls}-selection-item`]: {
-        position: 'relative',
         display: 'flex',
         flex: 'none',
         boxSizing: 'border-box',
@@ -100,7 +99,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         borderRadius: token.borderRadiusSM,
         cursor: 'default',
         transition: `font-size ${token.motionDurationSlow}, line-height ${token.motionDurationSlow}, height ${token.motionDurationSlow}`,
-        userSelect: 'none',
         marginInlineEnd: FIXED_ITEM_MARGIN * 2,
         paddingInlineStart: token.paddingXS,
         paddingInlineEnd: token.paddingXS / 2,

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -49,11 +49,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           },
         },
 
-        [`${componentCls}-selection-item`]: {
-          position: 'relative',
-          userSelect: 'none',
-        },
-
         [`${componentCls}-selection-placeholder`]: {
           transition: 'none',
           pointerEvents: 'none',


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

close #40421

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Select alignment issue when label is Typography         |
| 🇨🇳 Chinese | 修复 Select 的 label 为 Typography 组件时的选中文本对齐问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50a9a20</samp>

Fixed some style issues and bugs in the `select` component and its variants. Added a new `antCls` property to the `genSizeStyle` function to support customizing the ant design class prefix.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 50a9a20</samp>

* Add `antCls` property to `token` parameter of `genSizeStyle` function in both `multiple.tsx` and `single.tsx` files to access ant-design prefix class name for typography components ([link](https://github.com/ant-design/ant-design/pull/44756/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L19-R19), [link](https://github.com/ant-design/ant-design/pull/44756/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L7-R7))
* Add CSS rule to set display property of typography components to inline in `genSizeStyle` function in both `multiple.tsx` and `single.tsx` files to fix overflow bug for select components ([link](https://github.com/ant-design/ant-design/pull/44756/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5R142-R146), [link](https://github.com/ant-design/ant-design/pull/44756/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2R55-R59))
