### PR TITLE
refactor: convertLegacyProps function moved to buttonHelpers

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -2,7 +2,7 @@ import useState from 'rc-util/lib/hooks/useState';
 import * as React from 'react';
 import Button from '../button';
 import type { ButtonProps, LegacyButtonType } from '../button/button';
-import { convertLegacyProps } from '../button/button';
+import { convertLegacyProps } from '../button/buttonHelpers';
 
 export interface ActionButtonProps {
   type?: LegacyButtonType;

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -29,15 +29,6 @@ import CompactCmp from './style/compactCmp';
 
 export type LegacyButtonType = ButtonType | 'danger';
 
-export function convertLegacyProps(
-  type?: LegacyButtonType,
-): Pick<BaseButtonProps, 'danger' | 'type'> {
-  if (type === 'danger') {
-    return { danger: true };
-  }
-  return { type };
-}
-
 export interface BaseButtonProps {
   type?: ButtonType;
   icon?: React.ReactNode;

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import { cloneElement, isFragment } from '../_util/reactNode';
+import type { BaseButtonProps, LegacyButtonType } from './button';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 export const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
+
+export function convertLegacyProps(
+  type?: LegacyButtonType,
+): Pick<BaseButtonProps, 'danger' | 'type'> {
+  if (type === 'danger') {
+    return { danger: true };
+  }
+  return { type };
+}
 
 export function isString(str: any): str is string {
   return typeof str === 'string';

--- a/components/modal/components/NormalOkBtn.tsx
+++ b/components/modal/components/NormalOkBtn.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import React, { useContext } from 'react';
 
 import Button from '../../button';
-import { convertLegacyProps } from '../../button/button';
+import { convertLegacyProps } from '../../button/buttonHelpers';
 import { ModalContext } from '../context';
 import type { ModalProps } from '../interface';
 

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -5,7 +5,7 @@ import type { PopconfirmProps } from '.';
 import ActionButton from '../_util/ActionButton';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import Button from '../button';
-import { convertLegacyProps } from '../button/button';
+import { convertLegacyProps } from '../button/buttonHelpers';
 import { ConfigContext } from '../config-provider';
 import { useLocale } from '../locale';
 import defaultLocale from '../locale/en_US';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 💡 Background and solution
moved the convertLegacyProps function from button.tsx to buttonHelpers.tsx file because it's not even used on the button.tsx file already.. so I think it would be better to move it to buttonHelpers.tsx file.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         x |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5056377</samp>

Moved `convertLegacyProps` function from `button.tsx` to `buttonHelpers.tsx` and updated the imports in other components that use it. This change improves code organization and avoids circular dependencies.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5056377</samp>

*  Move `convertLegacyProps` function from `button.tsx` to `buttonHelpers.tsx` to avoid circular dependencies and improve code organization ([link](https://github.com/ant-design/ant-design/pull/44777/files?diff=unified&w=0#diff-463cd38ab465e1f3b90463a403d8e8399f926361436eaa9adb8a76a8bf9d4140L32-L40), [link](https://github.com/ant-design/ant-design/pull/44777/files?diff=unified&w=0#diff-47a152d13483d9d39b5d0114d506ba003d0572b4470a94a03f98ef93ae52619cL3-R16))
* Update imports of `convertLegacyProps` in other components that use it to point to `buttonHelpers.tsx` instead of `button.tsx` ([link](https://github.com/ant-design/ant-design/pull/44777/files?diff=unified&w=0#diff-87d6be5f51fe1b2da545c92af66c2d3ef4e04db2cd3cfb661c442decfac3eaefL5-R5), [link](https://github.com/ant-design/ant-design/pull/44777/files?diff=unified&w=0#diff-bb2cdcb0b65a2807dff0587a2fbc3492482676baa9a6c4fcfceea49bde289f88L5-R5), [link](https://github.com/ant-design/ant-design/pull/44777/files?diff=unified&w=0#diff-d57f0a697c7d1520b5a3174edf0317ae67cb31369b7ca569afa32ce074e2c770L8-R8))
