### PR TITLE
fix: CardGrid style issue with left bottom corner

### DIFF
--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -352,6 +352,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       [`${componentCls}-body`]: {
         display: 'flex',
         flexWrap: 'wrap',
+        overflow: 'hidden',
       },
 
       [`&:not(${componentCls}-loading) ${componentCls}-body`]: {

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -349,10 +349,10 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-contain-grid`]: {
+      borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0 `,
       [`${componentCls}-body`]: {
         display: 'flex',
         flexWrap: 'wrap',
-        overflow: 'hidden',
       },
 
       [`&:not(${componentCls}-loading) ${componentCls}-body`]: {


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: CardGrid style issue with left bottom corner       |
| 🇨🇳 Chinese |    修复了CardGrid边缘样式问题        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

fixed the CardGrid style issue with left bottom corner in the document
![image](https://github.com/ant-design/ant-design/assets/73976606/710793bd-7b9a-40cc-9dd8-c4b42d5c0b7d)


### 🔍 Walkthrough

Add a style to the “. ant card contain grid. ant card body”
