### PR TITLE
feat: ConfigProvider support config warning level

### DIFF
--- a/components/_util/warning.ts
+++ b/components/_util/warning.ts
@@ -51,7 +51,7 @@ export const WarningContext = React.createContext<WarningContextProps>({});
 export const devUseWarning: () => TypeWarning =
   process.env.NODE_ENV !== 'production'
     ? () => {
-        const { strict = true } = React.useContext(WarningContext);
+        const { strict } = React.useContext(WarningContext);
 
         const typeWarning: TypeWarning = (valid, component, type, message) => {
           if (!valid) {

--- a/components/_util/warning.ts
+++ b/components/_util/warning.ts
@@ -32,7 +32,7 @@ type TypeWarning = (
 ) => void;
 
 export interface WarningContextProps {
-  deprecated?: boolean;
+  strict?: boolean;
 }
 
 export const WarningContext = React.createContext<WarningContextProps>({});
@@ -45,10 +45,10 @@ export const WarningContext = React.createContext<WarningContextProps>({});
 export const devUseWarning: () => TypeWarning =
   process.env.NODE_ENV !== 'production'
     ? () => {
-        const { deprecated } = React.useContext(WarningContext);
+        const { strict = true } = React.useContext(WarningContext);
 
         const typeWarning: TypeWarning = (valid, component, type, message) => {
-          if (deprecated !== false || type !== 'deprecated') {
+          if (strict || type !== 'deprecated') {
             warning(valid, component, message);
           }
         };

--- a/components/_util/warning.ts
+++ b/components/_util/warning.ts
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import rcWarning, { resetWarned } from 'rc-util/lib/warning';
+import rcWarning, { resetWarned as rcResetWarned } from 'rc-util/lib/warning';
 
-export { resetWarned };
 export function noop() {}
+
+let deprecatedWarnList: Record<string, string[]> | null = null;
+
+export function resetWarned() {
+  deprecatedWarnList = null;
+  rcResetWarned();
+}
 
 type Warning = (valid: boolean, component: string, message?: string) => void;
 
@@ -48,8 +54,30 @@ export const devUseWarning: () => TypeWarning =
         const { strict = true } = React.useContext(WarningContext);
 
         const typeWarning: TypeWarning = (valid, component, type, message) => {
-          if (strict || type !== 'deprecated') {
-            warning(valid, component, message);
+          if (!valid) {
+            if (strict === false && type === 'deprecated') {
+              const existWarning = deprecatedWarnList;
+
+              if (!deprecatedWarnList) {
+                deprecatedWarnList = {};
+              }
+
+              deprecatedWarnList[component] = deprecatedWarnList[component] || [];
+              if (!deprecatedWarnList[component].includes(message || '')) {
+                deprecatedWarnList[component].push(message || '');
+              }
+
+              // Warning for the first time
+              if (!existWarning) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                  '[antd] There exists deprecated usage in your code:',
+                  deprecatedWarnList,
+                );
+              }
+            } else {
+              warning(valid, component, message);
+            }
           }
         };
 

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -139,7 +139,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
     warning(
       !(typeof icon === 'string' && icon.length > 2),
       'Avatar',
-      'deprecated',
+      'breaking',
       `\`icon\` is using ReactNode instead of string naming in v4. Please check \`${icon}\` at https://ant.design/components/icon`,
     );
   }

--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -3,6 +3,7 @@ import { SmileOutlined } from '@ant-design/icons';
 
 import type { ConfigConsumerProps, RenderEmptyHandler } from '..';
 import ConfigProvider, { ConfigContext } from '..';
+import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import { fireEvent, render } from '../../../tests/utils';
 import Button from '../../button';
@@ -123,5 +124,21 @@ describe('ConfigProvider', () => {
 
     expect(rendered).toBeTruthy();
     expect(cacheRenderEmpty).toBeFalsy();
+  });
+
+  it('warning support filter level', () => {
+    resetWarned();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rerender } = render(<ConfigProvider dropdownMatchSelectWidth />);
+    expect(errSpy).toHaveBeenCalled();
+
+    resetWarned();
+    errSpy.mockReset();
+
+    rerender(<ConfigProvider dropdownMatchSelectWidth warning={{ strict: false }} />);
+    expect(errSpy).not.toHaveBeenCalled();
+
+    errSpy.mockRestore();
   });
 });

--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -129,16 +129,13 @@ describe('ConfigProvider', () => {
   it('warning support filter level', () => {
     resetWarned();
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const { rerender } = render(<ConfigProvider dropdownMatchSelectWidth />);
-    expect(errSpy).toHaveBeenCalled();
-
-    resetWarned();
-    errSpy.mockReset();
-
-    rerender(<ConfigProvider dropdownMatchSelectWidth warning={{ strict: false }} />);
+    render(<ConfigProvider dropdownMatchSelectWidth warning={{ strict: false }} />);
     expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
 
     errSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/components/config-provider/demo/warning.md
+++ b/components/config-provider/demo/warning.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+调整 warning 策略。
+
+## en-US
+
+Adjust warning strategy.

--- a/components/config-provider/demo/warning.tsx
+++ b/components/config-provider/demo/warning.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Alert, ConfigProvider, Input, Typography } from 'antd';
+
+const App: React.FC = () => (
+  <>
+    <Typography.Title level={4}>Open single page to check the console</Typography.Title>
+    <ConfigProvider warning={{ strict: false }}>
+      <Alert closeText="deprecated" />
+      <Input.Group />
+    </ConfigProvider>
+  </>
+);
+
+export default App;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -46,6 +46,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 <code src="./demo/wave.tsx">Custom Wave</code>
 <code src="./demo/prefixCls.tsx" debug>prefixCls</code>
 <code src="./demo/useConfig.tsx" debug>useConfig</code>
+<code src="./demo/warning.tsx" debug>warning</code>
 
 ## API
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -13,8 +13,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*YC4ERpGAddoAAA
 This component provides a configuration to all React components underneath itself via the [context API](https://facebook.github.io/react/docs/context.html). In the render tree all components will have access to the provided config.
 
 ```tsx
-import { ConfigProvider } from 'antd';
 import React from 'react';
+import { ConfigProvider } from 'antd';
 
 // ...
 const Demo: React.FC = () => (
@@ -66,6 +66,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 | renderEmpty | Set empty content of components. Ref [Empty](/components/empty/) | function(componentName: string): ReactNode | - |  |
 | theme | Set theme, ref [Customize Theme](/docs/react/customize-theme) | - | - | 5.0.0 |
 | virtual | Disable virtual scroll when set to `false` | boolean | - | 4.3.0 |
+| warning | Config warning level, when `strict` is `false`, it will aggregate deprecated information into a single message | { strict: boolean } | - | 5.10.0 |
 
 ### ConfigProvider.config()
 

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -336,7 +336,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     colorPicker,
     datePicker,
     wave,
-    // warning: warningConfig,
+    warning: warningConfig,
   } = props;
 
   // =================================== Context ===================================
@@ -426,7 +426,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     colorPicker,
     datePicker,
     wave,
-    // warning: warningConfig,
+    warning: warningConfig,
   };
 
   const config = {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -6,7 +6,7 @@ import useMemo from 'rc-util/lib/hooks/useMemo';
 import { merge } from 'rc-util/lib/utils/set';
 import type { Options } from 'scroll-into-view-if-needed';
 
-import warning, { WarningContext, WarningContextProps } from '../_util/warning';
+import warning, { WarningContext, type WarningContextProps } from '../_util/warning';
 import type { RequiredMark } from '../form/Form';
 import ValidateMessagesContext from '../form/validateMessagesContext';
 import type { InputProps } from '../input';

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -6,7 +6,7 @@ import useMemo from 'rc-util/lib/hooks/useMemo';
 import { merge } from 'rc-util/lib/utils/set';
 import type { Options } from 'scroll-into-view-if-needed';
 
-import warning from '../_util/warning';
+import warning, { WarningContext, WarningContextProps } from '../_util/warning';
 import type { RequiredMark } from '../form/Form';
 import ValidateMessagesContext from '../form/validateMessagesContext';
 import type { InputProps } from '../input';
@@ -146,8 +146,7 @@ export interface ConfigProviderProps {
   popupOverflow?: PopupOverflow;
   theme?: ThemeConfig;
 
-  // TODO: wait for https://github.com/ant-design/ant-design/discussions/44551
-  // warning?: WarningContextProps;
+  warning?: WarningContextProps;
 
   alert?: ComponentStyleConfig;
   anchor?: ComponentStyleConfig;
@@ -562,11 +561,11 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   }
 
   // ================================== Warning ===================================
-  // if (memoedConfig.warning) {
-  //   childNode = (
-  //     <WarningContext.Provider value={memoedConfig.warning}>{childNode}</WarningContext.Provider>
-  //   );
-  // }
+  if (memoedConfig.warning) {
+    childNode = (
+      <WarningContext.Provider value={memoedConfig.warning}>{childNode}</WarningContext.Provider>
+    );
+  }
 
   // =================================== Render ===================================
   if (componentDisabled !== undefined) {

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -14,8 +14,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*YC4ERpGAddoAAA
 ConfigProvider 使用 React 的 [context](https://facebook.github.io/react/docs/context.html) 特性，只需在应用外围包裹一次即可全局生效。
 
 ```tsx
-import { ConfigProvider } from 'antd';
 import React from 'react';
+import { ConfigProvider } from 'antd';
 
 // ...
 const Demo: React.FC = () => (
@@ -67,6 +67,7 @@ export default Demo;
 | renderEmpty | 自定义组件空状态。参考 [空状态](/components/empty-cn) | function(componentName: string): ReactNode | - |  |
 | theme | 设置主题，参考 [定制主题](/docs/react/customize-theme-cn) | - | - | 5.0.0 |
 | virtual | 设置 `false` 时关闭虚拟滚动 | boolean | - | 4.3.0 |
+| warning | 设置警告等级，`strict` 为 `false` 时会将废弃相关信息聚合为单条信息 | { strict: boolean } | - | 5.10.0 |
 
 ### ConfigProvider.config()
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -46,7 +46,8 @@ export default Demo;
 <code src="./demo/theme.tsx">主题</code>
 <code src="./demo/wave.tsx">自定义波纹</code>
 <code src="./demo/prefixCls.tsx" debug>前缀</code>
-<code src="./demo/useConfig.tsx" debug>useConfig</code>
+<code src="./demo/useConfig.tsx" debug>获取配置</code>
+<code src="./demo/warning.tsx" debug>警告</code>
 
 ## API
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref #44551

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ConfigProvider support `warning` to config warning log level (like filter deprecated warning).      |
| 🇨🇳 Chinese |     ConfigProvider 支持 `warning` 属性以配置警告等级（如过滤掉废弃 API 警告）。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e57eb6e</samp>

This pull request adds a new feature to the `ConfigProvider` component that allows users to control the warning level for deprecated or breaking changes in the ant-design components. It also updates the documentation, tests, and demos for the feature and modifies the warning type for the `icon` prop change in the `Avatar` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e57eb6e</samp>

* Enable warning feature for `ConfigProvider` component to control the level of deprecation warnings (F0,F6,F7,F5)
  - Import `resetWarned` function from `rc-util/lib/warning` and rename it as `rcResetWarned` to avoid conflict with custom `resetWarned` function ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-75853a37744088ef730adfb0906473685c80080827a097c12079581f39203ffbL2-R12))
  - Change `WarningContextProps` interface to use `strict` instead of `deprecated` as property name ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-75853a37744088ef730adfb0906473685c80080827a097c12079581f39203ffbL35-R41))
  - Modify `typeWarning` function to aggregate deprecated warnings based on `strict` property from warning context and use global variable `deprecatedWarnList` to store and print deprecated warnings once ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-75853a37744088ef730adfb0906473685c80080827a097c12079581f39203ffbL48-R80))
  - Add `warning` property to `ConfigProviderProps` interface to allow users to pass warning level configuration ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L149-R149))
  - Destructure `warning` property from `props` object and include it in `memoedConfig` object ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L340-R339),[link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L430-R429))
  - Uncomment code for creating and rendering `WarningContext` provider with `memoedConfig.warning` value ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L9-R9),[link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56L565-R568))
  - Add `warning` property to API sections of English and Chinese documentation for `ConfigProvider` component and describe its type, default value and version ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R70),[link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R71))
  - Add code examples for warning feature to examples sections of English and Chinese documentation for `ConfigProvider` component and reference demo files ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R49),[link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L49-R50))
* Change `type` argument of `typeWarning` function call in `Avatar` component from `deprecated` to `breaking` to reflect severity of change in `icon` prop ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL142-R142))
* Import `resetWarned` function from `../_util/warning` in test file for `ConfigProvider` component and reset global variable `deprecatedWarnList` before each test case ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R6))
* Add test case for warning support for `ConfigProvider` component and mock and restore `console.error` and `console.warn` methods to spy on calls ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-0240afe2faa6807b920ad4c86a45d6724eb47ed4cde840f097b69fdb4d28cdb5R128-R140))
* Change order of imports in usage sections of English and Chinese documentation for `ConfigProvider` component to follow convention of importing React first and then other modules ([link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563L16-R17),[link](https://github.com/ant-design/ant-design/pull/44809/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775L17-R18))
