### PR TITLE
fix: Checkbox in Tree should align self start with text

### DIFF
--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3889,6 +3889,326 @@ exports[`renders components/tree/demo/line.tsx extend context correctly 1`] = `
 
 exports[`renders components/tree/demo/line.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/tree/demo/multiple-line.tsx extend context correctly 1`] = `
+<div
+  class="ant-tree ant-tree-icon-hide"
+  role="tree"
+>
+  <div>
+    <input
+      aria-label="for screen reader"
+      style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
+      tabindex="0"
+      value=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="ant-tree-treenode"
+    style="position: absolute; pointer-events: none; visibility: hidden; height: 0px; overflow: hidden; border: 0px; padding: 0px;"
+  >
+    <div
+      class="ant-tree-indent"
+    >
+      <div
+        class="ant-tree-indent-unit"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-tree-list"
+    style="width: 200px; position: relative;"
+  >
+    <div
+      class="ant-tree-list-holder"
+    >
+      <div>
+        <div
+          class="ant-tree-list-holder-inner"
+          style="display: flex; flex-direction: column;"
+        >
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked ant-tree-checkbox-disabled"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1-0"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1-0
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-disabled"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title="This is a very very very very long text"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                This is a very very very very long text
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title="This is also a very very very very very long text"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                This is also a very very very very very long text
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1-1"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1-1
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title=""
+            >
+              <span
+                class="ant-tree-title"
+              >
+                <span
+                  style="color: rgb(22, 119, 255);"
+                >
+                  sss
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/tree/demo/multiple-line.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/tree/demo/search.tsx extend context correctly 1`] = `
 <div>
   <span

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -3774,6 +3774,324 @@ exports[`renders components/tree/demo/line.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/tree/demo/multiple-line.tsx correctly 1`] = `
+<div
+  class="ant-tree ant-tree-icon-hide"
+  role="tree"
+>
+  <div>
+    <input
+      aria-label="for screen reader"
+      style="width:0;height:0;display:flex;overflow:hidden;opacity:0;border:0;padding:0;margin:0"
+      tabindex="0"
+      value=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="ant-tree-treenode"
+    style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden;border:0;padding:0"
+  >
+    <div
+      class="ant-tree-indent"
+    >
+      <div
+        class="ant-tree-indent-unit"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-tree-list"
+    style="width:200px;position:relative"
+  >
+    <div
+      class="ant-tree-list-holder"
+    >
+      <div>
+        <div
+          class="ant-tree-list-holder-inner"
+          style="display:flex;flex-direction:column"
+        >
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            />
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked ant-tree-checkbox-disabled"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1-0"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1-0
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-disabled"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title="This is a very very very very long text"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                This is a very very very very long text
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title="This is also a very very very very very long text"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                This is also a very very very very very long text
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher_open"
+            >
+              <span
+                aria-label="caret-down"
+                class="anticon anticon-caret-down ant-tree-switcher-icon"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="caret-down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              title="parent 1-1"
+            >
+              <span
+                class="ant-tree-title"
+              >
+                parent 1-1
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="ant-tree-treenode ant-tree-treenode-switcher-close ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="ant-tree-indent"
+            >
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+              />
+              <span
+                class="ant-tree-indent-unit ant-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="ant-tree-switcher ant-tree-switcher-noop"
+            />
+            <span
+              class="ant-tree-checkbox ant-tree-checkbox-checked"
+            >
+              <span
+                class="ant-tree-checkbox-inner"
+              />
+            </span>
+            <span
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+              title=""
+            >
+              <span
+                class="ant-tree-title"
+              >
+                <span
+                  style="color:#1677ff"
+                >
+                  sss
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/tree/demo/search.tsx correctly 1`] = `
 <div>
   <span

--- a/components/tree/demo/multiple-line.md
+++ b/components/tree/demo/multiple-line.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+多行树节点。
+
+## en-US
+
+Multiple line tree node.

--- a/components/tree/demo/multiple-line.tsx
+++ b/components/tree/demo/multiple-line.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Tree } from 'antd';
+import type { DataNode, TreeProps } from 'antd/es/tree';
+
+const treeData: DataNode[] = [
+  {
+    title: 'parent 1',
+    key: '0-0',
+    children: [
+      {
+        title: 'parent 1-0',
+        key: '0-0-0',
+        disabled: true,
+        children: [
+          {
+            title: 'This is a very very very very long text',
+            key: '0-0-0-0',
+            disableCheckbox: true,
+          },
+          {
+            title: 'This is also a very very very very very long text',
+            key: '0-0-0-1',
+          },
+        ],
+      },
+      {
+        title: 'parent 1-1',
+        key: '0-0-1',
+        children: [{ title: <span style={{ color: '#1677ff' }}>sss</span>, key: '0-0-1-0' }],
+      },
+    ],
+  },
+];
+
+const App: React.FC = () => {
+  const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
+    console.log('selected', selectedKeys, info);
+  };
+
+  const onCheck: TreeProps['onCheck'] = (checkedKeys, info) => {
+    console.log('onCheck', checkedKeys, info);
+  };
+
+  return (
+    <Tree
+      checkable
+      defaultExpandedKeys={['0-0-0', '0-0-1']}
+      defaultSelectedKeys={['0-0-0', '0-0-1']}
+      defaultCheckedKeys={['0-0-0', '0-0-1']}
+      onSelect={onSelect}
+      onCheck={onCheck}
+      treeData={treeData}
+      style={{ width: 200 }}
+    />
+  );
+};
+
+export default App;

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -31,6 +31,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 <code src="./demo/big-data.tsx" debug>Big data</code>
 <code src="./demo/block-node.tsx">Block Node</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
+<code src="./demo/multiple-line.tsx" debug>Multiple lines</code>
 
 ## API
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -32,6 +32,7 @@ demo:
 <code src="./demo/big-data.tsx" debug>大数据</code>
 <code src="./demo/block-node.tsx">占据整行</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
+<code src="./demo/multiple-line.tsx" debug>多行</code>
 
 ## API
 

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -290,6 +290,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeCls}-checkbox`]: {
         top: 'initial',
         marginInlineEnd: treeCheckBoxMarginHorizontal,
+        alignSelf: 'flex-start',
+        marginTop: token.marginXXS,
       },
 
       // >>> Title


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/44803
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Tree that Checkbox should be aligned with first line.       |
| 🇨🇳 Chinese |   修复 Tree 组件样式，使 Checkbox 与文字第一行对齐        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82c55ff</samp>

Added a new multiple-line demo for the `Tree` component and updated the documentation and style accordingly. Simplified the horizontal demo of the `Anchor` component and fixed some issues with the image test and the back-top demo of the `FloatButton` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82c55ff</samp>

* Remove unused anchor links and div elements from the horizontal demo of the `Anchor` component ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-e4f82bd504a6c149673b06818fdeda0e62fa109a425ffb97cfbf69a9c540d48aL25-L39), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-e4f82bd504a6c149673b06818fdeda0e62fa109a425ffb97cfbf69a9c540d48aL66-L77))
* Reduce the height of the div element in the back-top demo of the `FloatButton` component to fit in the screen ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-9fb02d529339aaff9025222dc21982db051cd261b68a3c68fdbc4eadcc096930L5-R5))
* Add a new multiple-line demo of the `Tree` component, with nodes that have long and multiple lines of text ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-0d3e80b8ad7bb406ca0e4597d96339a7c8227e8c02f3f4caeb9961d3d557d9a9R1-R7), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-ab9029c883001e3ffe6fcf41d4326b970a0bbf6724f1a01dae324836fad6f7e1R1-R58), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-02cdc797e1338024879c3cdfa6c1d35d7beb888c68654f9cecd9d46eb8b53ff9R34), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-0bdf37a1fc0ec124fb3aa391932eaa134bd1de8c6f766f5e4082edbc30ce6c42R35), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010R293-R294))
* Modify the style of the tree node title to improve the layout of the multiple-line nodes ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010R293-R294))
* Change the logic of the image test file to use the scroll height of the rendered page to set the viewport, instead of waiting for the end-of-screen element, to ensure the full page screenshot is captured correctly ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-34d634572b80c540ebecd7780004e6031fbb9f004387e3df7302e346940ffae4L58-L60), [link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-34d634572b80c540ebecd7780004e6031fbb9f004387e3df7302e346940ffae4L78-R80))
* Delete the image test file for the `BackTop` component, as it is not needed ([link](https://github.com/ant-design/ant-design/pull/44827/files?diff=unified&w=0#diff-4d2e29de81d06c52df106656adc6ac2c0c4f4aefd623e11f0ef60e67e114572e))
