### PR TITLE
fix(radio): use its own disabled first

### DIFF
--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Radio, { Button, Group } from '..';
+import Form from '../../form';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -32,5 +33,25 @@ describe('Radio', () => {
 
     fireEvent.mouseLeave(container.querySelector('label')!);
     expect(onMouseLeave).toHaveBeenCalled();
+  });
+
+  it('should use own disabled status first', () => {
+    const { getByRole } = render(
+      <Form disabled>
+        <Radio disabled={false} />
+      </Form>,
+    );
+    expect(getByRole('radio')).not.toBeDisabled();
+  });
+
+  it('should obtained correctly disabled status', () => {
+    const { getByRole } = render(
+      <Form disabled>
+        <Radio.Group disabled={false}>
+          <Radio />
+        </Radio.Group>
+      </Form>,
+    );
+    expect(getByRole('radio')).not.toBeDisabled();
   });
 });

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -26,14 +26,7 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
     groupContext?.onChange?.(e);
   };
 
-  const {
-    prefixCls: customizePrefixCls,
-    className,
-    children,
-    style,
-    disabled: customDisabled,
-    ...restProps
-  } = props;
+  const { prefixCls: customizePrefixCls, className, children, style, ...restProps } = props;
   const radioPrefixCls = getPrefixCls('radio', customizePrefixCls);
   const prefixCls =
     (groupContext?.optionType || radioOptionTypeContext) === 'button'
@@ -44,14 +37,15 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
 
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
-  radioProps.disabled = customDisabled || disabled;
 
   if (groupContext) {
     radioProps.name = groupContext.name;
     radioProps.onChange = onChange;
     radioProps.checked = props.value === groupContext.value;
-    radioProps.disabled = radioProps.disabled || groupContext.disabled;
+    radioProps.disabled = radioProps.disabled ?? groupContext.disabled;
   }
+
+  radioProps.disabled = radioProps.disabled ?? disabled;
   const wrapperClassString = classNames(
     `${prefixCls}-wrapper`,
     {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
close https://github.com/ant-design/ant-design/issues/44781

ref: 
https://github.com/ant-design/ant-design/pull/40728
https://github.com/ant-design/ant-design/pull/40741
### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the disabled of a radio button is overridden by the disabled of the form it belongs to.          |
| 🇨🇳 Chinese | 解决 `radio` 的 disabled 被外部 `form` 表单的 disabled 覆盖         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c38e305</samp>

Improved the disabled behavior of the `Radio` component and added tests for it. Refactored the code to use the nullish coalescing operator and avoid unnecessary overrides.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c38e305</samp>

*  Refactor the disabled logic of the `Radio` component to use the nullish coalescing operator and avoid overriding falsy values ([link](https://github.com/ant-design/ant-design/pull/44837/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL29-R29), [link](https://github.com/ant-design/ant-design/pull/44837/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL47), [link](https://github.com/ant-design/ant-design/pull/44837/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL53-R48))
* Add two test cases for the `Radio` component to check the disabled status when nested inside a `Form` component ([link](https://github.com/ant-design/ant-design/pull/44837/files?diff=unified&w=0#diff-a6b316e6fad7ff1ce27a055149bfabd92c61a26de376a178e67ab0e9104ff27bR37-R56))
* Import the `Form` component from `../../form` to be used in the new test cases ([link](https://github.com/ant-design/ant-design/pull/44837/files?diff=unified&w=0#diff-a6b316e6fad7ff1ce27a055149bfabd92c61a26de376a178e67ab0e9104ff27bR3))
