### PR TITLE
fix(popover): Nested Controlled Popover won't close when click away

### DIFF
--- a/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -984,11 +984,10 @@ exports[`renders components/popover/demo/nest-controled-closed.tsx extend contex
 Array [
   <button
     class="ant-btn ant-btn-default"
-    style="background: red; color: white;"
     type="button"
   >
     <span>
-      layer 1
+      controlled 1
     </span>
   </button>,
   <div
@@ -1014,7 +1013,7 @@ Array [
             type="button"
           >
             <span>
-              layer 2
+              controlled 2
             </span>
           </button>
           <div
@@ -1036,7 +1035,7 @@ Array [
                   class="ant-popover-inner-content"
                 >
                   <div>
-                    content won't close on click away
+                    content ware not close on click away
                   </div>
                 </div>
               </div>
@@ -1048,11 +1047,10 @@ Array [
   </div>,
   <button
     class="ant-btn ant-btn-default"
-    style="background: green; color: white;"
     type="button"
   >
     <span>
-      layer 1
+      uncontrolled 1
     </span>
   </button>,
   <div
@@ -1078,7 +1076,7 @@ Array [
             type="button"
           >
             <span>
-              layer 2
+              uncontrolled 2
             </span>
           </button>
           <div

--- a/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -980,6 +980,141 @@ Array [
 
 exports[`renders components/popover/demo/hover-with-click.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/popover/demo/nest-controled-closed.tsx extend context correctly 1`] = `
+Array [
+  <button
+    class="ant-btn ant-btn-default"
+    style="background: red; color: white;"
+    type="button"
+  >
+    <span>
+      layer 1
+    </span>
+  </button>,
+  <div
+    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-placement-top"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div
+      class="ant-popover-arrow"
+      style="position: absolute; bottom: 0px; left: 0px;"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <button
+            class="ant-btn ant-btn-default"
+            type="button"
+          >
+            <span>
+              layer 2
+            </span>
+          </button>
+          <div
+            class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-placement-top"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <div
+              class="ant-popover-arrow"
+              style="position: absolute; bottom: 0px; left: 0px;"
+            />
+            <div
+              class="ant-popover-content"
+            >
+              <div
+                class="ant-popover-inner"
+                role="tooltip"
+              >
+                <div
+                  class="ant-popover-inner-content"
+                >
+                  <div>
+                    content won't close on click away
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <button
+    class="ant-btn ant-btn-default"
+    style="background: green; color: white;"
+    type="button"
+  >
+    <span>
+      layer 1
+    </span>
+  </button>,
+  <div
+    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-placement-top"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div
+      class="ant-popover-arrow"
+      style="position: absolute; bottom: 0px; left: 0px;"
+    />
+    <div
+      class="ant-popover-content"
+    >
+      <div
+        class="ant-popover-inner"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-inner-content"
+        >
+          <button
+            class="ant-btn ant-btn-default"
+            type="button"
+          >
+            <span>
+              layer 2
+            </span>
+          </button>
+          <div
+            class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-placement-top"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <div
+              class="ant-popover-arrow"
+              style="position: absolute; bottom: 0px; left: 0px;"
+            />
+            <div
+              class="ant-popover-content"
+            >
+              <div
+                class="ant-popover-inner"
+                role="tooltip"
+              >
+                <div
+                  class="ant-popover-inner-content"
+                >
+                  <div>
+                    expected behavior
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`renders components/popover/demo/nest-controled-closed.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/popover/demo/placement.tsx extend context correctly 1`] = `
 <div>
   <div

--- a/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
@@ -318,6 +318,29 @@ exports[`renders components/popover/demo/hover-with-click.tsx correctly 1`] = `
 </button>
 `;
 
+exports[`renders components/popover/demo/nest-controled-closed.tsx correctly 1`] = `
+Array [
+  <button
+    class="ant-btn ant-btn-default"
+    style="background:red;color:white"
+    type="button"
+  >
+    <span>
+      layer 1
+    </span>
+  </button>,
+  <button
+    class="ant-btn ant-btn-default"
+    style="background:green;color:white"
+    type="button"
+  >
+    <span>
+      layer 1
+    </span>
+  </button>,
+]
+`;
+
 exports[`renders components/popover/demo/placement.tsx correctly 1`] = `
 <div>
   <div

--- a/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
@@ -322,20 +322,18 @@ exports[`renders components/popover/demo/nest-controled-closed.tsx correctly 1`]
 Array [
   <button
     class="ant-btn ant-btn-default"
-    style="background:red;color:white"
     type="button"
   >
     <span>
-      layer 1
+      controlled 1
     </span>
   </button>,
   <button
     class="ant-btn ant-btn-default"
-    style="background:green;color:white"
     type="button"
   >
     <span>
-      layer 1
+      uncontrolled 1
     </span>
   </button>,
 ]

--- a/components/popover/demo/nest-controled-closed.md
+++ b/components/popover/demo/nest-controled-closed.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+嵌套使用。
+
+## en-US
+
+Nesting is used.

--- a/components/popover/demo/nest-controled-closed.md
+++ b/components/popover/demo/nest-controled-closed.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-嵌套使用。
+嵌套使用气泡，受控模式和非受控模式。
 
 ## en-US
 
-Nesting is used.
+Nested using bubbles, controlled modes, and uncontrolled modes.

--- a/components/popover/demo/nest-controled-closed.tsx
+++ b/components/popover/demo/nest-controled-closed.tsx
@@ -8,20 +8,18 @@ const App: React.FC = () => {
     <>
       <Popover
         onOpenChange={(open) => {
-          console.log(1, open);
           setOpen1(open);
         }}
         open={open1}
-        trigger={'click'}
+        trigger="click"
         content={
           <Popover
             onOpenChange={(open) => {
-              console.log(2, open);
               setOpen2(open);
             }}
             open={open2}
-            trigger={'click'}
-            content={<div>content won't close on click away</div>}
+            trigger="click"
+            content={<div>content ware not close on click away</div>}
           >
             <Button>layer 2</Button>
           </Popover>
@@ -30,9 +28,9 @@ const App: React.FC = () => {
         <Button style={{ background: 'red', color: 'white' }}>layer 1</Button>
       </Popover>
       <Popover
-        trigger={'click'}
+        trigger="click"
         content={
-          <Popover trigger={'click'} content={<div>expected behavior</div>}>
+          <Popover trigger="click" content={<div>expected behavior</div>}>
             <Button>layer 2</Button>
           </Popover>
         }

--- a/components/popover/demo/nest-controled-closed.tsx
+++ b/components/popover/demo/nest-controled-closed.tsx
@@ -16,6 +16,7 @@ const App: React.FC = () => {
         content={
           <Popover
             onOpenChange={(open) => {
+              console.log(2, open);
               setOpen2(open);
             }}
             open={open2}

--- a/components/popover/demo/nest-controled-closed.tsx
+++ b/components/popover/demo/nest-controled-closed.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Button, Popover } from 'antd';
+
+const App: React.FC = () => {
+  const [open1, setOpen1] = useState(false);
+  const [open2, setOpen2] = useState(false);
+  return (
+    <>
+      <Popover
+        onOpenChange={(open) => {
+          console.log(1, open);
+          setOpen1(open);
+        }}
+        open={open1}
+        trigger={'click'}
+        content={
+          <Popover
+            onOpenChange={(open) => {
+              setOpen2(open);
+            }}
+            open={open2}
+            trigger={'click'}
+            content={<div>content won't close on click away</div>}
+          >
+            <Button>layer 2</Button>
+          </Popover>
+        }
+      >
+        <Button style={{ background: 'red', color: 'white' }}>layer 1</Button>
+      </Popover>
+      <Popover
+        trigger={'click'}
+        content={
+          <Popover trigger={'click'} content={<div>expected behavior</div>}>
+            <Button>layer 2</Button>
+          </Popover>
+        }
+      >
+        <Button style={{ background: 'green', color: 'white' }}>layer 1</Button>
+      </Popover>
+    </>
+  );
+};
+
+export default App;

--- a/components/popover/demo/nest-controled-closed.tsx
+++ b/components/popover/demo/nest-controled-closed.tsx
@@ -21,21 +21,21 @@ const App: React.FC = () => {
             trigger="click"
             content={<div>content ware not close on click away</div>}
           >
-            <Button>layer 2</Button>
+            <Button>controlled 2</Button>
           </Popover>
         }
       >
-        <Button style={{ background: 'red', color: 'white' }}>layer 1</Button>
+        <Button>controlled 1</Button>
       </Popover>
       <Popover
         trigger="click"
         content={
           <Popover trigger="click" content={<div>expected behavior</div>}>
-            <Button>layer 2</Button>
+            <Button>uncontrolled 2</Button>
           </Popover>
         }
       >
-        <Button style={{ background: 'green', color: 'white' }}>layer 1</Button>
+        <Button>uncontrolled 1</Button>
       </Popover>
     </>
   );

--- a/components/popover/index.en-US.md
+++ b/components/popover/index.en-US.md
@@ -20,6 +20,7 @@ Comparing with `Tooltip`, besides information `Popover` card can also provide ac
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/nest-controled-closed.tsx">Nested Controlled Shutdown</code>
 <code src="./demo/triggerType.tsx">Three ways to trigger</code>
 <code src="./demo/placement.tsx">Placement</code>
 <code src="./demo/arrow.tsx">Arrow</code>

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -40,7 +40,6 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
     mouseEnterDelay = 0.1,
     mouseLeaveDelay = 0.1,
     overlayStyle = {},
-    destroyTooltipOnHide,
     ...otherProps
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
@@ -53,7 +52,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
 
   return wrapSSR(
     <Tooltip
-      destroyTooltipOnHide={destroyTooltipOnHide ?? !!otherProps?.onOpenChange}
+      destroyTooltipOnHide={otherProps?.destroyTooltipOnHide ?? otherProps?.open != undefined}
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,5 +1,6 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
+
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
@@ -51,6 +52,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
 
   return wrapSSR(
     <Tooltip
+      destroyTooltipOnHide
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -52,7 +52,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
 
   return wrapSSR(
     <Tooltip
-      destroyTooltipOnHide={otherProps?.destroyTooltipOnHide ?? otherProps?.open != undefined}
+      destroyTooltipOnHide={otherProps?.destroyTooltipOnHide ?? otherProps?.open !== undefined}
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -40,6 +40,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
     mouseEnterDelay = 0.1,
     mouseLeaveDelay = 0.1,
     overlayStyle = {},
+    destroyTooltipOnHide,
     ...otherProps
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
@@ -52,7 +53,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
 
   return wrapSSR(
     <Tooltip
-      destroyTooltipOnHide={!!otherProps?.onOpenChange}
+      destroyTooltipOnHide={destroyTooltipOnHide ?? !!otherProps?.onOpenChange}
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -52,7 +52,7 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
 
   return wrapSSR(
     <Tooltip
-      destroyTooltipOnHide
+      destroyTooltipOnHide={!!otherProps?.onOpenChange}
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.zh-CN.md
+++ b/components/popover/index.zh-CN.md
@@ -21,6 +21,7 @@ demo:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本</code>
+<code src="./demo/nest-controled-closed.tsx">嵌套受控关闭</code>
 <code src="./demo/triggerType.tsx">三种触发方式</code>
 <code src="./demo/placement.tsx">位置</code>
 <code src="./demo/arrow.tsx">箭头展示</code>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- close #44830

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Nested Controlled Popover won't close when click away |
| 🇨🇳 Chinese | 修复单击离开时，嵌套的受控弹出框不会关闭 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1675629</samp>

This pull request adds a new demo and a new prop for the `Popover` component. The demo shows how to use nested popovers with controlled open state and the prop allows to improve the performance of the component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1675629</samp>

*  Add `destroyTooltipOnHide` prop to `Popover` component to allow destroying popover content when hidden ([link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0R55))
*  Add demo file `nest-controled-closed.tsx` and `nest-controled-closed.md` to show how to use nested popovers with controlled open state and prevent them from closing on click away ([link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-b98f6d6a45421b56576aa24749593ee69b1206c85b472751c44139770ee3c461R1-R45), [link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-834198955243d696bf30d6eb643443b959351894cb126cd6b6fbdb381e11944aR1-R7))
*  Add links to the demo file in both English and Chinese documentation files ([link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-be0bbc246cbe091c40db4aae74f6c5bae7920d84a1ff0024c68d6e3851e5d0cdR23), [link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-4adc3a014c480e4b095ef419f25dd05df6a317c5396cf8b83b98484c854246d6R24))
*  Reorder import statements in `index.tsx` to follow convention ([link](https://github.com/ant-design/ant-design/pull/44867/files?diff=unified&w=0#diff-8255c20b0fc82fa28472ee578129241aab0b6c6d3f2cdafba5f74fa2614a92f0L1-R3))
