### PR TITLE
demo(Table): add sticky offsetHeader

### DIFF
--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -29271,7 +29271,7 @@ exports[`renders components/table/demo/sticky.tsx extend context correctly 1`] =
         >
           <div
             class="ant-table-header ant-table-sticky-holder"
-            style="overflow: hidden; top: 0px;"
+            style="overflow: hidden; top: 64px;"
           >
             <table
               style="table-layout: fixed; visibility: hidden;"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -23871,7 +23871,7 @@ exports[`renders components/table/demo/sticky.tsx correctly 1`] = `
         >
           <div
             class="ant-table-header ant-table-sticky-holder"
-            style="overflow:hidden;top:0"
+            style="overflow:hidden;top:64px"
           >
             <table
               style="table-layout:fixed;visibility:hidden"

--- a/components/table/demo/sticky.tsx
+++ b/components/table/demo/sticky.tsx
@@ -114,7 +114,8 @@ const App: React.FC = () => {
           </Table.Summary.Row>
         </Table.Summary>
       )}
-      sticky
+      // antd site header height
+      sticky={{ offsetHeader: 64 }}
     />
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

https://ant.design/components/table-cn#components-table-demo-sticky
现在的网站 header 改成 sticky 了，导致 Table sticky 会被遮挡，设置下偏移量

修改前
<img width="1066" alt="image" src="https://github.com/ant-design/ant-design/assets/47104575/b477cfb7-bae7-4c22-bef8-35bbff4f5925">

修改后
<img width="921" alt="image" src="https://github.com/ant-design/ant-design/assets/47104575/ff800864-065f-4d92-9939-4fb8735c8a62">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82e7dd2</samp>

Fixed table header overlap with site header by adding `offsetHeader` option to `sticky` prop of `Table` component. Updated `components/table/demo/sticky.tsx` to demonstrate the new option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82e7dd2</samp>

* Fix table header overlap with site header by adding `offsetHeader` property to `sticky` prop of `Table` component ([link](https://github.com/ant-design/ant-design/pull/44876/files?diff=unified&w=0#diff-7c1a809db90bddb71f9320eb5ac82cf2c4cd683c2c3507e2ffc4bed6b36988a5L117-R118))
