### PR TITLE
site: add LocalStorage caching for bannerVisible

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, startTransition } from 'react';
+import dayjs from 'dayjs';
 import {
   createCache,
   extractStyle,
@@ -107,12 +108,15 @@ const GlobalLayout: React.FC = () => {
   useEffect(() => {
     const _theme = searchParams.getAll('theme') as ThemeName[];
     const _direction = searchParams.get('direction') as DirectionType;
-    const storedBannerVisible = !(localStorage && localStorage.getItem(ANT_DESIGN_NOT_SHOW_BANNER));
+    const storedBannerVisibleLastTime =
+      localStorage && localStorage.getItem(ANT_DESIGN_NOT_SHOW_BANNER);
+    const storedBannerVisible =
+      storedBannerVisibleLastTime && dayjs().diff(dayjs(storedBannerVisibleLastTime), 'day') >= 1;
 
     setSiteState({
       theme: _theme,
       direction: _direction === 'rtl' ? 'rtl' : 'ltr',
-      bannerVisible: storedBannerVisible,
+      bannerVisible: storedBannerVisibleLastTime ? storedBannerVisible : true,
     });
     // Handle isMobile
     updateMobileMode();

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -32,6 +32,7 @@ type Entries<T> = { [K in keyof T]: [K, T[K]] }[keyof T][];
 type SiteState = Partial<Omit<SiteContextProps, 'updateSiteContext'>>;
 
 const RESPONSIVE_MOBILE = 768;
+export const ANT_DESIGN_NOT_SHOW_BANNER = 'ANT_DESIGN_NOT_SHOW_BANNER';
 
 // const styleCache = createCache();
 // if (typeof global !== 'undefined') {
@@ -56,12 +57,12 @@ const GlobalLayout: React.FC = () => {
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [, , setPrefersColor] = usePrefersColor();
-  const [{ theme = [], direction, isMobile, bannerVisible = true }, setSiteState] =
+  const [{ theme = [], direction, isMobile, bannerVisible = false }, setSiteState] =
     useLayoutState<SiteState>({
       isMobile: false,
       direction: 'ltr',
       theme: [],
-      bannerVisible: true,
+      bannerVisible: false,
     });
 
   const updateSiteConfig = useCallback(
@@ -106,8 +107,13 @@ const GlobalLayout: React.FC = () => {
   useEffect(() => {
     const _theme = searchParams.getAll('theme') as ThemeName[];
     const _direction = searchParams.get('direction') as DirectionType;
+    const storedBannerVisible = !(localStorage && localStorage.getItem(ANT_DESIGN_NOT_SHOW_BANNER));
 
-    setSiteState({ theme: _theme, direction: _direction === 'rtl' ? 'rtl' : 'ltr' });
+    setSiteState({
+      theme: _theme,
+      direction: _direction === 'rtl' ? 'rtl' : 'ltr',
+      bannerVisible: storedBannerVisible,
+    });
     // Handle isMobile
     updateMobileMode();
 

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -1,5 +1,6 @@
 import { GithubOutlined, MenuOutlined } from '@ant-design/icons';
 import { createStyles } from 'antd-style';
+import dayjs from 'dayjs';
 import classNames from 'classnames';
 import { useLocation, useSiteData } from 'dumi';
 import DumiSearchBar from 'dumi/theme-default/slots/SearchBar';
@@ -182,7 +183,7 @@ const Header: React.FC = () => {
     updateSiteConfig({ bannerVisible: false });
 
     if (utils.isLocalStorageNameSupported()) {
-      localStorage.setItem(ANT_DESIGN_NOT_SHOW_BANNER, 1);
+      localStorage.setItem(ANT_DESIGN_NOT_SHOW_BANNER, dayjs().toISOString());
     }
   };
 

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -10,6 +10,7 @@ import DirectionIcon from '../../common/DirectionIcon';
 import * as utils from '../../utils';
 import { getThemeConfig } from '../../utils';
 import type { SiteContextProps } from '../SiteContext';
+import { ANT_DESIGN_NOT_SHOW_BANNER } from '../../layouts/GlobalLayout';
 import SiteContext from '../SiteContext';
 import Logo from './Logo';
 import More from './More';
@@ -154,7 +155,8 @@ const Header: React.FC = () => {
     windowWidth: 1400,
     searching: false,
   });
-  const { direction, isMobile, updateSiteConfig } = useContext<SiteContextProps>(SiteContext);
+  const { direction, isMobile, bannerVisible, updateSiteConfig } =
+    useContext<SiteContextProps>(SiteContext);
   const pingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const location = useLocation();
   const { pathname, search } = location;
@@ -178,6 +180,10 @@ const Header: React.FC = () => {
   };
   const onBannerClose = () => {
     updateSiteConfig({ bannerVisible: false });
+
+    if (utils.isLocalStorageNameSupported()) {
+      localStorage.setItem(ANT_DESIGN_NOT_SHOW_BANNER, 1);
+    }
   };
 
   useEffect(() => {
@@ -352,7 +358,7 @@ const Header: React.FC = () => {
           <MenuOutlined className="nav-phone-icon" onClick={handleShowMenu} />
         </Popover>
       )}
-      {isZhCN && (
+      {isZhCN && bannerVisible && (
         <Alert
           className={styles.banner}
           message={


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary
Add persistent storage using localStorage for bannerVisible to improve user experience
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87e1f6b</samp>

Added a banner component to the global layout that can be closed by the user and will reappear after one day. Used the `dayjs` library and local storage to handle the banner visibility and expiration logic. Modified the `GlobalLayout.tsx` and `Header/index.tsx` files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87e1f6b</samp>

* Import and use `dayjs` library to handle date operations for banner component ([link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R2), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728R3), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728R184-R187))
* Define and use `ANT_DESIGN_NOT_SHOW_BANNER` constant as key for local storage item that indicates banner visibility ([link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R36), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728R14), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728R184-R187))
* Add and update `bannerVisible` state to `useLayoutState` hook and `SiteContext` to control banner component rendering ([link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L59-R66), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L109-R120), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L157-R160), [link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L355-R362))
* Render banner component conditionally in `Header` component based on `bannerVisible` prop ([link](https://github.com/ant-design/ant-design/pull/44910/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728L355-R362))
