### PR TITLE
docs: Part of update

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable global-require */
 import React, { useMemo } from 'react';
-import { createStyles } from 'antd-style';
 import { HistoryOutlined } from '@ant-design/icons';
 import { Button, Drawer, Timeline, Typography } from 'antd';
-import Link from '../Link';
-import useLocale from '../../../hooks/useLocale';
+import { createStyles } from 'antd-style';
+
 import useFetch from '../../../hooks/useFetch';
+import useLocale from '../../../hooks/useLocale';
+import Link from '../Link';
 
 const useStyle = createStyles(({ token, css }) => ({
   history: css`
@@ -46,7 +47,7 @@ function ParseChangelog(props: { changelog: string; refs: string[]; styles: any 
   const { changelog = '', refs = [], styles } = props;
 
   const parsedChangelog = React.useMemo(() => {
-    const nodes: React.ReactElement[] = [];
+    const nodes: React.ReactNode[] = [];
 
     let isQuota = false;
     let lastStr = '';
@@ -57,7 +58,7 @@ function ParseChangelog(props: { changelog: string; refs: string[]; styles: any 
       if (char !== '`') {
         lastStr += char;
       } else {
-        let node = lastStr;
+        let node: React.ReactNode = lastStr;
         if (isQuota) {
           node = <code>{node}</code>;
         }
@@ -88,8 +89,14 @@ function ParseChangelog(props: { changelog: string; refs: string[]; styles: any 
   );
 }
 
-function useChangelog(componentPath, lang) {
-  const data = useFetch(
+type ChangelogInfo = {
+  version: string;
+  changelog: string;
+  refs: string[];
+};
+
+function useChangelog(componentPath: string, lang: 'cn' | 'en'): ChangelogInfo[] {
+  const data: any = useFetch(
     lang === 'cn'
       ? {
           key: 'component-changelog-cn',
@@ -108,7 +115,7 @@ function useChangelog(componentPath, lang) {
       (name) => name.toLowerCase() === component.toLowerCase(),
     );
 
-    return data[componentName];
+    return data[componentName!];
   }, [data, componentPath]);
 }
 
@@ -124,7 +131,7 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
   const list = useChangelog(componentPath, lang);
 
   const timelineItems = React.useMemo(() => {
-    const changelogMap = {};
+    const changelogMap: Record<string, ChangelogInfo[]> = {};
 
     list?.forEach((info) => {
       changelogMap[info.version] = changelogMap[info.version] || [];

--- a/.dumi/theme/common/styles/Markdown.tsx
+++ b/.dumi/theme/common/styles/Markdown.tsx
@@ -26,6 +26,10 @@ const GlobalStyle: React.FC = () => {
         .markdown img {
           max-width: calc(100% - 32px);
           max-height: 100%;
+        }
+
+        .markdown > a > img,
+        .markdown > img {
           display: block;
           margin: 0 auto;
         }

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -141,7 +141,6 @@ const miscKeys = [
             refs.push(ref);
           }
 
-          console.log('->', match);
           if (title && (title[0] === '#' || title[0] === '@')) {
             return '';
           }

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -8,7 +8,10 @@ const output = '.dumi/preset';
 
 // Collect components
 const componentNames = globSync(
-  path.join(process.cwd(), 'components/!(version|icon|col|row)/index.zh-CN.md').split(path.sep).join('/'),
+  path
+    .join(process.cwd(), 'components/!(version|icon|col|row)/index.zh-CN.md')
+    .split(path.sep)
+    .join('/'),
 )
   .map((filePath) => filePath.replace(/\\/g, '/').match(/components\/([^/]*)\//)![1])
   .filter((name) => name !== 'overview');
@@ -131,13 +134,20 @@ const miscKeys = [
       const refs: string[] = [];
 
       let changelogLine = line.trim().replace('- ', '');
+      console.log('>>>', line, changelogLine);
       changelogLine = changelogLine
         .replace(/\[([^\]]+)]\(([^)]+)\)/g, (...match) => {
-          const [, , ref] = match;
+          const [, title, ref] = match;
           if (ref.includes('/pull/')) {
             refs.push(ref);
           }
-          return '';
+
+          console.log('->', match);
+          if (title && (title[0] === '#' || title[0] === '@')) {
+            return '';
+          }
+
+          return title;
         })
         .trim();
 
@@ -161,6 +171,8 @@ const miscKeys = [
         }
       });
 
+      break;
+
       if (matched) {
         continue;
       }
@@ -181,7 +193,7 @@ const miscKeys = [
   }
 
   syncChangelog('CHANGELOG.zh-CN.md', 'components-changelog-cn.json');
-  syncChangelog('CHANGELOG.en-US.md', 'components-changelog-en.json');
+  // syncChangelog('CHANGELOG.en-US.md', 'components-changelog-en.json');
   fs.writeFileSync(
     path.join(output, 'misc-changelog.json'),
     JSON.stringify(miscChangelog),

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -134,7 +134,6 @@ const miscKeys = [
       const refs: string[] = [];
 
       let changelogLine = line.trim().replace('- ', '');
-      console.log('>>>', line, changelogLine);
       changelogLine = changelogLine
         .replace(/\[([^\]]+)]\(([^)]+)\)/g, (...match) => {
           const [, title, ref] = match;
@@ -171,8 +170,6 @@ const miscKeys = [
         }
       });
 
-      break;
-
       if (matched) {
         continue;
       }
@@ -193,7 +190,7 @@ const miscKeys = [
   }
 
   syncChangelog('CHANGELOG.zh-CN.md', 'components-changelog-cn.json');
-  // syncChangelog('CHANGELOG.en-US.md', 'components-changelog-en.json');
+  syncChangelog('CHANGELOG.en-US.md', 'components-changelog-en.json');
   fs.writeFileSync(
     path.join(output, 'misc-changelog.json'),
     JSON.stringify(miscChangelog),

--- a/scripts/post-script.ts
+++ b/scripts/post-script.ts
@@ -46,6 +46,7 @@ const DEPRECIATED_VERSION = {
     'https://github.com/ant-design/ant-design/issues/43684',
   ],
   '5.8.0': ['https://github.com/ant-design/ant-design/issues/43943'],
+  '5.9.1': ['https://github.com/ant-design/ant-design/issues/44907'],
 } as const;
 
 function matchDeprecated(v: string) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #44921


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2507fcd</samp>

This pull request improves the component changelog feature in the documentation. It fixes some TypeScript and CSS issues, enhances the cross-platform compatibility and the content of the changelog, and adds a deprecation notice for the `5.9.1` version. The main files affected are `.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx`, `scripts/generate-component-changelog.ts`, `.dumi/theme/common/styles/Markdown.tsx`, and `scripts/post-script.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2507fcd</samp>

*  Fix the style issue of images in the component changelog page by adding a CSS selector for images that are direct children of links or the markdown container ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-6d4081217418af981e22c0fd474410c584b0d3c238609e557164b0ebd07c9ab4R29-R32))
*  Improve the readability and consistency of the code style in `ComponentChangelog.tsx` by reordering the imports to group the external and internal modules separately, and to follow the alphabetical order within each group ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L3-R9))
*  Fix the TypeScript errors in `ComponentChangelog.tsx` by changing the type of the `nodes` variable to `React.ReactNode[]`, declaring the type of the `node` variable as `React.ReactNode`, asserting the non-null value of the `componentName` variable, and adding the types of the parameters and the return value of the `useChangelog` function, as well as the types of the `data` and `changelogMap` variables and the `info` parameter in the `forEach` callback ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L49-R50), [link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L60-R61), [link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L91-R99), [link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L111-R118), [link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-baac8f9e495ebe8f121c468c0b4576693b0f2998d1c333d48059c5ef385692c1L127-R134))
*  Fix the issue of the `generate-component-changelog.ts` script failing on Windows machines by wrapping the `path.join` method with `path.split` and `path.join` methods, to ensure the consistent use of the path separator ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-efabeeabb5662ac7a23e812608766678484b0d9a56b9225805d3f5b45ab4e43cL11-R14))
*  Improve the readability and relevance of the changelog content by modifying the regular expression replacement logic in the `syncChangelog` function in the `generate-component-changelog.ts` script, to preserve the title of the links that are not pull requests, and to remove the links that start with `#` or `@`, which are usually issue references or user mentions ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-efabeeabb5662ac7a23e812608766678484b0d9a56b9225805d3f5b45ab4e43cL136-R149))
*  Inform the users of the reason and the solution for the deprecation of the `5.9.1` version by updating the `DEPRECIATED_VERSION` object in the `post-script.ts` script with a new entry that contains a link to the issue that explains the deprecation ([link](https://github.com/ant-design/ant-design/pull/44930/files?diff=unified&w=0#diff-f90e598624ba13764610410ae49732147dec4738e55891b356f6162482dc8923R49))
