### PR TITLE
fix: Form hasFeedback should passed to children with noStyle

### DIFF
--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -50,8 +50,12 @@ export default function StatusProvider({
     validateStatus,
   );
 
-  const { isFormItemInput: parentIsFormItemInput, status: parentStatus } =
-    React.useContext(FormItemInputContext);
+  const {
+    isFormItemInput: parentIsFormItemInput,
+    status: parentStatus,
+    hasFeedback: parentHasFeedback,
+    feedbackIcon: parentFeedbackIcon,
+  } = React.useContext(FormItemInputContext);
 
   // ====================== Context =======================
   const formItemStatusContext = React.useMemo<FormItemStatusContextProps>(() => {
@@ -75,23 +79,24 @@ export default function StatusProvider({
         ) : null;
     }
 
-    let isFormItemInput: boolean | undefined = true;
-    let status: ValidateStatus = mergedValidateStatus || '';
-
-    // No style will follow parent context
-    if (noStyle) {
-      isFormItemInput = parentIsFormItemInput;
-      status = (mergedValidateStatus ?? parentStatus) || '';
-    }
-
-    return {
-      status,
+    const context: FormItemStatusContextProps = {
+      status: mergedValidateStatus || '',
       errors,
       warnings,
       hasFeedback: !!hasFeedback,
       feedbackIcon,
-      isFormItemInput,
+      isFormItemInput: true,
     };
+
+    // No style will follow parent context
+    if (noStyle) {
+      context.status = (mergedValidateStatus ?? parentStatus) || '';
+      context.isFormItemInput = parentIsFormItemInput;
+      context.hasFeedback = !!(hasFeedback ?? parentHasFeedback);
+      context.feedbackIcon = hasFeedback !== undefined ? context.feedbackIcon : parentFeedbackIcon;
+    }
+
+    return context;
   }, [mergedValidateStatus, hasFeedback, noStyle, parentIsFormItemInput, parentStatus]);
 
   // ======================= Render =======================

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1418,15 +1418,15 @@ describe('Form', () => {
           </Form.Item>
 
           {/* should follow parent status */}
-          <Form.Item validateStatus="error">
+          <Form.Item validateStatus="error" hasFeedback>
             <Form.Item noStyle>
               <Select className="custom-select-b" />
             </Form.Item>
           </Form.Item>
 
           {/* should follow child status */}
-          <Form.Item validateStatus="error">
-            <Form.Item noStyle validateStatus="warning">
+          <Form.Item validateStatus="error" hasFeedback>
+            <Form.Item noStyle validateStatus="warning" hasFeedback={false}>
               <Select className="custom-select-c" />
             </Form.Item>
           </Form.Item>
@@ -1455,9 +1455,19 @@ describe('Form', () => {
 
       expect(container.querySelector('.custom-select-b')).toHaveClass('ant-select-status-error');
       expect(container.querySelector('.custom-select-b')).toHaveClass('ant-select-in-form-item');
+      expect(
+        container
+          .querySelector('.custom-select-b')
+          ?.querySelector('.ant-form-item-feedback-icon-error'),
+      ).toBeTruthy();
 
       expect(container.querySelector('.custom-select-c')).toHaveClass('ant-select-status-warning');
       expect(container.querySelector('.custom-select-c')).toHaveClass('ant-select-in-form-item');
+      expect(
+        container
+          .querySelector('.custom-select-c')
+          ?.querySelector('.ant-form-item-feedback-icon-warning'),
+      ).toBeFalsy();
 
       expect(container.querySelector('.custom-select-d')).toHaveClass('ant-select-status-warning');
       expect(container.querySelector('.custom-select-d')).toHaveClass('ant-select-in-form-item');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/44932
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix missing inherited feedbackIcon in Form.Item with `noStyle`.        |
| 🇨🇳 Chinese |    修复 Form.Item 有 `noStyle` 属性时没有继承上下文的反馈图标的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 81783d4</samp>

The pull request enhances the form item component by adding more tests for the `hasFeedback` prop and improving the feedback icon inheritance for nested `noStyle` form items. It also refactors the `StatusProvider.tsx` file to simplify the context creation.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 81783d4</samp>

* Add `hasFeedback` prop to parent form item and assert feedback icons in test case for `noStyle` child form item ([link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1421-R1421),[link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1458-R1470))
* Add `hasFeedback` prop to both parent and child form item and assert feedback icons in test case for `noStyle` and `hasFeedback={false}` child form item ([link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1428-R1429),[link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL1458-R1470))
* Refactor context creation and add logic to inherit feedback icon from parent in `StatusProvider.tsx` ([link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-7a124e4feb3ed83faefa4893c82bbddc676dee9ca48913e568d269b4740cefa1L53-R58),[link](https://github.com/ant-design/ant-design/pull/44937/files?diff=unified&w=0#diff-7a124e4feb3ed83faefa4893c82bbddc676dee9ca48913e568d269b4740cefa1L78-R99))
