### PR TITLE
Feat/dropdown support render props

### DIFF
--- a/components/dropdown/demo/render-props-chidren.md
+++ b/components/dropdown/demo/render-props-chidren.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+支持render props做孩子从而可以获取open状态。
+
+## en-US
+
+Support render props as children so that you can obtain the open state.

--- a/components/dropdown/demo/render-props-children.tsx
+++ b/components/dropdown/demo/render-props-children.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { DownOutlined, UpOutlined, SmileOutlined } from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { Dropdown, Space } from 'antd';
+
+const items: MenuProps['items'] = [
+  {
+    key: '1',
+    label: (
+      <a target="_blank" rel="noopener noreferrer" href="https://www.antgroup.com">
+        1st menu item
+      </a>
+    ),
+  },
+  {
+    key: '2',
+    label: (
+      <a target="_blank" rel="noopener noreferrer" href="https://www.aliyun.com">
+        2nd menu item (disabled)
+      </a>
+    ),
+    icon: <SmileOutlined />,
+    disabled: true,
+  },
+  {
+    key: '3',
+    label: (
+      <a target="_blank" rel="noopener noreferrer" href="https://www.luohanacademy.com">
+        3rd menu item (disabled)
+      </a>
+    ),
+    disabled: true,
+  },
+  {
+    key: '4',
+    danger: true,
+    label: 'a danger item',
+  },
+];
+
+const App: React.FC = () => (
+  <Dropdown menu={{ items }}>
+    {(open) => (
+      <a onClick={(e) => e.preventDefault()}>
+        <Space>
+          Hover me
+          {open ? <UpOutlined /> : <DownOutlined />} 
+        </Space>
+      </a>
+    )}
+  </Dropdown>
+);
+
+export default App;

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -62,7 +62,7 @@ export interface DropdownProps {
   mouseEnterDelay?: number;
   mouseLeaveDelay?: number;
   openClassName?: string;
-  children?: React.ReactNode;
+  children?: React.ReactNode | ((open?: boolean) => React.ReactNode);
   autoAdjustOverflow?: boolean | AdjustOverflow;
 
   // Deprecated
@@ -169,7 +169,18 @@ const Dropdown: CompoundedComponent = (props) => {
 
   const [, token] = useToken();
 
-  const child = React.Children.only(children) as React.ReactElement<any>;
+  // =========================== Open ============================
+  const [mergedOpen, setOpen] = useMergedState(false, {
+    value: open ?? visible,
+  });
+
+  const onInnerOpenChange = useEvent((nextOpen: boolean) => {
+    onOpenChange?.(nextOpen);
+    onVisibleChange?.(nextOpen);
+    setOpen(nextOpen);
+  });
+
+  const child = React.Children.only(typeof children === 'function' ? children(mergedOpen) : children) as React.ReactElement<any>;
 
   const dropdownTrigger = cloneElement(child, {
     className: classNames(
@@ -187,17 +198,6 @@ const Dropdown: CompoundedComponent = (props) => {
   if (triggerActions && triggerActions.includes('contextMenu')) {
     alignPoint = true;
   }
-
-  // =========================== Open ============================
-  const [mergedOpen, setOpen] = useMergedState(false, {
-    value: open ?? visible,
-  });
-
-  const onInnerOpenChange = useEvent((nextOpen: boolean) => {
-    onOpenChange?.(nextOpen);
-    onVisibleChange?.(nextOpen);
-    setOpen(nextOpen);
-  });
 
   // =========================== Overlay ============================
   const overlayClassNameCustomized = classNames(overlayClassName, rootClassName, hashId, {

--- a/components/dropdown/index.en-US.md
+++ b/components/dropdown/index.en-US.md
@@ -20,6 +20,7 @@ When there are more than a few options to choose from, you can wrap them in a `D
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/placement.tsx">Placement</code>
 <code src="./demo/arrow.tsx">Arrow</code>
+<code src="./demo/render-props-children.tsx">Render props children</code>
 <code src="./demo/item.tsx">Other elements</code>
 <code src="./demo/arrow-center.tsx">Arrow pointing at the center</code>
 <code src="./demo/trigger.tsx">Trigger mode</code>

--- a/components/dropdown/index.zh-CN.md
+++ b/components/dropdown/index.zh-CN.md
@@ -25,6 +25,7 @@ demo:
 <code src="./demo/placement.tsx">弹出位置</code>
 <code src="./demo/arrow.tsx">箭头</code>
 <code src="./demo/item.tsx">其他元素</code>
+<code src="./demo/render-props-children.tsx">render props做孩子</code>
 <code src="./demo/arrow-center.tsx">箭头指向</code>
 <code src="./demo/trigger.tsx">触发方式</code>
 <code src="./demo/event.tsx">触发事件</code>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

dropdown在不受控的情况下无法获取其open状态，一个常见的需求，dropdown close时现在向下箭头，open时展示向上箭头。
因此我增加了render props children形式，可以方便的获取内部open状态来驱动UI变化。

```tsx
<Dropdown menu={{ items }}>
    {(open) => (
      <a onClick={(e) => e.preventDefault()}>
        <Space>
          Hover me
          {open ? <UpOutlined /> : <DownOutlined />} 
        </Space>
      </a>
    )}
 </Dropdown>
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | support render props as children so that you can obtain the open state |
| 🇨🇳 中文 | 支持render props做孩子从而可以获取open状态 |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1c8bf7</samp>

This pull request adds a new feature to the `Dropdown` component that allows using render props as children to access the open state of the dropdown menu. It includes the type definition, the component logic, and a new demo with documentation in both languages.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1c8bf7</samp>

*  Allow using render props as children for the `Dropdown` component to access the open state of the dropdown menu ([link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL65-R65), [link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL172-R184), [link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL191-L201))
* Add a new demo of the `Dropdown` component that shows how to use render props as children with a custom menu and a link with an icon that changes based on the open state ([link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-41c5bf730ae32f29668064b8bae7408cd807229534023484ccfd393ad580a5e5R1-R54), [link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-78fa345aebf982726cd32f797650d1c2400ea536635e6b24f199a527687b2a56R1-R7))
* Add the new demo to the Examples section of the English documentation of the `Dropdown` component (`components/dropdown/index.en-US.md`, [link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-3e827e07be7d30ca7ca522ea5c430500d8946a62d213cc18cf11bf1c25c1ca97R23))
* Add the new demo to the 代码演示 section of the Chinese documentation of the `Dropdown` component (`components/dropdown/index.zh-CN.md`, [link](https://github.com/ant-design/ant-design/pull/44961/files?diff=unified&w=0#diff-ac765bc110b950888a109547694db780cc37930ca44d894616ec69ae8187b1ebR28))