### PR TITLE
fix: dropdown should not block ref

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -1,11 +1,12 @@
-import type { TriggerProps } from '@rc-component/trigger';
 import React from 'react';
+import type { TriggerProps } from '@rc-component/trigger';
+
 import type { DropDownProps } from '..';
 import Dropdown from '..';
+import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
-import { resetWarned } from '../../_util/warning';
 
 let triggerProps: TriggerProps;
 
@@ -251,5 +252,16 @@ describe('Dropdown', () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it('not block ref', () => {
+    const divRef = React.createRef<HTMLDivElement>();
+    render(
+      <Dropdown open dropdownRender={() => <div ref={divRef} />}>
+        <a />
+      </Dropdown>,
+    );
+
+    expect(divRef.current).toBeTruthy();
   });
 });

--- a/components/menu/OverrideContext.tsx
+++ b/components/menu/OverrideContext.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { supportNodeRef, useComposeRef } from 'rc-util';
+
 import { NoCompactStyle } from '../space/Compact';
 import type { MenuProps } from './menu';
-import { supportNodeRef } from 'rc-util';
 
 // Used for Dropdown only
 export interface OverrideContextProps {
@@ -35,12 +36,13 @@ export const OverrideProvider = React.forwardRef<
     ],
   );
 
+  const canRef = supportNodeRef(children);
+  const mergedRef = useComposeRef(ref, canRef ? (children as any).ref : null);
+
   return (
     <OverrideContext.Provider value={context}>
       <NoCompactStyle>
-        {supportNodeRef(children)
-          ? React.cloneElement(children as React.ReactElement, { ref })
-          : children}
+        {canRef ? React.cloneElement(children as React.ReactElement, { ref: mergedRef }) : children}
       </NoCompactStyle>
     </OverrideContext.Provider>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #44965

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Dropdown can not give `ref` for the root children rendered by `dropdownRender`.        |
| 🇨🇳 Chinese |     修复 Dropdown 通过 `dropdownRender` 渲染的子节点配置 `ref` 不生效的问题。  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3c83da</samp>

Fixed a focus bug in menu items and added a test case for the `dropdownRender` prop. Improved the code quality of `OverrideContext.tsx` by using a custom hook.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3c83da</samp>

*  Fix issue #32890 where `dropdownRender` prop blocks the ref of the custom dropdown element by:
  - Using `useComposeRef` hook to merge multiple refs into one in `OverrideProvider` component ([link](https://github.com/ant-design/ant-design/pull/44971/files?diff=unified&w=0#diff-fab289ecf381929ccfd1ab5e53c7170d3e249910d5774f13f2a76eca26bb6630L2-R5), [link](https://github.com/ant-design/ant-design/pull/44971/files?diff=unified&w=0#diff-fab289ecf381929ccfd1ab5e53c7170d3e249910d5774f13f2a76eca26bb6630L38-R45))
  - Adding a test case to verify the ref is accessible in `dropdownRender` prop ([link](https://github.com/ant-design/ant-design/pull/44971/files?diff=unified&w=0#diff-a5e933ff15a7392fe4b00b0eb3b62fc823173b3ec9c87dda164f0e03488cf738R256-R266))
* Reorder import statements to group type imports together and separate them from default imports in `index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/44971/files?diff=unified&w=0#diff-a5e933ff15a7392fe4b00b0eb3b62fc823173b3ec9c87dda164f0e03488cf738L1-R9))
