### PR TITLE
feat: apply new input component border style

### DIFF
--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -20,9 +20,9 @@ export interface ColorPickerToken extends FullToken<'ColorPicker'> {
   colorPickerPresetColorSize: number;
 }
 
-export const genActiveStyle = (token: ColorPickerToken) => ({
-  boxShadow: `0 0 0 ${token.controlOutlineWidth}px ${token.controlOutline}`,
+export const genActiveStyle = (token: ColorPickerToken, borderColor: string) => ({
   borderInlineEndWidth: token.lineWidth,
+  borderColor,
   outline: 0,
 });
 
@@ -78,40 +78,24 @@ const genClearStyle = (
 };
 
 const genStatusStyle = (token: ColorPickerToken): CSSObject => {
-  const {
-    componentCls,
-    colorError,
-    colorWarning,
-    colorErrorBorderHover,
-    colorWarningBorderHover,
-    colorErrorOutline,
-    colorWarningOutline,
-  } = token;
+  const { componentCls, colorError, colorWarning, colorErrorHover, colorWarningHover } = token;
   return {
     [`&${componentCls}-status-error`]: {
       borderColor: colorError,
       '&:hover': {
-        borderColor: colorErrorBorderHover,
+        borderColor: colorErrorHover,
       },
       [`&${componentCls}-trigger-active`]: {
-        ...genActiveStyle(
-          mergeToken<ColorPickerToken>(token, {
-            controlOutline: colorErrorOutline,
-          }),
-        ),
+        ...genActiveStyle(token, colorError),
       },
     },
     [`&${componentCls}-status-warning`]: {
       borderColor: colorWarning,
       '&:hover': {
-        borderColor: colorWarningBorderHover,
+        borderColor: colorWarningHover,
       },
       [`&${componentCls}-trigger-active`]: {
-        ...genActiveStyle(
-          mergeToken<ColorPickerToken>(token, {
-            controlOutline: colorWarningOutline,
-          }),
-        ),
+        ...genActiveStyle(token, colorWarning),
       },
     },
   };
@@ -178,6 +162,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
     colorBorder,
     paddingXXS,
     fontSize,
+    colorPrimaryHover,
   } = token;
 
   return [
@@ -221,12 +206,11 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
             fontSize,
             color: colorText,
           },
-          '&-active': {
-            ...genActiveStyle(token),
-            borderColor: colorPrimary,
-          },
           '&:hover': {
-            borderColor: colorPrimary,
+            borderColor: colorPrimaryHover,
+          },
+          [`&${componentCls}-trigger-active`]: {
+            ...genActiveStyle(token, colorPrimary),
           },
           '&-disabled': {
             color: colorTextDisabled,

--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -996,14 +996,18 @@ const genPickerStatusStyle: GenerateStyle<PickerToken> = (token) => {
     errorActiveShadow,
     colorWarning,
     warningActiveShadow,
+    colorErrorHover,
+    colorWarningHover,
   } = token;
 
   return {
-    [`${componentCls}:not(${componentCls}-disabled)`]: {
+    [`${componentCls}:not(${componentCls}-disabled):not([disabled])`]: {
       [`&${componentCls}-status-error`]: {
-        '&, &:not([disabled]):hover': {
-          backgroundColor: colorBgContainer,
-          borderColor: colorError,
+        backgroundColor: colorBgContainer,
+        borderColor: colorError,
+
+        '&:hover': {
+          borderColor: colorErrorHover,
         },
 
         [`&${componentCls}-focused, &:focus`]: {
@@ -1021,9 +1025,11 @@ const genPickerStatusStyle: GenerateStyle<PickerToken> = (token) => {
       },
 
       [`&${componentCls}-status-warning`]: {
-        '&, &:not([disabled]):hover': {
-          backgroundColor: colorBgContainer,
-          borderColor: colorWarning,
+        backgroundColor: colorBgContainer,
+        borderColor: colorWarning,
+
+        '&:hover': {
+          borderColor: colorWarningHover,
         },
 
         [`&${componentCls}-focused, &:focus`]: {
@@ -1105,11 +1111,11 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
         borderRadius,
         transition: `border ${motionDurationMid}, box-shadow ${motionDurationMid}`,
 
-        '&:hover, &-focused': {
+        '&:hover': {
           ...genHoverStyle(token),
         },
 
-        '&-focused': {
+        [`&-focused${componentCls}`]: {
           ...genActiveStyle(token),
         },
 

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -1,14 +1,12 @@
-import type { SharedInputToken, SharedComponentToken } from '../../input/style';
+import type { SharedComponentToken, SharedInputToken } from '../../input/style';
 import {
-  initComponentToken,
-  initInputToken,
-  genActiveStyle,
   genBasicInputStyle,
   genDisabledStyle,
-  genHoverStyle,
   genInputGroupStyle,
   genPlaceholderStyle,
   genStatusStyle,
+  initComponentToken,
+  initInputToken,
 } from '../../input/style';
 import { resetComponent, resetIcon } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -151,14 +151,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
           },
         },
 
-        '&:hover': {
-          ...genHoverStyle(token),
-        },
-
-        '&-focused': {
-          ...genActiveStyle(token),
-        },
-
         // ===================== Out Of Range =====================
         '&-out-of-range': {
           [`${componentCls}-input-wrap`]: {
@@ -395,7 +387,6 @@ const genAffixWrapperStyles: GenerateStyle<InputNumberToken> = (token: InputNumb
       },
 
       [`&:not(${componentCls}-affix-wrapper-disabled):hover`]: {
-        ...genHoverStyle(token),
         zIndex: 1,
       },
 

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -1,5 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { clearFix, genFocusOutline, resetComponent } from '../../style';
+import { clearFix, resetComponent } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import type { GlobalToken } from '../../theme/interface';
 import type { FullToken, GenerateStyle } from '../../theme/internal';

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -1,5 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { clearFix, resetComponent } from '../../style';
+import { clearFix, genFocusOutline, resetComponent } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import type { GlobalToken } from '../../theme/interface';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
@@ -121,7 +121,12 @@ export const genDisabledStyle = (token: InputToken): CSSObject => ({
   opacity: 1,
 
   '&:hover': {
-    ...genHoverStyle(mergeToken<InputToken>(token, { hoverBorderColor: token.colorBorder })),
+    ...genHoverStyle(
+      mergeToken<InputToken>(token, {
+        hoverBorderColor: token.colorBorder,
+        hoverBg: token.colorBgContainerDisabled,
+      }),
+    ),
   },
 });
 
@@ -160,7 +165,7 @@ export const genStatusStyle = (token: InputToken, parentCls: string): CSSObject 
         borderColor: colorErrorBorderHover,
       },
 
-      '&:focus, &-focused': {
+      '&:focus, &:focus-within': {
         ...genActiveStyle(
           mergeToken<InputToken>(token, {
             activeBorderColor: colorError,
@@ -180,7 +185,7 @@ export const genStatusStyle = (token: InputToken, parentCls: string): CSSObject 
         borderColor: colorWarningBorderHover,
       },
 
-      '&:focus, &-focused': {
+      '&:focus, &:focus-within': {
         ...genActiveStyle(
           mergeToken<InputToken>(token, {
             activeBorderColor: colorWarning,
@@ -217,7 +222,7 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
     ...genHoverStyle(token),
   },
 
-  '&:focus, &-focused': {
+  '&:focus, &:focus-within': {
     ...genActiveStyle(token),
   },
 
@@ -647,7 +652,6 @@ const genAffixStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       display: 'inline-flex',
 
       [`&:not(${componentCls}-affix-wrapper-disabled):hover`]: {
-        ...genHoverStyle(token),
         zIndex: 1,
         [`${componentCls}-search-with-button &`]: {
           zIndex: 0,
@@ -1034,10 +1038,7 @@ export const initComponentToken = (token: GlobalToken): SharedComponentToken => 
     controlPaddingHorizontal,
     colorFillAlter,
     colorPrimaryHover,
-    controlOutlineWidth,
-    controlOutline,
-    colorErrorOutline,
-    colorWarningOutline,
+    colorPrimary,
   } = token;
 
   return {
@@ -1055,11 +1056,11 @@ export const initComponentToken = (token: GlobalToken): SharedComponentToken => 
     paddingInlineSM: controlPaddingHorizontalSM - lineWidth,
     paddingInlineLG: controlPaddingHorizontal - lineWidth,
     addonBg: colorFillAlter,
-    activeBorderColor: colorPrimaryHover,
+    activeBorderColor: colorPrimary,
     hoverBorderColor: colorPrimaryHover,
-    activeShadow: `0 0 0 ${controlOutlineWidth}px ${controlOutline}`,
-    errorActiveShadow: `0 0 0 ${controlOutlineWidth}px ${colorErrorOutline}`,
-    warningActiveShadow: `0 0 0 ${controlOutlineWidth}px ${colorWarningOutline}`,
+    activeShadow: `none`,
+    errorActiveShadow: `none`,
+    warningActiveShadow: `none`,
     hoverBg: 'transparent',
     activeBg: 'transparent',
   };

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -160,17 +160,16 @@ const genStatusStyle = (
     componentCls: string;
     antCls: string;
     borderHoverColor: string;
-    outlineColor: string;
-    controlOutlineWidth: number;
+    borderActiveColor: string;
   },
   overwriteDefaultBorder: boolean = false,
 ): CSSObject => {
-  const { componentCls, borderHoverColor, outlineColor, antCls } = token;
+  const { componentCls, borderHoverColor, antCls, borderActiveColor } = token;
 
   const overwriteStyle: CSSObject = overwriteDefaultBorder
     ? {
         [`${componentCls}-selector`]: {
-          borderColor: borderHoverColor,
+          borderColor: borderActiveColor,
         },
       }
     : {};
@@ -181,14 +180,13 @@ const genStatusStyle = (
         {
           ...overwriteStyle,
 
-          [`${componentCls}-focused& ${componentCls}-selector`]: {
-            borderColor: borderHoverColor,
-            boxShadow: `0 0 0 ${token.controlOutlineWidth}px ${outlineColor}`,
-            outline: 0,
-          },
-
           [`&:hover ${componentCls}-selector`]: {
             borderColor: borderHoverColor,
+          },
+
+          [`${componentCls}-focused& ${componentCls}-selector`]: {
+            borderColor: borderActiveColor,
+            outline: 0,
           },
         },
     },
@@ -398,14 +396,14 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
       componentCls,
       mergeToken<any>(token, {
         borderHoverColor: token.colorPrimaryHover,
-        outlineColor: token.controlOutline,
+        borderActiveColor: token.colorPrimary,
       }),
     ),
     genStatusStyle(
       `${componentCls}-status-error`,
       mergeToken<any>(token, {
         borderHoverColor: token.colorErrorHover,
-        outlineColor: token.colorErrorOutline,
+        borderActiveColor: token.colorError,
       }),
       true,
     ),
@@ -413,7 +411,7 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
       `${componentCls}-status-warning`,
       mergeToken<any>(token, {
         borderHoverColor: token.colorWarningHover,
-        outlineColor: token.colorWarningOutline,
+        borderActiveColor: token.colorWarning,
       }),
       true,
     ),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/44452
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
更新 Input 等组件的 focus 样式
![Kapture 2023-09-21 at 21 39 00](https://github.com/ant-design/ant-design/assets/27722486/3095ad79-9610-4647-bc92-89f00d13f6db)

- [x] Input/InputNumber/Mentions
- [x] Select/Cascader/TreeSelect
- [x] DatePicker/TimePicker
- [x] ColorPicker
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Optimize active style of Input, InputNumber, Select, Cascader, TreeSelect, DatePicker and ColorPicker.      |
| 🇨🇳 Chinese |  优化 Input、InputNumber、Select、Cascader、TreeSelect、DatePicker、ColorPicker 的激活态样式。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6004780</samp>

This pull request improves the appearance and consistency of the `InputNumber` component and its related components, such as `Input` and `Select`. It simplifies and refactors the style code, fixes some style issues, and uses common functions and variables for the focus outline and the border color.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6004780</samp>

*  Remove hover and focus styles from input number component and affix wrapper to match design spec and input component ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-63d0bbc4ed8cb1745da77de552d75aa0fd581ef3eb2d25d0108b2d55eb5f1857L154-L161), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-63d0bbc4ed8cb1745da77de552d75aa0fd581ef3eb2d25d0108b2d55eb5f1857L398), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL650))
*  Import `genFocusOutline` function to generate focus outline style for input number component ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL2-R2))
*  Use `:focus-within` selector instead of `-focused` class to apply active style to input number component when any child is focused ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL163-R168), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL183-R188), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL220-R225))
*  Add `hoverBg` property to disabled style of input number component to match container background color ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL124-R129))
*  Remove unused variables and outline style from `initComponentToken` function of input number component ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL1037-R1041), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL1058-R1063))
*  Use primary and primary hover colors instead of outline and hover colors for border color of input number component and select component ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L163-R172), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L401-R399), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L408-R406), [link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L416-R414))
*  Swap hover and focus selectors and set outline to 0 for `genStatusStyle` function of input number component and select component ([link](https://github.com/ant-design/ant-design/pull/45009/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L184-R189))
