### PR TITLE
feat: add `fresh` prop for tooltip

### DIFF
--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -93,7 +93,7 @@ Tooltip will cache content when it is closed to avoid flicker when content is up
 <img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*KVx7QLOYwVsAAAAAAAAAAAAADrJ8AQ/original" />
 </div>
 
-If need update content when close, you can set `fresh` property:
+If need update content when close, you can set `fresh` property ([#44830](https://github.com/ant-design/ant-design/issues/44830)):
 
 ```jsx
 <Tooltip open={user} title={user?.name} fresh />

--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -49,6 +49,7 @@ The following APIs are shared by Tooltip, Popconfirm, Popover.
 | color | The background color | string | - | 4.3.0 |
 | defaultOpen | Whether the floating tooltip card is open by default | boolean | false | 4.23.0 |
 | destroyTooltipOnHide | Whether destroy tooltip when hidden | boolean | false |  |
+| fresh | Tooltip will cache content when it is closed by default. Setting this property will always keep updating | boolean | false | 5.10.0 |
 | getPopupContainer | The DOM container of the tip, the default behavior is to create a `div` element in `body` | (triggerNode: HTMLElement) => HTMLElement | () => document.body |  |
 | mouseEnterDelay | Delay in seconds, before tooltip is shown on mouse enter | number | 0.1 |  |
 | mouseLeaveDelay | Delay in seconds, before tooltip is hidden on mouse leave | number | 0.1 |  |

--- a/components/tooltip/index.en-US.md
+++ b/components/tooltip/index.en-US.md
@@ -79,3 +79,26 @@ It will follow `placement` config when screen has enough space. And flip when sp
 <img alt="shift" height="200" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sxaTTJjLtIMAAAAAAAAAAAAADrJ8AQ/original" />
 
 When `placement` is set to edge align such as `topLeft` `bottomRight`, it will only do flip but not do shift.
+
+### Why Tooltip not update content when close?
+
+Tooltip will cache content when it is closed to avoid flicker when content is updated:
+
+```jsx
+// `title` will not blink when `user` is empty
+<Tooltip open={user} title={user?.name} />
+```
+
+<div>
+<img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*KVx7QLOYwVsAAAAAAAAAAAAADrJ8AQ/original" />
+</div>
+
+If need update content when close, you can set `fresh` property:
+
+```jsx
+<Tooltip open={user} title={user?.name} fresh />
+```
+
+<div>
+<img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*rUbsR4xWpMsAAAAAAAAAAAAADrJ8AQ/original" />
+</div>

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -95,7 +95,7 @@ Tooltip 默认在关闭时会缓存内容，以防止内容更新时出现闪烁
 <img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*KVx7QLOYwVsAAAAAAAAAAAAADrJ8AQ/original" />
 </div>
 
-如果需要在关闭时也更新内容，可以设置 `fresh` 属性：
+如果需要在关闭时也更新内容，可以设置 `fresh` 属性（例如 [#44830](https://github.com/ant-design/ant-design/issues/44830) 中的场景）：
 
 ```jsx
 <Tooltip open={user} title={user?.name} fresh />

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -88,11 +88,19 @@ Tooltip 默认在关闭时会缓存内容，以防止内容更新时出现闪烁
 
 ```jsx
 // `title` 不会因为 `user` 置空而闪烁置空
-<Tooltip open={!user} title={user?.name} />
+<Tooltip open={user} title={user?.name} />
 ```
+
+<div>
+<img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*KVx7QLOYwVsAAAAAAAAAAAAADrJ8AQ/original" />
+</div>
 
 如果需要在关闭时也更新内容，可以设置 `fresh` 属性：
 
 ```jsx
-<Tooltip open={!user} title={user?.name} fresh />
+<Tooltip open={user} title={user?.name} fresh />
 ```
+
+<div>
+<img alt="no blink" height="50" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*rUbsR4xWpMsAAAAAAAAAAAAADrJ8AQ/original" />
+</div>

--- a/components/tooltip/index.zh-CN.md
+++ b/components/tooltip/index.zh-CN.md
@@ -51,6 +51,7 @@ demo:
 | color | 背景颜色 | string | - | 4.3.0 |
 | defaultOpen | 默认是否显隐 | boolean | false | 4.23.0 |
 | destroyTooltipOnHide | 关闭后是否销毁 Tooltip | boolean | false |  |
+| fresh | 默认情况下，Tooltip 在关闭时会缓存内容。设置该属性后会始终保持更新 | boolean | false | 5.10.0 |
 | getPopupContainer | 浮层渲染父节点，默认渲染到 body 上 | (triggerNode: HTMLElement) => HTMLElement | () => document.body |  |
 | mouseEnterDelay | 鼠标移入后延时多少才显示 Tooltip，单位：秒 | number | 0.1 |  |
 | mouseLeaveDelay | 鼠标移出后延时多少才隐藏 Tooltip，单位：秒 | number | 0.1 |  |
@@ -80,3 +81,18 @@ demo:
 <img alt="shift" height="200" src="https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sxaTTJjLtIMAAAAAAAAAAAAADrJ8AQ/original" />
 
 当设置为边缘对齐方向如 `topLeft` `bottomRight` 等，则会仅做翻转而不做位移。
+
+### 为何 Tooltip 的内容在关闭时不会更新？
+
+Tooltip 默认在关闭时会缓存内容，以防止内容更新时出现闪烁：
+
+```jsx
+// `title` 不会因为 `user` 置空而闪烁置空
+<Tooltip open={!user} title={user?.name} />
+```
+
+如果需要在关闭时也更新内容，可以设置 `fresh` 属性：
+
+```jsx
+<Tooltip open={!user} title={user?.name} fresh />
+```

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "rc-table": "~7.34.0",
     "rc-tabs": "~12.12.1",
     "rc-textarea": "~1.4.0",
-    "rc-tooltip": "~6.0.1",
+    "rc-tooltip": "~6.1.0",
     "rc-tree": "~5.7.12",
     "rc-tree-select": "~5.13.0",
     "rc-upload": "~4.3.4",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #44830
close #44867

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Tooltip support `fresh` prop to keep content update when closed.       |
| 🇨🇳 Chinese |   Tooltip 添加 `fresh` 属性以支持在关闭时仍然需要更新内容的场景。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cda9a1</samp>

This pull request adds a new feature to the Tooltip component to allow dynamic content updates. It modifies the `components/tooltip/index.en-US.md` and `components/tooltip/index.zh-CN.md` files to document the new `fresh` property, and updates the `rc-tooltip` dependency in the `package.json` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5cda9a1</samp>

* Add a new property `fresh` to the Tooltip component to control whether the content is cached or updated when closed (#33382)
  - Update the dependency version of `rc-tooltip` to `6.1.0` in `package.json` ([link](https://github.com/ant-design/ant-design/pull/45020/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L153-R153))
  - Add the `fresh` property to the common API of the Tooltip component in both English and Chinese documentation (`index.en-US.md` and `index.zh-CN.md`) ([link](https://github.com/ant-design/ant-design/pull/45020/files?diff=unified&w=0#diff-5e2180bb3595a48a443b9845ce81890929e5b99580df55b3905dda6805484876R52), [link](https://github.com/ant-design/ant-design/pull/45020/files?diff=unified&w=0#diff-55ca4dc68bad04b61d30f286605588ea4eb77dea56527d9bfbfbeada5011e4c1R54))
  - Add a new section to explain the placement logic and the behavior of the `fresh` property in both English and Chinese documentation (`index.en-US.md` and `index.zh-CN.md`) ([link](https://github.com/ant-design/ant-design/pull/45020/files?diff=unified&w=0#diff-5e2180bb3595a48a443b9845ce81890929e5b99580df55b3905dda6805484876R82-R104), [link](https://github.com/ant-design/ant-design/pull/45020/files?diff=unified&w=0#diff-55ca4dc68bad04b61d30f286605588ea4eb77dea56527d9bfbfbeada5011e4c1R84-R106))
