### PR TITLE
fix(Button): loading icon appearing when rendering

### DIFF
--- a/components/button/LoadingIcon.tsx
+++ b/components/button/LoadingIcon.tsx
@@ -56,6 +56,7 @@ const LoadingIcon: React.FC<LoadingIconProps> = (props) => {
       visible={visible}
       // We do not really use this motionName
       motionName={`${prefixCls}-loading-icon-motion`}
+      motionLeave={visible}
       removeOnLeave
       onAppearStart={getCollapsedWidth}
       onAppearActive={getRealWidth}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #44379 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the loading icon appearing when rendering |
| 🇨🇳 Chinese | 修复渲染时按钮出现加载图标 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe81152</samp>

Added a feature to support suspense loading for buttons, which shows a loading icon when the button's child is a promise that has not resolved. Added a test case and a prop to control the loading icon animation. Modified `index.test.tsx` and `LoadingIcon.tsx` in `components/button`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe81152</samp>

* Add a prop `motionLeave` to `CSSTransition` in `LoadingIcon.tsx` to control the animation of the loading icon when the button is not loading ([link](https://github.com/ant-design/ant-design/pull/45030/files?diff=unified&w=0#diff-2107ebf32abbf181377ff77c8318c01ab12c098f9276fa74c6d8ea4956f3c33dR59))
* Import `Suspense`, `useRef`, and `useEffect` in `index.test.tsx` to create a test component `Suspender` that simulates a suspenseful child for a button ([link](https://github.com/ant-design/ant-design/pull/45030/files?diff=unified&w=0#diff-276fe24dfac9bfa7de4a29f91e72acd80a99b1034b459bc7b7ebf2db5c47805cL3-R3))
* Add a test case in `index.test.tsx` that renders a component `MyCom` with two buttons, one that toggles the suspension state of the other, and checks the loading icon and fallback content of the suspended button ([link](https://github.com/ant-design/ant-design/pull/45030/files?diff=unified&w=0#diff-276fe24dfac9bfa7de4a29f91e72acd80a99b1034b459bc7b7ebf2db5c47805cR391-R430))
