### PR TITLE
fix🐛(DirectoryTree): fieldNames support

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -44,7 +44,7 @@ function getTreeData({ treeData, children }: DirectoryTreeProps) {
 }
 
 const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> = (
-  { defaultExpandAll, defaultExpandParent, defaultExpandedKeys, ...props },
+  { defaultExpandAll, defaultExpandParent, defaultExpandedKeys, fieldNames, ...props },
   ref,
 ) => {
   // Shift click usage
@@ -137,7 +137,9 @@ const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> 
       newSelectedKeys = keys;
       lastSelectedKey.current = key;
       cachedSelectedKeys.current = newSelectedKeys;
-      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys);
+      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys, {
+        fieldNames,
+      });
     } else if (multiple && shiftPick) {
       // Shift click
       newSelectedKeys = Array.from(
@@ -151,13 +153,17 @@ const DirectoryTree: React.ForwardRefRenderFunction<RcTree, DirectoryTreeProps> 
           }),
         ]),
       );
-      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys);
+      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys, {
+        fieldNames,
+      });
     } else {
       // Single click
       newSelectedKeys = [key];
       lastSelectedKey.current = key;
       cachedSelectedKeys.current = newSelectedKeys;
-      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys);
+      newEvent.selectedNodes = convertDirectoryKeysToNodes(treeData, newSelectedKeys, {
+        fieldNames,
+      });
     }
 
     props.onSelect?.(newSelectedKeys, newEvent);

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -264,4 +264,31 @@ describe('Directory Tree', () => {
     render(createTree({ ref: treeRef }));
     expect('scrollTo' in treeRef.current!).toBeTruthy();
   });
+
+  it('fieldNames support', () => {
+    const treeData = [
+      {
+        id: '0-0-0',
+        title: 'Folder',
+        children: [
+          {
+            title: 'Folder2',
+            id: '0-0-1',
+            children: [
+              {
+                title: 'File',
+                id: '0-0-2',
+                isLeaf: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const onSelect = jest.fn();
+    // @ts-ignore
+    const { container } = render(createTree({ defaultExpandAll: true, treeData, onSelect }));
+    fireEvent.click(container.querySelectorAll('.ant-tree-node-content-wrapper')[0]);
+    expect(onSelect.mock.calls[0][1].selectedNodes.length).toBe(1);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/pull/45035

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fieldNames.key is modified, selectedNodes in onSelect cannot get a value      |
| 🇨🇳 Chinese |    修改fieldNames.key，onSelect方法中的selectedNodes无法获取值       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5852bba</samp>

Added a new feature to the `DirectoryTree` component that allows users to specify custom field names for the `treeData` prop. Updated the utility functions and added a test case to ensure the feature works correctly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5852bba</samp>

*  Add `fieldNames` prop to `DirectoryTree` component to allow customizing the field names of the `treeData` nodes ([link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-abd41216def304abcca63211e726233e8c9e736775dee6d0cd4df926d981ccdfL47-R47))
*  Pass `fieldNames` prop to `convertDirectoryKeysToNodes` function to respect custom field names when selecting nodes in `DirectoryTree` ([link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-abd41216def304abcca63211e726233e8c9e736775dee6d0cd4df926d981ccdfL140-R142), [link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-abd41216def304abcca63211e726233e8c9e736775dee6d0cd4df926d981ccdfL154-R158), [link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-abd41216def304abcca63211e726233e8c9e736775dee6d0cd4df926d981ccdfL160-R166))
*  Modify `traverseNodesKey` and `convertDirectoryKeysToNodes` functions in `components/tree/utils/dictUtil.ts` to accept and use `fieldNames` prop or default values ([link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-da0e832e3ec129967618fc6f25dc3004ee84def0fed079587ecebe1a146741dfL9-R36), [link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-da0e832e3ec129967618fc6f25dc3004ee84def0fed079587ecebe1a146741dfL74-R113))
*  Import `fillFieldNames` function and `TreeProps` type in `components/tree/utils/dictUtil.ts` to fill missing field names and type check `fieldNames` prop ([link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-da0e832e3ec129967618fc6f25dc3004ee84def0fed079587ecebe1a146741dfR2-R3))
*  Add test case to `components/tree/__tests__/directory.test.tsx` to check that `fieldNames` prop works as expected in `DirectoryTree` ([link](https://github.com/ant-design/ant-design/pull/45035/files?diff=unified&w=0#diff-1af094226c29ceaeedf3eaff5f6972884cac3c6f8783315a1ee56c1fda2ff92fR267-R293))
