### PR TITLE
docs: add faq

### DIFF
--- a/components/upload/demo/directory.md
+++ b/components/upload/demo/directory.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-支持上传一个文件夹里的所有文件。
+支持上传一个文件夹里的所有文件。 [Safari 里仍然能选择文件?]('#/%E6%96%87%E4%BB%B6%E5%A4%B9%E4%B8%8A%E4%BC%A0%E5%9C%A8%20Safari%20%E4%BB%8D%E7%84%B6%E5%8F%AF%E4%BB%A5%E9%80%89%E4%B8%AD%E6%96%87%E4%BB%B6')
 
 ## en-US
 
-You can select and upload a whole directory.
+You can select and upload a whole directory. [Can still select files when uploading a folder in Safari?]('#/Can%20still%20select%20files%20when%20uploading%20a%20folder%20in%20Safari')

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -159,3 +159,11 @@ Ref:
 - [#32672](https://github.com/ant-design/ant-design/issues/32672)
 - [#32913](https://github.com/ant-design/ant-design/issues/32913)
 - [#33988](https://github.com/ant-design/ant-design/issues/33988)
+
+### Can still select files when uploading a folder in Safari?
+
+Inside the upload component, we use the "directory" and "webkitdirectory" properties to control only directories can be selected. However, in Safari's implementation it doesn't seem to work. Please try passing an additional "accept" attribute that cannot match any files. For example:
+
+```jsx
+accept: `.${'n'.repeat(100)}`;
+```

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -162,7 +162,7 @@ Ref:
 
 ### Can still select files when uploading a folder in Safari?
 
-Inside the upload component, we use the `directory` and `webkitdirectory` properties to control only directories can be selected. However, in Safari's implementation it doesn't seem to work. Please try passing an additional `accept` attribute that cannot match any files. For example:
+Inside the upload component, we use the `directory` and `webkitdirectory` properties to control only directories can be selected. However, in Safari's implementation it doesn't seem to work. See [here](https://stackoverflow.com/q/55649945/3040605). Please try passing an additional `accept` attribute that cannot match any files. For example:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -162,7 +162,7 @@ Ref:
 
 ### Can still select files when uploading a folder in Safari?
 
-Inside the upload component, we use the "directory" and "webkitdirectory" properties to control only directories can be selected. However, in Safari's implementation it doesn't seem to work. Please try passing an additional "accept" attribute that cannot match any files. For example:
+Inside the upload component, we use the `directory` and `webkitdirectory` properties to control only directories can be selected. However, in Safari's implementation it doesn't seem to work. Please try passing an additional `accept` attribute that cannot match any files. For example:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -162,7 +162,7 @@ demo:
 
 ### 文件夹上传在 Safari 仍然可以选中文件?
 
-组件内部是以 `directory`、`webkitdirectory` 属性控制input来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
+组件内部是以 `directory`、`webkitdirectory` 属性控制 input 来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -162,7 +162,7 @@ demo:
 
 ### 文件夹上传在 Safari 仍然可以选中文件?
 
-组件内部是以 `directory`、`webkitdirectory` 属性控制 input 来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
+组件内部是以 `directory`、`webkitdirectory` 属性控制 input 来实现文件夹选择的, 但似乎在 Safari 的实现中，[并不会阻止用户选择文件](https://stackoverflow.com/q/55649945/3040605)，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -159,3 +159,11 @@ demo:
 - [#32672](https://github.com/ant-design/ant-design/issues/32672)
 - [#32913](https://github.com/ant-design/ant-design/issues/32913)
 - [#33988](https://github.com/ant-design/ant-design/issues/33988)
+
+### 文件夹上传在 Safari 仍然可以选中文件?
+
+组件内部是以 `directory`、`webkitdirectory`属性控制input来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
+
+```jsx
+accept: `.${'n'.repeat(100)}`;
+```

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -162,7 +162,7 @@ demo:
 
 ### 文件夹上传在 Safari 仍然可以选中文件?
 
-组件内部是以 `directory`、`webkitdirectory` 属性控制 input 来实现文件夹选择的, 但似乎在 Safari 的实现中，[并不会阻止用户选择文件](https://stackoverflow.com/q/55649945/3040605)，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
+组件内部是以 `directory`、`webkitdirectory` 属性控制 input 来实现文件夹选择的, 但似乎在 Safari 的实现中，[并不会阻止用户选择文件](https://stackoverflow.com/q/55649945/3040605)，请尝试额外传递无法匹配文件的 `accept` 属性来规避此问题 例如:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -162,7 +162,7 @@ demo:
 
 ### 文件夹上传在 Safari 仍然可以选中文件?
 
-组件内部是以 `directory`、`webkitdirectory`属性控制input来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
+组件内部是以 `directory`、`webkitdirectory` 属性控制input来实现文件夹选择的, 但似乎在 Safari 的实现中，并不会阻止用户选择文件，请尝试额外传递无法匹配文件的 `accept` 属性来归并此问题 例如:
 
 ```jsx
 accept: `.${'n'.repeat(100)}`;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/react-component/upload/pull/516
close https://github.com/ant-design/ant-design/issues/44170
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add FAQ for Upload       |
| 🇨🇳 Chinese |    为Upload添加 FAQ      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9080325</samp>

Add documentation for a workaround for Safari folder upload issue. Update `components/upload/demo/directory.md` and `components/upload/index.en-US.md` and `components/upload/index.zh-CN.md` with a link and a new section that explain how to use an invalid `accept` attribute to prevent file selection.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9080325</samp>

*  Add a workaround for a Safari issue that prevents folder uploading ([link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-37e6dc09605a20a66070f496aefa182a532795cdd00ca3e969145e574663b4d7L3-R7), [link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9R162-R169), [link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390R162-R169))
  - Insert a link to the workaround section in the `directory.md` demo file for both English and Chinese versions ([link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-37e6dc09605a20a66070f496aefa182a532795cdd00ca3e969145e574663b4d7L3-R7))
  - Explain the workaround in the `index.en-US.md` and `index.zh-CN.md` files under the upload component documentation ([link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9R162-R169), [link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390R162-R169))
  - Show an example of using an invalid `accept` attribute to disable file selection when uploading a folder ([link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-e13a415e44a507ae4638ea63983ee4b0b46b7910777a732251275d62e61aa0b9R162-R169), [link](https://github.com/ant-design/ant-design/pull/45050/files?diff=unified&w=0#diff-c9ad8f85ddc3c08c66b3f610bc06e0e1f8839d23a2f298c37edec8dfb18de390R162-R169))
