### PR TITLE
docs: fix site issue

### DIFF
--- a/.dumi/theme/SiteThemeProvider.tsx
+++ b/.dumi/theme/SiteThemeProvider.tsx
@@ -3,6 +3,7 @@ import { theme as antdTheme, ConfigProvider } from 'antd';
 import type { ThemeConfig } from 'antd';
 import type { ThemeProviderProps } from 'antd-style';
 import { ThemeProvider } from 'antd-style';
+import SiteContext from './slots/SiteContext';
 
 interface NewToken {
   bannerHeight: number;
@@ -17,13 +18,17 @@ interface NewToken {
   marginFar: number;
   codeFamily: string;
   contentMarginTop: number;
+  anchorTop: number;
 }
+
+const headerHeight = 64;
+const bannerHeight = 38;
 
 const SiteThemeProvider: React.FC<ThemeProviderProps<any>> = ({ children, theme, ...rest }) => {
   const { getPrefixCls, iconPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const rootPrefixCls = getPrefixCls();
   const { token } = antdTheme.useToken();
-
+  const { bannerVisible } = useContext(SiteContext);
   React.useEffect(() => {
     ConfigProvider.config({ theme: theme as ThemeConfig });
   }, [theme]);
@@ -33,8 +38,8 @@ const SiteThemeProvider: React.FC<ThemeProviderProps<any>> = ({ children, theme,
       {...rest}
       theme={theme}
       customToken={{
-        headerHeight: 64,
-        bannerHeight: 38,
+        headerHeight,
+        bannerHeight,
         menuItemBorder: 2,
         mobileMaxWidth: 767.99,
         siteMarkdownCodeBg: token.colorFillTertiary,
@@ -48,6 +53,7 @@ const SiteThemeProvider: React.FC<ThemeProviderProps<any>> = ({ children, theme,
         marginFar: token.marginXXL * 2,
         codeFamily: `'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace`,
         contentMarginTop: 40,
+        anchorTop: headerHeight + token.margin + (bannerVisible ? bannerHeight : 0),
       }}
     >
       {children}

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -80,13 +80,13 @@ const { Title } = Typography;
 
 const Overview: React.FC = () => {
   const { styles } = useStyle();
-  const { theme, bannerVisible } = useContext(SiteContext);
+  const { theme } = useContext(SiteContext);
 
   const data = useSidebarData();
   const [searchBarAffixed, setSearchBarAffixed] = useState<boolean>(false);
 
   const token = useTheme();
-  const { borderRadius, colorBgContainer, fontSizeXL } = token;
+  const { borderRadius, colorBgContainer, fontSizeXL, anchorTop } = token;
 
   const affixedStyle: CSSProperties = {
     boxShadow: 'rgba(50, 50, 93, 0.25) 0 6px 12px -2px, rgba(0, 0, 0, 0.3) 0 3px 7px -3px',
@@ -143,10 +143,7 @@ const Overview: React.FC = () => {
   return (
     <section className="markdown" ref={sectionRef}>
       <Divider />
-      <Affix
-        offsetTop={24 + token.headerHeight + (bannerVisible ? token.bannerHeight : 0)}
-        onChange={setSearchBarAffixed}
-      >
+      <Affix offsetTop={anchorTop} onChange={setSearchBarAffixed}>
         <div
           className={styles.componentsOverviewAffix}
           style={searchBarAffixed ? affixedStyle : {}}

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -60,7 +60,6 @@ const IconSearch: React.FC = () => {
     theme: ThemeType.Outlined,
   });
   const token = useTheme();
-  const { bannerVisible } = useContext(SiteContext);
 
   const newIconNames: string[] = [];
 
@@ -114,7 +113,7 @@ const IconSearch: React.FC = () => {
   }, [displayState.searchKey, displayState.theme]);
 
   const [searchBarAffixed, setSearchBarAffixed] = useState<boolean>(false);
-  const { borderRadius, colorBgContainer } = token;
+  const { borderRadius, colorBgContainer, anchorTop } = token;
 
   const affixedStyle: CSSProperties = {
     boxShadow: 'rgba(50, 50, 93, 0.25) 0 6px 12px -2px, rgba(0, 0, 0, 0.3) 0 3px 7px -3px',
@@ -126,10 +125,7 @@ const IconSearch: React.FC = () => {
 
   return (
     <div className="markdown">
-      <Affix
-        offsetTop={24 + token.headerHeight + (bannerVisible ? token.bannerHeight : 0)}
-        onChange={setSearchBarAffixed}
-      >
+      <Affix offsetTop={anchorTop} onChange={setSearchBarAffixed}>
         <div className={styles.iconSearchAffix} style={searchBarAffixed ? affixedStyle : {}}>
           <Segmented
             size="large"

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -1,17 +1,16 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
 import type { CSSProperties } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Icon, * as AntdIcons from '@ant-design/icons';
 import type { IntlShape } from 'react-intl';
 import { createStyles, useTheme } from 'antd-style';
 import { useIntl } from 'dumi';
 import debounce from 'lodash/debounce';
-import { Segmented, Input, Empty, Affix } from 'antd';
 import type { SegmentedProps } from 'antd';
+import { Affix, Empty, Input, Segmented } from 'antd';
 import Category from './Category';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 import type { CategoriesKeys } from './fields';
 import { categories } from './fields';
-import SiteContext from '../../slots/SiteContext';
 
 export enum ThemeType {
   Filled = 'Filled',

--- a/.dumi/theme/common/styles/Common.tsx
+++ b/.dumi/theme/common/styles/Common.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTheme } from 'antd-style';
 
 export default () => {
-  const { headerHeight, margin } = useTheme();
+  const { anchorTop } = useTheme();
 
   return (
     <Global
@@ -60,8 +60,8 @@ export default () => {
         border-style: none;
       }
 
-      html {
-        scroll-padding-top: ${headerHeight + margin}px;
+      [id] {
+        scroll-margin-top: ${anchorTop}px;
       }
 
       [data-prefers-color='dark'] {

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -211,7 +211,7 @@ const Content: React.FC<{ children: ReactNode }> = ({ children }) => {
             <Anchor
               className={styles.toc}
               affix={false}
-              targetOffset={token.marginXXL}
+              targetOffset={token.anchorTop}
               showInkInFixed
               items={anchorItems.map((item) => ({
                 href: `#${item.id}`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
1. 修复在搜索框输入时会让页面上滚的问题
2. 修复 toc 定位偏移
<!--
1. Describe the problem and the scenario.
3. GIF or snapshot should be provided if includes UI/interactive modification.
4. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  -         |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5ca173</samp>

This pull request enhances the theme system for the documentation site by introducing a new `anchorTop` property for the theme token, which controls the affix position and offset of various components. It also refactors and simplifies some components and styles that use the theme token. The affected files are `.dumi/theme/builtins/ComponentOverview/index.tsx`, `.dumi/theme/builtins/IconSearch/IconSearch.tsx`, `.dumi/theme/common/styles/Common.tsx`, `.dumi/theme/SiteThemeProvider.tsx`, and `.dumi/theme/slots/Content/index.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5ca173</samp>

*  Add `anchorTop` property to theme token to simplify the offset calculation for anchor links and affix components ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995L20-R31), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995R56))
*  Use `anchorTop` property instead of `headerHeight`, `bannerHeight`, and `margin` properties in `Overview` and `IconSearch` components ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L89-R89), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L146-R146), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-8b799f7fc1319c44839ab462e8211e9e598d446618f5770aac912faebc536077L117-R116), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-8b799f7fc1319c44839ab462e8211e9e598d446618f5770aac912faebc536077L129-R128))
*  Remove unused `bannerVisible` variable from `Overview` and `IconSearch` components ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L83-R83), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-8b799f7fc1319c44839ab462e8211e9e598d446618f5770aac912faebc536077L63))
*  Use `scroll-margin-top` property instead of `scroll-padding-top` property for anchor links in `Common` style component, and remove unused `headerHeight` and `margin` properties from useTheme hook ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-47bec176af3312fe06e411808360623c0f260f173fda373db619c6a4bc4ef5f1L6-R6), [link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-47bec176af3312fe06e411808360623c0f260f173fda373db619c6a4bc4ef5f1L63-R64))
*  Replace `targetOffset` prop for `Anchor` component in `Content` slot component with `anchorTop` property ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-1533ad458dddb5cacbf24062cc5d262ca684a57e2754bf4777f24f37411d5f82L214-R214))
*  Import `SiteContext` component from `slots` folder to access `bannerVisible` variable in `SiteThemeProvider` component ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995R6))
*  Replace hardcoded values for `headerHeight` and `bannerHeight` with constants in `SiteThemeProvider` component ([link](https://github.com/ant-design/ant-design/pull/45063/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995L36-R42))
