### PR TITLE
Checkbox: defaultChecked works incorrectly

### DIFF
--- a/components/button/LoadingIcon.tsx
+++ b/components/button/LoadingIcon.tsx
@@ -37,11 +37,14 @@ const getCollapsedWidth = (): React.CSSProperties => ({
   transform: 'scale(0)',
 });
 
-const getRealWidth = (node: HTMLElement): React.CSSProperties => ({
-  width: node.scrollWidth,
-  opacity: 1,
-  transform: 'scale(1)',
-});
+const getRealWidth = (node: HTMLElement, visible: boolean): React.CSSProperties =>
+  visible
+    ? { width: node.scrollWidth, opacity: 1, transform: 'scale(1)' }
+    : {
+        width: 0,
+        opacity: 0,
+        transform: 'scale(0)',
+    };
 
 const LoadingIcon: React.FC<LoadingIconProps> = (props) => {
   const { prefixCls, loading, existIcon, className, style } = props;
@@ -58,10 +61,10 @@ const LoadingIcon: React.FC<LoadingIconProps> = (props) => {
       motionName={`${prefixCls}-loading-icon-motion`}
       removeOnLeave
       onAppearStart={getCollapsedWidth}
-      onAppearActive={getRealWidth}
+      onAppearActive={(node) => getRealWidth(node, visible)}
       onEnterStart={getCollapsedWidth}
-      onEnterActive={getRealWidth}
-      onLeaveStart={getRealWidth}
+      onEnterActive={(node) => getRealWidth(node, visible)}
+      onLeaveStart={(node) => getRealWidth(node, visible)}
       onLeaveActive={getCollapsedWidth}
     >
       {({ className: motionCls, style: motionStyle }, ref: React.Ref<HTMLSpanElement>) => (

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -119,6 +119,9 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     checkboxProps.name = checkboxGroup.name;
     checkboxProps.checked = checkboxGroup.value.includes(restProps.value);
   }
+  if (restProps.checked === undefined) {
+    delete checkboxProps.checked;
+  }
   const classString = classNames(
     `${prefixCls}-wrapper`,
     {

--- a/components/checkbox/__tests__/checkbox.test.tsx
+++ b/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+
 import Checkbox from '..';
+import { resetWarned } from '../../_util/warning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
-import { resetWarned } from '../../_util/warning';
 
 describe('Checkbox', () => {
   focusTest(Checkbox, { refFocus: true });
@@ -35,5 +36,16 @@ describe('Checkbox', () => {
       'Warning: [antd: Checkbox] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
+  });
+  it('defaultChecked should work if checked is passed as undefined and should be able to change state', () => {
+    resetWarned();
+    const { container } = render(<Checkbox defaultChecked checked={undefined} />);
+    const checkbox = container.getElementsByClassName('ant-checkbox-input')[0];
+
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
   });
 });

--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { List } from 'rc-field-form';
 import type { StoreValue, ValidatorRule } from 'rc-field-form/lib/interface';
+import { getNamePath } from 'rc-field-form/lib/utils/valueUtil';
 
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
-import { FormItemPrefixContext } from './context';
+import { FormContext, FormItemPrefixContext } from './context';
+import { getFieldId } from './util';
 
 export interface FormListFieldData {
   name: number;
@@ -56,22 +58,26 @@ const FormList: React.FC<FormListProps> = ({
     }),
     [prefixCls],
   );
+  const { name: formName } = React.useContext(FormContext);
+  const fieldId = getFieldId(getNamePath(props.name), formName);
 
   return (
-    <List {...props}>
-      {(fields, operation, meta) => (
-        <FormItemPrefixContext.Provider value={contextValue}>
-          {children(
-            fields.map((field) => ({ ...field, fieldKey: field.key })),
-            operation,
-            {
-              errors: meta.errors,
-              warnings: meta.warnings,
-            },
-          )}
-        </FormItemPrefixContext.Provider>
-      )}
-    </List>
+    <div id={fieldId}>
+      <List {...props}>
+        {(fields, operation, meta) => (
+          <FormItemPrefixContext.Provider value={contextValue}>
+            {children(
+              fields.map((field) => ({ ...field, fieldKey: field.key })),
+              operation,
+              {
+                errors: meta.errors,
+                warnings: meta.warnings,
+              },
+            )}
+          </FormItemPrefixContext.Provider>
+        )}
+      </List>
+    </div>
   );
 };
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -346,7 +346,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     action,
     accept,
     supportServerRender,
-    prefixCls,
+    prefixCls: `${prefixCls}-trigger`,
     disabled: mergedDisabled,
     beforeUpload: mergedBeforeUpload,
     onChange: undefined,

--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -119,7 +119,7 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
         cursor: 'pointer',
         transition: `border-color ${token.motionDurationSlow}`,
 
-        [`> ${componentCls}`]: {
+        [`> ${componentCls}-trigger`]: {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
[35130](https://github.com/ant-design/ant-design/issues/35130)

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9040b9</samp>

This pull request updates, fixes, and enhances several components related to the AutoComplete component. It imports some utility functions from `rc-util` and `rc-field-form`, uses the `ConfigConsumer` component, omits and deprecates some props, adds a custom `Input` component, improves the loading icon, fixes a bug with the `defaultChecked` prop in the `Checkbox` component, adds a unique id to the `FormList` component, and resolves a style conflict with the `Select` component by using the `-trigger` suffix for the `Upload` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9040b9</samp>

*  Add and use warning function to show deprecation and usage messages for some props of the AutoComplete component ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL6-R20), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL35-R51), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dR164-R168), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL113-R215), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-670fc06a0ecc91fa35c2a39dfb4995f9a513625e697a23aee8b7445d3ad507baL2-R8), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-670fc06a0ecc91fa35c2a39dfb4995f9a513625e697a23aee8b7445d3ad507baR40-R50))
*  Modify the input element of the AutoComplete component to use a custom Input component that handles ref and onChange logic, and replace the customizeInput prop with the inputElement prop ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dR1-R8), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dR58-R106), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL77-R134), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL113-R215))
*  Fix a bug where the Checkbox component would not use the defaultChecked prop if the checked prop is passed as undefined, and add a test case for it ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R122-R124), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-670fc06a0ecc91fa35c2a39dfb4995f9a513625e697a23aee8b7445d3ad507baR40-R50))
*  Improve the accessibility of the FormList component by adding a unique id for the list based on the name path and the form name, and import the required functions from the rc-field-form and form modules ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-691085a7670f5a2b2ce8f80fba164377389d91d7e42de16b355a652d7538b8daL4-R9), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-691085a7670f5a2b2ce8f80fba164377389d91d7e42de16b355a652d7538b8daL59-R80))
*  Modify the getRealWidth function and the Transition component of the LoadingIcon component to accept and pass a visible prop, which controls the transition of the loading icon when the AutoComplete component is loading or not ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-2107ebf32abbf181377ff77c8318c01ab12c098f9276fa74c6d8ea4956f3c33dL40-R47), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-2107ebf32abbf181377ff77c8318c01ab12c098f9276fa74c6d8ea4956f3c33dL61-R67))
*  Modify the prefixCls prop of the Upload component to append the -trigger suffix, and update the genPictureCardStyle function accordingly, to avoid the style conflict with the Select component when the Upload component is used as the trigger element of the AutoComplete component ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL349-R349), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-f46faf24b775d47e5d87734c12b085fbbf31db15bda33d29b354b1dbc0c549c2L122-R122))
*  Remove the unused SelectProps type, the PurePanel component, and the displayName property from the `components/auto-complete/index.tsx` file ([link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL18), [link](https://github.com/ant-design/ant-design/pull/45074/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL160-R233))
