### PR TITLE
fix: DatePicker and Select should use token `fontFamily` in input element.

### DIFF
--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -1148,6 +1148,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
             background: 'transparent',
             border: 0,
             borderRadius: 0,
+            fontFamily: 'inherit',
 
             '&:focus': {
               boxShadow: 'none',

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -208,6 +208,7 @@ const getSearchInputWithoutBorderStyle: GenerateStyle<SelectToken, CSSObject> = 
       border: 'none',
       outline: 'none',
       appearance: 'none',
+      fontFamily: 'inherit',
 
       '&::-webkit-search-cancel-button': {
         display: 'none',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/45080
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Select and DatePicker that input should use `fontFamily` token.        |
| 🇨🇳 Chinese |  修复 Select 和 DatePicker 组件没有使用 `fontFamily` token 的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd97c74</samp>

This pull request adds the `fontFamily: 'inherit'` property to the style functions of the date picker and select components, to make them use the same font as their parent elements. This improves the accessibility and consistency of the ant design components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd97c74</samp>

*  Ensure that date picker and select components inherit font family from parent element for accessibility and consistency ([link](https://github.com/ant-design/ant-design/pull/45088/files?diff=unified&w=0#diff-a4f33cb3f0dfef43aa860e509b2c43fc62168efd797b258ed2cf47dfc4b1eaa4R1151), [link](https://github.com/ant-design/ant-design/pull/45088/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804R211))
*  Add `fontFamily: 'inherit'` property to `genPickerStyle` function in `components/date-picker/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45088/files?diff=unified&w=0#diff-a4f33cb3f0dfef43aa860e509b2c43fc62168efd797b258ed2cf47dfc4b1eaa4R1151))
*  Add `fontFamily: 'inherit'` property to `getSearchInputWithoutBorderStyle` function in `components/select/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45088/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804R211))
