### PR TITLE
Revert "chore: enable resolvePackageJsonExports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "fetch-jsonp": "^1.1.3",
     "fs-extra": "^11.0.0",
     "gh-pages": "^6.0.0",
-    "glob": "^10.3.7",
+    "glob": "10.3.6",
     "html2sketch": "^1.0.0",
     "http-server": "^14.0.0",
     "husky": "^8.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     },
     "strictNullChecks": true,
     "module": "esnext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",
@@ -22,8 +22,7 @@
     "target": "es6",
     "lib": ["dom", "es2017"],
     "skipLibCheck": true,
-    "stripInternal": true,
-    "resolvePackageJsonExports": true
+    "stripInternal": true
   },
   "include": [".dumirc.ts", "**/*"],
   "exclude": ["node_modules", "lib", "es"]


### PR DESCRIPTION
![image](https://github.com/ant-design/ant-design/assets/10286961/72ac6ce5-2242-4f31-b8fa-72a6e95f751f)

由于 dist 命令依赖于 antd-tools, 而该库目前依赖 Typescript 4.x，esolvePackageJsonExports 和 "moduleResolution": "bundler" 都是5.0 开始支持的。因此先回滚提交，升级 antd-tools 的 Typescript 到 5.0 后 再恢复

Reverts ant-design/ant-design#45085