### PR TITLE
docs: move copy button into code previewer

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -1,11 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import {
-  CheckOutlined,
-  LinkOutlined,
-  SnippetsOutlined,
-  ThunderboltOutlined,
-  UpOutlined,
-} from '@ant-design/icons';
+import { LinkOutlined, ThunderboltOutlined, UpOutlined } from '@ant-design/icons';
 import type { Project } from '@stackblitz/sdk';
 import stackblitzSdk from '@stackblitz/sdk';
 import { Alert, Badge, Space, Tooltip } from 'antd';
@@ -13,7 +7,6 @@ import { createStyles, css } from 'antd-style';
 import classNames from 'classnames';
 import { FormattedMessage, useSiteData } from 'dumi';
 import LZString from 'lz-string';
-import CopyToClipboard from 'react-copy-to-clipboard';
 
 import type { AntdPreviewerProps } from '.';
 import useLocation from '../../../hooks/useLocation';
@@ -125,8 +118,6 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   const riddleIconRef = useRef<HTMLFormElement>(null);
   const codepenIconRef = useRef<HTMLFormElement>(null);
   const [codeExpand, setCodeExpand] = useState<boolean>(false);
-  const [copyTooltipOpen, setCopyTooltipOpen] = useState<boolean>(false);
-  const [copied, setCopied] = useState<boolean>(false);
   const [codeType, setCodeType] = useState<string>('tsx');
   const { theme } = useContext<SiteContextProps>(SiteContext);
 
@@ -145,18 +136,6 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   const handleCodeExpand = (demo: string) => {
     setCodeExpand((prev) => !prev);
     track({ type: 'expand', demo });
-  };
-
-  const handleCodeCopied = (demo: string) => {
-    setCopied(true);
-    track({ type: 'copy', demo });
-  };
-
-  const onCopyTooltipOpenChange = (open: boolean) => {
-    setCopyTooltipOpen(open);
-    if (open) {
-      setCopied(false);
-    }
   };
 
   useEffect(() => {
@@ -483,17 +462,6 @@ createRoot(document.getElementById('container')).render(<Demo />);
               <ThunderboltOutlined className="code-box-stackblitz" />
             </span>
           </Tooltip>
-          <CopyToClipboard text={parsedSourceCode} onCopy={() => handleCodeCopied(asset.id)}>
-            <Tooltip
-              open={copyTooltipOpen as boolean}
-              onOpenChange={onCopyTooltipOpenChange}
-              title={<FormattedMessage id={`app.demo.${copied ? 'copied' : 'copy'}`} />}
-            >
-              {React.createElement(copied && copyTooltipOpen ? CheckOutlined : SnippetsOutlined, {
-                className: 'code-box-code-copy code-box-code-action',
-              })}
-            </Tooltip>
-          </CopyToClipboard>
           <Tooltip title={<FormattedMessage id="app.demo.separate" />}>
             <a
               className="code-box-code-action"
@@ -564,10 +532,10 @@ createRoot(document.getElementById('container')).render(<Demo />);
     if (!style) {
       return;
     }
-    const styleTag = document.createElement('style');
+    const styleTag = document.createElement('style') as HTMLStyleElement;
     styleTag.type = 'text/css';
     styleTag.innerHTML = style;
-    styleTag['data-demo-url'] = demoUrl;
+    (styleTag as any)['data-demo-url'] = demoUrl;
     document.head.appendChild(styleTag);
     return () => {
       document.head.removeChild(styleTag);
@@ -576,7 +544,7 @@ createRoot(document.getElementById('container')).render(<Demo />);
 
   if (version) {
     return (
-      <Badge.Ribbon text={version} color={version.includes('<') ? 'red' : null}>
+      <Badge.Ribbon text={version} color={version.includes('<') ? 'red' : undefined}>
         {codeBox}
       </Badge.Ribbon>
     );

--- a/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
@@ -5,7 +5,7 @@ import { CheckOutlined, SketchOutlined } from '@ant-design/icons';
 import { nodeToGroup } from 'html2sketch';
 import copy from 'copy-to-clipboard';
 import { App } from 'antd';
-import type { AntdPreviewerProps } from '.';
+import type { AntdPreviewerProps } from './Previewer';
 
 const useStyle = createStyles(({ token, css }) => ({
   wrapper: css`

--- a/.dumi/theme/common/CodePreview.tsx
+++ b/.dumi/theme/common/CodePreview.tsx
@@ -1,8 +1,43 @@
 import React, { useEffect, useMemo } from 'react';
-import { Tabs } from 'antd';
+import { Tabs, Typography, Button } from 'antd';
 import toReactElement from 'jsonml-to-react-element';
 import JsonML from 'jsonml.js/lib/utils';
 import Prism from 'prismjs';
+import { createStyles } from 'antd-style';
+
+const useStyle = createStyles(({ token, css }) => {
+  const { colorIcon, colorBgTextHover, antCls } = token;
+
+  return {
+    code: css`
+      position: relative;
+    `,
+
+    copyButton: css`
+      color: ${colorIcon};
+      position: absolute;
+      top: 0;
+      inset-inline-end: 16px;
+      width: 32px;
+      text-align: center;
+      background: ${colorBgTextHover};
+      padding: 0;
+    `,
+
+    copyIcon: css`
+      ${antCls}-typography-copy {
+        margin-inline-start: 0;
+      }
+      ${antCls}-typography-copy:not(${antCls}-typography-copy-success) {
+        color: ${colorIcon};
+
+        &:hover {
+          color: ${colorIcon};
+        }
+      }
+    `,
+  };
+});
 
 const LANGS = {
   tsx: 'TypeScript',
@@ -40,7 +75,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({
   onCodeTypeChange,
 }) => {
   // 避免 Tabs 数量不稳定的闪动问题
-  const initialCodes = {};
+  const initialCodes = {} as Record<'tsx' | 'jsx' | 'style', string>;
   if (sourceCode) {
     initialCodes.tsx = '';
   }
@@ -51,7 +86,11 @@ const CodePreview: React.FC<CodePreviewProps> = ({
     initialCodes.style = '';
   }
   const [highlightedCodes, setHighlightedCodes] = React.useState(initialCodes);
-
+  const sourceCodes = {
+    tsx: sourceCode,
+    jsx: jsxCode,
+    style: styleCode,
+  } as Record<'tsx' | 'jsx' | 'style', string>;
   useEffect(() => {
     const codes = {
       tsx: Prism.highlight(sourceCode, Prism.languages.javascript, 'jsx'),
@@ -59,7 +98,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({
       style: Prism.highlight(styleCode, Prism.languages.css, 'css'),
     };
     // 去掉空的代码类型
-    Object.keys(codes).forEach((key) => {
+    Object.keys(codes).forEach((key: keyof typeof codes) => {
       if (!codes[key]) {
         delete codes[key];
       }
@@ -68,12 +107,22 @@ const CodePreview: React.FC<CodePreviewProps> = ({
   }, [jsxCode, sourceCode, styleCode]);
 
   const langList = Object.keys(highlightedCodes);
+
+  const { styles } = useStyle();
+
   const items = useMemo(
     () =>
-      langList.map((lang) => ({
+      langList.map((lang: keyof typeof LANGS) => ({
         label: LANGS[lang],
         key: lang,
-        children: toReactComponent(['pre', { lang, highlighted: highlightedCodes[lang] }]),
+        children: (
+          <div className={styles.code}>
+            {toReactComponent(['pre', { lang, highlighted: highlightedCodes[lang] }])}
+            <Button type="text" className={styles.copyButton}>
+              <Typography.Text className={styles.copyIcon} copyable={{ text: sourceCodes[lang] }} />
+            </Button>
+          </div>
+        ),
       })),
     [JSON.stringify(highlightedCodes)],
   );
@@ -85,7 +134,11 @@ const CodePreview: React.FC<CodePreviewProps> = ({
   if (langList.length === 1) {
     return toReactComponent([
       'pre',
-      { lang: langList[0], highlighted: highlightedCodes[langList[0]], className: 'highlight' },
+      {
+        lang: langList[0],
+        highlighted: highlightedCodes[langList[0] as keyof typeof LANGS],
+        className: 'highlight',
+      },
     ]);
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
把代码复制按钮从工具条挪走，放到代码块里去。

<img width="607" alt="截屏2023-09-26 下午4 03 06" src="https://github.com/ant-design/ant-design/assets/507615/17527b77-4662-4a85-9ba7-b787a78d1cc9">

<img width="666" alt="截屏2023-09-26 下午4 03 10" src="https://github.com/ant-design/ant-design/assets/507615/bb2b9f3e-29f3-4dc5-be9f-28aa06bedb8f">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       --    |
| 🇨🇳 Chinese |      --     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95462c7</samp>

Refactored and improved the code previewer components for the documentation theme. Removed unused code, fixed TypeScript and CSS issues, and added copy functionality for different languages. Fixed a circular dependency issue in the design previewer component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95462c7</samp>

*  Remove unused imports and state variables, and replace `CopyToClipboard` and `Tooltip` components with `Typography.Text` component with `copyable` prop for code box in `CodePreviewer.tsx` ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL2-R2), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL16), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL128-L129), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL150-L161), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL486-L496))
*  Add type assertions and bracket notation to avoid TypeScript errors and use `undefined` instead of `null` for `color` prop of `Badge.Ribbon` component in `CodePreviewer.tsx` ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL567-R538), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-54c90701ed595205ea2cd4286b1cd0ee8b2f01f77a23088e0108feda7af2d65fL579-R547))
*  Change import path of `AntdPreviewerProps` type to fix circular dependency issue in `DesignPreviewer.tsx` ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-6cde915d5c0b04ad09169e4b5c2a35a68622af857002fe066582fd0f68913467L8-R8))
*  Move `CodePreview.tsx` to `CodePreviewer.tsx` and add imports and `useStyle` hook for new copy functionality and styling ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL2-R41))
*  Add type annotations to `initialCodes`, `sourceCodes`, and callback functions to avoid TypeScript errors in `CodePreviewer.tsx` ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL43-R78), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL54-R93), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL62-R101), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL71-R125), [link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL88-R141))
*  Apply custom CSS classes to code box and copy button and use `Button` and `Typography.Text` components in `CodePreviewer.tsx` ([link](https://github.com/ant-design/ant-design/pull/45099/files?diff=unified&w=0#diff-086f3227db976462d986107d6240e5fa7cba6d817b889ff580ea55b386950a9dL71-R125))
