### PR TITLE
fix: Button two Chinese chars

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -162,6 +162,20 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx extend context
     class="ant-space-item"
   >
     <button
+      class="ant-btn ant-btn-default ant-btn-two-chinese-chars"
+      type="button"
+    >
+      <span>
+        <span>
+          部署
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
       class="ant-btn ant-btn-default ant-btn-loading"
       type="button"
     >

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -158,6 +158,20 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx correctly 1`] 
     class="ant-space-item"
   >
     <button
+      class="ant-btn ant-btn-default"
+      type="button"
+    >
+      <span>
+        <span>
+          部署
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
       class="ant-btn ant-btn-default ant-btn-loading"
       type="button"
     >

--- a/components/button/demo/chinese-chars-loading.tsx
+++ b/components/button/demo/chinese-chars-loading.tsx
@@ -9,6 +9,11 @@ const Text3 = () => 'Submit';
 
 const App: React.FC = () => (
   <Space wrap>
+    <Button>
+      <span>
+        <span>部署</span>
+      </span>
+    </Button>
     <Button loading>部署</Button>
     <Button loading>
       <Text1 />

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -195,6 +195,15 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
         ...genFocusStyle(token),
       },
 
+      [`&${componentCls}-two-chinese-chars::first-letter`]: {
+        letterSpacing: '0.34em',
+      },
+
+      [`&${componentCls}-two-chinese-chars > *:not(${iconCls})`]: {
+        marginInlineEnd: '-0.34em',
+        letterSpacing: '0.34em',
+      },
+
       // make `btn-icon-only` not too narrow
       [`&-icon-only${componentCls}-compact-item`]: {
         flex: 'none',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Button that two Chinese characters in nested span should have space between.        |
| 🇨🇳 Chinese |       修复 Button 组件只有两个汉字且嵌套在多层 span 中时间距丢失的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4997816</samp>

This pull request enhances the button component to support two Chinese characters as its content. It adds a new demo file `components/button/demo/chinese-chars-loading.tsx` and updates the style file `components/button/style/index.ts` to adjust the spacing and letter spacing of the buttons.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4997816</samp>

* Add a button with two Chinese characters to the demo file `components/button/demo/chinese-chars-loading.tsx` ([link](https://github.com/ant-design/ant-design/pull/45126/files?diff=unified&w=0#diff-5450319d87c9812b1e385b104ed7b5a612fdf4aaaf359b69480c9857b0738701R12-R16))
* Adjust the spacing and letter spacing of buttons with two Chinese characters in the style file `components/button/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45126/files?diff=unified&w=0#diff-e8f947f22fc66308c74c500faf1cfeab5e8eed33d2ab4a27718770da99224693R198-R206))
