### PR TITLE
fix: CheckableTag support ref (#45070)

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -19,7 +19,7 @@ export interface CheckableTagProps {
   onClick?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
 }
 
-const CheckableTag: React.FC<CheckableTagProps> = (props) => {
+const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     style,
@@ -54,6 +54,7 @@ const CheckableTag: React.FC<CheckableTagProps> = (props) => {
   return wrapSSR(
     <span
       {...restProps}
+      ref={ref}
       style={{
         ...style,
         ...tag?.style,
@@ -62,6 +63,6 @@ const CheckableTag: React.FC<CheckableTagProps> = (props) => {
       onClick={handleClick}
     />,
   );
-};
+});
 
 export default CheckableTag;

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -197,6 +197,21 @@ describe('Tag', () => {
       fireEvent.click(container.querySelectorAll('.ant-tag')[0]);
       expect(onChange).toHaveBeenCalledWith(true);
     });
+
+    it('should support ref', () => {
+      const ref: React.RefObject<HTMLSpanElement> = React.createRef();
+      const { container } = render(
+        <Tag.CheckableTag checked={false} ref={ref}>
+          Tag Text
+        </Tag.CheckableTag>,
+      );
+      const refElement = ref.current;
+      const queryTarget = container.querySelector('.ant-tag');
+      expect(refElement instanceof HTMLSpanElement).toBe(true);
+      expect(refElement?.textContent).toBe('Tag Text');
+      expect(queryTarget?.textContent).toBe('Tag Text');
+      expect(refElement).toBe(queryTarget);
+    });
   });
   it('should onClick is undefined', async () => {
     const { container } = render(<Tag onClick={undefined} />);

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -199,7 +199,7 @@ describe('Tag', () => {
     });
 
     it('should support ref', () => {
-      const ref: React.RefObject<HTMLSpanElement> = React.createRef();
+      const ref = React.createRef<HTMLSpanElement>();
       const { container } = render(
         <Tag.CheckableTag checked={false} ref={ref}>
           Tag Text


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #45070 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | CheckableTag support ref          |
| 🇨🇳 Chinese | 可选择标签支持 ref          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 571afce</samp>

Added ref forwarding support for `CheckableTag` component and a corresponding test case. This allows users to access the underlying span element of the component for custom manipulation or styling.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 571afce</samp>

*  Enable ref forwarding for `CheckableTag` component ([link](https://github.com/ant-design/ant-design/pull/45164/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0L22-R22), [link](https://github.com/ant-design/ant-design/pull/45164/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0R57), [link](https://github.com/ant-design/ant-design/pull/45164/files?diff=unified&w=0#diff-11fcbee115f601b0b18aae3e932bf8a10521335fd1ab09b2901b50a3658af6f0L65-R66), [link](https://github.com/ant-design/ant-design/pull/45164/files?diff=unified&w=0#diff-4a596c2a8e41eb2e15662e8af034f98ded8f58894c1235b873918dbe0d8622e3R200-R214))
