### PR TITLE
fix(FormItem):As a subcomponent of FormItem, the 'aria-label' prop of t…

### DIFF
--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -255,7 +255,10 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   }
 
   if (!hasName && !isRenderProps && !dependencies) {
-    return wrapSSR(renderLayout(mergedChildren) as JSX.Element);
+    const element = label
+      ? cloneElement(mergedChildren, { ...mergedChildren.props, 'aria-label': label })
+      : mergedChildren;
+    return wrapSSR(renderLayout(element) as JSX.Element);
   }
 
   let variables: Record<string, string> = {};
@@ -365,6 +368,10 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
             childProps['aria-required'] = 'true';
           }
 
+          if (label) {
+            childProps['aria-label'] = label;
+          }
+
           if (supportRef(mergedChildren)) {
             childProps.ref = getItemRef(mergedName, mergedChildren);
           }
@@ -387,6 +394,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
             childProps['aria-required'],
             childProps['aria-invalid'],
             childProps['aria-describedby'],
+            childProps['aria-label'],
           ];
 
           childNode = (

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -255,9 +255,10 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   }
 
   if (!hasName && !isRenderProps && !dependencies) {
-    const element = label
-      ? cloneElement(mergedChildren, { ...mergedChildren.props, 'aria-label': label })
-      : mergedChildren;
+    const element =
+      label && isValidElement(mergedChildren)
+        ? cloneElement(mergedChildren, { ...mergedChildren.props, 'aria-label': label })
+        : mergedChildren;
     return wrapSSR(renderLayout(element) as JSX.Element);
   }
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -353,6 +353,28 @@ describe('Form', () => {
     expect(container.querySelector('input')?.getAttribute('aria-required')).toBe('true');
   });
 
+  it('input element should have the prop aria-label is `Search` when prop `label` doesn`t exist', () => {
+    const { container } = render(
+      <Form>
+        <Form.Item name="test name">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    expect(container.querySelector('input')?.getAttribute('aria-label')).toBe('Search');
+  });
+
+  it('input element should have the prop aria-label is same as prop `label` when it exists', () => {
+    const { container } = render(
+      <Form>
+        <Form.Item name="test name" label="test label">
+          <input />
+        </Form.Item>
+      </Form>,
+    );
+    expect(container.querySelector('input')?.getAttribute('aria-label')).toBe('test label');
+  });
+
   it('input element should have the prop aria-describedby pointing to the extra id when there is a extra message', () => {
     const { container } = render(
       <Form>

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -357,7 +357,7 @@ describe('Form', () => {
     const { container } = render(
       <Form>
         <Form.Item name="test name">
-          <input />
+          <Select />
         </Form.Item>
       </Form>,
     );
@@ -368,7 +368,7 @@ describe('Form', () => {
     const { container } = render(
       <Form>
         <Form.Item name="test name" label="test label">
-          <input />
+          <Select />
         </Form.Item>
       </Form>,
     );


### PR DESCRIPTION
…he Select component should correspond to the label prop of the FormItem.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #45168
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix(FormItem):As a subcomponent of FormItem, the aria-label prop of the Select component should correspond to the label prop of the FormItem.     |
| 🇨🇳 Chinese |     修复FormItem的bug，Select作为FormItem的子组件，其aria-label属性应该对应于FormItem的label属性。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary
Generated by Copilot at 692f638480362eb00306c085e444af1e464c057f
Assign the label prop of the FormItem to the aria-label prop of the child component.

### 🔍 Walkthrough
Assign the label prop of the FormItem to the aria-label prop of the child component.
To override `Select` default aria-label values.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 692f638</samp>

*  Add `aria-label` attribute to the child element of `Form.Item` component to improve accessibility ([link](https://github.com/ant-design/ant-design/pull/45172/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL258-R261), [link](https://github.com/ant-design/ant-design/pull/45172/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR371-R374), [link](https://github.com/ant-design/ant-design/pull/45172/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR397))
*  Add test cases for `aria-label` attribute on `Form.Item` child element in `components/form/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/45172/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR356-R377))
