### PR TITLE
fix(Autocomplete): internal input cannot apply fontFamily

### DIFF
--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -19,7 +19,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
 
       // ========================= Selector =========================
       [`${componentCls}-selector`]: {
-        ...resetComponent(token),
+        ...resetComponent(token, true),
 
         display: 'flex',
         borderRadius,

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -11,7 +11,10 @@ export const textEllipsis: CSSObject = {
   textOverflow: 'ellipsis',
 };
 
-export const resetComponent = (token: DerivativeToken): CSSObject => ({
+export const resetComponent = (
+  token: DerivativeToken,
+  needInheritFontFamily = false,
+): CSSObject => ({
   boxSizing: 'border-box',
   margin: 0,
   padding: 0,
@@ -21,7 +24,7 @@ export const resetComponent = (token: DerivativeToken): CSSObject => ({
   lineHeight: token.lineHeight,
   listStyle: 'none',
   // font-feature-settings: @font-feature-settings-base;
-  fontFamily: token.fontFamily,
+  fontFamily: needInheritFontFamily ? 'inherit' : token.fontFamily,
 });
 
 export const resetIcon = (): CSSObject => ({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/45028

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Autocomplete internal input cannot apply fontFamily         |
| 🇨🇳 Chinese | 修复  Autocomplete 内部 input 无法应用  fontFamily        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df625e2</samp>

Fixed a bug where select component did not inherit font family in some scenarios. Refactored `resetComponent` function and moved it to `components/style/index.ts` for better code organization and reuse.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df625e2</samp>

*  Move `resetComponent` function from `components/style/index.ts` to `components/select/style/single.tsx` to avoid unnecessary imports and style conflicts ([link](https://github.com/ant-design/ant-design/pull/45197/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL14-R17))
*  Add `needInheritFontFamily` argument to `resetComponent` function to control font family inheritance for select component ([link](https://github.com/ant-design/ant-design/pull/45197/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L22-R22), [link](https://github.com/ant-design/ant-design/pull/45197/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL24-R27))
