### PR TITLE
chore: merge master into feature

### DIFF
--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -319,7 +319,9 @@ export default function Theme() {
   const [themeData, setThemeData] = React.useState<ThemeData>(ThemeDefault);
 
   const onThemeChange = (_: Partial<ThemeData>, nextThemeData: ThemeData) => {
-    setThemeData({ ...ThemesInfo[nextThemeData.themeType], ...nextThemeData });
+    React.startTransition(() => {
+      setThemeData({ ...ThemesInfo[nextThemeData.themeType], ...nextThemeData });
+    });
   };
 
   const { compact, themeType, colorPrimary, ...themeToken } = themeData;

--- a/.dumi/theme/SiteThemeProvider.tsx
+++ b/.dumi/theme/SiteThemeProvider.tsx
@@ -21,6 +21,12 @@ interface NewToken {
   anchorTop: number;
 }
 
+// 通过给 antd-style 扩展 CustomToken 对象类型定义，可以为 useTheme 中增加相应的 token 对象
+declare module 'antd-style' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface CustomToken extends NewToken {}
+}
+
 const headerHeight = 64;
 const bannerHeight = 38;
 

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -3,7 +3,8 @@ import type { CSSProperties } from 'react';
 import { SearchOutlined } from '@ant-design/icons';
 import { Affix, Card, Col, Divider, Input, Row, Space, Tag, Typography } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
-import { Link, useIntl, useLocation, useSidebarData } from 'dumi';
+import { useIntl, useLocation, useSidebarData } from 'dumi';
+import Link from '../../common/Link';
 import debounce from 'lodash/debounce';
 
 import SiteContext from '../../slots/SiteContext';
@@ -102,7 +103,7 @@ const Overview: React.FC = () => {
   const [search, setSearch] = useState<string>(() => {
     const params = new URLSearchParams(urlSearch);
     if (params.has('s')) {
-      return params.get('s');
+      return params.get('s') || '';
     }
     return '';
   });
@@ -120,12 +121,12 @@ const Overview: React.FC = () => {
       data
         .filter((item) => item?.title)
         .map<{ title: string; children: Component[] }>((item) => ({
-          title: item?.title,
+          title: item?.title || '',
           children: item.children.map((child) => ({
-            title: child.frontmatter?.title,
-            subtitle: child.frontmatter.subtitle,
-            cover: child.frontmatter.cover,
-            coverDark: child.frontmatter.coverDark,
+            title: child.frontmatter?.title || '',
+            subtitle: child.frontmatter?.subtitle,
+            cover: child.frontmatter?.cover,
+            coverDark: child.frontmatter?.coverDark,
             link: child.link,
           })),
         }))
@@ -143,7 +144,7 @@ const Overview: React.FC = () => {
   return (
     <section className="markdown" ref={sectionRef}>
       <Divider />
-      <Affix offsetTop={anchorTop} onChange={setSearchBarAffixed}>
+      <Affix offsetTop={anchorTop} onChange={(affixed) => setSearchBarAffixed(!!affixed)}>
         <div
           className={styles.componentsOverviewAffix}
           style={searchBarAffixed ? affixedStyle : {}}
@@ -193,13 +194,11 @@ const Overview: React.FC = () => {
                       url += urlSearch;
                     }
 
-                    /** Link 不能跳转到外链 */
-                    const ComponentLink = isExternalLink ? 'a' : Link;
-
                     return (
                       <Col xs={24} sm={12} lg={8} xl={6} key={component?.title}>
-                        <ComponentLink to={url} href={url} onClick={() => onClickCard(url)}>
+                        <Link to={url}>
                           <Card
+                            onClick={() => onClickCard(url)}
                             bodyStyle={{
                               backgroundRepeat: 'no-repeat',
                               backgroundPosition: 'bottom right',
@@ -224,7 +223,7 @@ const Overview: React.FC = () => {
                               />
                             </div>
                           </Card>
-                        </ComponentLink>
+                        </Link>
                       </Col>
                     );
                   })}

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -158,7 +158,7 @@ const Overview: React.FC = () => {
             onChange={(e) => {
               setSearch(e.target.value);
               reportSearch(e.target.value);
-              if (sectionRef.current) {
+              if (sectionRef.current && searchBarAffixed) {
                 scrollIntoView(sectionRef.current, {
                   scrollMode: 'if-needed',
                   block: 'start',

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -4,9 +4,10 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Affix, Card, Col, Divider, Input, Row, Space, Tag, Typography } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { useIntl, useLocation, useSidebarData } from 'dumi';
-import Link from '../../common/Link';
 import debounce from 'lodash/debounce';
+import scrollIntoView from 'scroll-into-view-if-needed';
 
+import Link from '../../common/Link';
 import SiteContext from '../../slots/SiteContext';
 import type { Component } from './ProComponentsList';
 import proComponentsList from './ProComponentsList';
@@ -157,6 +158,16 @@ const Overview: React.FC = () => {
             onChange={(e) => {
               setSearch(e.target.value);
               reportSearch(e.target.value);
+              if (sectionRef.current) {
+                scrollIntoView(sectionRef.current, {
+                  scrollMode: 'if-needed',
+                  block: 'start',
+                  behavior: (actions) =>
+                    actions.forEach(({ el, top }) => {
+                      el.scrollTop = top - 64;
+                    }),
+                });
+              }
             }}
             onKeyDown={onKeyDown}
             bordered={false}

--- a/.dumi/theme/common/Link.tsx
+++ b/.dumi/theme/common/Link.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react';
+import type { MouseEvent, MouseEventHandler } from 'react';
 import React, { forwardRef, useLayoutEffect, useMemo, useTransition } from 'react';
 import { useLocation, useNavigate } from 'dumi';
 import nprogress from 'nprogress';
@@ -8,6 +8,7 @@ export interface LinkProps {
   children?: React.ReactNode;
   style?: React.CSSProperties;
   className?: string;
+  onClick?: MouseEventHandler;
 }
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
@@ -24,6 +25,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   }, [to]);
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    props.onClick?.(e);
     if (!href?.startsWith('http')) {
       // Should support open in new tab
       if (!e.metaKey && !e.ctrlKey && !e.shiftKey) {
@@ -46,7 +48,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   }, [isPending]);
 
   return (
-    <a ref={ref} href={href} onClick={handleClick} {...rest}>
+    <a ref={ref} onClick={handleClick} {...rest} href={href}>
       {children}
     </a>
   );

--- a/.dumi/theme/common/styles/Markdown.tsx
+++ b/.dumi/theme/common/styles/Markdown.tsx
@@ -38,7 +38,6 @@ const GlobalStyle: React.FC = () => {
           margin: 34px auto;
           box-shadow: 0 8px 20px rgba(143, 168, 191, 0.35);
           max-width: 1024px;
-          width: 100%;
           display: block;
         }
 

--- a/.github/workflows/verify-files-modify.yml
+++ b/.github/workflows/verify-files-modify.yml
@@ -26,3 +26,21 @@ jobs:
             Hi @${{ github.event.pull_request.user.login }}. Thanks for your contribution. The path `.github/` or `scripts/` and `CHANGELOG` is only maintained by team members. This current PR will be closed and team members will help on this.
           close: true
           set-failed: false
+
+  readme:
+    permissions:
+      pull-requests: write  # for actions-cool/verify-files-modify to update status of PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: verify-version
+        uses: actions-cool/verify-files-modify@v1
+        with:
+          forbid-files: 'README.md'
+          skip-verify-authority: 'write'
+          skip-label: 'skip-verify-files'
+          assignees: 'afc163, zombieJ, xrkffgg, MadCcc'
+          comment-mark: 'readmeCheck'
+          comment: |
+            Hi @${{ github.event.pull_request.user.login }}. Thanks for your contribution. But, we don't have plan to add README of more languages. This current PR will be closed and team members will help on this.
+          close: true
+          set-failed: false

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -99,7 +99,6 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
       [`${prefixCls}-in-form-item`]: isFormItemInput,
     },
     getStatusClassNames(prefixCls, mergedStatus),
-    compactItemClassnames,
     hashId,
   );
   const wrapperClassName = `${prefixCls}-group`;
@@ -108,7 +107,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     <RcInputNumber
       ref={inputRef}
       disabled={mergedDisabled}
-      className={classNames(className, rootClassName)}
+      className={classNames(className, rootClassName, compactItemClassnames)}
       upHandler={upIcon}
       downHandler={downIcon}
       prefixCls={prefixCls}

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -319,7 +319,7 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
         fontWeight: 'normal',
         fontSize: token.fontSize,
         textAlign: 'center',
-        backgroundColor: token.colorFillAlter,
+        backgroundColor: token.addonBg,
         border: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
         borderRadius: token.borderRadius,
         transition: `all ${token.motionDurationSlow}`,

--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4136,7 +4136,11 @@ Array [
             <span
               class="ant-menu-title-content"
             >
-              Option 3
+              <span
+                class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team
+              </span>
             </span>
           </li>
           <div
@@ -4300,7 +4304,11 @@ Array [
           <span
             class="ant-menu-title-content"
           >
-            Option 3
+            <span
+              class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
+            >
+              Ant Design, a design language for background applications, is refined by Ant UED Team
+            </span>
           </span>
         </li>
         <div

--- a/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1466,7 +1466,28 @@ Array [
           <span
             class="ant-menu-title-content"
           >
-            Option 3
+            <span
+              aria-label="Ant Design, a design language for background applications, is refined by Ant UED Team"
+              class="ant-typography ant-typography-ellipsis ant-typography-single-line"
+            >
+              Ant Design, a design language for background applications, is refined by Ant UED Team
+              <span
+                aria-hidden="true"
+                style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;word-break:keep-all;white-space:nowrap"
+              >
+                lg
+              </span>
+              <span
+                aria-hidden="true"
+                style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;width:0;white-space:normal;margin:0;padding:0"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  ...
+                </span>
+              </span>
+            </span>
           </span>
         </li>
         <li

--- a/components/menu/demo/menu-v4.tsx
+++ b/components/menu/demo/menu-v4.tsx
@@ -6,7 +6,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import React, { useState } from 'react';
-import { ConfigProvider, Menu, Switch } from 'antd';
+import { ConfigProvider, Menu, Switch, Typography } from 'antd';
 import type { MenuProps } from 'antd/es/menu';
 
 type MenuItem = Required<MenuProps>['items'][number];
@@ -29,7 +29,12 @@ const items: MenuItem[] = [
   getItem('Navigation One', '1', <MailOutlined />),
   getItem('Navigation Two', '2', <CalendarOutlined />),
   getItem('Navigation Two', 'sub1', <AppstoreOutlined />, [
-    getItem('Option 3', '3'),
+    getItem(
+      <Typography.Text ellipsis>
+        Ant Design, a design language for background applications, is refined by Ant UED Team
+      </Typography.Text>,
+      '3',
+    ),
     getItem('Option 4', '4'),
     getItem('Submenu', 'sub1-2', null, [getItem('Option 5', '5'), getItem('Option 6', '6')]),
   ]),

--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -601,6 +601,12 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
 
         [`${componentCls}-title-content`]: {
           transition: `color ${motionDurationSlow}`,
+
+          // https://github.com/ant-design/ant-design/issues/41143
+          [`> ${antCls}-typography-ellipsis-single-line`]: {
+            display: 'inline',
+            verticalAlign: 'unset',
+          },
         },
 
         [`${componentCls}-item a`]: {

--- a/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -47,7 +47,7 @@ exports[`renders components/modal/demo/component-token.tsx extend context correc
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width: 100%; height: 200px;"
+    style="width: 100%;"
   >
     <div
       aria-hidden="true"
@@ -132,7 +132,7 @@ exports[`renders components/modal/demo/component-token.tsx extend context correc
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width: 100%; height: 200px;"
+    style="width: 100%;"
   >
     <div
       aria-hidden="true"
@@ -217,7 +217,7 @@ exports[`renders components/modal/demo/component-token.tsx extend context correc
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-success"
     role="dialog"
-    style="width: 200px; height: 150px;"
+    style="width: 200px;"
   >
     <div
       aria-hidden="true"
@@ -290,7 +290,7 @@ exports[`renders components/modal/demo/component-token.tsx extend context correc
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-confirm"
     role="dialog"
-    style="width: 300px; height: 200px;"
+    style="width: 300px;"
   >
     <div
       aria-hidden="true"
@@ -993,7 +993,7 @@ exports[`renders components/modal/demo/wireframe.tsx extend context correctly 1`
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width: 100%; height: 200px;"
+    style="width: 100%;"
   >
     <div
       aria-hidden="true"
@@ -1078,7 +1078,7 @@ exports[`renders components/modal/demo/wireframe.tsx extend context correctly 1`
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-success"
     role="dialog"
-    style="width: 200px; height: 150px;"
+    style="width: 200px;"
   >
     <div
       aria-hidden="true"
@@ -1151,7 +1151,7 @@ exports[`renders components/modal/demo/wireframe.tsx extend context correctly 1`
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-confirm"
     role="dialog"
-    style="width: 300px; height: 200px;"
+    style="width: 300px;"
   >
     <div
       aria-hidden="true"

--- a/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`renders components/modal/demo/component-token.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width:100%;height:200px"
+    style="width:100%"
   >
     <div
       aria-hidden="true"
@@ -126,7 +126,7 @@ exports[`renders components/modal/demo/component-token.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width:100%;height:200px"
+    style="width:100%"
   >
     <div
       aria-hidden="true"
@@ -211,7 +211,7 @@ exports[`renders components/modal/demo/component-token.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-success"
     role="dialog"
-    style="width:200px;height:150px"
+    style="width:200px"
   >
     <div
       aria-hidden="true"
@@ -284,7 +284,7 @@ exports[`renders components/modal/demo/component-token.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-confirm"
     role="dialog"
-    style="width:300px;height:200px"
+    style="width:300px"
   >
     <div
       aria-hidden="true"
@@ -957,7 +957,7 @@ exports[`renders components/modal/demo/wireframe.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel"
     role="dialog"
-    style="width:100%;height:200px"
+    style="width:100%"
   >
     <div
       aria-hidden="true"
@@ -1042,7 +1042,7 @@ exports[`renders components/modal/demo/wireframe.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-success"
     role="dialog"
-    style="width:200px;height:150px"
+    style="width:200px"
   >
     <div
       aria-hidden="true"
@@ -1115,7 +1115,7 @@ exports[`renders components/modal/demo/wireframe.tsx correctly 1`] = `
     aria-modal="true"
     class="ant-modal ant-modal-pure-panel ant-modal-confirm ant-modal-confirm-confirm"
     role="dialog"
-    style="width:300px;height:200px"
+    style="width:300px"
   >
     <div
       aria-hidden="true"

--- a/components/modal/demo/component-token.tsx
+++ b/components/modal/demo/component-token.tsx
@@ -20,18 +20,18 @@ export default () => (
     }}
   >
     <div style={{ display: 'flex', flexDirection: 'column', rowGap: 16 }}>
-      <InternalPanel title="Hello World!" style={{ width: '100%', height: 200 }}>
+      <InternalPanel title="Hello World!" style={{ width: '100%' }}>
         Hello World?!
       </InternalPanel>
       <ConfigProvider theme={{ token: { wireframe: true } }}>
-        <InternalPanel title="Hello World!" style={{ width: '100%', height: 200 }}>
+        <InternalPanel title="Hello World!" style={{ width: '100%' }}>
           Hello World?!
         </InternalPanel>
       </ConfigProvider>
-      <InternalPanel type="success" style={{ width: 200, height: 150 }}>
+      <InternalPanel type="success" style={{ width: 200 }}>
         A good news!
       </InternalPanel>
-      <InternalPanel title="Confirm This?" type="confirm" style={{ width: 300, height: 200 }}>
+      <InternalPanel title="Confirm This?" type="confirm" style={{ width: 300 }}>
         Some descriptions.
       </InternalPanel>
     </div>

--- a/components/modal/demo/wireframe.tsx
+++ b/components/modal/demo/wireframe.tsx
@@ -7,13 +7,13 @@ const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = Modal;
 export default () => (
   <ConfigProvider theme={{ token: { wireframe: true } }}>
     <div style={{ display: 'flex', flexDirection: 'column', rowGap: 16 }}>
-      <InternalPanel title="Hello World!" style={{ width: '100%', height: 200 }}>
+      <InternalPanel title="Hello World!" style={{ width: '100%' }}>
         Hello World?!
       </InternalPanel>
-      <InternalPanel type="success" style={{ width: 200, height: 150 }}>
+      <InternalPanel type="success" style={{ width: 200 }}>
         A good news!
       </InternalPanel>
-      <InternalPanel title="Confirm This?" type="confirm" style={{ width: 300, height: 200 }}>
+      <InternalPanel title="Confirm This?" type="confirm" style={{ width: 300 }}>
         Some descriptions.
       </InternalPanel>
     </div>

--- a/components/modal/style/confirmCmp.tsx
+++ b/components/modal/style/confirmCmp.tsx
@@ -53,6 +53,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
         flexDirection: 'column',
         flex: 'auto',
         rowGap: token.marginXS,
+        maxWidth: `calc(100% - ${token.modalConfirmIconSize + token.marginSM}px)`,
       },
 
       [`${confirmComponentCls}-title`]: {

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -324,15 +324,8 @@ const genWireframeStyle: GenerateStyle<ModalToken> = (token) => {
       [`${antCls}-modal-body`]: {
         padding: `${token.padding * 2}px ${token.padding * 2}px ${token.paddingLG}px`,
       },
-      [`${confirmComponentCls}-body`]: {
-        [`> ${token.iconCls}`]: {
-          marginInlineEnd: token.margin,
-
-          // `content` after `icon` should set marginLeft
-          [`+ ${confirmComponentCls}-title + ${confirmComponentCls}-content`]: {
-            marginInlineStart: token.modalConfirmIconSize + token.margin,
-          },
-        },
+      [`${confirmComponentCls}-body > ${token.iconCls}`]: {
+        marginInlineEnd: token.margin,
       },
       [`${confirmComponentCls}-btns`]: {
         marginTop: token.marginLG,

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -19,7 +19,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
 
       // ========================= Selector =========================
       [`${componentCls}-selector`]: {
-        ...resetComponent(token),
+        ...resetComponent(token, true),
 
         display: 'flex',
         borderRadius,

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11498,7 +11498,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
       class="ant-space-compact"
     >
       <div
-        class="ant-input-number-group-wrapper"
+        class="ant-input-number-group-wrapper ant-input-number-compact-item ant-input-number-compact-first-item ant-input-number-compact-last-item"
       >
         <div
           class="ant-input-number-wrapper ant-input-number-group"
@@ -11509,7 +11509,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
             +
           </div>
           <div
-            class="ant-input-number ant-input-number-compact-item ant-input-number-compact-first-item ant-input-number-compact-last-item"
+            class="ant-input-number"
           >
             <div
               class="ant-input-number-handler-wrap"

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3073,7 +3073,7 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
       class="ant-space-compact"
     >
       <div
-        class="ant-input-number-group-wrapper"
+        class="ant-input-number-group-wrapper ant-input-number-compact-item ant-input-number-compact-first-item ant-input-number-compact-last-item"
       >
         <div
           class="ant-input-number-wrapper ant-input-number-group"
@@ -3084,7 +3084,7 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
             +
           </div>
           <div
-            class="ant-input-number ant-input-number-compact-item ant-input-number-compact-first-item ant-input-number-compact-last-item"
+            class="ant-input-number"
           >
             <div
               class="ant-input-number-handler-wrap"

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -11,7 +11,10 @@ export const textEllipsis: CSSObject = {
   textOverflow: 'ellipsis',
 };
 
-export const resetComponent = (token: DerivativeToken): CSSObject => ({
+export const resetComponent = (
+  token: DerivativeToken,
+  needInheritFontFamily = false,
+): CSSObject => ({
   boxSizing: 'border-box',
   margin: 0,
   padding: 0,
@@ -21,7 +24,7 @@ export const resetComponent = (token: DerivativeToken): CSSObject => ({
   lineHeight: token.lineHeight,
   listStyle: 'none',
   // font-feature-settings: @font-feature-settings-base;
-  fontFamily: token.fontFamily,
+  fontFamily: needInheritFontFamily ? 'inherit' : token.fontFamily,
 });
 
 export const resetIcon = (): CSSObject => ({

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -129,7 +129,7 @@ import React from 'react';
 import { ConfigProvider } from 'antd';
 import type { AppProps } from 'next/app';
 
-import theme from './themeConfig';
+import theme from './theme/themeConfig';
 
 const App = ({ Component, pageProps }: AppProps) => (
   <ConfigProvider theme={theme}>
@@ -236,7 +236,7 @@ export default theme;
 import React from 'react';
 import { Button, ConfigProvider } from 'antd';
 
-import theme from './themeConfig';
+import theme from './theme/themeConfig';
 
 const HomePage = () => (
   <ConfigProvider theme={theme}>

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -129,7 +129,7 @@ import React from 'react';
 import { ConfigProvider } from 'antd';
 import type { AppProps } from 'next/app';
 
-import theme from './themeConfig';
+import theme from './theme/themeConfig';
 
 const App = ({ Component, pageProps }: AppProps) => (
   <ConfigProvider theme={theme}>
@@ -236,7 +236,7 @@ export default theme;
 import React from 'react';
 import { Button, ConfigProvider } from 'antd';
 
-import theme from './themeConfig';
+import theme from './theme/themeConfig';
 
 const HomePage = () => (
   <ConfigProvider theme={theme}>

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "antd-img-crop": "^4.9.0",
-    "antd-style": "^3.4.2-beta.1",
+    "antd-style": "^3.5.0",
     "antd-token-previewer": "^2.0.1",
     "chalk": "^4.0.0",
     "cheerio": "1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.2",
     "@types/fs-extra": "^11.0.1",
-    "@types/gtag.js": "^0.0.14",
+    "@types/gtag.js": "^0.0.16",
     "@types/http-server": "^0.12.1",
     "@types/inquirer": "^9.0.3",
     "@types/isomorphic-fetch": "^0.0.37",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        --   |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 604948e</samp>

This pull request improves the component overview page, the dumi theme, the input number, menu, and modal components, and the documentation for Next.js integration. It also updates some dependencies, adds a new workflow for README verification, and uses new tokens for some styles.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 604948e</samp>

*  Enable concurrent mode and smooth theme switching for the theme component ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL322-R324), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-3bb66880942ca129db42a1a6c20126916fc7b9be5daf9723506df03fa96f0995R24-R29))
*  Improve the scrolling and link handling of the component overview page ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L6-R10), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585R161-R170), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L196-R212), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f1df5cf9560d26c9862a4824e7d1a13f6a8bec1ec7338e9327f3e7a6a74c1585L227-R237), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL1-R1), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bR11), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bR28), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-710e188e465a89d2e744c5183aa1ee6375dbefdcd24be26ad95e11ca7805e37bL49-R51))
*  Fix the image scaling issue in the markdown preview ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-6d4081217418af981e22c0fd474410c584b0d3c238609e557164b0ebd07c9ab4L41))
*  Add a workflow to close and comment on README modifications ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-9f0058a0255ef889832ea3db310cbc4878295a3aef67ad431da9fd75bacbfa96R29-R46))
*  Apply the compact style to the input number component when inside an input group ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL102), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL111-R110))
*  Use the new token for the input group addon background color ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL322-R322))
*  Demonstrate the overflow handling of the menu component with typography ellipsis ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-d42c088ccc7db6592bba58c8661bbc67db3e246d4e4e2478f0e3d05622b7f9afL9-R9), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-d42c088ccc7db6592bba58c8661bbc67db3e246d4e4e2478f0e3d05622b7f9afL32-R37), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dR604-R609))
*  Use the default height for the internal panel components in the modal demos ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-9074e0b68d50f720bdba9aa718cf86d4aaf7ec13a484d12eb953e6e95bdb79faL23-R34), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-054411f45c36db2541d94da7475c3c220acd29142a84952c3c6f2604c495d235L10-R16))
*  Limit the width of the modal confirm content when it has an icon ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-99ef0451fefa19a2e28ee86c53122dd8bdde5704ca454859e5e7230c05df45dfR56), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486L327-R328))
*  Allow the select component to inherit the font family from the parent element ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L22-R22), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL14-R17), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL24-R27))
*  Update the theme import path in the use-with-next documentation ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L132-R132), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L239-R239), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L132-R132), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L239-R239))
*  Update the dependency versions for `@types/gtag.js` and `antd-style` ([link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L185-R185), [link](https://github.com/ant-design/ant-design/pull/45225/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L211-R211))
