### PR TITLE
feat: support variant option, deprecated bordered option

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import classNames from 'classnames';
 import type { Tab } from 'rc-tabs/lib/interface';
 import omit from 'rc-util/lib/omit';
-import * as React from 'react';
+
 import { ConfigContext } from '../config-provider';
 import useSize from '../config-provider/hooks/useSize';
 import Skeleton from '../skeleton';
@@ -24,6 +25,10 @@ export interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 't
   prefixCls?: string;
   title?: React.ReactNode;
   extra?: React.ReactNode;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   headStyle?: React.CSSProperties;
   bodyStyle?: React.CSSProperties;
@@ -67,6 +72,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     title,
     loading,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     size: customizeSize,
     type,
     cover,
@@ -154,9 +160,9 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   const classString = classNames(
     prefixCls,
     card?.className,
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-loading`]: loading,
-      [`${prefixCls}-bordered`]: bordered,
       [`${prefixCls}-hoverable`]: hoverable,
       [`${prefixCls}-contain-grid`]: isContainGrid,
       [`${prefixCls}-contain-tabs`]: tabList && tabList.length,

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -160,8 +160,8 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   const classString = classNames(
     prefixCls,
     card?.className,
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-loading`]: loading,
       [`${prefixCls}-hoverable`]: hoverable,
       [`${prefixCls}-contain-grid`]: isContainGrid,

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -161,7 +161,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     prefixCls,
     card?.className,
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-loading`]: loading,
       [`${prefixCls}-hoverable`]: hoverable,
       [`${prefixCls}-contain-grid`]: isContainGrid,

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -310,8 +310,8 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       prefixCls={prefixCls}
       className={classNames(
         !customizePrefixCls && cascaderPrefixCls,
-        `${prefixCls}-${variant}`,
         {
+          [`${prefixCls}-${variant}`]: variant !== 'borderless',
           [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-sm`]: mergedSize === 'small',
           [`${prefixCls}-rtl`]: isRtl,

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -311,7 +311,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       className={classNames(
         !customizePrefixCls && cascaderPrefixCls,
         {
-          [`${prefixCls}-${variant}`]: variant !== 'borderless',
+          [`${prefixCls}-${variant}`]: variant !== 'outlined',
           [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-sm`]: mergedSize === 'small',
           [`${prefixCls}-rtl`]: isRtl,

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -29,8 +29,8 @@ import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import useSelectStyle from '../select/style';
 import useBuiltinPlacements from '../select/useBuiltinPlacements';
-import useShowArrow from '../select/useShowArrow';
 import useIcons from '../select/useIcons';
+import useShowArrow from '../select/useShowArrow';
 import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
 
@@ -124,6 +124,10 @@ export type CascaderProps<DataNodeType extends BaseOptionType = any> =
      */
     showArrow?: boolean;
     disabled?: boolean;
+    variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+    /**
+     * @deprecated Please use `variant` instead
+     */
     bordered?: boolean;
     placement?: SelectCommonPlacement;
     suffixIcon?: React.ReactNode;
@@ -151,6 +155,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     rootClassName,
     multiple,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     transitionName,
     choiceTransitionName = '',
     popupClassName,
@@ -305,11 +310,11 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       prefixCls={prefixCls}
       className={classNames(
         !customizePrefixCls && cascaderPrefixCls,
+        `${prefixCls}-${variant}`,
         {
           [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-sm`]: mergedSize === 'small',
           [`${prefixCls}-rtl`]: isRtl,
-          [`${prefixCls}-borderless`]: !bordered,
           [`${prefixCls}-in-form-item`]: isFormItemInput,
         },
         getStatusClassNames(prefixCls, mergedStatus, hasFeedback),

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -121,8 +121,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
 
   const collapseClassName = classNames(
     `${prefixCls}-icon-position-${mergedExpandIconPosition}`,
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-ghost`]: !!ghost,
       [`${prefixCls}-${mergedSize}`]: mergedSize !== 'middle',

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -31,6 +31,10 @@ export interface CollapseProps extends Pick<RcCollapseProps, 'items'> {
   style?: React.CSSProperties;
   className?: string;
   rootClassName?: string;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   prefixCls?: string;
   expandIcon?: (panelProps: PanelProps) => React.ReactNode;
@@ -66,6 +70,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     rootClassName,
     style,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     ghost,
     size: customizeSize,
     expandIconPosition = 'start',
@@ -116,8 +121,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
 
   const collapseClassName = classNames(
     `${prefixCls}-icon-position-${mergedExpandIconPosition}`,
+    `${prefixCls}-${variant}`,
     {
-      [`${prefixCls}-borderless`]: !bordered,
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-ghost`]: !!ghost,
       [`${prefixCls}-${mergedSize}`]: mergedSize !== 'middle',

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -122,7 +122,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
   const collapseClassName = classNames(
     `${prefixCls}-icon-position-${mergedExpandIconPosition}`,
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-ghost`]: !!ghost,
       [`${prefixCls}-${mergedSize}`]: mergedSize !== 'middle',

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -131,8 +131,8 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         {...restProps}
         {...additionalOverrideProps}
         className={classNames(
-          `${prefixCls}-${variant}`,
           {
+            [`${prefixCls}-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-${mergedSize}`]: mergedSize,
           },
           getStatusClassNames(prefixCls, getMergedStatus(contextStatus, customStatus), hasFeedback),

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -52,6 +52,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
       size: customizeSize,
       disabled: customDisabled,
       bordered = true,
+      variant = bordered ? 'outlined' : 'borderless',
       placeholder,
       popupClassName,
       dropdownClassName,
@@ -130,9 +131,9 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         {...restProps}
         {...additionalOverrideProps}
         className={classNames(
+          `${prefixCls}-${variant}`,
           {
             [`${prefixCls}-${mergedSize}`]: mergedSize,
-            [`${prefixCls}-borderless`]: !bordered,
           },
           getStatusClassNames(prefixCls, getMergedStatus(contextStatus, customStatus), hasFeedback),
           hashId,

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -132,7 +132,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
         {...additionalOverrideProps}
         className={classNames(
           {
-            [`${prefixCls}-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-${mergedSize}`]: mergedSize,
           },
           getStatusClassNames(prefixCls, getMergedStatus(contextStatus, customStatus), hasFeedback),

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -159,7 +159,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
             locale={locale!.lang}
             className={classNames(
               {
-                [`${prefixCls}-${variant}`]: variant !== 'borderless',
+                [`${prefixCls}-${variant}`]: variant !== 'outlined',
                 [`${prefixCls}-${mergedSize}`]: mergedSize,
               },
               getStatusClassNames(

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -36,7 +36,9 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
     popupClassName?: string;
     rootClassName?: string;
   };
-  type DatePickerProps = PickerProps<DateType> & CustomPickerProps;
+  type DatePickerProps = Omit<PickerProps<DateType>, 'bordered'> &
+    CustomPickerProps &
+    Pick<PickerProps<DateType>, 'bordered'>;
   type TimePickerProps = PickerTimeProps<DateType> & CustomPickerProps;
 
   function getPicker<InnerPickerProps extends DatePickerProps>(
@@ -54,6 +56,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
           rootClassName,
           size: customizeSize,
           bordered = true,
+          variant = bordered ? 'outlined' : 'borderless',
           placement,
           placeholder,
           popupClassName,
@@ -155,9 +158,9 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
             {...additionalOverrideProps}
             locale={locale!.lang}
             className={classNames(
+              `${prefixCls}-${variant}`,
               {
                 [`${prefixCls}-${mergedSize}`]: mergedSize,
-                [`${prefixCls}-borderless`]: !bordered,
               },
               getStatusClassNames(
                 prefixCls,

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -158,8 +158,8 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
             {...additionalOverrideProps}
             locale={locale!.lang}
             className={classNames(
-              `${prefixCls}-${variant}`,
               {
+                [`${prefixCls}-${variant}`]: variant !== 'borderless',
                 [`${prefixCls}-${mergedSize}`]: mergedSize,
               },
               getStatusClassNames(

--- a/components/date-picker/generatePicker/index.tsx
+++ b/components/date-picker/generatePicker/index.tsx
@@ -1,3 +1,5 @@
+import type { GenerateConfig } from 'rc-picker/lib/generate/index';
+import type { Locale as RcPickerLocale } from 'rc-picker/lib/interface';
 import type {
   PickerBaseProps as RCPickerBaseProps,
   PickerDateProps as RCPickerDateProps,
@@ -8,8 +10,7 @@ import type {
   RangePickerDateProps as RCRangePickerDateProps,
   RangePickerTimeProps as RCRangePickerTimeProps,
 } from 'rc-picker/lib/RangePicker';
-import type { GenerateConfig } from 'rc-picker/lib/generate/index';
-import type { Locale as RcPickerLocale } from 'rc-picker/lib/interface';
+
 import type { InputStatus } from '../../_util/statusUtils';
 import type { SizeType } from '../../config-provider/SizeContext';
 import type { TimePickerLocale } from '../../time-picker';
@@ -26,6 +27,10 @@ type InjectDefaultProps<Props> = Omit<
   locale?: PickerLocale;
   size?: SizeType;
   placement?: DataPickerPlacement;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   status?: InputStatus;
 };

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -1,5 +1,5 @@
-import classNames from 'classnames';
 import * as React from 'react';
+import classNames from 'classnames';
 
 function notEmpty(val: any) {
   return val !== undefined && val !== null;
@@ -13,6 +13,10 @@ export interface CellProps {
   style?: React.CSSProperties;
   labelStyle?: React.CSSProperties;
   contentStyle?: React.CSSProperties;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   label?: React.ReactNode;
   content?: React.ReactNode;

--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -89,6 +89,10 @@ export interface RowProps {
   prefixCls: string;
   vertical: boolean;
   row: InternalDescriptionsItemType[];
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   colon: boolean;
   index: number;

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -111,8 +111,8 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
         className={classNames(
           prefixCls,
           descriptions?.className,
-          `${prefixCls}-${variant}`,
           {
+            [`${prefixCls}-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-${mergedSize}`]: mergedSize && mergedSize !== 'default',
             [`${prefixCls}-rtl`]: direction === 'rtl',
           },

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -112,7 +112,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
           prefixCls,
           descriptions?.className,
           {
-            [`${prefixCls}-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-${mergedSize}`]: mergedSize && mergedSize !== 'default',
             [`${prefixCls}-rtl`]: direction === 'rtl',
           },

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -33,6 +33,10 @@ export interface DescriptionsProps {
   className?: string;
   rootClassName?: string;
   style?: React.CSSProperties;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   size?: 'middle' | 'small' | 'default';
   /**
@@ -57,6 +61,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
     column,
     colon = true,
     bordered,
+    variant = bordered ? 'outlined' : 'borderless',
     layout,
     children,
     className,
@@ -106,9 +111,9 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
         className={classNames(
           prefixCls,
           descriptions?.className,
+          `${prefixCls}-${variant}`,
           {
             [`${prefixCls}-${mergedSize}`]: mergedSize && mergedSize !== 'default',
-            [`${prefixCls}-bordered`]: !!bordered,
             [`${prefixCls}-rtl`]: direction === 'rtl',
           },
           className,

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -1,15 +1,16 @@
+import * as React from 'react';
 import DownOutlined from '@ant-design/icons/DownOutlined';
 import UpOutlined from '@ant-design/icons/UpOutlined';
 import classNames from 'classnames';
 import type { InputNumberProps as RcInputNumberProps, ValueType } from 'rc-input-number';
 import RcInputNumber from 'rc-input-number';
-import * as React from 'react';
+
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import ConfigProvider, { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
-import type { SizeType } from '../config-provider/SizeContext';
 import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext, NoFormStyle } from '../form/context';
 import { NoCompactStyle, useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
@@ -23,6 +24,10 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   prefix?: React.ReactNode;
   size?: SizeType;
   disabled?: boolean;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   status?: InputStatus;
   controls?: boolean | { upIcon?: React.ReactNode; downIcon?: React.ReactNode };
@@ -45,6 +50,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     addonAfter,
     prefix,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     readOnly,
     status: customStatus,
     controls,
@@ -91,11 +97,11 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   const mergedDisabled = customDisabled ?? disabled;
 
   const inputNumberClass = classNames(
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',
-      [`${prefixCls}-borderless`]: !bordered,
       [`${prefixCls}-in-form-item`]: isFormItemInput,
     },
     getStatusClassNames(prefixCls, mergedStatus),

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -98,7 +98,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
 
   const inputNumberClass = classNames(
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -146,7 +146,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
         affixWrapper: classNames(
           getStatusClassNames(`${prefixCls}-affix-wrapper`, mergedStatus, hasFeedback),
           {
-            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -97,8 +97,8 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   const mergedDisabled = customDisabled ?? disabled;
 
   const inputNumberClass = classNames(
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -146,10 +146,10 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
         affixWrapper: classNames(
           getStatusClassNames(`${prefixCls}-affix-wrapper`, mergedStatus, hasFeedback),
           {
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
-            [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
           },
           hashId,
         ),

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -63,6 +63,10 @@ export interface InputProps
   size?: SizeType;
   disabled?: boolean;
   status?: InputStatus;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   [key: `data-${string}`]: string | undefined;
 }
@@ -71,6 +75,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     status: customStatus,
     size: customSize,
     disabled: customDisabled,
@@ -201,11 +206,11 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         ...classes,
         ...input?.classNames,
         input: classNames(
+          `${prefixCls}-${variant}`,
           {
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
             [`${prefixCls}-rtl`]: direction === 'rtl',
-            [`${prefixCls}-borderless`]: !bordered,
           },
           !inputHasPrefixSuffix && getStatusClassNames(prefixCls, mergedStatus),
           classes?.input,

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -206,8 +206,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         ...classes,
         ...input?.classNames,
         input: classNames(
-          `${prefixCls}-${variant}`,
           {
+            [`${prefixCls}-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
             [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -221,10 +221,10 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       classes={{
         affixWrapper: classNames(
           {
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
-            [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
           },
           getStatusClassNames(`${prefixCls}-affix-wrapper`, mergedStatus, hasFeedback),
           hashId,

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -207,7 +207,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         ...input?.classNames,
         input: classNames(
           {
-            [`${prefixCls}-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
             [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -221,7 +221,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       classes={{
         affixWrapper: classNames(
           {
-            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -1,23 +1,28 @@
+import * as React from 'react';
+import { forwardRef } from 'react';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import classNames from 'classnames';
 import type { BaseInputProps } from 'rc-input/lib/interface';
 import type { TextAreaRef as RcTextAreaRef } from 'rc-textarea';
 import RcTextArea from 'rc-textarea';
 import type { TextAreaProps as RcTextAreaProps } from 'rc-textarea/lib/interface';
-import * as React from 'react';
-import { forwardRef } from 'react';
+
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
-import type { SizeType } from '../config-provider/SizeContext';
 import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import type { InputFocusOptions } from './Input';
 import { triggerFocus } from './Input';
 import useStyle from './style';
 
 export interface TextAreaProps extends Omit<RcTextAreaProps, 'suffix'> {
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   size?: SizeType;
   status?: InputStatus;
@@ -34,6 +39,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     size: customizeSize,
     disabled: customDisabled,
     status: customStatus,
@@ -108,8 +114,8 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
       classNames={{
         ...classes,
         textarea: classNames(
+          `${prefixCls}-${variant}`,
           {
-            [`${prefixCls}-borderless`]: !bordered,
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
           },

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -101,7 +101,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
         affixWrapper: classNames(
           `${prefixCls}-textarea-affix-wrapper`,
           {
-            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
@@ -115,7 +115,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
         ...classes,
         textarea: classNames(
           {
-            [`${prefixCls}-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
           },

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -101,8 +101,8 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
         affixWrapper: classNames(
           `${prefixCls}-textarea-affix-wrapper`,
           {
+            [`${prefixCls}-affix-wrapper-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-affix-wrapper-rtl`]: direction === 'rtl',
-            [`${prefixCls}-affix-wrapper-borderless`]: !bordered,
             [`${prefixCls}-affix-wrapper-sm`]: mergedSize === 'small',
             [`${prefixCls}-affix-wrapper-lg`]: mergedSize === 'large',
             [`${prefixCls}-textarea-show-count`]: showCount,
@@ -114,8 +114,8 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
       classNames={{
         ...classes,
         textarea: classNames(
-          `${prefixCls}-${variant}`,
           {
+            [`${prefixCls}-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-sm`]: mergedSize === 'small',
             [`${prefixCls}-lg`]: mergedSize === 'large',
           },

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -177,7 +177,7 @@ function List<T>({
   const classString = classNames(
     prefixCls,
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-vertical`]: itemLayout === 'vertical',
       [`${prefixCls}-${sizeCls}`]: sizeCls,
       [`${prefixCls}-split`]: split,

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -1,23 +1,23 @@
-import classNames from 'classnames';
 // eslint-disable-next-line import/no-named-as-default
 import * as React from 'react';
+import classNames from 'classnames';
+
 import extendsObject from '../_util/extendsObject';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { responsiveArray } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import useSize from '../config-provider/hooks/useSize';
 import { Row } from '../grid';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
 import type { PaginationConfig } from '../pagination';
 import Pagination from '../pagination';
 import type { SpinProps } from '../spin';
 import Spin from '../spin';
-import Item from './Item';
-
 // CSSINJS
 import { ListContext } from './context';
+import Item from './Item';
 import useStyle from './style';
-import useSize from '../config-provider/hooks/useSize';
 
 export type { ListItemMetaProps, ListItemProps } from './Item';
 export type { ListConsumerProps } from './context';
@@ -42,6 +42,10 @@ export type ListSize = 'small' | 'default' | 'large';
 export type ListItemLayout = 'horizontal' | 'vertical';
 
 export interface ListProps<T> {
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   className?: string;
   rootClassName?: string;
@@ -73,6 +77,7 @@ function List<T>({
   pagination = false as ListProps<T>['pagination'],
   prefixCls: customizePrefixCls,
   bordered = false,
+  variant = bordered ? 'outlined' : 'borderless',
   split = true,
   className,
   rootClassName,
@@ -171,11 +176,11 @@ function List<T>({
 
   const classString = classNames(
     prefixCls,
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-vertical`]: itemLayout === 'vertical',
       [`${prefixCls}-${sizeCls}`]: sizeCls,
       [`${prefixCls}-split`]: split,
-      [`${prefixCls}-bordered`]: bordered,
       [`${prefixCls}-loading`]: isLoading,
       [`${prefixCls}-grid`]: !!grid,
       [`${prefixCls}-something-after-last-item`]: isSomethingAfterLastItem(),

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -176,8 +176,8 @@ function List<T>({
 
   const classString = classNames(
     prefixCls,
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-vertical`]: itemLayout === 'vertical',
       [`${prefixCls}-${sizeCls}`]: sizeCls,
       [`${prefixCls}-split`]: split,

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -73,7 +73,9 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     return null;
   }
 
-  const cls = classNames(prefixCls, className, rootClassName, hashId, `${prefixCls}-${variant}`);
+  const cls = classNames(prefixCls, className, rootClassName, hashId, {
+    [`${prefixCls}-${variant}`]: variant !== 'borderless',
+  });
 
   return wrapSSR(
     <div style={{ ...style, width: size, height: size, backgroundColor: bgColor }} className={cls}>

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -74,7 +74,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   }
 
   const cls = classNames(prefixCls, className, rootClassName, hashId, {
-    [`${prefixCls}-${variant}`]: variant !== 'borderless',
+    [`${prefixCls}-${variant}`]: variant !== 'outlined',
   });
 
   return wrapSSR(

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -25,6 +25,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     errorLevel = 'M',
     status = 'active',
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     onRefresh,
     style,
     className,
@@ -72,9 +73,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     return null;
   }
 
-  const cls = classNames(prefixCls, className, rootClassName, hashId, {
-    [`${prefixCls}-borderless`]: !bordered,
-  });
+  const cls = classNames(prefixCls, className, rootClassName, hashId, `${prefixCls}-${variant}`);
 
   return wrapSSR(
     <div style={{ ...style, width: size, height: size, backgroundColor: bgColor }} className={cls}>

--- a/components/qr-code/interface.ts
+++ b/components/qr-code/interface.ts
@@ -30,6 +30,10 @@ export interface QRCodeProps extends QRProps {
   prefixCls?: string;
   icon?: string;
   iconSize?: number;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   errorLevel?: 'L' | 'M' | 'Q' | 'H';
   status?: 'active' | 'expired' | 'loading';

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -201,8 +201,8 @@ const InternalSelect = <
   const mergedDisabled = customDisabled ?? disabled;
 
   const mergedClassName = classNames(
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -22,8 +22,8 @@ import { FormItemInputContext } from '../form/context';
 import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
 import useBuiltinPlacements from './useBuiltinPlacements';
-import useShowArrow from './useShowArrow';
 import useIcons from './useIcons';
+import useShowArrow from './useShowArrow';
 
 type RawValue = string | number;
 
@@ -46,6 +46,10 @@ export interface InternalSelectProps<
   size?: SizeType;
   disabled?: boolean;
   mode?: 'multiple' | 'tags' | 'SECRET_COMBOBOX_MODE_DO_NOT_USE' | 'combobox';
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   /**
    * @deprecated `showArrow` is deprecated which will be removed in next major version. It will be a
@@ -81,6 +85,7 @@ const InternalSelect = <
   {
     prefixCls: customizePrefixCls,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     className,
     rootClassName,
     getPopupContainer,
@@ -196,11 +201,11 @@ const InternalSelect = <
   const mergedDisabled = customDisabled ?? disabled;
 
   const mergedClassName = classNames(
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',
-      [`${prefixCls}-borderless`]: !bordered,
       [`${prefixCls}-in-form-item`]: isFormItemInput,
     },
     getStatusClassNames(prefixCls, mergedStatus, hasFeedback),

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -202,7 +202,7 @@ const InternalSelect = <
 
   const mergedClassName = classNames(
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -93,6 +93,10 @@ export interface TableProps<RecordType>
   pagination?: false | TablePaginationConfig;
   loading?: boolean | SpinProps;
   size?: SizeType;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   locale?: TableLocale;
   rootClassName?: string;
@@ -125,6 +129,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     style,
     size: customizeSize,
     bordered,
+    variant = bordered ? 'outlined' : 'borderless',
     dropdownPrefixCls: customizeDropdownPrefixCls,
     dataSource,
     pagination,
@@ -581,10 +586,9 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
           direction={direction}
           expandable={mergedExpandable}
           prefixCls={prefixCls}
-          className={classNames({
+          className={classNames(`${prefixCls}-${variant}`, {
             [`${prefixCls}-middle`]: mergedSize === 'middle',
             [`${prefixCls}-small`]: mergedSize === 'small',
-            [`${prefixCls}-bordered`]: bordered,
             [`${prefixCls}-empty`]: rawData.length === 0,
           })}
           data={pageData}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -586,7 +586,8 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
           direction={direction}
           expandable={mergedExpandable}
           prefixCls={prefixCls}
-          className={classNames(`${prefixCls}-${variant}`, {
+          className={classNames({
+            [`${prefixCls}-${variant}`]: variant !== 'borderless',
             [`${prefixCls}-middle`]: mergedSize === 'middle',
             [`${prefixCls}-small`]: mergedSize === 'small',
             [`${prefixCls}-empty`]: rawData.length === 0,

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -587,7 +587,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
           expandable={mergedExpandable}
           prefixCls={prefixCls}
           className={classNames({
-            [`${prefixCls}-${variant}`]: variant !== 'borderless',
+            [`${prefixCls}-${variant}`]: variant !== 'outlined',
             [`${prefixCls}-middle`]: mergedSize === 'middle',
             [`${prefixCls}-small`]: mergedSize === 'small',
             [`${prefixCls}-empty`]: rawData.length === 0,

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -90,8 +90,8 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
   const tagClassName = classNames(
     prefixCls,
     tag?.className,
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,
       [`${prefixCls}-hidden`]: !visible,

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -91,7 +91,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     prefixCls,
     tag?.className,
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,
       [`${prefixCls}-hidden`]: !visible,

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -29,6 +29,10 @@ export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   onClose?: (e: React.MouseEvent<HTMLElement>) => void;
   style?: React.CSSProperties;
   icon?: React.ReactNode;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
 }
 
@@ -50,6 +54,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     closeIcon,
     closable,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     ...props
   } = tagProps;
   const { getPrefixCls, direction, tag } = React.useContext(ConfigContext);
@@ -85,12 +90,12 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
   const tagClassName = classNames(
     prefixCls,
     tag?.className,
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,
       [`${prefixCls}-hidden`]: !visible,
       [`${prefixCls}-rtl`]: direction === 'rtl',
-      [`${prefixCls}-borderless`]: !bordered,
     },
     className,
     rootClassName,

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -21,8 +21,8 @@ import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import useSelectStyle from '../select/style';
 import useBuiltinPlacements from '../select/useBuiltinPlacements';
-import useShowArrow from '../select/useShowArrow';
 import useIcons from '../select/useIcons';
+import useShowArrow from '../select/useShowArrow';
 import { useCompactItemContext } from '../space/Compact';
 import type { AntTreeNodeProps, TreeProps } from '../tree';
 import type { SwitcherIcon } from '../tree/Tree';
@@ -59,6 +59,10 @@ export interface TreeSelectProps<
   popupClassName?: string;
   /** @deprecated Please use `popupClassName` instead */
   dropdownClassName?: string;
+  variant?: 'outlined' | 'filled' | 'underlined' | 'borderless';
+  /**
+   * @deprecated Please use `variant` instead
+   */
   bordered?: boolean;
   treeLine?: TreeProps['showLine'];
   status?: InputStatus;
@@ -84,6 +88,7 @@ const InternalTreeSelect = <
     size: customizeSize,
     disabled: customDisabled,
     bordered = true,
+    variant = bordered ? 'outlined' : 'borderless',
     className,
     rootClassName,
     treeCheckable,
@@ -226,11 +231,11 @@ const InternalTreeSelect = <
 
   const mergedClassName = classNames(
     !customizePrefixCls && treeSelectPrefixCls,
+    `${prefixCls}-${variant}`,
     {
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',
-      [`${prefixCls}-borderless`]: !bordered,
       [`${prefixCls}-in-form-item`]: isFormItemInput,
     },
     getStatusClassNames(prefixCls, mergedStatus, hasFeedback),

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -231,8 +231,8 @@ const InternalTreeSelect = <
 
   const mergedClassName = classNames(
     !customizePrefixCls && treeSelectPrefixCls,
-    `${prefixCls}-${variant}`,
     {
+      [`${prefixCls}-${variant}`]: variant !== 'borderless',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -232,7 +232,7 @@ const InternalTreeSelect = <
   const mergedClassName = classNames(
     !customizePrefixCls && treeSelectPrefixCls,
     {
-      [`${prefixCls}-${variant}`]: variant !== 'borderless',
+      [`${prefixCls}-${variant}`]: variant !== 'outlined',
       [`${prefixCls}-lg`]: mergedSize === 'large',
       [`${prefixCls}-sm`]: mergedSize === 'small',
       [`${prefixCls}-rtl`]: direction === 'rtl',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...


- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

Refer to https://github.com/ant-design/ant-design/discussions/43464


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      support variant option, deprecated bordered option     |
| 🇨🇳 Chinese |    支持 variant 参数，废弃 bordered 参数       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97f7b91</samp>

Added a new `variant` prop to several components (`Card`, `Cascader`, `Collapse`, `DatePicker`, `Descriptions`, `InputNumber`, `Input`, `List`, `QRCode`, `Select`, `Table`, and `Tag`) to support different border styles and colors. Deprecated the `bordered` prop from these components and refactored the code to use the `variant` prop instead. This improves the consistency, flexibility, and customization of the component library.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97f7b91</samp>

*  Add a new `variant` prop to various components to allow different styles, such as `outlined`, `filled`, `underlined`, or `borderless` ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dR28-R31), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R127-R130), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R34-R37),   [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5d44f830f82f98732efaf0941e3f256349080a2ff3d86b944f8d185810c48afR16-R19), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcb11c57b2e8b947b2984450e84ea568db47a0862a41b9751bedd8ced4b25954R92-R95), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR36-R39), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaR27-R30), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaR66-R69), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089R22-R25), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R45-R48), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e0c3a47e807c756e9e5ce881c8ed47e446c7714d49f0074def0a02d76cf524ffR33-R36), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R49-R52), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R96-R99), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R32-R35))
*  Mark the `variant` prop as deprecated, since it is a temporary solution to avoid breaking changes for the existing `bordered` prop ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dR28-R31), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R127-R130), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R34-R37), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR36-R39), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaR27-R30), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaR66-R69), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089R22-R25), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R45-R48), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R49-R52), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R96-R99), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R32-R35))
*  Assign a default value to the `variant` prop based on the `bordered` prop, to provide backward compatibility and avoid repeating the logic in multiple places ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dR75), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R158), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9R73), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34R55), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bR59), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR64), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaR53), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaR78), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089R42), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R80), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaR28), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R88), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R132), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913R57))
*  Add a new className to the components based on the `variant` prop, to apply different styles for different variants ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL158-R165), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L309-R317), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L120-R125), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L134-R136), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL159-R163), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL110-R116), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL95-R104), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL143-R152), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL205-R213), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL219-R227), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L98-R105), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L112-R118), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L175-R183), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL76-R77), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L200-R208), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616L585-R592), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L89-R98))
*  Remove the original className based on the `bordered` prop, since it is redundant and conflicts with the new variant styles ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL158-R165), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L309-R317), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-3541251bb31318316b91e1f6710b646bd92edaff4318ca790c6401bea6962fc9L120-R125), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fba17c237c150271f91ee2ca848654484ecbbbcc71b010a8947620e945e10e34L134-R136), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL159-R163), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL110-R116), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL95-R104), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL143-R152), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL205-R213), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL219-R227), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L98-R105), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L112-R118), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L175-R183), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL76-R77), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L200-R208), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L357-L363), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616L585-R592), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-bcceb016a2b5f77c9c373d92bb6e81d64f26323154b13adfc6b74243e78b4913L89-R98))
*  Modify the style of the selector component in `components/select/style/index.tsx` to use transparent background and border by default, and only apply the original background and border color when the variant is `outlined` ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L122-R129))
*  Modify the style of the status classes for the select component in `components/select/style/index.tsx` to only apply to the `outlined` variant, since the other variants do not have a border color change on focus or hover ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L180-R188))
*  Modify the style of the base tag component in `components/tag/style/index.ts` to use transparent background and border by default, and only apply the original background and border color when the variant is `outlined` ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L49-R50))
*  Add the style of the `outlined` className for the tag component in `components/tag/style/index.ts`, to apply the original background and border color when the variant is `outlined` ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cb2262b77ae285e7da02504971f378bec871797a530abbf2a34f14fdb3d92f85L121-R123))
*  Modify the type `DatePickerProps` in `components/date-picker/generatePicker/generateSinglePicker.tsx` to omit the `bordered` prop from the `PickerProps` type, and then add it back as an optional prop, to avoid a TypeScript error when passing the `bordered` prop to the `Picker` component, which does not accept it as a prop ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-678a0178404ab41221775c01d203e79ccb84496e2f0b7cf4ef38222d7a7b562bL39-R41))
*  Move two type imports from `components/date-picker/generatePicker/index.tsx` to `components/date-picker/generatePicker/generateSinglePicker.tsx`, since they are only used in the latter file and not in the former ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-17a0f2c93d7ac31319015aad11a4a87c2abd9ff3e2b9db737c1736ee1840ae6aR1-R2), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-17a0f2c93d7ac31319015aad11a4a87c2abd9ff3e2b9db737c1736ee1840ae6aL11-R13))
*  Add a new prop `variant` to the type `InjectDefaultProps` in `components/date-picker/generatePicker/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-17a0f2c93d7ac31319015aad11a4a87c2abd9ff3e2b9db737c1736ee1840ae6aR30-R33))
*  Add a new import of `useSize` to `components/list/index.tsx`, since it is used in the file and was missing before ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R10))
*  Add a new import of `React` to `components/input-number/index.tsx` and `components/input/TextArea.tsx`, since it is used in the files and should be imported explicitly ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaR1), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089R1-R2))
*  Change the import order of various files to follow the convention of importing React first, then third-party libraries, then internal modules ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL1-R5), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L32-R33), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-a5d44f830f82f98732efaf0941e3f256349080a2ff3d86b944f8d185810c48afL1-R2), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL6-R13),  [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L1-R4), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L25-R26), [link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L1-R3))
*  Remove an empty line in `components/select/style/index.tsx` to improve code readability and formatting ([link](https://github.com/ant-design/ant-design/pull/45233/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L189))
