### PR TITLE
feat: Table support `scrollTo` `reference`

### DIFF
--- a/components/_util/hooks/useProxyImperativeHandle.ts
+++ b/components/_util/hooks/useProxyImperativeHandle.ts
@@ -36,7 +36,7 @@ export default function useProxyImperativeHandle<
             return (refObj as any)[prop];
           }
 
-          return obj[prop];
+          return Reflect.get(obj, prop);
         },
       });
     }

--- a/components/_util/hooks/useProxyImperativeHandle.ts
+++ b/components/_util/hooks/useProxyImperativeHandle.ts
@@ -1,0 +1,24 @@
+// Proxy the dom ref with `{ nativeElement, otherFn }` type
+// ref: https://github.com/ant-design/ant-design/discussions/45242
+
+import { useImperativeHandle, type Ref } from 'react';
+
+export default function useProxyImperativeHandle<
+  NativeELementType extends HTMLElement,
+  ReturnRefType extends { nativeElement: NativeELementType },
+>(ref: Ref<any> | undefined, init: () => ReturnRefType) {
+  return useImperativeHandle(ref, () => {
+    const refObj = init();
+    const { nativeElement } = refObj;
+
+    return new Proxy(nativeElement, {
+      get(obj: any, prop: any) {
+        if ((refObj as any)[prop]) {
+          return (refObj as any)[prop];
+        }
+
+        return obj[prop];
+      },
+    });
+  });
+}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -9,6 +9,7 @@ import { convertChildrenToColumns } from 'rc-table/lib/hooks/useColumns';
 import { useComposeRef } from 'rc-util';
 import omit from 'rc-util/lib/omit';
 
+import useProxyImperativeHandle from '../_util/hooks/useProxyImperativeHandle';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import scrollTo from '../_util/scrollTo';
 import type { AnyObject } from '../_util/type';
@@ -152,7 +153,6 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     locale,
     showSorterTooltip = true,
     virtual,
-    reference,
   } = props;
 
   const warning = devUseWarning('Table');
@@ -232,9 +232,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const rootRef = React.useRef<HTMLDivElement>(null);
   const tblRef = React.useRef<RcReference>(null);
 
-  const mergedRootRef = useComposeRef(rootRef, ref);
-
-  React.useImperativeHandle(reference, () => ({
+  useProxyImperativeHandle(ref, () => ({
     ...tblRef.current!,
     nativeElement: rootRef.current!,
   }));
@@ -588,13 +586,13 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   }
 
   return wrapSSR(
-    <div ref={mergedRootRef} className={wrapperClassNames} style={mergedStyle}>
+    <div ref={rootRef} className={wrapperClassNames} style={mergedStyle}>
       <Spin spinning={false} {...spinProps}>
         {topPaginationNode}
         <TableComponent
           {...virtualProps}
           {...tableProps}
-          reference={tblRef}
+          ref={tblRef}
           columns={mergedColumns as RcTableProps<RecordType>['columns']}
           direction={direction}
           expandable={mergedExpandable}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { INTERNAL_HOOKS, type TableProps as RcTableProps, type Reference } from 'rc-table';
+import {
+  INTERNAL_HOOKS,
+  type Reference as RcReference,
+  type TableProps as RcTableProps,
+} from 'rc-table';
 import { convertChildrenToColumns } from 'rc-table/lib/hooks/useColumns';
 import { useComposeRef } from 'rc-util';
 import omit from 'rc-util/lib/omit';
@@ -226,7 +230,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
 
   // ============================= Refs =============================
   const rootRef = React.useRef<HTMLDivElement>(null);
-  const tblRef = React.useRef<Reference>(null);
+  const tblRef = React.useRef<RcReference>(null);
 
   const mergedRootRef = useComposeRef(rootRef, ref);
 

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -6,7 +6,6 @@ import {
   type TableProps as RcTableProps,
 } from 'rc-table';
 import { convertChildrenToColumns } from 'rc-table/lib/hooks/useColumns';
-import { useComposeRef } from 'rc-util';
 import omit from 'rc-util/lib/omit';
 
 import useProxyImperativeHandle from '../_util/hooks/useProxyImperativeHandle';

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,10 +1,9 @@
-import { EXPAND_COLUMN, Summary } from 'rc-table';
 import * as React from 'react';
+import { EXPAND_COLUMN, Summary } from 'rc-table';
+
 import type { AnyObject } from '../_util/type';
 import Column from './Column';
 import ColumnGroup from './ColumnGroup';
-import type { TableProps } from './InternalTable';
-import InternalTable from './InternalTable';
 import {
   SELECTION_ALL,
   SELECTION_COLUMN,
@@ -12,6 +11,8 @@ import {
   SELECTION_NONE,
 } from './hooks/useSelection';
 import type { RefTable } from './interface';
+import type { TableProps } from './InternalTable';
+import InternalTable from './InternalTable';
 
 const Table = <RecordType extends AnyObject = AnyObject>(
   props: TableProps<RecordType>,

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EXPAND_COLUMN, Summary } from 'rc-table';
+import { EXPAND_COLUMN, Summary, type Reference } from 'rc-table';
 
 import type { AnyObject } from '../_util/type';
 import Column from './Column';
@@ -16,7 +16,7 @@ import InternalTable from './InternalTable';
 
 const Table = <RecordType extends AnyObject = AnyObject>(
   props: TableProps<RecordType>,
-  ref: React.Ref<HTMLDivElement>,
+  ref: React.Ref<Reference>,
 ) => {
   const renderTimesRef = React.useRef<number>(0);
   renderTimesRef.current += 1;

--- a/components/table/__tests__/Table.IE.test.tsx
+++ b/components/table/__tests__/Table.IE.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { Reference } from '..';
+import type { TableRef } from '..';
 import Table from '..';
 import { render } from '../../../tests/utils';
 
@@ -11,7 +11,7 @@ describe('Table.IE', () => {
   });
 
   it('support reference', () => {
-    const tblRef = React.createRef<Reference>();
+    const tblRef = React.createRef<TableRef>();
     const { container } = render(<Table ref={tblRef} />);
 
     const wrapDom = container.querySelector('.ant-table-wrapper')!;

--- a/components/table/__tests__/Table.IE.test.tsx
+++ b/components/table/__tests__/Table.IE.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import type { Reference } from '..';
+import Table from '..';
+import { render } from '../../../tests/utils';
+
+describe('Table.IE', () => {
+  beforeAll(() => {
+    window.Proxy = undefined as any;
+    global.Proxy = undefined as any;
+  });
+
+  it('support reference', () => {
+    const tblRef = React.createRef<Reference>();
+    const { container } = render(<Table ref={tblRef} />);
+
+    const wrapDom = container.querySelector('.ant-table-wrapper')!;
+
+    expect(tblRef.current).toBe(wrapDom);
+    expect(tblRef.current?.nativeElement).toBe(wrapDom);
+  });
+});

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { ConfigProvider } from 'antd';
-import type { TableProps } from '..';
+
+import type { Reference, TableProps } from '..';
 import Table from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -400,5 +401,12 @@ describe('Table', () => {
     fireEvent.click(container.querySelector('.ant-table-filter-trigger')!);
     await waitFakeTimer();
     expect(container.querySelector('.ant-dropdown')).toBeTruthy();
+  });
+
+  it('support reference', () => {
+    const tblRef = React.createRef<Reference>();
+    const { container } = render(<Table reference={tblRef} />);
+
+    expect(tblRef.current?.nativeElement).toBe(container.querySelector('.ant-table-wrapper')!);
   });
 });

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { ConfigProvider } from 'antd';
 
-import type { Reference, TableProps } from '..';
+import type { TableProps, TableRef } from '..';
 import Table from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -404,7 +404,7 @@ describe('Table', () => {
   });
 
   it('support reference', () => {
-    const tblRef = React.createRef<Reference>();
+    const tblRef = React.createRef<TableRef>();
     const { container } = render(<Table ref={tblRef} />);
 
     const wrapDom = container.querySelector('.ant-table-wrapper')!;

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -280,7 +280,7 @@ describe('Table', () => {
       },
     ];
     const Wrapper: React.FC = () => {
-      const ref = React.useRef<HTMLDivElement>(null);
+      const ref = React.useRef<any>(null);
       return <Table ref={ref} columns={columns} />;
     };
     render(<Wrapper />);

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -405,8 +405,12 @@ describe('Table', () => {
 
   it('support reference', () => {
     const tblRef = React.createRef<Reference>();
-    const { container } = render(<Table reference={tblRef} />);
+    const { container } = render(<Table ref={tblRef} />);
 
-    expect(tblRef.current?.nativeElement).toBe(container.querySelector('.ant-table-wrapper')!);
+    const wrapDom = container.querySelector('.ant-table-wrapper')!;
+
+    expect(tblRef.current).toHaveClass('ant-table-wrapper');
+    expect(tblRef.current?.nativeElement).toBe(wrapDom);
+    expect(tblRef.current?.scrollTo instanceof Function).toBeTruthy();
   });
 });

--- a/components/table/demo/virtual-list.tsx
+++ b/components/table/demo/virtual-list.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Segmented, Space, Switch, Table, Typography } from 'antd';
+import { Button, Segmented, Space, Switch, Table, Typography } from 'antd';
 import type { TableProps } from 'antd';
 
 interface RecordType {
@@ -114,6 +114,7 @@ const App = () => {
   const [empty, setEmpty] = React.useState(false);
   const [count, setCount] = React.useState(10000);
 
+  const tblRef: Parameters<typeof Table>[0]['ref'] = React.useRef(null);
   const data = React.useMemo(() => getData(count), [count]);
 
   const mergedColumns = React.useMemo<typeof fixedColumns>(() => {
@@ -186,6 +187,16 @@ const App = () => {
               },
             ]}
           />
+
+          {data.length >= 999 && (
+            <Button
+              onClick={() => {
+                tblRef.current?.scrollTo({ index: 999 });
+              }}
+            >
+              Scroll To index 999
+            </Button>
+          )}
         </Space>
 
         <Table
@@ -196,6 +207,7 @@ const App = () => {
           rowKey="id"
           dataSource={empty ? [] : data}
           pagination={false}
+          ref={tblRef}
           rowSelection={
             expanded
               ? undefined

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -125,6 +125,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | loading | Loading status of table | boolean \| [Spin Props](/components/spin/#api) | false |  |
 | locale | The i18n text including filter, sort, empty text, etc | object | [Default Value](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/en_US.tsx#L19-L37) |  |
 | pagination | Config of pagination. You can ref table pagination [config](#pagination) or full [`pagination`](/components/pagination/) document, hide it by setting it to `false` | object \| `false` | - |  |
+| reference | Similar as `ref`. Support get native dom or other function | { nativeElement: HTMLDivElement, scrollTo: (config: { index?: number, key?: React.Key, top?: number }) => void } | - | 5.11.0 |
 | rowClassName | Row's className | function(record, index): string | - |  |
 | rowKey | Row's unique key, could be a string or function that returns a string | string \| function(record): string | `key` |  |
 | rowSelection | Row selection [config](#rowselection) | object | - |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -147,7 +147,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Version |
 | --- | --- | --- | --- |
 | nativeElement | The wrap element | HTMLDivElement | 5.11.0 |
-| scrollTo | Trigger to scroll to target position | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
+| scrollTo | Trigger to scroll to target position. `key` match with record `rowKey` | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
 
 #### onRow usage
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -125,7 +125,6 @@ Common props ref：[Common props](/docs/react/common-props)
 | loading | Loading status of table | boolean \| [Spin Props](/components/spin/#api) | false |  |
 | locale | The i18n text including filter, sort, empty text, etc | object | [Default Value](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/en_US.tsx#L19-L37) |  |
 | pagination | Config of pagination. You can ref table pagination [config](#pagination) or full [`pagination`](/components/pagination/) document, hide it by setting it to `false` | object \| `false` | - |  |
-| reference | Similar as `ref`. Support get native dom or other function | { nativeElement: HTMLDivElement, scrollTo: (config: { index?: number, key?: React.Key, top?: number }) => void } | - | 5.11.0 |
 | rowClassName | Row's className | function(record, index): string | - |  |
 | rowKey | Row's unique key, could be a string or function that returns a string | string \| function(record): string | `key` |  |
 | rowSelection | Row selection [config](#rowselection) | object | - |  |
@@ -142,6 +141,13 @@ Common props ref：[Common props](/docs/react/common-props)
 | onHeaderRow | Set props on per header row | function(columns, index) | - |  |
 | onRow | Set props on per row | function(record, index) | - |  |
 | virtual | Support virtual list | boolean | - | 5.9.0 |
+
+### Table ref
+
+| Property | Description | Type | Version |
+| --- | --- | --- | --- |
+| nativeElement | The wrap element | HTMLDivElement | 5.11.0 |
+| scrollTo | Trigger to scroll to target position | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
 
 #### onRow usage
 

--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -3,6 +3,7 @@ import Table from './Table';
 
 export type { ColumnProps } from './Column';
 export type { ColumnGroupType, ColumnType, ColumnsType } from './interface';
+export type { Reference } from 'rc-table';
 export type { TablePaginationConfig, TableProps };
 
 export default Table;

--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -3,7 +3,7 @@ import Table from './Table';
 
 export type { ColumnProps } from './Column';
 export type { ColumnGroupType, ColumnType, ColumnsType } from './interface';
-export type { Reference } from 'rc-table';
+export type { Reference as TableRef } from 'rc-table';
 export type { TablePaginationConfig, TableProps };
 
 export default Table;

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -126,7 +126,6 @@ const columns = [
 | loading | 页面是否加载中 | boolean \| [Spin Props](/components/spin-cn#api) | false |  |
 | locale | 默认文案设置，目前包括排序、过滤、空数据文案 | object | [默认值](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/zh_CN.tsx#L20-L37) |  |
 | pagination | 分页器，参考[配置项](#pagination)或 [pagination](/components/pagination-cn) 文档，设为 false 时不展示和进行分页 | object \| `false` | - |  |
-| reference | 同 `ref` ，支持获取原生 dom 元素以及操作方法。 | { nativeElement: HTMLDivElement, scrollTo: (config: { index?: number, key?: React.Key, top?: number }) => void } | - | 5.11.0 |
 | rowClassName | 表格行的类名 | function(record, index): string | - |  |
 | rowKey | 表格行 key 的取值，可以是字符串或一个函数 | string \| function(record): string | `key` |  |
 | rowSelection | 表格行是否可选择，[配置项](#rowselection) | object | - |  |
@@ -143,6 +142,13 @@ const columns = [
 | onHeaderRow | 设置头部行属性 | function(columns, index) | - |  |
 | onRow | 设置行属性 | function(record, index) | - |  |
 | virtual | 支持虚拟列表 | boolean | - | 5.9.0 |
+
+### Table ref
+
+| Property | Description | Type | Version |
+| --- | --- | --- | --- |
+| nativeElement | 最外层 div 元素 | HTMLDivElement | 5.11.0 |
+| scrollTo | 滚动到目标位置 | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
 
 #### onRow 用法
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -148,7 +148,7 @@ const columns = [
 | Property | Description | Type | Version |
 | --- | --- | --- | --- |
 | nativeElement | 最外层 div 元素 | HTMLDivElement | 5.11.0 |
-| scrollTo | 滚动到目标位置 | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
+| scrollTo | 滚动到目标位置（设置 `key` 时为 Record 对应的 `rowKey`） | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |
 
 #### onRow 用法
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -126,6 +126,7 @@ const columns = [
 | loading | 页面是否加载中 | boolean \| [Spin Props](/components/spin-cn#api) | false |  |
 | locale | 默认文案设置，目前包括排序、过滤、空数据文案 | object | [默认值](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/zh_CN.tsx#L20-L37) |  |
 | pagination | 分页器，参考[配置项](#pagination)或 [pagination](/components/pagination-cn) 文档，设为 false 时不展示和进行分页 | object \| `false` | - |  |
+| reference | 同 `ref` ，支持获取原生 dom 元素以及操作方法。 | { nativeElement: HTMLDivElement, scrollTo: (config: { index?: number, key?: React.Key, top?: number }) => void } | - | 5.11.0 |
 | rowClassName | 表格行的类名 | function(record, index): string | - |  |
 | rowKey | 表格行 key 的取值，可以是字符串或一个函数 | string \| function(record): string | `key` |  |
 | rowSelection | 表格行是否可选择，[配置项](#rowselection) | object | - |  |
@@ -170,7 +171,6 @@ const columns = [
 
 列描述数据对象，是 columns 中的一项，Column 使用相同的 API。
 
-<!-- prettier-ignore -->
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | align | 设置列的对齐方式 | `left` \| `right` \| `center` | `left` |  |
@@ -205,7 +205,7 @@ const columns = [
 | width | 列宽度（[指定了也不生效？](https://github.com/ant-design/ant-design/issues/13825#issuecomment-449889241)） | string \| number | - |  |
 | onCell | 设置单元格属性 | function(record, rowIndex) | - |  |
 | onFilter | 本地模式下，确定筛选的运行函数 | function | - |  |
-| onFilterDropdownOpenChange | 自定义筛选菜单可见变化时调用 | function(visible) {} | - |  |  |
+| onFilterDropdownOpenChange | 自定义筛选菜单可见变化时调用 | function(visible) {} | - |  |
 | onHeaderCell | 设置头部单元格属性 | function(column) | - |  |
 
 ### ColumnGroup

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -145,7 +145,7 @@ const columns = [
 
 ### Table ref
 
-| Property | Description | Type | Version |
+| 参数 | 说明 | 类型 | 版本 |
 | --- | --- | --- | --- |
 | nativeElement | 最外层 div 元素 | HTMLDivElement | 5.11.0 |
 | scrollTo | 滚动到目标位置（设置 `key` 时为 Record 对应的 `rowKey`） | (config: { index?: number, key?: React.Key, top?: number }) => void | 5.11.0 |

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import type { Reference } from 'rc-table';
 import type {
   FixedType,
   GetComponentProps,
@@ -16,12 +17,12 @@ import type { INTERNAL_SELECTION_ITEM } from './hooks/useSelection';
 import type { InternalTableProps, TableProps } from './InternalTable';
 
 export type RefTable = <RecordType extends AnyObject = AnyObject>(
-  props: React.PropsWithChildren<TableProps<RecordType>> & { ref?: React.Ref<HTMLDivElement> },
+  props: React.PropsWithChildren<TableProps<RecordType>> & { ref?: React.Ref<Reference> },
 ) => React.ReactElement;
 
 export type RefInternalTable = <RecordType extends AnyObject = AnyObject>(
   props: React.PropsWithChildren<InternalTableProps<RecordType>> & {
-    ref?: React.Ref<HTMLDivElement>;
+    ref?: React.Ref<Reference>;
   },
 ) => React.ReactElement;
 

--- a/components/theme/util/statistic.ts
+++ b/components/theme/util/statistic.ts
@@ -54,7 +54,7 @@ export default function statisticToken<T extends object>(token: T) {
   let flush: (componentName: string, componentToken: Record<string, string | number>) => void =
     noop;
 
-  if (enableStatistic) {
+  if (enableStatistic && typeof Proxy !== 'undefined') {
     tokenKeys = new Set<string>();
 
     proxy = new Proxy(token, {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "rc-slider": "~10.3.0",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
-    "rc-table": "~7.34.4",
+    "rc-table": "~7.35.0",
     "rc-tabs": "~12.12.1",
     "rc-textarea": "~1.4.0",
     "rc-tooltip": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "rc-slider": "~10.3.0",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
-    "rc-table": "~7.35.0",
+    "rc-table": "~7.35.1",
     "rc-tabs": "~12.12.1",
     "rc-textarea": "~1.4.0",
     "rc-tooltip": "~6.1.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

ref https://github.com/ant-design/ant-design/discussions/45242
resolve #44595
resolve #45234

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   🚨 Refactor Table `ref` to support `scrollTo` to scroll to target `key` or `index` or `top`.        |
| 🇨🇳 Chinese |     🚨 重构 Table `ref` 支持 `scrollTo` 以滚动到目标 `key` 或 `index` 或 `top`      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09b71fd</samp>

Added a `reference` prop to the `Table` component to allow accessing the table dom element and scrolling methods. Updated the documentation, tests, and dependencies accordingly. Refactored some internal components and types of the `Table` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09b71fd</samp>

*  Add `reference` prop to `Table` component to support getting the native dom element and other methods from the table instance ([link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R151), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R227-R237), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616R593), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-9e016ea02fe7dd0ea42d8774d29d45e1a10b8dd108de9c89d50c828c74b993b8R14-R15), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-1472817fa7245b7d992a6a03b35192c613278a6248370d54eb2a8b0e62814ed1L3-R4), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-1472817fa7245b7d992a6a03b35192c613278a6248370d54eb2a8b0e62814ed1R405-R411), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-8d3a4194d516aa3322b22843bc2a379cdb0ad134c5e22899e6468d16c85d85c9R128), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-926ab5191876ea212b18b01284be99615b47d3d569e1c6e0c410b944c35431d2R6), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209R129), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L150-R150))
* Move `EXPAND_COLUMN` and `Summary` from `Table.tsx` to `InternalTable.tsx` as they are only used in the latter file ([link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-a5896d4aa0af160e25dae36aec024d58f1f1769814b1777acedf581c53140616L3-R5), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-9e016ea02fe7dd0ea42d8774d29d45e1a10b8dd108de9c89d50c828c74b993b8L1-R6))
* Remove unnecessary `prettier-ignore` comment and extra `|` symbol from `index.zh-CN.md` file ([link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209L173), [link](https://github.com/ant-design/ant-design/pull/45245/files?diff=unified&w=0#diff-1d555de1f30d5e46ff95e81b3d10b27baf15321e455557e7d3a55ca09ff61209L208-R208))
