### PR TITLE
fix: options missing id

### DIFF
--- a/.dumi/pages/index/components/Theme/ColorPicker.tsx
+++ b/.dumi/pages/index/components/Theme/ColorPicker.tsx
@@ -35,6 +35,7 @@ const useStyle = createStyles(({ token, css }) => ({
 }));
 
 export interface ColorPickerProps {
+  id?: string;
   children?: React.ReactNode;
   value?: string | Color;
   onChange?: (value?: Color | string) => void;
@@ -66,7 +67,7 @@ const DebouncedColorPicker: React.FC<ColorPickerProps> = (props) => {
   );
 };
 
-const ThemeColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
+const ThemeColorPicker: React.FC<ColorPickerProps> = ({ value, onChange, id }) => {
   const { styles } = useStyle();
 
   const matchColors = React.useMemo(() => {
@@ -95,6 +96,7 @@ const ThemeColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
         value={typeof value === 'string' ? value : value?.toHexString()}
         onChange={(event) => onChange?.(event.target.value)}
         style={{ width: 120 }}
+        id={id}
       />
 
       <Space size="middle">

--- a/.dumi/pages/index/components/Theme/RadiusPicker.tsx
+++ b/.dumi/pages/index/components/Theme/RadiusPicker.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { InputNumber, Space, Slider } from 'antd';
+import { InputNumber, Slider, Space } from 'antd';
 
 export interface RadiusPickerProps {
+  id?: string;
   value?: number;
   onChange?: (value: number | null) => void;
 }
 
-export default function RadiusPicker({ value, onChange }: RadiusPickerProps) {
+export default function RadiusPicker({ value, onChange, id }: RadiusPickerProps) {
   return (
     <Space size="large">
       <InputNumber
@@ -16,6 +17,7 @@ export default function RadiusPicker({ value, onChange }: RadiusPickerProps) {
         min={0}
         formatter={(val) => `${val}px`}
         parser={(str) => (str ? parseFloat(str) : (str as any))}
+        id={id}
       />
 
       <Slider

--- a/.dumi/pages/index/components/Theme/ThemePicker.tsx
+++ b/.dumi/pages/index/components/Theme/ThemePicker.tsx
@@ -1,7 +1,8 @@
-import { createStyles, useTheme } from 'antd-style';
 import * as React from 'react';
-import classNames from 'classnames';
 import { Space } from 'antd';
+import { createStyles, useTheme } from 'antd-style';
+import classNames from 'classnames';
+
 import useLocale from '../../../../hooks/useLocale';
 
 export const THEMES = {
@@ -33,48 +34,54 @@ const locales = {
 
 const useStyle = createStyles(({ token, css }) => ({
   themeCard: css`
-      border-radius: ${token.borderRadius}px;
-      cursor: pointer;
-      transition: all ${token.motionDurationSlow};
-      overflow: hidden;
-      display: inline-block;
+    border-radius: ${token.borderRadius}px;
+    cursor: pointer;
+    transition: all ${token.motionDurationSlow};
+    overflow: hidden;
+    display: inline-block;
 
-      & > input[type="radio"] {
-        width: 0;
-        height: 0;
-        opacity: 0;
-        position: absolute;
-      }
+    & > input[type='radio'] {
+      width: 0;
+      height: 0;
+      opacity: 0;
+      position: absolute;
+    }
 
-      img {
-        vertical-align: top;
-        box-shadow: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08),
-          0 9px 28px 8px rgba(0, 0, 0, 0.05);
-      }
+    img {
+      vertical-align: top;
+      box-shadow:
+        0 3px 6px -4px rgba(0, 0, 0, 0.12),
+        0 6px 16px 0 rgba(0, 0, 0, 0.08),
+        0 9px 28px 8px rgba(0, 0, 0, 0.05);
+    }
 
-      &:focus-within,
-      &:hover {
-        transform: scale(1.04);
-      }
-    `,
+    &:focus-within,
+    &:hover {
+      transform: scale(1.04);
+    }
+  `,
 
   themeCardActive: css`
-      box-shadow: 0 0 0 1px ${token.colorBgContainer},
-        0 0 0 ${token.controlOutlineWidth * 2 + 1}px ${token.colorPrimary};
+    box-shadow:
+      0 0 0 1px ${token.colorBgContainer},
+      0 0 0 ${token.controlOutlineWidth * 2 + 1}px ${token.colorPrimary};
 
-      &,
-      &:hover:not(:focus-within) {
-        transform: scale(1);
-      }
-    `,
+    &,
+    &:hover:not(:focus-within) {
+      transform: scale(1);
+    }
+  `,
 }));
 
 export interface ThemePickerProps {
+  id?: string;
   value?: string;
   onChange?: (value: string) => void;
 }
 
-export default function ThemePicker({ value, onChange }: ThemePickerProps) {
+export default function ThemePicker(props: ThemePickerProps) {
+  const { value, onChange, id } = props;
+
   const token = useTheme();
   const { styles } = useStyle();
 
@@ -82,7 +89,7 @@ export default function ThemePicker({ value, onChange }: ThemePickerProps) {
 
   return (
     <Space size={token.paddingLG}>
-      {Object.keys(THEMES).map((theme) => {
+      {Object.keys(THEMES).map((theme, index) => {
         const url = THEMES[theme as THEME];
 
         return (
@@ -94,7 +101,7 @@ export default function ThemePicker({ value, onChange }: ThemePickerProps) {
                 onChange?.(theme);
               }}
             >
-              <input type="radio" name="theme" />
+              <input type="radio" name="theme" id={index === 0 ? id : null} />
               <img src={url} alt={theme} />
             </label>
             <span>{locale[theme as keyof typeof locale]}</span>

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -534,11 +534,20 @@ export default function Theme() {
                     <Form.Item label={locale.titleBorderRadius} name="borderRadius">
                       <RadiusPicker />
                     </Form.Item>
-                    <Form.Item label={locale.titleCompact} name="compact">
-                      <Radio.Group>
-                        <Radio value="default">{locale.default}</Radio>
-                        <Radio value="compact">{locale.compact}</Radio>
-                      </Radio.Group>
+                    <Form.Item label={locale.titleCompact} name="compact" htmlFor="compact_default">
+                      <Radio.Group
+                        options={[
+                          {
+                            label: locale.default,
+                            value: 'default',
+                            id: 'compact_default',
+                          },
+                          {
+                            label: locale.compact,
+                            value: 'compact',
+                          },
+                        ]}
+                      />
                     </Form.Item>
                   </Form>
                 </Card>

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,11 +1,11 @@
+import * as React from 'react';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
-import * as React from 'react';
+
 import { ConfigContext } from '../config-provider';
 import type { CheckboxChangeEvent } from './Checkbox';
 import Checkbox from './Checkbox';
 import GroupContext from './GroupContext';
-
 import useStyle from './style';
 
 export type CheckboxValueType = string | number | boolean;
@@ -16,6 +16,7 @@ export interface CheckboxOptionType {
   style?: React.CSSProperties;
   disabled?: boolean;
   title?: string;
+  id?: string;
   onChange?: (e: CheckboxChangeEvent) => void;
 }
 
@@ -124,6 +125,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
           className={`${groupPrefixCls}-item`}
           style={option.style}
           title={option.title}
+          id={option.id}
         >
           {option.label}
         </Checkbox>

--- a/components/checkbox/__tests__/group.test.tsx
+++ b/components/checkbox/__tests__/group.test.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
@@ -267,5 +268,12 @@ describe('CheckboxGroup', () => {
     fireEvent.change(container.querySelector('.ant-input')!, { target: { value: '' } });
     fireEvent.click(container.querySelector('.ant-checkbox-input')!);
     expect(onChange).toHaveBeenCalledWith(['A']);
+  });
+
+  it('options support id', () => {
+    const { container } = render(
+      <Checkbox.Group options={[{ label: 'bamboo', id: 'bamboo', value: 'bamboo' }]} />,
+    );
+    expect(container.querySelector('#bamboo')).toBeTruthy();
   });
 });

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -1,5 +1,6 @@
 import type { RefAttributes } from 'react';
 import React from 'react';
+
 import type { RadioGroupProps } from '..';
 import Radio from '..';
 import { fireEvent, render } from '../../../tests/utils';
@@ -251,5 +252,12 @@ describe('Radio Group', () => {
     expect(handleFocus).toHaveBeenCalledTimes(1);
     fireEvent.blur(container.firstChild!);
     expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('options support id', () => {
+    const { container } = render(
+      <Radio.Group options={[{ label: 'bamboo', id: 'bamboo', value: 'bamboo' }]} />,
+    );
+    expect(container.querySelector('#bamboo')).toBeTruthy();
   });
 });

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -79,6 +79,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
           checked={value === option.value}
           title={option.title}
           style={option.style}
+          id={option.id}
         >
           {option.label}
         </Radio>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #44505

### 💡 Background and solution

补了一下文档 label for，发现可以优化一下 options

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Checkbox.Group & Radio.Group `options` add missing `id` props.     |
| 🇨🇳 Chinese |     Checkbox.Group 与 Radio.Group 的 `options` 添加 `id` 属性支持。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9df555</samp>

This pull request improves the accessibility and code style of the theme picker and the checkbox and radio groups by adding and passing `id` props to the components. It also adds test cases and formats the test files for the `Checkbox.Group` and `Radio.Group` components. It modifies the `ThemePicker.tsx`, `ColorPicker.tsx`, `RadiusPicker.tsx`, and `index.tsx` files to use the `id` props and link the labels with the inputs.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9df555</samp>

*  Add `id` prop to `Checkbox.Group`, `Radio.Group`, `ThemePicker`, `ThemeColorPicker`, and `RadiusPicker` components to improve accessibility ([link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63R19), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63R128), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-85547b1be5fa04a65a8ea1ce2c7f454ee66c4bb75c4453f7491f0c2c0f651996R272-R278), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749R82), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-3bde68ef6e79970a3dd6e92cf661a4eb62e1bec50dbbb33c49833837e4f5e8cdR256-R262), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-bb71d3e7437a45c3978afff7a00abefa4e0c15a401677f1a732c773f7027d36eR38), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-bb71d3e7437a45c3978afff7a00abefa4e0c15a401677f1a732c773f7027d36eL69-R70), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-bb71d3e7437a45c3978afff7a00abefa4e0c15a401677f1a732c773f7027d36eR99), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9acb0fe7a2ae211f88fcb1122ef6f12b644b1ee22e33c47bded7cce09b8e7009L2-R10), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9acb0fe7a2ae211f88fcb1122ef6f12b644b1ee22e33c47bded7cce09b8e7009R20), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9ac0f4a6f5f6e7f8ca9a08ba42c07109b6705731c89c6b1af5daf7e2e9d5850dL36-R84), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9ac0f4a6f5f6e7f8ca9a08ba42c07109b6705731c89c6b1af5daf7e2e9d5850dL85-R92), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9ac0f4a6f5f6e7f8ca9a08ba42c07109b6705731c89c6b1af5daf7e2e9d5850dL97-R104), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL537-R550))
*  Refactor `Radio.Group` component in `.dumi/pages/index/components/Theme/index.tsx` to use `options` prop instead of `Radio` children ([link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-fb37d7abd9dddd9f2a8c076bfd9eea2336873f1051d1f37dceaca099206a4aedL537-R550))
*  Reorder import statements in `ThemePicker.tsx` and `Group.tsx` ([link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-9ac0f4a6f5f6e7f8ca9a08ba42c07109b6705731c89c6b1af5daf7e2e9d5850dL1-R5), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L1-R8))
*  Add empty lines at the beginning of `group.test.tsx` files ([link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-85547b1be5fa04a65a8ea1ce2c7f454ee66c4bb75c4453f7491f0c2c0f651996R2), [link](https://github.com/ant-design/ant-design/pull/45287/files?diff=unified&w=0#diff-3bde68ef6e79970a3dd6e92cf661a4eb62e1bec50dbbb33c49833837e4f5e8cdR3))
