### PR TITLE
feat: App support component

### DIFF
--- a/components/_util/type.ts
+++ b/components/_util/type.ts
@@ -2,3 +2,5 @@
 export type LiteralUnion<T extends string> = T | (string & {});
 
 export type AnyObject = Record<PropertyKey, any>;
+
+export type CustomComponent<P = AnyObject> = React.ComponentType<P> | string;

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
-import { SmileOutlined } from '@ant-design/icons';
 import React, { useEffect } from 'react';
+import { SmileOutlined } from '@ant-design/icons';
 import type { NotificationConfig } from 'antd/es/notification/interface';
+
 import App from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -207,5 +208,15 @@ describe('App', () => {
         }),
       ).toBeTruthy();
     });
+  });
+
+  it('component to false', () => {
+    const { container } = render(
+      <App component={false}>
+        <p />
+      </App>,
+    );
+
+    expect(container.querySelector('.ant-app')).toBeFalsy();
   });
 });

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -210,13 +210,25 @@ describe('App', () => {
     });
   });
 
-  it('component to false', () => {
-    const { container } = render(
-      <App component={false}>
-        <p />
-      </App>,
-    );
+  describe('component', () => {
+    it('replace', () => {
+      const { container } = render(
+        <App component="section">
+          <p />
+        </App>,
+      );
 
-    expect(container.querySelector('.ant-app')).toBeFalsy();
+      expect(container.querySelector('section.ant-app')).toBeTruthy();
+    });
+
+    it('to false', () => {
+      const { container } = render(
+        <App component={false}>
+          <p />
+        </App>,
+      );
+
+      expect(container.querySelector('.ant-app')).toBeFalsy();
+    });
   });
 });

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -29,8 +29,8 @@ Application wrapper for some global usages.
 App provides upstream and downstream method calls through `Context`, because useApp needs to be used as a subcomponent, we recommend encapsulating App at the top level in the application.
 
 ```tsx
-import { App } from 'antd';
 import React from 'react';
+import { App } from 'antd';
 
 const MyPage: React.FC = () => {
   const { message, notification, modal } = App.useApp();
@@ -102,8 +102,9 @@ export { message, modal, notification };
 
 ```tsx
 // sub page
-import { Button, Space } from 'antd';
 import React from 'react';
+import { Button, Space } from 'antd';
+
 import { message } from './store';
 
 export default () => {
@@ -129,6 +130,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| component | Config render element, if `false` will not create DOM node | ComponentType | div | 5.11.0 |
 | message | Global config for Message | [MessageConfig](/components/message/#messageconfig) | - | 5.3.0 |
 | notification | Global config for Notification | [NotificationConfig](/components/notification/#notificationconfig) | - | 5.3.0 |
 

--- a/components/app/index.tsx
+++ b/components/app/index.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 
+import type { CustomComponent } from '../_util/type';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import useMessage from '../message/useMessage';
@@ -17,7 +18,7 @@ export interface AppProps extends AppConfig {
   rootClassName?: string;
   prefixCls?: string;
   children?: ReactNode;
-  component?: false | string | React.FC<any> | React.ComponentClass<any>;
+  component?: false | CustomComponent;
 }
 
 const useApp = () => React.useContext<useAppProps>(AppContext);

--- a/components/app/index.tsx
+++ b/components/app/index.tsx
@@ -1,6 +1,7 @@
-import classNames from 'classnames';
 import type { ReactNode } from 'react';
 import React, { useContext } from 'react';
+import classNames from 'classnames';
+
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import useMessage from '../message/useMessage';
@@ -16,6 +17,7 @@ export interface AppProps extends AppConfig {
   rootClassName?: string;
   prefixCls?: string;
   children?: ReactNode;
+  component?: false | string | React.FC<any> | React.ComponentClass<any>;
 }
 
 const useApp = () => React.useContext<useAppProps>(AppContext);
@@ -29,6 +31,7 @@ const App: React.FC<AppProps> & { useApp: typeof useApp } = (props) => {
     message,
     notification,
     style,
+    component = 'div',
   } = props;
   const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('app', customizePrefixCls);
@@ -60,15 +63,22 @@ const App: React.FC<AppProps> & { useApp: typeof useApp } = (props) => {
     [messageApi, notificationApi, ModalApi],
   );
 
+  // ============================ Render ============================
+  const Component = component === false ? React.Fragment : component;
+  const rootProps = {
+    className: customClassName,
+    style,
+  };
+
   return wrapSSR(
     <AppContext.Provider value={memoizedContextValue}>
       <AppConfigContext.Provider value={mergedAppConfig}>
-        <div className={customClassName} style={style}>
+        <Component {...rootProps}>
           {ModalContextHolder}
           {messageContextHolder}
           {notificationContextHolder}
           {children}
-        </div>
+        </Component>
       </AppConfigContext.Provider>
     </AppContext.Provider>,
   );

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -131,6 +131,7 @@ export default () => {
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| component | 设置渲染元素，为 `false` 则不创建 DOM 节点 | ComponentType | div | 5.11.0 |
 | message | App 内 Message 的全局配置 | [MessageConfig](/components/message-cn/#messageconfig) | - | 5.3.0 |
 | notification | App 内 Notification 的全局配置 | [NotificationConfig](/components/notification-cn/#notificationconfig) | - | 5.3.0 |
 

--- a/components/flex/interface.ts
+++ b/components/flex/interface.ts
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import type { AnyObject } from '../_util/type';
+import type { AnyObject, CustomComponent } from '../_util/type';
 import type { SizeType } from '../config-provider/SizeContext';
 
 export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLElement> {
@@ -13,5 +13,5 @@ export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLEleme
   flex?: React.CSSProperties['flex'];
   gap?: React.CSSProperties['gap'] | SizeType;
   children: React.ReactNode;
-  component?: React.ComponentType<P> | string;
+  component?: CustomComponent<P>;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #44716

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   App support `component` for customization.        |
| 🇨🇳 Chinese |  App 支持 `component` 以自定义渲染元素。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2c84ab</samp>

Added a new prop `component` to the `App` component to allow customizing or removing the root element. Updated the documentation and tests for the `App` component in both English and Chinese. Fixed the import order of some files to follow ESLint rule.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2c84ab</samp>

*  Add a new `component` prop to the `App` component to allow customizing or disabling the render element ([link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-95b0dcfbdd9a195d1d0141272a065d901452a60a60632bd0e30f74e80eb85a6bR20), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-95b0dcfbdd9a195d1d0141272a065d901452a60a60632bd0e30f74e80eb85a6bR34), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-95b0dcfbdd9a195d1d0141272a065d901452a60a60632bd0e30f74e80eb85a6bL63-R81))
*  Update the documentation of the `App` component in English and Chinese to include the `component` prop and its usage examples ([link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cR133), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-88905ff2c3941f956e0d1dbf8871b8f2d633992532d79997fc5be05032729291R134), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cL32-R33), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cL105-R107))
*  Add two test cases to verify the behavior of the `component` prop in the `App` component ([link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-52400589dcfd21bced4d2c624c0fbb235acac6ec308f1cf4c3fa37fcc8e80cf8R212-R233))
*  Adjust the import order of external and internal modules in the source code and documentation of the `App` component to follow the ESLint rule ([link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-52400589dcfd21bced4d2c624c0fbb235acac6ec308f1cf4c3fa37fcc8e80cf8L1-R4), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cL32-R33), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-c779f7d3b6a66acd0ce5e8bf4f1625badb983056711cc82435808368588ed38cL105-R107), [link](https://github.com/ant-design/ant-design/pull/45292/files?diff=unified&w=0#diff-95b0dcfbdd9a195d1d0141272a065d901452a60a60632bd0e30f74e80eb85a6bL1-R4))
