### PR TITLE
feat: Watermark support inherit to disable passing

### DIFF
--- a/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1249,7 +1249,7 @@ Array [
         type="button"
       >
         <span>
-          Show Modal
+          Show in Modal
         </span>
       </button>
     </div>
@@ -1261,10 +1261,30 @@ Array [
         type="button"
       >
         <span>
-          Show Drawer
+          Show in Drawer
         </span>
       </button>
     </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default"
+        type="button"
+      >
+        <span>
+          Not Show in Drawer
+        </span>
+      </button>
+    </div>
+  </div>,
+  <div
+    class=""
+    style="position: relative;"
+  >
+    <div
+      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px;"
+    />
   </div>,
   <div
     class=""

--- a/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
@@ -810,7 +810,7 @@ Array [
         type="button"
       >
         <span>
-          Show Modal
+          Show in Modal
         </span>
       </button>
     </div>
@@ -822,11 +822,27 @@ Array [
         type="button"
       >
         <span>
-          Show Drawer
+          Show in Drawer
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default"
+        type="button"
+      >
+        <span>
+          Not Show in Drawer
         </span>
       </button>
     </div>
   </div>,
+  <div
+    class=""
+    style="position:relative"
+  />,
   <div
     class=""
     style="position:relative"

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -134,6 +134,19 @@ describe('Watermark', () => {
       <Drawer open />,
       () => document.body.querySelector('.ant-drawer-content')!.lastChild!,
     );
+
+    it('inherit=false', async () => {
+      render(
+        <Watermark inherit={false}>
+          <Drawer open />
+        </Watermark>,
+      );
+      await waitFakeTimer();
+
+      expect(document.body.querySelector('.ant-drawer-content')!.lastChild).toHaveClass(
+        'ant-drawer-wrapper-body',
+      );
+    });
   });
 
   it('should not crash if content is empty string', async () => {

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -135,7 +135,7 @@ describe('Watermark', () => {
       () => document.body.querySelector('.ant-drawer-content')!.lastChild!,
     );
 
-    it('inherit=false', async () => {
+    it('inherit = false', async () => {
       render(
         <Watermark inherit={false}>
           <Drawer open />

--- a/components/watermark/demo/portal.tsx
+++ b/components/watermark/demo/portal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Watermark, Modal, Drawer, Button, Space } from 'antd';
+import { Button, Drawer, Modal, Space, Watermark } from 'antd';
 
 const placeholder = (
   <div
@@ -18,15 +18,18 @@ const placeholder = (
 const App: React.FC = () => {
   const [showModal, setShowModal] = React.useState(false);
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const [showDrawer2, setShowDrawer2] = React.useState(false);
 
   const closeModal = () => setShowModal(false);
   const closeDrawer = () => setShowDrawer(false);
+  const closeDrawer2 = () => setShowDrawer2(false);
 
   return (
     <>
       <Space>
-        <Button onClick={() => setShowModal(true)}>Show Modal</Button>
-        <Button onClick={() => setShowDrawer(true)}>Show Drawer</Button>
+        <Button onClick={() => setShowModal(true)}>Show in Modal</Button>
+        <Button onClick={() => setShowDrawer(true)}>Show in Drawer</Button>
+        <Button onClick={() => setShowDrawer2(true)}>Not Show in Drawer</Button>
       </Space>
 
       <Watermark content="Ant Design">
@@ -40,6 +43,11 @@ const App: React.FC = () => {
           {placeholder}
         </Modal>
         <Drawer destroyOnClose open={showDrawer} title="Drawer" onClose={closeDrawer}>
+          {placeholder}
+        </Drawer>
+      </Watermark>
+      <Watermark content="Ant Design" inherit={false}>
+        <Drawer destroyOnClose open={showDrawer2} title="Drawer" onClose={closeDrawer2}>
           {placeholder}
         </Drawer>
       </Watermark>

--- a/components/watermark/index.en-US.md
+++ b/components/watermark/index.en-US.md
@@ -34,6 +34,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | width | The width of the watermark, the default value of `content` is its own width | number | 120 |  |
 | height | The height of the watermark, the default value of `content` is its own height | number | 64 |  |
+| inherit | Pass the watermark to the pop-up component such as Modal, Drawer | boolean | true | 5.11.0 |
 | rotate | When the watermark is drawn, the rotation Angle, unit `°` | number | -22 |  |
 | zIndex | The z-index of the appended watermark element | number | 9 |  |
 | image | Image source, it is recommended to export 2x or 3x image, high priority (support base64 format) | string | - |  |

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -31,6 +31,7 @@ export interface WatermarkProps {
   gap?: [number, number];
   offset?: [number, number];
   children?: React.ReactNode;
+  inherit?: boolean;
 }
 
 /**

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -61,6 +61,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
     gap = [100, 100],
     offset,
     children,
+    inherit = true,
   } = props;
   const [, token] = useToken();
   const {
@@ -268,13 +269,19 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
   );
 
   // ============================= Render =============================
+  const childNode = inherit ? (
+    <WatermarkContext.Provider value={watermarkContext}>{children}</WatermarkContext.Provider>
+  ) : (
+    children
+  );
+
   return (
     <div
       ref={setContainer}
       className={classNames(className, rootClassName)}
       style={{ position: 'relative', ...style }}
     >
-      <WatermarkContext.Provider value={watermarkContext}>{children}</WatermarkContext.Provider>
+      {childNode}
     </div>
   );
 };

--- a/components/watermark/index.zh-CN.md
+++ b/components/watermark/index.zh-CN.md
@@ -36,6 +36,7 @@ tag: New
 | --- | --- | --- | --- | --- |
 | width | 水印的宽度，`content` 的默认值为自身的宽度 | number | 120 |  |
 | height | 水印的高度，`content` 的默认值为自身的高度 | number | 64 |  |
+| inherit | 是否将水印传导给弹出组件如 Modal、Drawer | boolean | true | 5.11.0 |
 | rotate | 水印绘制时，旋转的角度，单位 `°` | number | -22 |  |
 | zIndex | 追加的水印元素的 z-index | number | 9 |  |
 | image | 图片源，建议导出 2 倍或 3 倍图，优先级高 (支持 base64 格式) | string | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Watermark support `inherit` prop to disable watermark pass to Drawer & Modal.      |
| 🇨🇳 Chinese |  Watermark 支持 `inherit` 配置，关闭水印传导至弹出 Drawer 与 Modal。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd080eb</samp>

This pull request adds a new `inherit` prop to the `Watermark` component, which allows users to control whether the watermark effect is inherited by the nested components or not. It also updates the demo, the tests, and the documentation files to reflect the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd080eb</samp>

* Add a new prop `inherit` to the Watermark component, which controls whether the watermark appears in the portal components such as Drawer or not ([link](https://github.com/ant-design/ant-design/pull/45319/files?diff=unified&w=0#diff-f338d58197c4270e4dded5a90516016afd08271c7cd24a3c57cd4d5e6613f317R37), [link](https://github.com/ant-design/ant-design/pull/45319/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19R34), [link](https://github.com/ant-design/ant-design/pull/45319/files?diff=unified&w=0#diff-add08763825dd36ecf1bf3482c1f2e331f8b6c9d83eff23a5fd55a2a25fd2e19R64), [link](https://github.com/ant-design/ant-design/pull/45319/files?diff=unified&w=0#diff-877ffb6be3567430f8b12395585cc902eca9d2b7a0cd56e032a10bb28e105ad7R39)).
