### PR TITLE
chore: fix tsc

### DIFF
--- a/.dumi/hooks/useLayoutState.ts
+++ b/.dumi/hooks/useLayoutState.ts
@@ -1,6 +1,6 @@
 import { startTransition, useState } from 'react';
 
-const useLayoutState = <S>(
+const useLayoutState: typeof useState = <S>(
   ...args: Parameters<typeof useState<S>>
 ): ReturnType<typeof useState<S>> => {
   const [state, setState] = useState<S>(...args);

--- a/.dumi/pages/index/components/Theme/ThemePicker.tsx
+++ b/.dumi/pages/index/components/Theme/ThemePicker.tsx
@@ -101,7 +101,7 @@ export default function ThemePicker(props: ThemePickerProps) {
                 onChange?.(theme);
               }}
             >
-              <input type="radio" name="theme" id={index === 0 ? id : null} />
+              <input type="radio" name="theme" id={index === 0 ? id : undefined} />
               <img src={url} alt={theme} />
             </label>
             <span>{locale[theme as keyof typeof locale]}</span>

--- a/.dumi/theme/common/Color/ColorStyle.tsx
+++ b/.dumi/theme/common/Color/ColorStyle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Global, css } from '@emotion/react';
 import { useTheme } from 'antd-style';
 
-const gray = {
+const gray: { [key: number]: string } = {
   1: '#fff',
   2: '#fafafa',
   3: '#f5f5f5',
@@ -25,7 +25,7 @@ const ColorStyle = () => {
     if (index <= 10) {
       return `
 .palette-${color}-${index} {
-  background: ${token[`${color}-${index}`]};
+  background: ${(token as any)[`${color}-${index}`]};
 }
 ${makePalette(color, index + 1)}
     `;

--- a/.dumi/theme/common/DirectionIcon.tsx
+++ b/.dumi/theme/common/DirectionIcon.tsx
@@ -7,7 +7,7 @@ const ltrD =
 const rtlD =
   'M256 64l512 0 0 128-128 0 0 768-128 0 0-768-128 0 0 768-128 0 0-448c-123.712 0-224-100.288-224-224s100.288-224 224-224zM960 896l-256-224 256-224z';
 
-const DirectionIcon: React.FC<{ direction: DirectionType }> = (props) => (
+const DirectionIcon: React.FC<{ direction: DirectionType; className?: string }> = (props) => (
   <Icon {...props}>
     <svg viewBox="0 0 1024 1024" fill="currentColor">
       <path d={props.direction === 'ltr' ? ltrD : rtlD} />

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -45,7 +45,7 @@ const getAlgorithm = (themes: ThemeName[] = []) =>
       }
       return null;
     })
-    .filter((item) => item);
+    .filter((item) => item) as typeof antdTheme.darkAlgorithm[];
 
 const GlobalLayout: React.FC = () => {
   const outlet = useOutlet();
@@ -109,7 +109,7 @@ const GlobalLayout: React.FC = () => {
     setSiteState({
       theme: _theme,
       direction: _direction === 'rtl' ? 'rtl' : 'ltr',
-      bannerVisible: storedBannerVisibleLastTime ? storedBannerVisible : true,
+      bannerVisible: storedBannerVisibleLastTime ? !!storedBannerVisible : true,
     });
     // Handle isMobile
     updateMobileMode();

--- a/.dumi/theme/layouts/ResourceLayout/AffixTabs.tsx
+++ b/.dumi/theme/layouts/ResourceLayout/AffixTabs.tsx
@@ -57,7 +57,7 @@ const AffixTabs: React.FC = () => {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const idsRef = React.useRef<string[]>([]);
   const [loaded, setLoaded] = React.useState(false);
-  const [fixedId, setFixedId] = React.useState<string | null>(null);
+  const [fixedId, setFixedId] = React.useState<string | undefined>(undefined);
 
   const {
     styles: { affixTabs, affixTabsFixed, span },
@@ -100,7 +100,7 @@ const AffixTabs: React.FC = () => {
         }
       }
 
-      setFixedId(null);
+      setFixedId(undefined);
     }
 
     return throttle(doSync);

--- a/.dumi/theme/slots/Header/More.tsx
+++ b/.dumi/theme/slots/Header/More.tsx
@@ -37,7 +37,7 @@ const Community: React.FC = () => {
   );
 };
 
-export const getEcosystemGroup = (): MenuProps['items'] => [
+export const getEcosystemGroup = (): Exclude<MenuProps['items'], undefined> => [
   {
     label: (
       <a href="https://charts.ant.design" target="_blank" rel="noopener noreferrer">

--- a/.dumi/theme/slots/Header/Navigation.tsx
+++ b/.dumi/theme/slots/Header/Navigation.tsx
@@ -215,7 +215,8 @@ export default ({
           label: (
             <Link
               to={utils.getLocalizedPathname(
-                blogList.sort((a, b) => (a.frontmatter.date > b.frontmatter.date ? -1 : 1))[0].link,
+                blogList.sort((a, b) => (a.frontmatter?.date > b.frontmatter?.date ? -1 : 1))[0]
+                  .link,
                 isZhCN,
                 search,
               )}

--- a/.dumi/theme/slots/Header/SwitchBtn.tsx
+++ b/.dumi/theme/slots/Header/SwitchBtn.tsx
@@ -11,6 +11,7 @@ export interface LangBtnProps {
   value: 1 | 2;
   pure?: boolean;
   onClick?: React.MouseEventHandler;
+  ['aria-label']?: string;
 }
 
 const BASE_SIZE = '1.2em';

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -30,6 +30,11 @@ const locales = {
     shortMessage: '支付宝语雀 · 大学生公益计划火热进行中！',
     more: '了解更多',
   },
+  en: {
+    message: '',
+    shortMessage: '',
+    more: '',
+  },
 };
 
 const useStyle = createStyles(({ token, css }) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fead58</samp>

Fixed various TypeScript errors and improved accessibility and localization features in the theme files of the documentation website. Some of the changes include adding type annotations and casts, using `undefined` instead of `null` for some props, adding an optional `className` prop, providing default English messages, and adding an `aria-label` attribute.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fead58</samp>

*  Annotate `useLayoutState` hook with `typeof useState` type for consistency and clarity ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-bc43f0b0ba170bae4bb56b94be9c0f176bc31b2a0534aaef89aeb1a178c451ddL3-R3))
*  Change `id` attribute of input element from `null` to `undefined` to avoid rendering `"null"` string in HTML output ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-9ac0f4a6f5f6e7f8ca9a08ba42c07109b6705731c89c6b1af5daf7e2e9d5850dL104-R104))
*  Annotate `gray` object with `{ [key: number]: string }` type to avoid implicit `any` type and match other color objects ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-f18c0ae50b6f2d03ee72182d1e96304ec9cc6a143f445f4f8376b6eeba22ff9cL5-R5))
*  Cast `token` object to `any` type to avoid TypeScript error when accessing properties with dynamic keys ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-f18c0ae50b6f2d03ee72182d1e96304ec9cc6a143f445f4f8376b6eeba22ff9cL28-R28))
*  Add optional `className` prop to `DirectionIcon` component to allow passing custom styles from parent component ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-2fbc529702a24e3ce2e2b6a011610b570c8dcce0f8a72be81c81f6773ffa87edL10-R10))
*  Cast result of `filter` method to `typeof antdTheme.darkAlgorithm[]` type to avoid TypeScript error when passing it to `setDarkAlgorithm` function ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L48-R48))
*  Coerce `storedBannerVisible` value to boolean with `!!` operator to avoid TypeScript error when passing it to `setBannerVisible` function ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46L112-R112))
*  Change initial state and function call of `fixedId` state from `null` to `undefined` to match type of `id` prop of `Affix` component ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-a1a8af1a50735a6e8772319517303fa26cee992b515a53fa605c4196de05fe55L60-R60), [link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-a1a8af1a50735a6e8772319517303fa26cee992b515a53fa605c4196de05fe55L103-R103))
*  Add `en` object to `locales` object to provide default values for English language messages and avoid runtime error when switching to English language mode ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-2b1224dbeb7d20f1cb1b4590eb12b68104c605d2a67f0b0bd4fd9d8b0100a728R33-R37))
*  Change return type of `getEcosystemGroup` function from `MenuProps['items']` to `Exclude<MenuProps['items'], undefined>` to avoid TypeScript error when passing result to `items` prop of `Menu` component ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-a9282d78e0292d805e422e5cb4cb781e9af7b10ad53b3f0ca66bfb6ccbf8fa6eL40-R40))
*  Make `frontmatter` property of blog list items optional with `?` operator to avoid TypeScript error when accessing `date` property ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-632020f2d1bdd2829b18be604bbd84f96a304722cc050a8584a90d760699b4c5L218-R219))
*  Add `aria-label` attribute to `LangBtnProps` interface to allow passing custom label for language switch button for accessibility purposes ([link](https://github.com/ant-design/ant-design/pull/45352/files?diff=unified&w=0#diff-fd18bbc7462b252cabea727c41bc836f4edc080fb5926ec395f27127a388bbd2R14))
