### PR TITLE
fix(auto-complete): placeholder content overlap

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -65,6 +65,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
   // ============================= Input =============================
   let customizeInput: React.ReactElement | undefined;
+  let { placeholder } = props;
 
   if (
     childNodes.length === 1 &&
@@ -72,6 +73,11 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     !isSelectOptionOrSelectOptGroup(childNodes[0])
   ) {
     [customizeInput] = childNodes;
+
+    // if auto-complete and customize input both have placeholder, we should merge it into input
+    if (placeholder && customizeInput.props.placeholder) {
+      placeholder = undefined;
+    }
   }
 
   const getInputElement = customizeInput ? (): React.ReactElement => customizeInput! : undefined;
@@ -132,8 +138,9 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     <Select
       ref={ref}
       suffixIcon={null}
-      {...omit(props, ['dataSource', 'dropdownClassName'])}
+      {...omit(props, ['dataSource', 'dropdownClassName', 'placeholder'])}
       prefixCls={prefixCls}
+      placeholder={placeholder}
       popupClassName={popupClassName || dropdownClassName}
       className={classNames(`${prefixCls}-auto-complete`, className)}
       mode={Select.SECRET_COMBOBOX_MODE_DO_NOT_USE as SelectProps['mode']}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://codesandbox.io/s/zi-ding-yi-shu-ru-zu-jian-antd-5-10-1-forked-ktykgs?file=/demo.tsx

### 💡 Background and solution

close: #45355

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      auto-complete placeholder content overlaps with children's input element placeholder.     |
| 🇨🇳 Chinese |    auto-complete placeholder 属性与子元素的 placeholder 重复渲染      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fadc33</samp>

Fix placeholder handling of `auto-complete` component. Prevent passing `placeholder` to `Select` and overriding custom input `placeholder`. Ensure `placeholder` style and display in input element.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fadc33</samp>

*  Extract `placeholder` prop from `props` object and assign it to a local variable to avoid passing it to `Select` component ([link](https://github.com/ant-design/ant-design/pull/45356/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dR68))
*  Add condition to check if both `auto-complete` and `customizeInput` components have a `placeholder` prop and set `auto-complete`'s `placeholder` to `undefined` if they do to prevent overriding `customizeInput`'s `placeholder` ([link](https://github.com/ant-design/ant-design/pull/45356/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dR76-R80))
*  Modify props passed to `Select` component to omit `placeholder` from `props` object and pass it as a separate prop and add it to `className` prop to apply correct style to input element ([link](https://github.com/ant-design/ant-design/pull/45356/files?diff=unified&w=0#diff-c55203058d3a4064d8f52a5b4e7d7770153d215966d276d6814011d99268f76dL135-R143))
