### PR TITLE
feat: Tabs items support destroyInactiveTabPane

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -75,8 +75,9 @@ More option at [rc-tabs tabs](https://github.com/react-component/tabs#tabs)
 ### TabItemType
 
 | Property | Description | Type | Default |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | closeIcon | Customize close icon in TabPane's head. Only works while `type="editable-card"`. 5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | - |
+| destroyInactiveTabPane | Whether destroy inactive TabPane when change tab | boolean | false | 5.11.0 |
 | disabled | Set TabPane disabled | boolean | false |
 | forceRender | Forced render of content in tabs, not lazy render after clicking on tabs | boolean | false |
 | key | TabPane's key | string | - |

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -77,8 +77,9 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 ### TabItemType
 
 | 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | closeIcon | 自定义关闭图标，在 `type="editable-card"` 时有效。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | - |
+| destroyInactiveTabPane | 被隐藏时是否销毁 DOM 结构 | boolean | false | 5.11.0 |
 | disabled | 禁用某一项 | boolean | false |
 | forceRender | 被隐藏时是否渲染 DOM 结构 | boolean | false |
 | key | 对应 activeKey | string | - |

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.35.1",
-    "rc-tabs": "~12.12.1",
+    "rc-tabs": "~12.13.0",
     "rc-textarea": "~1.5.1",
     "rc-tooltip": "~6.1.1",
     "rc-tree": "~5.7.12",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #45338

### 💡 Background and solution

`rc-tabs` PR https://github.com/react-component/tabs/pull/675

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Tabs `items` support tab pane level `destroyInactiveTabPane`.     |
| 🇨🇳 Chinese |     Tabs `items` 支持单个标签页设置 `destroyInactiveTabPane`。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72e692e</samp>

This pull request adds a new `destroyInactiveTabPane` property to the `TabItemType` interface in the `components/tabs/index.en-US.md` and `components/tabs/index.zh-CN.md` files, and updates the `rc-tabs` dependency version in the `package.json` file. The purpose of this pull request is to enable the feature of destroying inactive tab panes when switching tabs.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72e692e</samp>

* Add a new property `destroyInactiveTabPane` to the `TabItemType` interface to control whether the inactive tab pane is destroyed when switching tabs ([link](https://github.com/ant-design/ant-design/pull/45359/files?diff=unified&w=0#diff-55d7b2e14d2f70c11368544596a23fa53e1c2d392b85295e52cbf9d21bec7ebcL78-R80), [link](https://github.com/ant-design/ant-design/pull/45359/files?diff=unified&w=0#diff-aae9511c7fe785a991682a0bb026fec2a489547d55493b5fd8264299cd290b15L80-R82))
* Update the dependency version of `rc-tabs` to 12.13.0 in the `package.json` file to use the latest version that supports the `destroyInactiveTabPane` feature ([link](https://github.com/ant-design/ant-design/pull/45359/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L151-R151))
