### PR TITLE
feat: support changeOnBlur

### DIFF
--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -42,6 +42,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | addonBefore | The label text displayed before (on the left side of) the input field | ReactNode | - |  |
 | autoFocus | If get focus when component mounted | boolean | false | - |
 | bordered | Whether has border style | boolean | true | 4.12.0 |
+| changeOnBlur | Trigger `onChange` when blur. e.g. reset value in range by blur | boolean | true | 5.11.0 |
 | controls | Whether to show `+-` controls, or set custom arrows icon | boolean \| { upIcon?: React.ReactNode; downIcon?: React.ReactNode; } | - | 4.19.0 |
 | decimalSeparator | Decimal separator | string | - | - |
 | defaultValue | The initial value | number | - | - |

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -43,6 +43,7 @@ demo:
 | addonBefore | 带标签的 input，设置前置标签 | ReactNode | - | 4.17.0 |
 | autoFocus | 自动获取焦点 | boolean | false | - |
 | bordered | 是否有边框 | boolean | true | 4.12.0 |
+| changeOnBlur | 是否在失去焦点时，触发 `onChange` 事件（例如值超出范围时，重新限制回范围并触发事件） | boolean | true | 5.11.0 |
 | controls | 是否显示增减按钮，也可设置自定义箭头图标 | boolean \| { upIcon?: React.ReactNode; downIcon?: React.ReactNode; } | - | 4.19.0 |
 | decimalSeparator | 小数点 | string | - | - |
 | defaultValue | 初始值 | number | - | - |

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "rc-field-form": "~1.40.0",
     "rc-image": "~7.3.1",
     "rc-input": "~1.3.5",
-    "rc-input-number": "~8.3.0",
+    "rc-input-number": "~8.4.0",
     "rc-mentions": "~2.9.1",
     "rc-menu": "~9.12.2",
     "rc-motion": "^2.9.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref https://github.com/react-component/input-number/pull/596

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     InputNumber support `changeOnBlur` prop to disable trigger `onChange` event when blur.       |
| 🇨🇳 Chinese |     InputNumber 添加 `changeOnBlur` 属性以支持在失去焦点时不触发 `onChange` 事件。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9eb9060</samp>

This pull request adds a new prop `changeOnBlur` to the `InputNumber` component, which allows users to control the `onChange` event behavior when the input loses focus. It also updates the documentation and the dependency version of `rc-input-number` accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9eb9060</samp>

* Add a new prop `changeOnBlur` to the `InputNumber` component to control the `onChange` event when the input loses focus ([link](https://github.com/ant-design/ant-design/pull/45395/files?diff=unified&w=0#diff-d4dfbab6a9c3ebf42befebf5f688098c1bde29438032f7dfbf3ee60b21aaab48R45), [link](https://github.com/ant-design/ant-design/pull/45395/files?diff=unified&w=0#diff-d9764eb7b17906ec731b4e109e9024e7597ad3deae3f2faddd147a18fc549c04R46))
* Update the dependency version of `rc-input-number` to `~8.4.0` in `package.json` to reflect the new feature of `changeOnBlur` ([link](https://github.com/ant-design/ant-design/pull/45395/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L136-R136))
