### PR TITLE
type: Table pagination.position support none as value

### DIFF
--- a/components/table/__tests__/type.test.tsx
+++ b/components/table/__tests__/type.test.tsx
@@ -37,9 +37,7 @@ describe('Table.typescript', () => {
     const table = <Table<RecordType> dataSource={[{ key: 'Bamboo' }]} />;
     expect(table).toBeTruthy();
   });
-});
 
-describe('Table.typescript types', () => {
   it('ColumnProps', () => {
     interface User {
       name: string;
@@ -55,5 +53,10 @@ describe('Table.typescript types', () => {
     ];
 
     expect(columns).toBeTruthy();
+  });
+
+  it('table pagination position support none', () => {
+    const table = <Table pagination={{ position: ['none', 'none'] }} />;
+    expect(table).toBeTruthy();
   });
 });

--- a/components/table/demo/component-token.tsx
+++ b/components/table/demo/component-token.tsx
@@ -3,7 +3,7 @@ import { DownOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
 import { Form, Radio, Space, Switch, Table, ConfigProvider } from 'antd';
 import type { SizeType } from 'antd/es/config-provider/SizeContext';
-import type { ColumnsType, TableProps } from 'antd/es/table';
+import type { ColumnsType, TableProps, TablePaginationConfig } from 'antd/es/table';
 import type { ExpandableConfig, TableRowSelection } from 'antd/es/table/interface';
 
 interface DataType {
@@ -13,14 +13,6 @@ interface DataType {
   address: string;
   description: string;
 }
-
-type TablePaginationPosition =
-  | 'topLeft'
-  | 'topCenter'
-  | 'topRight'
-  | 'bottomLeft'
-  | 'bottomCenter'
-  | 'bottomRight';
 
 const columns: ColumnsType<DataType> = [
   {
@@ -76,6 +68,8 @@ for (let i = 1; i <= 10; i++) {
   });
 }
 
+type TablePaginationPosition = NonNullable<TablePaginationConfig['position']>[number];
+
 const defaultExpandable = { expandedRowRender: (record: DataType) => <p>{record.description}</p> };
 const defaultTitle = () => 'Here is title';
 const defaultFooter = () => 'Here is footer';
@@ -89,11 +83,11 @@ const App: React.FC = () => {
   );
   const [showTitle, setShowTitle] = useState(false);
   const [showHeader, setShowHeader] = useState(true);
-  const [showfooter, setShowFooter] = useState(true);
+  const [showFooter, setShowFooter] = useState(true);
   const [rowSelection, setRowSelection] = useState<TableRowSelection<DataType> | undefined>({});
   const [hasData, setHasData] = useState(true);
   const [tableLayout, setTableLayout] = useState();
-  const [top, setTop] = useState<TablePaginationPosition | 'none'>('none');
+  const [top, setTop] = useState<TablePaginationPosition>('none');
   const [bottom, setBottom] = useState<TablePaginationPosition>('bottomRight');
   const [ellipsis, setEllipsis] = useState(false);
   const [yScroll, setYScroll] = useState(false);
@@ -172,7 +166,7 @@ const App: React.FC = () => {
     expandable,
     title: showTitle ? defaultTitle : undefined,
     showHeader,
-    footer: showfooter ? defaultFooter : undefined,
+    footer: showFooter ? defaultFooter : undefined,
     rowSelection,
     scroll,
     tableLayout,
@@ -198,7 +192,7 @@ const App: React.FC = () => {
           <Switch checked={showHeader} onChange={handleHeaderChange} />
         </Form.Item>
         <Form.Item label="Footer">
-          <Switch checked={showfooter} onChange={handleFooterChange} />
+          <Switch checked={showFooter} onChange={handleFooterChange} />
         </Form.Item>
         <Form.Item label="Expandable">
           <Switch checked={!!expandable} onChange={handleExpandChange} />
@@ -300,7 +294,7 @@ const App: React.FC = () => {
       >
         <Table
           {...tableProps}
-          pagination={{ position: [top as TablePaginationPosition, bottom] }}
+          pagination={{ position: [top, bottom] }}
           columns={tableColumns}
           dataSource={hasData ? data : []}
           scroll={scroll}

--- a/components/table/demo/dynamic-settings.tsx
+++ b/components/table/demo/dynamic-settings.tsx
@@ -3,7 +3,7 @@ import { DownOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
 import { Form, Radio, Space, Switch, Table } from 'antd';
 import type { SizeType } from 'antd/es/config-provider/SizeContext';
-import type { ColumnsType, TableProps } from 'antd/es/table';
+import type { ColumnsType, TableProps, TablePaginationConfig } from 'antd/es/table';
 import type { ExpandableConfig, TableRowSelection } from 'antd/es/table/interface';
 
 interface DataType {
@@ -14,13 +14,7 @@ interface DataType {
   description: string;
 }
 
-type TablePaginationPosition =
-  | 'topLeft'
-  | 'topCenter'
-  | 'topRight'
-  | 'bottomLeft'
-  | 'bottomCenter'
-  | 'bottomRight';
+type TablePaginationPosition = NonNullable<TablePaginationConfig['position']>[number];
 
 const columns: ColumnsType<DataType> = [
   {
@@ -89,11 +83,11 @@ const App: React.FC = () => {
   );
   const [showTitle, setShowTitle] = useState(false);
   const [showHeader, setShowHeader] = useState(true);
-  const [showfooter, setShowFooter] = useState(true);
+  const [showFooter, setShowFooter] = useState(true);
   const [rowSelection, setRowSelection] = useState<TableRowSelection<DataType> | undefined>({});
   const [hasData, setHasData] = useState(true);
   const [tableLayout, setTableLayout] = useState();
-  const [top, setTop] = useState<TablePaginationPosition | 'none'>('none');
+  const [top, setTop] = useState<TablePaginationPosition>('none');
   const [bottom, setBottom] = useState<TablePaginationPosition>('bottomRight');
   const [ellipsis, setEllipsis] = useState(false);
   const [yScroll, setYScroll] = useState(false);
@@ -172,7 +166,7 @@ const App: React.FC = () => {
     expandable,
     title: showTitle ? defaultTitle : undefined,
     showHeader,
-    footer: showfooter ? defaultFooter : undefined,
+    footer: showFooter ? defaultFooter : undefined,
     rowSelection,
     scroll,
     tableLayout,
@@ -198,7 +192,7 @@ const App: React.FC = () => {
           <Switch checked={showHeader} onChange={handleHeaderChange} />
         </Form.Item>
         <Form.Item label="Footer">
-          <Switch checked={showfooter} onChange={handleFooterChange} />
+          <Switch checked={showFooter} onChange={handleFooterChange} />
         </Form.Item>
         <Form.Item label="Expandable">
           <Switch checked={!!expandable} onChange={handleExpandChange} />
@@ -264,7 +258,7 @@ const App: React.FC = () => {
       </Form>
       <Table
         {...tableProps}
-        pagination={{ position: [top as TablePaginationPosition, bottom] }}
+        pagination={{ position: [top, bottom] }}
         columns={tableColumns}
         dataSource={hasData ? data : []}
         scroll={scroll}

--- a/components/table/demo/pagination.tsx
+++ b/components/table/demo/pagination.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Radio, Space, Table, Tag } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 
 interface DataType {
   key: string;
@@ -10,13 +10,7 @@ interface DataType {
   tags: string[];
 }
 
-type TablePaginationPosition =
-  | 'topLeft'
-  | 'topCenter'
-  | 'topRight'
-  | 'bottomLeft'
-  | 'bottomCenter'
-  | 'bottomRight';
+type TablePaginationPosition = NonNullable<TablePaginationConfig['position']>[number];
 
 const topOptions = [
   { label: 'topLeft', value: 'topLeft' },

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -231,7 +231,8 @@ type TablePaginationPosition =
   | 'topRight'
   | 'bottomLeft'
   | 'bottomCenter'
-  | 'bottomRight';
+  | 'bottomRight'
+  | 'none';
 
 export interface TablePaginationConfig extends PaginationProps {
   position?: TablePaginationPosition[];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/45362

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Table `pagination.position` should accept `'none'`.         |
| 🇨🇳 Chinese | 修复 Table `pagination.position` TS 定义不支持 `'none'` 的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82df0ca</samp>

This pull request improves the type definitions and usage of table pagination in the Table component and its demos. It adds a new option for `TablePaginationPosition` to hide pagination, fixes some typos and imports, and refactors some code for clarity and consistency. It affects the files `components/table/__tests__/type.test.tsx`, `components/table/demo/component-token.tsx`, `components/table/demo/dynamic-settings.tsx`, `components/table/demo/pagination.tsx`, and `components/table/interface.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82df0ca</samp>

*  Add support for `none` value in `pagination.position` prop of Table component, which hides the pagination ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-c7bb8ec59175366c52da6ca55ff47144b4328563bc2742cc18809362a8d40b4fR57-R61), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bR71-R72), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L267-R261), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-7009bf2cfc2c86ed5fb1e6822fd59a7f1a72ee74eeeefbeddf5d3a5852b10f16L3-R3), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9L234-R235))
*  Import `TablePaginationConfig` type from `antd/es/table` in demo files to avoid duplication and use it for defining `TablePaginationPosition` type ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL6-R6), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L6-R6), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-7009bf2cfc2c86ed5fb1e6822fd59a7f1a72ee74eeeefbeddf5d3a5852b10f16L3-R3))
*  Remove redundant `TablePaginationPosition` type from demo files, as it is already defined in `interface.ts` ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL17-L24), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L17-R17), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-7009bf2cfc2c86ed5fb1e6822fd59a7f1a72ee74eeeefbeddf5d3a5852b10f16L13-R13))
*  Simplify `top` variable in demo files to use `TablePaginationPosition` type directly, without casting it ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL303-R297), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L267-R261))
*  Fix typo in `showFooter` variable name in demo files for consistency and readability ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL92-R90), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL175-R169), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-1f53a059e08fa6f174594a1e9615a7eb622d7e2ec28de2d776260323dfc3843bL201-R195), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L92-R90), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L175-R169), [link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-00c581a2e7c4f7619b5d68bfd01ebe70904ee2fe784475ff0cebe773dfb7aef2L201-R195))
*  Move `describe` block for testing typescript types of Table component inside the `describe` block for testing Table component in `type.test.tsx` file, to group related tests together ([link](https://github.com/ant-design/ant-design/pull/45398/files?diff=unified&w=0#diff-c7bb8ec59175366c52da6ca55ff47144b4328563bc2742cc18809362a8d40b4fL40-R40))
