### PR TITLE
fix: Table sorter tooltip cannot be open when showSorterTooltip is a object

### DIFF
--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -321,6 +321,21 @@ describe('Table.sorter', () => {
     expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
     fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
 
+    // should merge original title into showSorterTooltip object
+    rerender(
+      createTable({
+        showSorterTooltip: {
+          overlayClassName: 'custom-tooltip',
+        },
+      }),
+    );
+    fireEvent.mouseEnter(container.querySelector('.ant-table-column-sorters')!);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(container.querySelector('.ant-tooltip-open')).toBeTruthy();
+    fireEvent.mouseOut(container.querySelector('.ant-table-column-sorters')!);
+
     // Root to false
     rerender(createTable({ showSorterTooltip: false }));
     act(() => {

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -168,7 +168,12 @@ function injectSorter<RecordType>(
         sortTip = triggerAsc;
       }
       const tooltipProps: TooltipProps =
-        typeof showSorterTooltip === 'object' ? showSorterTooltip : { title: sortTip };
+        typeof showSorterTooltip === 'object'
+          ? {
+              title: sortTip,
+              ...showSorterTooltip,
+            }
+          : { title: sortTip };
       newColumn = {
         ...newColumn,
         className: classNames(newColumn.className, { [`${prefixCls}-column-sort`]: sortOrder }),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
ref https://github.com/ant-design/ant-design/issues/45392

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

When `column.showSorterTooltip` is a object, original title would be overrided to null: https://codesandbox.io/s/shai-xuan-he-pai-xu-antd-5-10-1-forked-lz8s8h?file=/demo.tsx

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Table sorter tooltip cannot be open when `column.showSorterTooltip` is a object.        |
| 🇨🇳 Chinese |   修复 Table 当 `column.showSorterTooltip` 是一个对象时排序 tooltip 不显示的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e649c1</samp>

Fix the `showSorterTooltip` prop of the table component to accept an object with custom properties and merge the original `title` prop. Add a test case for this feature in `Table.sorter.test.tsx`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e649c1</samp>

*  Merge original `title` prop into `showSorterTooltip` object for table columns ([link](https://github.com/ant-design/ant-design/pull/45403/files?diff=unified&w=0#diff-33a34c8ef463c5e1cad14a8046c87aa47265d4927644753c226a65211511dc41L171-R176))
* Add test case for customizing `showSorterTooltip` prop with an object ([link](https://github.com/ant-design/ant-design/pull/45403/files?diff=unified&w=0#diff-42a0123b4da3518218b3261eab843f62cf855d913ae11baa9b6094bbdb33baf0R324-R338))
