### PR TITLE
fix: improve upload component scrolling issue during form validation 

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -43121,11 +43121,14 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
     class="config-upload config-upload-select"
   >
     <span
-      class="config-upload"
+      class="config-upload config-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="config-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43217,12 +43220,14 @@ exports[`ConfigProvider components Upload configProvider componentDisabled 1`] =
     class="config-upload config-upload-select config-upload-disabled"
   >
     <span
-      class="config-upload config-upload-disabled"
+      class="config-upload config-upload-disabled config-upload-trigger-wrapper"
+      role="button"
     >
       <input
         accept=""
+        class="config-upload-trigger"
         disabled=""
-        style="display: none;"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43283,11 +43288,14 @@ exports[`ConfigProvider components Upload configProvider componentSize large 1`]
     class="config-upload config-upload-select"
   >
     <span
-      class="config-upload"
+      class="config-upload config-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="config-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43379,11 +43387,14 @@ exports[`ConfigProvider components Upload configProvider componentSize middle 1`
     class="config-upload config-upload-select"
   >
     <span
-      class="config-upload"
+      class="config-upload config-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="config-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43475,11 +43486,14 @@ exports[`ConfigProvider components Upload configProvider componentSize small 1`]
     class="config-upload config-upload-select"
   >
     <span
-      class="config-upload"
+      class="config-upload config-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="config-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43571,11 +43585,14 @@ exports[`ConfigProvider components Upload normal 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />
@@ -43667,11 +43684,14 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
     class="prefix-Upload prefix-Upload-select"
   >
     <span
-      class="prefix-Upload"
+      class="prefix-Upload prefix-Upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="prefix-Upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <span />

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5197,12 +5197,14 @@ Array [
                     class="ant-upload ant-upload-select ant-upload-disabled"
                   >
                     <span
-                      class="ant-upload ant-upload-disabled"
+                      class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+                      role="button"
                     >
                       <input
                         accept=""
+                        class="ant-upload-trigger"
                         disabled=""
-                        style="display: none;"
+                        style="display: unset; visibility: hidden;"
                         type="file"
                       />
                       <button
@@ -21604,13 +21606,16 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 class="ant-upload ant-upload-select"
               >
                 <span
-                  class="ant-upload"
+                  class="ant-upload ant-upload-trigger-wrapper"
+                  role="button"
+                  tabindex="0"
                 >
                   <input
                     accept=""
                     aria-describedby="validate_other_upload_extra"
+                    class="ant-upload-trigger"
                     id="validate_other_upload"
-                    style="display: none;"
+                    style="display: unset; visibility: hidden;"
                     type="file"
                   />
                   <button
@@ -21693,14 +21698,15 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 class="ant-upload ant-upload-drag"
               >
                 <span
-                  class="ant-upload ant-upload-btn"
+                  class="ant-upload ant-upload-trigger-wrapper ant-upload-btn"
                   role="button"
                   tabindex="0"
                 >
                   <input
                     accept=""
+                    class="ant-upload-trigger"
                     id="validate_other_dragger"
-                    style="display: none;"
+                    style="display: unset; visibility: hidden;"
                     type="file"
                   />
                   <div

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2718,12 +2718,14 @@ Array [
                     class="ant-upload ant-upload-select ant-upload-disabled"
                   >
                     <span
-                      class="ant-upload ant-upload-disabled"
+                      class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+                      role="button"
                     >
                       <input
                         accept=""
+                        class="ant-upload-trigger"
                         disabled=""
-                        style="display:none"
+                        style="display:unset;visibility:hidden"
                         type="file"
                       />
                       <button
@@ -9642,13 +9644,16 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 class="ant-upload ant-upload-select"
               >
                 <span
-                  class="ant-upload"
+                  class="ant-upload ant-upload-trigger-wrapper"
+                  role="button"
+                  tabindex="0"
                 >
                   <input
                     accept=""
                     aria-describedby="validate_other_upload_extra"
+                    class="ant-upload-trigger"
                     id="validate_other_upload"
-                    style="display:none"
+                    style="display:unset;visibility:hidden"
                     type="file"
                   />
                   <button
@@ -9731,14 +9736,15 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 class="ant-upload ant-upload-drag"
               >
                 <span
-                  class="ant-upload ant-upload-btn"
+                  class="ant-upload ant-upload-trigger-wrapper ant-upload-btn"
                   role="button"
                   tabindex="0"
                 >
                   <input
                     accept=""
+                    class="ant-upload-trigger"
                     id="validate_other_dragger"
-                    style="display:none"
+                    style="display:unset;visibility:hidden"
                     type="file"
                   />
                   <div

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -933,12 +933,14 @@ exports[`Form form should support disabled 1`] = `
                 style="display: none;"
               >
                 <span
-                  class="ant-upload ant-upload-disabled"
+                  class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+                  role="button"
                 >
                   <input
                     accept=""
+                    class="ant-upload-trigger"
                     disabled=""
-                    style="display: none;"
+                    style="display: unset; visibility: hidden;"
                     type="file"
                   />
                 </span>

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -176,11 +176,14 @@ exports[`renders components/space/demo/base.tsx extend context correctly 1`] = `
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
-            style="display: none;"
+            class="ant-upload-trigger"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           <button

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -174,11 +174,14 @@ exports[`renders components/space/demo/base.tsx correctly 1`] = `
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
-            style="display:none"
+            class="ant-upload-trigger"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           <button

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -60,7 +60,6 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     maxCount,
     data = {},
     multiple = false,
-    hasControlInside = true,
     action = '',
     accept = '',
     supportServerRender = true,

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -343,6 +343,10 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     onProgress,
     onSuccess,
     ...props,
+    className: classNames({
+      [`${prefixCls}-trigger-wrapper`]: true, // internal className, rewrite by antd upload
+      [`${prefixCls}-btn`]: type === 'drag',
+    }),
     data,
     multiple,
     action,
@@ -352,10 +356,14 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     disabled: mergedDisabled,
     beforeUpload: mergedBeforeUpload,
     onChange: undefined,
-    hasControlInside,
+    styles: {
+      input: { display: 'unset', visibility: 'hidden' },
+    },
+    classNames: {
+      input: `${prefixCls}-trigger`,
+    },
   } as RcUploadProps;
 
-  delete rcUploadProps.className;
   delete rcUploadProps.style;
 
   // Remove id to avoid open by label when trigger is hidden
@@ -448,7 +456,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
           onDragOver={onFileDrop}
           onDragLeave={onFileDrop}
         >
-          <RcUpload {...rcUploadProps} ref={upload} className={`${prefixCls}-btn`}>
+          <RcUpload {...rcUploadProps} ref={upload}>
             <div className={`${prefixCls}-drag-container`}>{children}</div>
           </RcUpload>
         </div>

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,11 +9,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -58,11 +61,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -113,11 +119,14 @@ exports[`renders components/upload/demo/basic.tsx extend context correctly 1`] =
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -169,11 +178,14 @@ exports[`renders components/upload/demo/component-token.tsx extend context corre
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -467,11 +479,14 @@ exports[`renders components/upload/demo/customize-progress-bar.tsx extend contex
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -529,12 +544,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
         class="ant-upload ant-upload-select ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+          role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display: none;"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           Click Text to Upload
@@ -555,12 +572,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
         class="ant-upload ant-upload-select ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+          role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display: none;"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           <button
@@ -830,12 +849,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
           class="ant-upload ant-upload-select ant-upload-disabled"
         >
           <span
-            class="ant-upload ant-upload-disabled"
+            class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+            role="button"
           >
             <input
               accept=""
+              class="ant-upload-trigger"
               disabled=""
-              style="display: none;"
+              style="display: unset; visibility: hidden;"
               type="file"
             />
             <button
@@ -1104,12 +1125,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
           class="ant-upload ant-upload-select ant-upload-disabled"
         >
           <span
-            class="ant-upload ant-upload-disabled"
+            class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+            role="button"
           >
             <input
               accept=""
+              class="ant-upload-trigger"
               disabled=""
-              style="display: none;"
+              style="display: unset; visibility: hidden;"
               type="file"
             />
             <button
@@ -1159,13 +1182,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
         class="ant-upload ant-upload-drag ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled ant-upload-btn"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper ant-upload-btn"
           role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display: none;"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           <div
@@ -1225,11 +1249,14 @@ exports[`renders components/upload/demo/defaultFileList.tsx extend context corre
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -1523,12 +1550,15 @@ exports[`renders components/upload/demo/directory.tsx extend context correctly 1
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         directory="directory"
-        style="display: none;"
+        style="display: unset; visibility: hidden;"
         type="file"
         webkitdirectory="webkitdirectory"
       />
@@ -1581,14 +1611,15 @@ exports[`renders components/upload/demo/drag.tsx extend context correctly 1`] = 
     class="ant-upload ant-upload-drag"
   >
     <span
-      class="ant-upload ant-upload-btn"
+      class="ant-upload ant-upload-trigger-wrapper ant-upload-btn"
       role="button"
       tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         multiple=""
-        style="display: none;"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <div
@@ -1647,11 +1678,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -2704,11 +2738,14 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -2759,12 +2796,15 @@ exports[`renders components/upload/demo/fileList.tsx extend context correctly 1`
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         multiple=""
-        style="display: none;"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -2898,11 +2938,14 @@ exports[`renders components/upload/demo/max-count.tsx extend context correctly 1
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
-            style="display: none;"
+            class="ant-upload-trigger"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           <button
@@ -2953,12 +2996,15 @@ exports[`renders components/upload/demo/max-count.tsx extend context correctly 1
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             multiple=""
-            style="display: none;"
+            style="display: unset; visibility: hidden;"
             type="file"
           />
           <button
@@ -3500,11 +3546,14 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -3776,11 +3825,14 @@ exports[`renders components/upload/demo/picture-circle.tsx extend context correc
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -3832,11 +3884,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -4127,11 +4182,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -4426,11 +4484,14 @@ exports[`renders components/upload/demo/preview-file.tsx extend context correctl
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -4482,11 +4543,14 @@ exports[`renders components/upload/demo/transform-file.tsx extend context correc
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -4538,11 +4602,14 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -4855,11 +4922,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display: none;"
+          class="ant-upload-trigger"
+          style="display: unset; visibility: hidden;"
           type="file"
         />
         <button
@@ -4922,11 +4992,14 @@ exports[`renders components/upload/demo/upload-png-only.tsx extend context corre
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -5007,11 +5080,14 @@ exports[`renders components/upload/demo/upload-with-aliyun-oss.tsx extend contex
                 class="ant-upload ant-upload-select"
               >
                 <span
-                  class="ant-upload"
+                  class="ant-upload ant-upload-trigger-wrapper"
+                  role="button"
+                  tabindex="0"
                 >
                   <input
                     accept=""
-                    style="display: none;"
+                    class="ant-upload-trigger"
+                    style="display: unset; visibility: hidden;"
                     type="file"
                   />
                   <button

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -9,11 +9,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -58,11 +61,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -111,11 +117,14 @@ exports[`renders components/upload/demo/basic.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -165,11 +174,14 @@ exports[`renders components/upload/demo/component-token.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -442,11 +454,14 @@ exports[`renders components/upload/demo/customize-progress-bar.tsx correctly 1`]
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -502,12 +517,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
         class="ant-upload ant-upload-select ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+          role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display:none"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           Click Text to Upload
@@ -528,12 +545,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
         class="ant-upload ant-upload-select ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+          role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display:none"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           <button
@@ -784,12 +803,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
           class="ant-upload ant-upload-select ant-upload-disabled"
         >
           <span
-            class="ant-upload ant-upload-disabled"
+            class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+            role="button"
           >
             <input
               accept=""
+              class="ant-upload-trigger"
               disabled=""
-              style="display:none"
+              style="display:unset;visibility:hidden"
               type="file"
             />
             <button
@@ -1039,12 +1060,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
           class="ant-upload ant-upload-select ant-upload-disabled"
         >
           <span
-            class="ant-upload ant-upload-disabled"
+            class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper"
+            role="button"
           >
             <input
               accept=""
+              class="ant-upload-trigger"
               disabled=""
-              style="display:none"
+              style="display:unset;visibility:hidden"
               type="file"
             />
             <button
@@ -1094,13 +1117,14 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
         class="ant-upload ant-upload-drag ant-upload-disabled"
       >
         <span
-          class="ant-upload ant-upload-disabled ant-upload-btn"
+          class="ant-upload ant-upload-disabled ant-upload-trigger-wrapper ant-upload-btn"
           role="button"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             disabled=""
-            style="display:none"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           <div
@@ -1158,11 +1182,14 @@ exports[`renders components/upload/demo/defaultFileList.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -1435,12 +1462,15 @@ exports[`renders components/upload/demo/directory.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         directory="directory"
-        style="display:none"
+        style="display:unset;visibility:hidden"
         type="file"
         webkitdirectory="webkitdirectory"
       />
@@ -1491,14 +1521,15 @@ exports[`renders components/upload/demo/drag.tsx correctly 1`] = `
     class="ant-upload ant-upload-drag"
   >
     <span
-      class="ant-upload ant-upload-btn"
+      class="ant-upload ant-upload-trigger-wrapper ant-upload-btn"
       role="button"
       tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         multiple=""
-        style="display:none"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <div
@@ -1554,11 +1585,14 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -2517,11 +2551,14 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -2570,12 +2607,15 @@ exports[`renders components/upload/demo/fileList.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
+        class="ant-upload-trigger"
         multiple=""
-        style="display:none"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -2707,11 +2747,14 @@ exports[`renders components/upload/demo/max-count.tsx correctly 1`] = `
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
-            style="display:none"
+            class="ant-upload-trigger"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           <button
@@ -2762,12 +2805,15 @@ exports[`renders components/upload/demo/max-count.tsx correctly 1`] = `
         class="ant-upload ant-upload-select"
       >
         <span
-          class="ant-upload"
+          class="ant-upload ant-upload-trigger-wrapper"
+          role="button"
+          tabindex="0"
         >
           <input
             accept=""
+            class="ant-upload-trigger"
             multiple=""
-            style="display:none"
+            style="display:unset;visibility:hidden"
             type="file"
           />
           <button
@@ -3288,11 +3334,14 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -3543,11 +3592,14 @@ exports[`renders components/upload/demo/picture-circle.tsx correctly 1`] = `
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -3597,11 +3649,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -3873,11 +3928,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -4151,11 +4209,14 @@ exports[`renders components/upload/demo/preview-file.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -4205,11 +4266,14 @@ exports[`renders components/upload/demo/transform-file.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -4259,11 +4323,14 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -4555,11 +4622,14 @@ Array [
       class="ant-upload ant-upload-select"
     >
       <span
-        class="ant-upload"
+        class="ant-upload ant-upload-trigger-wrapper"
+        role="button"
+        tabindex="0"
       >
         <input
           accept=""
-          style="display:none"
+          class="ant-upload-trigger"
+          style="display:unset;visibility:hidden"
           type="file"
         />
         <button
@@ -4620,11 +4690,14 @@ exports[`renders components/upload/demo/upload-png-only.tsx correctly 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display:none"
+        class="ant-upload-trigger"
+        style="display:unset;visibility:hidden"
         type="file"
       />
       <button
@@ -4703,11 +4776,14 @@ exports[`renders components/upload/demo/upload-with-aliyun-oss.tsx correctly 1`]
                 class="ant-upload ant-upload-select"
               >
                 <span
-                  class="ant-upload"
+                  class="ant-upload ant-upload-trigger-wrapper"
+                  role="button"
+                  tabindex="0"
                 >
                   <input
                     accept=""
-                    style="display:none"
+                    class="ant-upload-trigger"
+                    style="display:unset;visibility:hidden"
                     type="file"
                   />
                   <button

--- a/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
@@ -9,11 +9,14 @@ exports[`Upload rtl render component should be rendered correctly in RTL directi
     style="display: none;"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
     </span>

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
@@ -8,11 +8,14 @@ exports[`Upload List handle error 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -168,11 +171,14 @@ exports[`Upload List should be uploading when upload a file 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -269,11 +275,14 @@ exports[`Upload List should non-image format file preview 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -985,11 +994,14 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -1130,11 +1142,14 @@ exports[`Upload List should support removeIcon and downloadIcon 2`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button
@@ -1275,11 +1290,14 @@ exports[`Upload List should support showRemoveIcon and showPreviewIcon 1`] = `
     class="ant-upload ant-upload-select"
   >
     <span
-      class="ant-upload"
+      class="ant-upload ant-upload-trigger-wrapper"
+      role="button"
+      tabindex="0"
     >
       <input
         accept=""
-        style="display: none;"
+        class="ant-upload-trigger"
+        style="display: unset; visibility: hidden;"
         type="file"
       />
       <button

--- a/components/upload/style/index.ts
+++ b/components/upload/style/index.ts
@@ -31,9 +31,16 @@ const genBaseStyle: GenerateStyle<UploadToken> = (token) => {
 
       [componentCls]: {
         outline: 0,
-        "input[type='file']": {
-          cursor: 'pointer',
+      },
+
+      [`${componentCls}-trigger`]: {
+        '&-wrapper': {
+          position: 'relative',
         },
+
+        cursor: 'pointer',
+        position: 'absolute',
+        inset: 0,
       },
 
       [`${componentCls}-select`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix: #28869

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

一个历史遗漏问题， 表单滚动到错误位置需要在表单控件中绑定id， 但是上传组件的 id 在一个隐藏的 input 上，所以 api 无法得到元素渲染的具体位置。所以需要将收入控件渲染在 dom 中，然后用 css 内联样式隐藏起来。 

如果表单中有上传组件，则推荐 `scrollToFirstError` 以对象方式设置元素块在视口中居中显示。

```jsx
scrollToFirstError={{
  block: 'center',
}}
```

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    improve upload component scrolling issue during form validation        |
| 🇨🇳 Chinese |    修复上传组件在表单滑动至校验失败位置错误       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcc79c3</samp>

This pull request updates the `rc-upload` dependency and modifies the `Upload` component to fix a Safari bug and improve the style consistency and flexibility. It changes the files `components/upload/style/index.ts`, `components/upload/Upload.tsx`, and `package.json`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fcc79c3</samp>

*  Fix upload button not clickable on Safari by adding custom styles and classNames to `rc-upload` component ([link](https://github.com/ant-design/ant-design/pull/45410/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dR353-R358), [link](https://github.com/ant-design/ant-design/pull/45410/files?diff=unified&w=0#diff-647a2b5c69bacca02d0a7fc39f44e3749ec7e7583a83df0259315542f6f49668L31-R44))
* Update `rc-upload` dependency version to 4.4.0 in `package.json` to use the latest bug fixes and improvements ([link](https://github.com/ant-design/ant-design/pull/45410/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L157-R157))
