### PR TITLE
chore: remove useless disabled style in Upload

### DIFF
--- a/components/upload/style/dragger.ts
+++ b/components/upload/style/dragger.ts
@@ -59,8 +59,6 @@ const genDraggerStyle: GenerateStyle<UploadToken> = (token) => {
 
         // ===================== Disabled =====================
         [`&${componentCls}-disabled`]: {
-          cursor: 'not-allowed',
-
           [`p${componentCls}-drag-icon ${iconCls},
             p${componentCls}-text,
             p${componentCls}-hint


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

![image](https://github.com/ant-design/ant-design/assets/6828924/5499f6e0-ac7d-4cc5-8033-fe0ff381f0d1)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Remove duplicate disabled styles in Upload.Dragger        |
| 🇨🇳 Chinese |   移除 Upload.Dragger 中重复的 `disabled` 样式        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6adcdb4</samp>

Removed `cursor: 'not-allowed'` style from upload component's drag and drop area. This fixed a bug where the cursor would show as not-allowed even when the component was enabled.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6adcdb4</samp>

*  Removed `cursor: 'not-allowed'` style from drag and drop area of upload component to fix bug where cursor would show as not-allowed even when component was enabled ([link](https://github.com/ant-design/ant-design/pull/45446/files?diff=unified&w=0#diff-3b4dbb97ee0c8cfbf0a7cae6e9aafaef93697d8552af9c0a29e5171b2bab7af6L62-L63))
