### PR TITLE
docs: improve home page banner style

### DIFF
--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -28,8 +28,15 @@ const useStyle = () => {
   const { direction } = React.useContext(ConfigProvider.ConfigContext);
   const isRTL = direction === 'rtl';
 
-  return createStyles(({ token, css }) => {
+  return createStyles(({ token, css, cx }) => {
     const textShadow = `0 0 3px ${token.colorBgContainer}`;
+
+    const mask = cx(css`
+      position: absolute;
+      inset: 0;
+      backdrop-filter: blur(2.5px);
+      transition: all 1s ease;
+    `);
 
     return {
       holder: css`
@@ -42,7 +49,13 @@ const useStyle = () => {
         overflow: hidden;
         perspective: 800px;
         row-gap: ${token.marginXL}px;
+
+        &:hover .${mask} {
+          backdrop-filter: none;
+        }
       `,
+
+      mask,
 
       typography: css`
         text-align: center;
@@ -117,6 +130,7 @@ const PreviewBanner: React.FC<PreviewBannerProps> = (props) => {
       <div className={styles.holder}>
         {/* Mobile not show the component preview */}
         {!isMobile && <ComponentsBlock className={styles.block} style={componentsBlockStyle} />}
+        <div className={styles.mask} />
 
         <Typography className={styles.typography}>
           <h1>Ant Design 5.0</h1>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
加一个毛玻璃效果，hover 后渐进移除。

<img width="1394" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/ca43bcb2-665c-4b67-b78c-bf6b5ce5cb35">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      --     |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bd3bf2</samp>

Added a hover effect to the preview banner on the home page. Used `@emotion/css` to create a `mask` element that blurs the background and shows the content.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bd3bf2</samp>

*  Add a hover effect to the preview banner that blurs the background and reveals the content ([link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beL31-R40), [link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beL45-R59), [link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beR133))
  * Use `cx` from `@emotion/css` to create a `mask` class name with blur effect in `useStyle` ([link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beL31-R40))
  * Add a hover selector to the `holder` class name that removes the blur effect from the `mask` element ([link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beL45-R59))
  * Add a `mask` element as a child of the `holder` element in `.dumi/pages/index/components/PreviewBanner/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45459/files?diff=unified&w=0#diff-45c8f0859db0c8abbf7a64e88161d5a8d4ffdb66c650e697a073e30dc7f8a5beR133))
