### PR TITLE
fix: useAppProps modal type definition

### DIFF
--- a/components/app/context.ts
+++ b/components/app/context.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { MessageInstance, ConfigOptions as MessageConfig } from '../message/interface';
 import type { NotificationInstance, NotificationConfig } from '../notification/interface';
-import type { ModalStaticFunctions } from '../modal/confirm';
+import type { HookAPI as ModalHookAPI } from '../modal/useModal';
 
 export type AppConfig = {
   message?: MessageConfig;
@@ -10,11 +10,10 @@ export type AppConfig = {
 
 export const AppConfigContext = React.createContext<AppConfig>({});
 
-type ModalType = Omit<ModalStaticFunctions, 'warn'>;
 export interface useAppProps {
   message: MessageInstance;
   notification: NotificationInstance;
-  modal: ModalType;
+  modal: ModalHookAPI;
 }
 
 const AppContext = React.createContext<useAppProps>({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Fix https://github.com/ant-design/ant-design/issues/45460

### 💡 Background and solution

`useApp().modal` came from `useModal`, and it's correct return type is `HookAPI` instead of `Omit<ModalStaticFunctions, 'warn'>`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix `modal` return type in `useApp` hook  |
| 🇨🇳 Chinese |  修复`useApp`中`modal`的类型定义     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddca65d</samp>

Refactor `useApp` hook to use `useModal` hook API and improve modal handling. Update types and imports in `components/app/context.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddca65d</samp>

* Refactor the `useApp` hook to use the `useModal` hook API instead of the static modal functions ([link](https://github.com/ant-design/ant-design/pull/45462/files?diff=unified&w=0#diff-161ee91aa2b38277f7bbed5f6172adff1c32db3de49ad453c3c9db506528a9a4L4-R4), [link](https://github.com/ant-design/ant-design/pull/45462/files?diff=unified&w=0#diff-161ee91aa2b38277f7bbed5f6172adff1c32db3de49ad453c3c9db506528a9a4L13-R16))
  - Import the `HookAPI` type from `../modal/useModal` in `components/app/context.ts` ([link](https://github.com/ant-design/ant-design/pull/45462/files?diff=unified&w=0#diff-161ee91aa2b38277f7bbed5f6172adff1c32db3de49ad453c3c9db506528a9a4L4-R4))
  - Change the `modal` property of the `useAppProps` interface to use the `ModalHookAPI` type in `components/app/context.ts` ([link](https://github.com/ant-design/ant-design/pull/45462/files?diff=unified&w=0#diff-161ee91aa2b38277f7bbed5f6172adff1c32db3de49ad453c3c9db506528a9a4L13-R16))
