### PR TITLE
👌 IMPROVE: allow passing filterDropdownProps to Table columns

### DIFF
--- a/components/table/demo/custom-filter-panel.tsx
+++ b/components/table/demo/custom-filter-panel.tsx
@@ -1,10 +1,10 @@
-import { SearchOutlined } from '@ant-design/icons';
 import React, { useRef, useState } from 'react';
-import Highlighter from 'react-highlight-words';
+import { SearchOutlined } from '@ant-design/icons';
 import type { InputRef } from 'antd';
 import { Button, Input, Space, Table } from 'antd';
-import type { ColumnType, ColumnsType } from 'antd/es/table';
+import type { ColumnsType, ColumnType } from 'antd/es/table';
 import type { FilterConfirmProps } from 'antd/es/table/interface';
+import Highlighter from 'react-highlight-words';
 
 interface DataType {
   key: string;
@@ -63,56 +63,64 @@ const App: React.FC = () => {
   };
 
   const getColumnSearchProps = (dataIndex: DataIndex): ColumnType<DataType> => ({
-    filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters, close }) => (
-      <div style={{ padding: 8 }} onKeyDown={(e) => e.stopPropagation()}>
-        <Input
-          ref={searchInput}
-          placeholder={`Search ${dataIndex}`}
-          value={selectedKeys[0]}
-          onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
-          onPressEnter={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
-          style={{ marginBottom: 8, display: 'block' }}
-        />
-        <Space>
-          <Button
-            type="primary"
-            onClick={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
-            icon={<SearchOutlined />}
-            size="small"
-            style={{ width: 90 }}
-          >
-            Search
-          </Button>
-          <Button
-            onClick={() => clearFilters && handleReset(clearFilters)}
-            size="small"
-            style={{ width: 90 }}
-          >
-            Reset
-          </Button>
-          <Button
-            type="link"
-            size="small"
-            onClick={() => {
-              confirm({ closeDropdown: false });
-              setSearchText((selectedKeys as string[])[0]);
-              setSearchedColumn(dataIndex);
-            }}
-          >
-            Filter
-          </Button>
-          <Button
-            type="link"
-            size="small"
-            onClick={() => {
-              close();
-            }}
-          >
-            close
-          </Button>
-        </Space>
-      </div>
-    ),
+    filterDropdown: (
+      { setSelectedKeys, selectedKeys, confirm, clearFilters, close },
+      originalNode,
+    ) =>
+      React.cloneElement(originalNode, {
+        dropdownRender: () => (
+          <div className="ant-table-filter-dropdown">
+            <div style={{ padding: 8 }} onKeyDown={(e) => e.stopPropagation()}>
+              <Input
+                ref={searchInput}
+                placeholder={`Search ${dataIndex}`}
+                value={selectedKeys[0]}
+                onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+                onPressEnter={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+                style={{ marginBottom: 8, display: 'block' }}
+              />
+              <Space>
+                <Button
+                  type="primary"
+                  onClick={() => handleSearch(selectedKeys as string[], confirm, dataIndex)}
+                  icon={<SearchOutlined />}
+                  size="small"
+                  style={{ width: 90 }}
+                >
+                  Search
+                </Button>
+                <Button
+                  onClick={() => clearFilters && handleReset(clearFilters)}
+                  size="small"
+                  style={{ width: 90 }}
+                >
+                  Reset
+                </Button>
+                <Button
+                  type="link"
+                  size="small"
+                  onClick={() => {
+                    confirm({ closeDropdown: false });
+                    setSearchText((selectedKeys as string[])[0]);
+                    setSearchedColumn(dataIndex);
+                  }}
+                >
+                  Filter
+                </Button>
+                <Button
+                  type="link"
+                  size="small"
+                  onClick={() => {
+                    close();
+                  }}
+                >
+                  close
+                </Button>
+              </Space>
+            </div>
+          </div>
+        ),
+      }),
     filterIcon: (filtered: boolean) => (
       <SearchOutlined style={{ color: filtered ? '#1677ff' : undefined }} />
     ),

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -524,6 +524,7 @@ function FilterDropdown<RecordType>(props: FilterDropdownProps<RecordType>) {
         onOpenChange={onVisibleChange}
         getPopupContainer={getPopupContainer}
         placement={direction === 'rtl' ? 'bottomLeft' : 'bottomRight'}
+        {...column.filterDropdownProps}
       >
         <span
           role="button"

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -187,6 +187,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | defaultSortOrder | Default order of sorted values | `ascend` \| `descend` | - |  |
 | ellipsis | The ellipsis cell content, not working with sorter and filters for now.<br />tableLayout would be `fixed` when `ellipsis` is `true` or `{ showTitle?: boolean }` | boolean \| {showTitle?: boolean } | false | showTitle: 4.3.0 |
 | filterDropdown | Customized filter overlay | ReactNode \| (props: [FilterDropdownProps](https://github.com/ant-design/ant-design/blob/ecc54dda839619e921c0ace530408871f0281c2a/components/table/interface.tsx#L79)) => ReactNode | - |  |
+| filterDropdownProps | Customized dropdown props | [DropdownProps](https://ant.design/components/dropdown#api) | - |  |
 | filterDropdownOpen | Whether `filterDropdown` is visible | boolean | - |  |
 | filtered | Whether the `dataSource` is filtered | boolean | false |  |
 | filteredValue | Controlled filtered value, filter icon will highlight | string\[] | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -188,6 +188,7 @@ const columns = [
 | defaultSortOrder | 默认排序顺序 | `ascend` \| `descend` | - |  |
 | ellipsis | 超过宽度将自动省略，暂不支持和排序筛选一起使用。<br />设置为 `true` 或 `{ showTitle?: boolean }` 时，表格布局将变成 `tableLayout="fixed"`。 | boolean \| { showTitle?: boolean } | false | showTitle: 4.3.0 |
 | filterDropdown | 可以自定义筛选菜单，此函数只负责渲染图层，需要自行编写各种交互 | ReactNode \| (props: [FilterDropdownProps](https://github.com/ant-design/ant-design/blob/ecc54dda839619e921c0ace530408871f0281c2a/components/table/interface.tsx#L79)) => ReactNode | - |  |
+| filterDropdownProps | 自定义下拉道具 | [DropdownProps](https://ant.design/components/dropdown#api) | - |  |
 | filterDropdownOpen | 用于控制自定义筛选菜单是否可见 | boolean | - |  |
 | filtered | 标识数据是否经过过滤，筛选图标会高亮 | boolean | false |  |
 | filteredValue | 筛选的受控属性，外界可用此控制列的筛选状态，值为已筛选的 value 数组 | string\[] | - |  |

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -11,6 +11,7 @@ import { ExpandableConfig, GetRowKey } from 'rc-table/lib/interface';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import type { AnyObject } from '../_util/type';
 import type { CheckboxProps } from '../checkbox';
+import type { DropdownProps } from '../dropdown';
 import type { PaginationProps } from '../pagination';
 import type { TooltipProps } from '../tooltip';
 import type { INTERNAL_SELECTION_ITEM } from './hooks/useSelection';
@@ -131,6 +132,10 @@ export interface ColumnType<RecordType> extends Omit<RcColumnType<RecordType>, '
   filtered?: boolean;
   filters?: ColumnFilterItem[];
   filterDropdown?: React.ReactNode | ((props: FilterDropdownProps) => React.ReactNode);
+  filterDropdownProps?: Omit<
+    DropdownProps,
+    'dropdownRender' | 'open' | 'onOpenChange' | 'getPopupContainer'
+  >;
   filterMultiple?: boolean;
   filteredValue?: FilterValue | null;
   defaultFilteredValue?: FilterValue | null;

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -62,7 +62,7 @@ export interface TableLocale {
 export type SortOrder = 'descend' | 'ascend' | null;
 
 const TableActions = ['paginate', 'sort', 'filter'] as const;
-export type TableAction = typeof TableActions[number];
+export type TableAction = (typeof TableActions)[number];
 
 export type CompareFn<T> = (a: T, b: T, sortOrder?: SortOrder) => number;
 
@@ -131,11 +131,12 @@ export interface ColumnType<RecordType> extends Omit<RcColumnType<RecordType>, '
   // Filter
   filtered?: boolean;
   filters?: ColumnFilterItem[];
-  filterDropdown?: React.ReactNode | ((props: FilterDropdownProps) => React.ReactNode);
-  filterDropdownProps?: Omit<
-    DropdownProps,
-    'dropdownRender' | 'open' | 'onOpenChange' | 'getPopupContainer'
-  >;
+  filterDropdown?:
+    | React.ReactElement<DropdownProps>
+    | ((
+        props: FilterDropdownProps,
+        originalNode: React.ReactElement<DropdownProps>,
+      ) => React.ReactElement<DropdownProps>);
   filterMultiple?: boolean;
   filteredValue?: FilterValue | null;
   defaultFilteredValue?: FilterValue | null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
![image](https://github.com/ant-design/ant-design/assets/33312687/b063d506-47e1-41e2-96a7-1190ebc899fc)

Currently when we want to implement filtering and search on Table component, we don't have access to the Dropdown component, I suggest allowing to pass DropdowonProps so we can customize Table filter & search more. For example I need my filters to open above the Table instead of inside it (need to change Dropdown placement), but currently I can't achieve this.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
User has the ability to change any of Dropdown props if needed.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | :new: add filterDropdownProps to `Table` columns object |
| 🇨🇳 Chinese | :new: 将filterDropdownProps添加到`Table`列对象 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 062ad08</samp>

This pull request adds a new feature to the table component that lets users customize the filter dropdown for each column. It adds a new `filterDropdownProps` property to the `ColumnType` interface and passes it to the `FilterDropdown` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 062ad08</samp>

* Add `filterDropdownProps` property to column configuration to allow customizing filter dropdown component ([link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9R14), [link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9R135-R138), [link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aR527))
  * Use `DropdownProps` type from `dropdown` component to define `filterDropdownProps` type, omitting some properties that are not relevant or handled internally ([link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9R14), [link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-3fee134a410a783dfd5f6f89b1a8f7e7eb1ba8e332aeaf4cafdefc4c723088e9R135-R138))
  * Pass `filterDropdownProps` to `FilterDropdown` component in `components/table/hooks/useFilter/FilterDropdown.tsx` and spread them on the `Dropdown` component ([link](https://github.com/ant-design/ant-design/pull/45515/files?diff=unified&w=0#diff-af396bfff8e0daa4eb8b9f25ed47a6006b544d36c1733636ad578f7109f9ee5aR527))
