### PR TITLE
chore(slider): improve SliderRangeProps types

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -91,10 +91,10 @@ export interface SliderSingleProps extends SliderBaseProps {
 
 export interface SliderRangeProps extends SliderBaseProps {
   range: true | SliderRange;
-  value?: number[];
-  defaultValue?: number[];
-  onChange?: (value: number[]) => void;
-  onAfterChange?: (value: number[]) => void;
+  value?: [number, number];
+  defaultValue?: [number, number];
+  onChange?: (value: [number, number]) => void;
+  onAfterChange?: (value: [number, number]) => void;
   /** @deprecated Please use `styles.handle` instead */
   handleStyle?: React.CSSProperties[];
   /** @deprecated Please use `styles.track` instead */


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

The values linked to a slider range are normally tuples of size 2 and not lists of values.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2a9b15</samp>

Refactored the slider component to use TypeScript and changed the type of range props to `[number, number]` for better type safety.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a2a9b15</samp>

* Enforce a fixed length of two elements for the range slider props by changing their type from `number[]` to `[number, number]` ([link](https://github.com/ant-design/ant-design/pull/45523/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL94-R97))
