### PR TITLE
feat(Modal): Modal static function accept 'styles'

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -148,9 +148,9 @@ export function ConfirmContent(
           <div className={`${confirmPrefixCls}-btns`}>
             {typeof footer === 'function'
               ? footer(footerOriginNode, {
-                OkBtn,
-                CancelBtn,
-              })
+                  OkBtn,
+                  CancelBtn,
+                })
               : footerOriginNode}
           </div>
         </ModalContextProvider>

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -148,9 +148,9 @@ export function ConfirmContent(
           <div className={`${confirmPrefixCls}-btns`}>
             {typeof footer === 'function'
               ? footer(footerOriginNode, {
-                  OkBtn,
-                  CancelBtn,
-                })
+                OkBtn,
+                CancelBtn,
+              })
               : footerOriginNode}
           </div>
         </ModalContextProvider>
@@ -185,6 +185,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     modalRender,
     focusTriggerAfterClose,
     onConfirm,
+    styles
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -244,7 +245,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         mask={mask}
         maskClosable={maskClosable}
         style={style}
-        styles={{
+        styles={styles || {
           body: bodyStyle,
           mask: maskStyle,
         }}

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -245,9 +245,10 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         mask={mask}
         maskClosable={maskClosable}
         style={style}
-        styles={styles || {
+        styles={{
           body: bodyStyle,
           mask: maskStyle,
+          ...styles,
         }}
         width={width}
         zIndex={zIndex}

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -185,7 +185,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     modalRender,
     focusTriggerAfterClose,
     onConfirm,
-    styles
+    styles,
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -663,6 +663,14 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     spy.mockRestore();
   });
 
+  it('styles', async () => {
+    resetWarned();
+    await open({ styles: { body: { width: 500 } } });
+
+    const { width } = $$('.ant-modal-body')[0].style;
+    expect(width).toBe('500px');
+  });
+
   describe('the callback close should be a method when onCancel has a close parameter', () => {
     (['confirm', 'info', 'success', 'warning', 'error'] as const).forEach((type) => {
       it(`click the close icon to trigger ${type} onCancel`, async () => {

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -8,7 +8,10 @@ export type ModalFooterRender = (
   originNode: React.ReactNode,
   extra: { OkBtn: FC; CancelBtn: FC },
 ) => React.ReactNode;
-export interface ModalProps {
+interface ModalCommonProps{
+  styles?: Omit<NonNullable<DialogProps['styles']>, 'wrapper'>;
+}
+export interface ModalProps extends ModalCommonProps {
   /** Whether the modal dialog is visible or not */
   open?: boolean;
   /** Whether to apply loading visual effect for OK button or not */
@@ -50,7 +53,6 @@ export interface ModalProps {
   className?: string;
   rootClassName?: string;
   classNames?: Omit<NonNullable<DialogProps['classNames']>, 'wrapper'>;
-  styles?: Omit<NonNullable<DialogProps['styles']>, 'wrapper'>;
   getContainer?: string | HTMLElement | getContainerFunc | false;
   zIndex?: number;
   /** @deprecated Please use `styles.body` instead */
@@ -74,7 +76,7 @@ export interface ModalProps {
 
 type getContainerFunc = () => HTMLElement;
 
-export interface ModalFuncProps {
+export interface ModalFuncProps extends ModalCommonProps {
   prefixCls?: string;
   className?: string;
   rootClassName?: string;

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -8,7 +8,7 @@ export type ModalFooterRender = (
   originNode: React.ReactNode,
   extra: { OkBtn: FC; CancelBtn: FC },
 ) => React.ReactNode;
-interface ModalCommonProps{
+interface ModalCommonProps {
   styles?: Omit<NonNullable<DialogProps['styles']>, 'wrapper'>;
 }
 export interface ModalProps extends ModalCommonProps {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #45580

### 💡 Background and solution
自5.10(#44934)，```bodyStyle```和```maskStyle```都被标记废弃。```ModalFuncProps```上对应的属性也被标为废弃，但是并没有对应地提供styles属性。
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Modal static function accept 'styles'        |
| 🇨🇳 Chinese |  Modal静态方法接受styles属性         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d7d6a4</samp>

This pull request adds a new `styles` prop to the modal components and functions, which allows users to customize the modal appearance. It also includes a test case and some code refactoring.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d7d6a4</samp>

*  Add `styles` prop to modal components and functions to allow customizing the modal body and mask styles ([link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3R188), [link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L11-R14), [link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L77-R79))
*  Use the `styles` prop value from the parent component or the default styles in the `Dialog` component ([link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L247-R248))
*  Remove the `styles` prop from the `ModalProps` interface as it is inherited from the `ModalCommonProps` interface ([link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-ac9fa8e4784b40c5c2a26fe86dc50bbd39572b8ecf42b73611745ec817d883a1L53))
*  Test that the `styles` prop works as expected in the `confirm.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-c211b371c72d68e91c25e16529bf8ded303122c95060910f58afdfc61a942a2bR666-R673))
*  Remove an extra space in the `footer` function call in the `ConfirmDialog.tsx` file ([link](https://github.com/ant-design/ant-design/pull/45558/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L151-R153))
