### PR TITLE
style: fix Typography.Text lost right border when text is ellipsis

### DIFF
--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -491,9 +491,36 @@ Array [
   </div>,
   <span
     class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
-    style="width: 100px;"
+    style="width: 200px;"
   >
     Ant Design, a design language for background applications, is refined by Ant UED Team.
+  </span>,
+  <div
+    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+  >
+    <div
+      class="ant-tooltip-arrow"
+      style="position: absolute; bottom: 0px; left: 0px;"
+    />
+    <div
+      class="ant-tooltip-content"
+    >
+      <div
+        class="ant-tooltip-inner"
+        role="tooltip"
+      >
+        I am ellipsis now!
+      </div>
+    </div>
+  </div>,
+  <span
+    class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line"
+    style="width: 200px;"
+  >
+    <code>
+      Ant Design, a design language for background applications, is refined by Ant UED Team.
+    </code>
   </span>,
   <div
     class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -507,7 +507,7 @@ Array [
   <span
     aria-label="Ant Design, a design language for background applications, is refined by Ant UED Team."
     class="ant-typography ant-typography-ellipsis ant-typography-single-line"
-    style="width:100px"
+    style="width:200px"
   >
     Ant Design, a design language for background applications, is refined by Ant UED Team.
     <span
@@ -525,6 +525,33 @@ Array [
       >
         ...
       </span>
+    </span>
+  </span>,
+  <span
+    aria-label="Ant Design, a design language for background applications, is refined by Ant UED Team."
+    class="ant-typography ant-typography-ellipsis ant-typography-single-line"
+    style="width:200px"
+  >
+    <code>
+      Ant Design, a design language for background applications, is refined by Ant UED Team.
+    </code>
+    <span
+      aria-hidden="true"
+      style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;word-break:keep-all;white-space:nowrap"
+    >
+      lg
+    </span>
+    <span
+      aria-hidden="true"
+      style="position:fixed;display:block;left:0;top:0;z-index:-9999;visibility:hidden;pointer-events:none;font-size:0;width:0;white-space:normal;margin:0;padding:0"
+    >
+      <code>
+        <span
+          aria-hidden="true"
+        >
+          ...
+        </span>
+      </code>
     </span>
   </span>,
 ]

--- a/components/typography/demo/basic.tsx
+++ b/components/typography/demo/basic.tsx
@@ -9,11 +9,13 @@ const blockContent = `AntV 是蚂蚁集团全新一代数据可视化解决方�
 const App: React.FC = () => (
   <Typography>
     <Title>Introduction</Title>
+
     <Paragraph>
       In the process of internal desktop applications development, many different design specs and
       implementations would be involved, which might cause designers and developers difficulties and
       duplication and reduce the efficiency of development.
     </Paragraph>
+
     <Paragraph>
       After massive project practice and summaries, Ant Design, a design language for background
       applications, is refined by Ant UED Team, which aims to{' '}
@@ -24,7 +26,9 @@ const App: React.FC = () => (
       </Text>
       .
     </Paragraph>
+
     <Title level={2}>Guidelines and Resources</Title>
+
     <Paragraph>
       We supply a series of design principles, practical patterns and high quality design resources
       (<Text code>Sketch</Text> and <Text code>Axure</Text>), to help people create their product
@@ -52,16 +56,20 @@ const App: React.FC = () => (
     <Divider />
 
     <Title>介绍</Title>
+
     <Paragraph>
       蚂蚁的企业级产品是一个庞大且复杂的体系。这类产品不仅量级巨大且功能复杂，而且变动和并发频繁，常常需要设计与开发能够快速的做出响应。同时这类产品中有存在很多类似的页面以及组件，可以通过抽象得到一些稳定且高复用性的内容。
     </Paragraph>
+
     <Paragraph>
       随着商业化的趋势，越来越多的企业级产品对更好的用户体验有了进一步的要求。带着这样的一个终极目标，我们（蚂蚁集团体验技术部）经过大量的项目实践和总结，逐步打磨出一个服务于企业级产品的设计体系
       Ant Design。基于<Text mark>『确定』和『自然』</Text>
       的设计价值观，通过模块化的解决方案，降低冗余的生产成本，让设计者专注于
       <Text strong>更好的用户体验</Text>。
     </Paragraph>
+
     <Title level={2}>设计资源</Title>
+
     <Paragraph>
       我们提供完善的设计原则、最佳实践和设计资源文件（<Text code>Sketch</Text> 和
       <Text code>Axure</Text>），来帮助业务快速设计出高质量的产品原型。

--- a/components/typography/demo/ellipsis.tsx
+++ b/components/typography/demo/ellipsis.tsx
@@ -34,7 +34,15 @@ const App: React.FC = () => {
       </Paragraph>
 
       <Text
-        style={ellipsis ? { width: 100 } : undefined}
+        style={ellipsis ? { width: 200 } : undefined}
+        ellipsis={ellipsis ? { tooltip: 'I am ellipsis now!' } : false}
+      >
+        Ant Design, a design language for background applications, is refined by Ant UED Team.
+      </Text>
+
+      <Text
+        code
+        style={ellipsis ? { width: 200 } : undefined}
         ellipsis={ellipsis ? { tooltip: 'I am ellipsis now!' } : false}
       >
         Ant Design, a design language for background applications, is refined by Ant UED Team.

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -253,6 +253,15 @@ export const getEllipsisStyles = (): CSSObject => ({
     'a&, span&': {
       verticalAlign: 'bottom',
     },
+
+    '> code': {
+      paddingBlock: 0,
+      maxWidth: 'calc(100% - 1.2em)',
+      display: 'inline-block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      verticalAlign: 'bottom',
+    },
   },
 
   '&-ellipsis-multiple-line': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/ant-design/ant-design/issues/40261
close https://github.com/ant-design/ant-design/pull/40503
close https://github.com/ant-design/ant-design/pull/40967
close https://github.com/ant-design/ant-design/pull/41005

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

<img width="449" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/34d3bcbc-b567-4c09-996c-b96cc10c5745">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Typography.Text lost right border when enable `ellipsis` and `code`.          |
| 🇨🇳 Chinese |   修复 Typography.Text 同时启用 `ellipsis` 和 `code` 时丢失右边框样式的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d60df6</samp>

This pull request enhances the typography component and its demos by adding ellipsis support for code style, adjusting the width of the ellipsis demo, and improving the code formatting and readability.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d60df6</samp>

* Increase the width of the text component with ellipsis and add another text component with code style and ellipsis in `components/typography/demo/ellipsis.tsx` ([link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-087584a45eea0476eeb93f7d78c3ae29930569b7bea871722e0a63b6a5f05109L37-R49))
* Enable ellipsis and overflow handling for the code element inside the typography component and set its vertical alignment to bottom in `components/typography/style/mixins.ts` ([link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-5e2c2184e054706f99691f617b33901f0929824030ce7847ac693ad475154775R256-R264))
* Add empty lines to separate the import statements, the component declaration, and the component usage in `components/typography/demo/basic.tsx` ([link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-70179fb9c68d923be8b3778dc155010b5adc133174c3ec8e4cefa014c058ad6bR12), [link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-70179fb9c68d923be8b3778dc155010b5adc133174c3ec8e4cefa014c058ad6bR18))
* Add empty lines to separate the paragraphs and titles in `components/typography/demo/basic.tsx` ([link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-70179fb9c68d923be8b3778dc155010b5adc133174c3ec8e4cefa014c058ad6bL27-R31), [link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-70179fb9c68d923be8b3778dc155010b5adc133174c3ec8e4cefa014c058ad6bL55-R63), [link](https://github.com/ant-design/ant-design/pull/45575/files?diff=unified&w=0#diff-70179fb9c68d923be8b3778dc155010b5adc133174c3ec8e4cefa014c058ad6bL64-R72))
