### PR TITLE
feat(color-picker): preset colors support collapsing at initialization

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -225,6 +225,39 @@ describe('ColorPicker', () => {
     expect(handleColorChange).toHaveBeenCalledTimes(2);
   });
 
+  describe('preset collapsed', () => {
+    const recommendedPreset = {
+      label: 'Recommended',
+      colors: ['#f00', '#0f0', '#00f'],
+    };
+
+    const selector = '.ant-color-picker-presets .ant-collapse-item.ant-collapse-item-active';
+
+    it('Should default collapsed work', async () => {
+      const { container } = render(<ColorPicker open presets={[recommendedPreset]} />);
+
+      expect(container.querySelectorAll(selector)).toHaveLength(1);
+    });
+
+    it('Should collapsed work', async () => {
+      const { container } = render(
+        <ColorPicker
+          open
+          presets={[
+            recommendedPreset,
+            {
+              label: 'Recent',
+              colors: ['#f00d', '#0f0d', '#00fd'],
+              collapsed: true,
+            },
+          ]}
+        />,
+      );
+
+      expect(container.querySelectorAll(selector)).toHaveLength(1);
+    });
+  });
+
   it('Should format change work', async () => {
     const { container } = render(<ColorPicker />);
     fireEvent.click(container.querySelector('.ant-color-picker-trigger')!);

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -248,7 +248,7 @@ describe('ColorPicker', () => {
             {
               label: 'Recent',
               colors: ['#f00d', '#0f0d', '#00fd'],
-              collapsed: true,
+              defaultCollapsed: true,
             },
           ]}
         />,

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -34,6 +34,8 @@ const isBright = (value: Color, bgColorToken: string) => {
   return r * 0.299 + g * 0.587 + b * 0.114 > 192;
 };
 
+const genCollapsePanelKey = ({ label }: PresetsItem) => `panel-${label}`;
+
 const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color, onChange }) => {
   const [locale] = useLocale('ColorPicker');
   const [, token] = useToken();
@@ -44,7 +46,13 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   const colorPresetsPrefixCls = `${prefixCls}-presets`;
 
   const activeKeys = useMemo<string[]>(
-    () => presetsValue.map((preset) => `panel-${preset.label}`),
+    () =>
+      presetsValue.reduce<string[]>((acc, preset) => {
+        if (preset.collapsed !== true) {
+          acc.push(genCollapsePanelKey(preset));
+        }
+        return acc;
+      }, []),
     [presetsValue],
   );
 
@@ -53,7 +61,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   };
 
   const items: CollapseProps['items'] = presetsValue.map((preset) => ({
-    key: `panel-${preset.label}`,
+    key: genCollapsePanelKey(preset),
     label: <div className={`${colorPresetsPrefixCls}-label`}>{preset?.label}</div>,
     children: (
       <div className={`${colorPresetsPrefixCls}-items`}>

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -48,7 +48,7 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   const activeKeys = useMemo(
     () =>
       presetsValue.reduce<string[]>((acc, preset) => {
-        if (!preset.collapsed) {
+        if (!preset.defaultCollapsed) {
           acc.push(genCollapsePanelKey(preset));
         }
         return acc;

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -45,10 +45,10 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   });
   const colorPresetsPrefixCls = `${prefixCls}-presets`;
 
-  const activeKeys = useMemo<string[]>(
+  const activeKeys = useMemo(
     () =>
       presetsValue.reduce<string[]>((acc, preset) => {
-        if (preset.collapsed !== true) {
+        if (!preset.collapsed) {
           acc.push(genCollapsePanelKey(preset));
         }
         return acc;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |
-| presets | Preset colors, `5.11.0+` Support for `defaultCollapsed` to achieve default folding during initialization | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | |
+| presets | Preset colors | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | `defaultCollapsed: 5.11.0` |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |
-| presets | 	Preset colors | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - | |
+| presets | Preset colors, `5.11.0+` Support for `collapsed` to achieve default folding during initialization | `{ label: ReactNode, colors: Array<string \| Color>, collapsed?: boolean }[]` | - | |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |
-| presets | Preset colors, `5.11.0+` Support for `collapsed` to achieve default folding during initialization | `{ label: ReactNode, colors: Array<string \| Color>, collapsed?: boolean }[]` | - | |
+| presets | Preset colors, `5.11.0+` Support for `defaultCollapsed` to achieve default folding during initialization | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -54,7 +54,7 @@ group:
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color> }[]` | - | |
+| presets | 预设的颜色，`5.11.0+` 支持 `collapsed` 以实现初始化时默认折叠预设 | `{ label: ReactNode, colors: Array<string \| Color>, collapsed?: boolean }[]` | - | |
 | placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -54,7 +54,7 @@ group:
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色，`5.11.0+` 支持 `collapsed` 以实现初始化时默认折叠预设 | `{ label: ReactNode, colors: Array<string \| Color>, collapsed?: boolean }[]` | - | |
+| presets | 预设的颜色，`5.11.0+` 支持 `defaultCollapsed` 以实现初始化时默认折叠预设 | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | |
 | placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -54,7 +54,7 @@ group:
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色，`5.11.0+` 支持 `defaultCollapsed` 以实现初始化时默认折叠预设 | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | |
+| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | `defaultCollapsed: 5.11.0` |
 | placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -11,6 +11,11 @@ export enum ColorFormat {
 export interface PresetsItem {
   label: ReactNode;
   colors: (string | Color)[];
+  /**
+   * Whether the initial state is collapsed
+   * @since 5.11.0
+   */
+  collapsed?: boolean;
 }
 export type TriggerType = 'click' | 'hover';
 

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -15,7 +15,7 @@ export interface PresetsItem {
    * Whether the initial state is collapsed
    * @since 5.11.0
    */
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 export type TriggerType = 'click' | 'hover';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     feat(color-picker): preset colors support collapsing at initialization      |
| 🇨🇳 Chinese |      color-picker 预设颜色支持默认折叠模式     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f88d3a8</samp>

This pull request adds a new feature to the color picker component, which allows the user to specify the initial folding state of the presets using the `collapsed` property. It also refactors the code for generating and managing the collapse panel keys, and adds tests and documentation for the new feature.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f88d3a8</samp>

*  Add `collapsed` property to `presets` prop of color picker component, allowing users to control the initial folding state of the presets ([link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560L56-R56), [link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249L57-R57), [link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-83dba3026e7dc41ad64d3a2f4d484eeb085f0c3798dc2316fbb90d23520fca6eR14-R18))
*  Generate unique keys for collapse panels based on preset labels using `genCollapsePanelKey` helper function ([link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822R37-R38), [link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L56-R64))
*  Filter out collapsed presets from default active keys using `genCollapsePanelKey` function ([link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L47-R55))
*  Test color picker behavior with collapsed and non-collapsed presets in `components/color-picker/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/45607/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4R228-R260))
