### PR TITLE
 add code example for autoInsertSpaceInButton prop of Button to avoid incorrect use by document readers

### DIFF
--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -91,7 +91,7 @@ It accepts all props which native buttons support.
 
 Following the Ant Design specification, we will add one space between if Button (exclude Text button and Link button) contains two Chinese characters only. If you don't need that, you can use [ConfigProvider](/components/config-provider/#api) to set `autoInsertSpaceInButton` as `false`.
 ```
-<ConfigProvider autoInsertSpaceInButton = {false}>
+<ConfigProvider autoInsertSpaceInButton={false}>
     <Button>Button</Button>
 </ConfigProvider>
 ```

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -91,6 +91,10 @@ It accepts all props which native buttons support.
 
 Following the Ant Design specification, we will add one space between if Button (exclude Text button and Link button) contains two Chinese characters only. If you don't need that, you can use [ConfigProvider](/components/config-provider/#api) to set `autoInsertSpaceInButton` as `false`.
 
+<ConfigProvider autoInsertSpaceInButton = {false}>
+    <Button>Button</Button>
+</ConfigProvider>
+
 <img src="https://gw.alipayobjects.com/zos/antfincdn/MY%26THAPZrW/38f06cb9-293a-4b42-b183-9f443e79ffea.png" width="100px" height="64px" style="box-shadow: none; margin: 0;" alt="Button with two Chinese characters" />
 
 <style>

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -90,7 +90,7 @@ It accepts all props which native buttons support.
 ### How to remove space between 2 chinese characters?
 
 Following the Ant Design specification, we will add one space between if Button (exclude Text button and Link button) contains two Chinese characters only. If you don't need that, you can use [ConfigProvider](/components/config-provider/#api) to set `autoInsertSpaceInButton` as `false`.
-```
+```tsx
 <ConfigProvider autoInsertSpaceInButton={false}>
     <Button>Button</Button>
 </ConfigProvider>

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -90,10 +90,11 @@ It accepts all props which native buttons support.
 ### How to remove space between 2 chinese characters?
 
 Following the Ant Design specification, we will add one space between if Button (exclude Text button and Link button) contains two Chinese characters only. If you don't need that, you can use [ConfigProvider](/components/config-provider/#api) to set `autoInsertSpaceInButton` as `false`.
-
+```
 <ConfigProvider autoInsertSpaceInButton = {false}>
     <Button>Button</Button>
 </ConfigProvider>
+```
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/MY%26THAPZrW/38f06cb9-293a-4b42-b183-9f443e79ffea.png" width="100px" height="64px" style="box-shadow: none; margin: 0;" alt="Button with two Chinese characters" />
 

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -90,9 +90,10 @@ It accepts all props which native buttons support.
 ### How to remove space between 2 chinese characters?
 
 Following the Ant Design specification, we will add one space between if Button (exclude Text button and Link button) contains two Chinese characters only. If you don't need that, you can use [ConfigProvider](/components/config-provider/#api) to set `autoInsertSpaceInButton` as `false`.
+
 ```tsx
 <ConfigProvider autoInsertSpaceInButton={false}>
-    <Button>Button</Button>
+  <Button>按钮</Button>
 </ConfigProvider>
 ```
 

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -95,9 +95,10 @@ group:
 ### 如何移除两个汉字之间的空格？
 
 根据 Ant Design 设计规范要求，我们会在按钮内(文本按钮和链接按钮除外)只有两个汉字时自动添加空格，如果你不需要这个特性，可以设置 [ConfigProvider](/components/config-provider-cn#api) 的 `autoInsertSpaceInButton` 为 `false`。
+
 ```tsx
 <ConfigProvider autoInsertSpaceInButton={false}>
-    <Button>按钮</Button>
+  <Button>按钮</Button>
 </ConfigProvider>
 ```
 

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -96,6 +96,10 @@ group:
 
 根据 Ant Design 设计规范要求，我们会在按钮内(文本按钮和链接按钮除外)只有两个汉字时自动添加空格，如果你不需要这个特性，可以设置 [ConfigProvider](/components/config-provider-cn#api) 的 `autoInsertSpaceInButton` 为 `false`。
 
+<ConfigProvider autoInsertSpaceInButton = {false}>
+    <Button>按钮</Button>
+</ConfigProvider>
+
 <img src="https://gw.alipayobjects.com/zos/antfincdn/MY%26THAPZrW/38f06cb9-293a-4b42-b183-9f443e79ffea.png" style="box-shadow: none; margin: 0" width="100px" height="64px" alt="移除两个汉字之间的空格"  />
 
 <style>

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -96,7 +96,7 @@ group:
 
 根据 Ant Design 设计规范要求，我们会在按钮内(文本按钮和链接按钮除外)只有两个汉字时自动添加空格，如果你不需要这个特性，可以设置 [ConfigProvider](/components/config-provider-cn#api) 的 `autoInsertSpaceInButton` 为 `false`。
 ```
-<ConfigProvider autoInsertSpaceInButton = {false}>
+<ConfigProvider autoInsertSpaceInButton={false}>
     <Button>按钮</Button>
 </ConfigProvider>
 ```

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -95,10 +95,11 @@ group:
 ### 如何移除两个汉字之间的空格？
 
 根据 Ant Design 设计规范要求，我们会在按钮内(文本按钮和链接按钮除外)只有两个汉字时自动添加空格，如果你不需要这个特性，可以设置 [ConfigProvider](/components/config-provider-cn#api) 的 `autoInsertSpaceInButton` 为 `false`。
-
+```
 <ConfigProvider autoInsertSpaceInButton = {false}>
     <Button>按钮</Button>
 </ConfigProvider>
+```
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/MY%26THAPZrW/38f06cb9-293a-4b42-b183-9f443e79ffea.png" style="box-shadow: none; margin: 0" width="100px" height="64px" alt="移除两个汉字之间的空格"  />
 

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -95,7 +95,7 @@ group:
 ### 如何移除两个汉字之间的空格？
 
 根据 Ant Design 设计规范要求，我们会在按钮内(文本按钮和链接按钮除外)只有两个汉字时自动添加空格，如果你不需要这个特性，可以设置 [ConfigProvider](/components/config-provider-cn#api) 的 `autoInsertSpaceInButton` 为 `false`。
-```
+```tsx
 <ConfigProvider autoInsertSpaceInButton={false}>
     <Button>按钮</Button>
 </ConfigProvider>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [X] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无相关issue

### 💡 需求背景和解决方案

在参考文档使用autoInsertSpaceInButton属性解决Button中2个汉字之间自动添加的空格时，由于文档不是特别清晰，造成了下列错误代码：
错误代码1： 
``` 
 <ConfigProvider
          theme={{
              token: {                  
                  autoInsertSpaceInButton: false
              },
          }}
      >
  <Button>按钮</Button>
</ConfigProvider>
```

错误代码2：
```
<ConfigProvider
          theme={{
              components: {
                  Button: {                                                           
                      autoInsertSpaceInButton: false
                  },
              },
          }}
  >
  <Button>按钮</Button>
</ConfigProvider>
```
  

以上2中错误的代码，均无法生效。 经过尝试，发现正确的代码应该是这样:
正确代码：

```
<ConfigProvider autoInsertSpaceInButton = {false}>
    <Button>按钮</Button>
</ConfigProvider>
```



为了防止后来人在阅读文档时，犯和我一样的错误，特此对文档进行补充，增加了autoInsertSpaceInButton属性的示例代码. thanks


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | - |
| 🇨🇳 中文 | - |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c41e8bf</samp>

Added documentation for the `autoInsertSpaceInButton` prop of the `ConfigProvider` component in both English and Chinese. This prop allows users to control the spacing between Chinese characters in buttons.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c41e8bf</samp>

*  Add a new prop `autoInsertSpaceInButton` to the `ConfigProvider` component to control whether to insert a space between two Chinese characters in a button ()
*  Update the English and Chinese documentation of the `Button` component to show how to use the `autoInsertSpaceInButton` prop with an example code snippet ([link](https://github.com/ant-design/ant-design/pull/45608/files?diff=unified&w=0#diff-80ce0ce5862cdbde65634fdeed1081c7812fabe85b736155e1be0c5da5760d16R94-R97),[link](https://github.com/ant-design/ant-design/pull/45608/files?diff=unified&w=0#diff-447d93c86c05c00f9924d883b65877d29b1d52a00560746e69352a1d1c8af4ffR99-R102))