### PR TITLE
demo: update tooltip demo

### DIFF
--- a/components/popover/demo/arrow.tsx
+++ b/components/popover/demo/arrow.tsx
@@ -1,15 +1,16 @@
 import React, { useMemo, useState } from 'react';
-import { Button, Popover, Segmented, ConfigProvider } from 'antd';
+import { Button, ConfigProvider, Popover, Segmented } from 'antd';
 
 const text = <span>Title</span>;
+
+const buttonWidth = 80;
+
 const content = (
   <div>
     <p>Content</p>
     <p>Content</p>
   </div>
 );
-
-const buttonWidth = 80;
 
 const App: React.FC = () => {
   const [arrow, setArrow] = useState('Show');
@@ -29,16 +30,10 @@ const App: React.FC = () => {
   }, [arrow]);
 
   return (
-    <ConfigProvider
-      button={{
-        style: { width: buttonWidth, margin: 4 },
-      }}
-    >
+    <ConfigProvider button={{ style: { width: buttonWidth, margin: 4 } }}>
       <Segmented
         options={['Show', 'Hide', 'Center']}
-        onChange={(val: string) => {
-          setArrow(val);
-        }}
+        onChange={(val: string) => setArrow(val)}
         style={{ marginBottom: 24 }}
       />
       <div className="demo">

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -62,7 +62,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -92,7 +92,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -122,7 +122,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -156,7 +156,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -186,7 +186,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -216,7 +216,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -250,7 +250,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -280,7 +280,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -310,7 +310,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -344,7 +344,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -374,7 +374,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>
@@ -404,7 +404,7 @@ Array [
       </div>
       <button
         class="ant-btn ant-btn-default"
-        style="width: 80px;"
+        style="width: 80px; margin: 4px;"
         type="button"
       >
         <span>

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -62,7 +62,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -71,7 +71,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -80,7 +80,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -93,7 +93,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -102,7 +102,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -111,7 +111,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -124,7 +124,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -133,7 +133,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -142,7 +142,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -155,7 +155,7 @@ Array [
     >
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -164,7 +164,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>
@@ -173,7 +173,7 @@ Array [
       </button>
       <button
         class="ant-btn ant-btn-default"
-        style="width:80px"
+        style="width:80px;margin:4px"
         type="button"
       >
         <span>

--- a/components/tooltip/demo/arrow.tsx
+++ b/components/tooltip/demo/arrow.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Button, Segmented, Tooltip, ConfigProvider } from 'antd';
+import { Button, ConfigProvider, Segmented, Tooltip } from 'antd';
 
 const text = <span>prompt text</span>;
 
@@ -23,17 +23,11 @@ const App: React.FC = () => {
   }, [arrow]);
 
   return (
-    <ConfigProvider
-      button={{
-        style: { width: buttonWidth },
-      }}
-    >
+    <ConfigProvider button={{ style: { width: buttonWidth, margin: 4 } }}>
       <Segmented
         value={arrow}
         options={['Show', 'Hide', 'Center']}
-        onChange={(val: string) => {
-          setArrow(val);
-        }}
+        onChange={(val: string) => setArrow(val)}
         style={{ marginBottom: 24 }}
       />
       <div className="demo">


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

### before:

<img width="498" alt="image" src="https://github.com/ant-design/ant-design/assets/49217418/0b994d2a-b291-4147-99b0-6bd096ed3b53">

### after:

<img width="492" alt="image" src="https://github.com/ant-design/ant-design/assets/49217418/819765b1-dec9-4506-9d2f-62ae3a1d1af3">

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | demo: update tooltip demo |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c9c36f</samp>

This pull request refactors and enhances the demo files for the `Popover` and `Tooltip` components, especially the arrow placement feature. It uses the `Popover` component consistently, simplifies the code, and improves the UI.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c9c36f</samp>

*  Rename `Tooltip` component to `Popover` and update its demo file ([link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-9d8282bfef88783426ca34cf677d55aa7d0823b54db0e0ccb2d256262b0524abL2-R2), [link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-9d8282bfef88783426ca34cf677d55aa7d0823b54db0e0ccb2d256262b0524abL26-R30))
*  Sort imports alphabetically in both demo files ([link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-11aa2afb57b060eea255d1b751e47cecc5f2787ba089076ae10227e7c6cf8cbdL2-R7), [link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-9d8282bfef88783426ca34cf677d55aa7d0823b54db0e0ccb2d256262b0524abL2-R2))
*  Move `buttonWidth` variable to higher scope and simplify `onChange` prop of `Segmented` component in `components/popover/demo/arrow.tsx` ([link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-11aa2afb57b060eea255d1b751e47cecc5f2787ba089076ae10227e7c6cf8cbdL12-L13), [link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-11aa2afb57b060eea255d1b751e47cecc5f2787ba089076ae10227e7c6cf8cbdL32-R36))
*  Add `margin` and `value` props to `ConfigProvider` and `Segmented` components in `components/tooltip/demo/arrow.tsx` ([link](https://github.com/ant-design/ant-design/pull/45620/files?diff=unified&w=0#diff-9d8282bfef88783426ca34cf677d55aa7d0823b54db0e0ccb2d256262b0524abL26-R30))
