### PR TITLE
feat: CP support Dropdown className and style

### DIFF
--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -18,6 +18,7 @@ import DatePicker from '../../date-picker';
 import Descriptions from '../../descriptions';
 import Divider from '../../divider';
 import Drawer from '../../drawer';
+import Dropdown from '../../dropdown';
 import Empty from '../../empty';
 import Flex from '../../flex';
 import Form from '../../form';
@@ -1306,5 +1307,16 @@ describe('ConfigProvider support style and className props', () => {
     const element = container.querySelector<HTMLDivElement>('.ant-flex');
     expect(element).toHaveClass('cp-flex');
     expect(element).toHaveStyle({ backgroundColor: 'blue' });
+  });
+
+  it('Should Dropdown className & style works', () => {
+    const { container } = render(
+      <ConfigProvider dropdown={{ className: 'cp-dropdown', style: { backgroundColor: 'red' } }}>
+        <Dropdown open>test</Dropdown>
+      </ConfigProvider>,
+    );
+    const element = container.querySelector<HTMLDivElement>('.ant-dropdown');
+    expect(element).toHaveClass('cp-dropdown');
+    expect(element).toHaveStyle({ backgroundColor: 'red' });
   });
 });

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1312,7 +1312,9 @@ describe('ConfigProvider support style and className props', () => {
   it('Should Dropdown className & style works', () => {
     const { container } = render(
       <ConfigProvider dropdown={{ className: 'cp-dropdown', style: { backgroundColor: 'red' } }}>
-        <Dropdown open>test</Dropdown>
+        <Dropdown menu={{ items: [{ label: 'foo', key: '1' }] }} open>
+          <span>test</span>
+        </Dropdown>
       </ConfigProvider>,
     );
     const element = container.querySelector<HTMLDivElement>('.ant-dropdown');

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -172,6 +172,7 @@ export interface ConfigConsumerProps {
   colorPicker?: ComponentStyleConfig;
   datePicker?: ComponentStyleConfig;
   rangePicker?: ComponentStyleConfig;
+  dropdown?: ComponentStyleConfig;
   flex?: FlexConfig;
   wave?: WaveConfig;
   warning?: WarningContextProps;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -122,6 +122,7 @@ const {
 | descriptions | Set Descriptions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | Set Divider common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | drawer | Set Drawer common props | { className?: string, style?: React.CSSProperties, classNames?: [DrawerProps\["classNames"\]](/components/drawer-cn#api), styles?: [DrawerProps\["styles"\]](/components/drawer-cn#api) } | - | 5.7.0, `classNames` and `styles`: 5.10.0 |
+| dropdown | Set Dropdown common props | { className?: string, style?: React.CSSProperties } | - | 5.11.0 |
 | empty | Set Empty common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | flex | Set Flex common props | { className?: string, style?: React.CSSProperties, vertical?: boolean } | - | 5.10.0 |
 | form | Set Form common props | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form/#validatemessages), requiredMark?: boolean \| `optional`, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) } | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -199,6 +199,7 @@ export interface ConfigProviderProps {
   colorPicker?: ComponentStyleConfig;
   datePicker?: ComponentStyleConfig;
   rangePicker?: ComponentStyleConfig;
+  dropdown?: ComponentStyleConfig;
   flex?: FlexConfig;
   /**
    * Wave is special component which only patch on the effect of component interaction.
@@ -343,6 +344,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     rangePicker,
     flex,
     wave,
+    dropdown,
     warning: warningConfig,
   } = props;
 
@@ -435,6 +437,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     rangePicker,
     flex,
     wave,
+    dropdown,
     warning: warningConfig,
   };
 

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -124,6 +124,7 @@ const {
 | descriptions | 设置 Descriptions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | divider | 设置 Divider 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | drawer | 设置 Drawer 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [DrawerProps\["classNames"\]](/components/drawer-cn#api), styles?: [DrawerProps\["styles"\]](/components/drawer-cn#api) } | - | 5.7.0, `classNames` 和 `styles`: 5.10.0 |
+| dropdown | 设置 Dropdown 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.11.0 |
 | empty | 设置 Empty 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | flex | 设置 Flex 组件的通用属性 | { className?: string, style?: React.CSSProperties, vertical?: boolean } | - | 5.10.0 |
 | form | 设置 Form 组件的通用属性 | { className?: string, style?: React.CSSProperties, validateMessages?: [ValidateMessages](/components/form-cn#validatemessages), requiredMark?: boolean \| `optional`, colon?: boolean, scrollToFirstError?: boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)} | - | requiredMark: 4.8.0; colon: 4.18.0; scrollToFirstError: 5.2.0; className: 5.7.0; style: 5.7.0 |

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -92,6 +92,7 @@ const Dropdown: CompoundedComponent = (props) => {
     getPopupContainer,
     overlayClassName,
     rootClassName,
+    overlayStyle,
     open,
     onOpenChange,
     // Deprecated
@@ -108,6 +109,7 @@ const Dropdown: CompoundedComponent = (props) => {
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
     direction,
+    dropdown,
   } = React.useContext(ConfigContext);
 
   // Warning for deprecated usage
@@ -202,9 +204,13 @@ const Dropdown: CompoundedComponent = (props) => {
   });
 
   // =========================== Overlay ============================
-  const overlayClassNameCustomized = classNames(overlayClassName, rootClassName, hashId, {
-    [`${prefixCls}-rtl`]: direction === 'rtl',
-  });
+  const overlayClassNameCustomized = classNames(
+    overlayClassName,
+    rootClassName,
+    hashId,
+    dropdown?.className,
+    { [`${prefixCls}-rtl`]: direction === 'rtl' },
+  );
 
   const builtinPlacements = getPlacements({
     arrowPointAtCenter: typeof arrow === 'object' && arrow.pointAtCenter,
@@ -267,7 +273,7 @@ const Dropdown: CompoundedComponent = (props) => {
   };
 
   // =========================== zIndex ============================
-  const [zIndex, contextZIndex] = useZIndex('Dropdown', props.overlayStyle?.zIndex as number);
+  const [zIndex, contextZIndex] = useZIndex('Dropdown', overlayStyle?.zIndex as number);
 
   // ============================ Render ============================
   return wrapSSR(
@@ -288,10 +294,7 @@ const Dropdown: CompoundedComponent = (props) => {
         overlay={renderOverlay}
         placement={memoPlacement}
         onVisibleChange={onInnerOpenChange}
-        overlayStyle={{
-          ...props.overlayStyle,
-          zIndex,
-        }}
+        overlayStyle={{ ...dropdown?.style, ...overlayStyle, zIndex }}
       >
         {dropdownTrigger}
       </RcDropdown>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- close #45604

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: CP support Dropdown className and style |
| 🇨🇳 Chinese |          - |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f328c45</samp>

This pull request adds a new feature to the `ConfigProvider` component, which allows users to customize the style of the `Dropdown` components in its context. It updates the relevant files to implement, test, and document the new `dropdown` prop. It also fixes a zIndex issue in the `Dropdown` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f328c45</samp>

*  Add `dropdown` prop to `ConfigProvider` component to allow customizing the `className` and `style` of the `Dropdown` component's overlay element ([link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-f7a3a5082a18fdd0627b75fb4f13fa559a2e5a5a781e381b8ba8c98b13318ccaR175), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R202), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R347), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-0a9895a32672ec55a084aa7165fc8666008942903b8e51e30b662e9e1ecffb56R440), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-975af6d8b4e359c4e88a7586cf1c91b35989cdadc9f2dc9ca16a376b5f5b0563R125), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-b6a7375df96aaccf21f7452705af80f8cd8c7323f0fc2b9dbdc71500b8478775R127))
*  Use `dropdown` prop from `ConfigContext` in `Dropdown` component to append `className` and merge `style` with `overlayStyle` prop and `zIndex` value ([link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR95), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beR112), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL205-R213), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL270-R276), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-978b29ecd5429963a073f5adfa7ded79d88d23850853c9fb6d453a82047365beL291-R297))
*  Import `Dropdown` component in `style.test.tsx` file and add test case to verify that `className` and `style` props from `ConfigProvider` are applied to overlay element ([link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R21), [link](https://github.com/ant-design/ant-design/pull/45621/files?diff=unified&w=0#diff-58612c0e42c2460919a2c73d9dac7eed9d88cb7d97da183b5f94e83ce74b8149R1311-R1321))
