### PR TITLE
fix: InputNumber in Form with hasFeedback should not lose focus

### DIFF
--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -10,7 +10,7 @@ import Form from '..';
 import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, pureRender, render, screen, waitFakeTimer } from '../../../tests/utils';
+import { act, fireEvent, pureRender, render, screen, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
@@ -2070,5 +2070,36 @@ describe('Form', () => {
     footerBts.forEach((bt) => {
       expect(bt).not.toHaveAttribute('disabled');
     });
+  });
+
+  it('InputNumber with hasFeedback should keep dom stable', () => {
+    const Demo = () => (
+      <Form>
+        <Form.Item
+          name="light"
+          hasFeedback
+          rules={[{ required: true, message: 'Please input a entry price' }]}
+        >
+          <InputNumber />
+        </Form.Item>
+      </Form>
+    );
+    const { container } = render(<Demo />);
+
+    const input = container.querySelector('input')!;
+
+    expect(container.querySelector('.ant-input-number-suffix')).toBeTruthy();
+
+    act(() => {
+      fireEvent.focus(input);
+    });
+    expect(container.querySelector('.ant-input-number-focused')).toBeTruthy();
+
+    fireEvent.change(input, {
+      target: { value: '1' },
+    });
+
+    expect(container.querySelector('.ant-input-number-suffix')).toBeTruthy();
+    expect(container.querySelector('.ant-input-number-focused')).toBeTruthy();
   });
 });

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -103,6 +103,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   );
   const wrapperClassName = `${prefixCls}-group`;
 
+  // eslint-disable-next-line react/jsx-no-useless-fragment
   const suffixNode = hasFeedback && <>{feedbackIcon}</>;
 
   const element = (

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -103,6 +103,8 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   );
   const wrapperClassName = `${prefixCls}-group`;
 
+  const suffixNode = hasFeedback && <>{feedbackIcon}</>;
+
   const element = (
     <RcInputNumber
       ref={inputRef}
@@ -114,7 +116,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
       readOnly={readOnly}
       controls={controlsTemp}
       prefix={prefix}
-      suffix={hasFeedback && feedbackIcon}
+      suffix={suffixNode}
       addonAfter={
         addonAfter && (
           <NoCompactStyle>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/45612
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix InputNumber in Form with `hasFeedback` that will lose focus when feedback icon appear.         |
| 🇨🇳 Chinese |      修复 InputNumber 组件在 Form 组件中使用并且启用 `hasFeedback` 时，反馈图标出现会使 InputNumber 失去焦点的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 362b2db</samp>

Improved form testing and fixed input number warning. Added a test case for `InputNumber` with `hasFeedback` and refactored the suffix icon logic in `components/input-number/index.tsx`. Fixed a warning caused by passing a boolean to the `suffix` prop of `Input`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 362b2db</samp>

* Fix the issue of suffix icon disappearing in `InputNumber` with `hasFeedback` prop ([link](https://github.com/ant-design/ant-design/pull/45632/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaR106-R107), [link](https://github.com/ant-design/ant-design/pull/45632/files?diff=unified&w=0#diff-6c85e13d1b03c66a69812b7717bd3695471bc2a1a381475e085c9dcf28662faaL117-R119))
* Import `act` function to wrap `fireEvent` calls in form tests and ensure consistent assertions ([link](https://github.com/ant-design/ant-design/pull/45632/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL13-R13))
* Add a test case for `InputNumber` with `hasFeedback` prop to check the suffix icon and focused style ([link](https://github.com/ant-design/ant-design/pull/45632/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR2074-R2104))
