### PR TITLE
feat: show Slider tooltip when focus handler

### DIFF
--- a/components/slider/style/index.tsx
+++ b/components/slider/style/index.tsx
@@ -110,8 +110,6 @@ const genBaseStyle: GenerateStyle<SliderToken> = (token) => {
       },
 
       [`${componentCls}-track-draggable`]: {
-        // base on https://github.com/ant-design/ant-design/pull/42825/files#diff-9b9560a611e7ed0e6ef24ca9f1faff1e8c816d3f35ed6a1f73c36d2b42790aba
-        // zIndex: 1,
         boxSizing: 'content-box',
         backgroundClip: 'content-box',
         border: 'solid rgba(0,0,0,0)',
@@ -144,10 +142,6 @@ const genBaseStyle: GenerateStyle<SliderToken> = (token) => {
         width: token.handleSize,
         height: token.handleSize,
         outline: 'none',
-
-        [`${componentCls}-dragging`]: {
-          zIndex: 1,
-        },
 
         // 扩大选区
         '&::before': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
<img width="433" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/246c1f01-2a6a-4679-85d6-7f885645e9ea">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Show Slider tooltip when focus handler.        |
| 🇨🇳 Chinese |   Slider 聚焦滑块时现在会显示 tooltip。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6132f6d</samp>

Refactored `Slider` component's formatter and tooltip logic and removed unnecessary styles. This fixes a bug where the tooltip would not show the correct value, simplifies the code, avoids duplication, and improves performance. Also removed `zIndex` styles from `components/slider/style/index.tsx` to improve tooltip visibility and code clarity.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6132f6d</samp>

* Fix a bug where the slider tooltip would not close when clicking outside the handle and enable both hover and focus triggers for the tooltip ([link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL220-R238), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL244-R246))
* Simplify the logic of choosing the appropriate formatter for the tooltip and extract it into a reusable function ([link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dR112-R125), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL207-R221))
* Use the `Formatter` type for the `formatter` and `tipFormatter` props to avoid duplication and allow `undefined` or `null` values ([link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL28-R28), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL36-R36), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL66-R66))
* Remove unnecessary cloning and improve performance by passing the `prefixCls` prop and the `node` variable directly to the `SliderTooltip` component ([link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL220-R238), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL244-R246))
* Remove unused and conflicting `zIndex` styles from the `genBaseStyle` function in `components/slider/style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-9b9560a611e7ed0e6ef24ca9f1faff1e8c816d3f35ed6a1f73c36d2b42790abaL113-L114), [link](https://github.com/ant-design/ant-design/pull/45653/files?diff=unified&w=0#diff-9b9560a611e7ed0e6ef24ca9f1faff1e8c816d3f35ed6a1f73c36d2b42790abaL148-L151))
