### PR TITLE
refactor(color-picker): rename `defaultCollapsed` => `defaultOpen`

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -248,7 +248,7 @@ describe('ColorPicker', () => {
             {
               label: 'Recent',
               colors: ['#f00d', '#0f0d', '#00fd'],
-              defaultCollapsed: true,
+              defaultOpen: false,
             },
           ]}
         />,

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -48,9 +48,8 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
   const activeKeys = useMemo(
     () =>
       presetsValue.reduce<string[]>((acc, preset) => {
-        if (!preset.defaultCollapsed) {
-          acc.push(genCollapsePanelKey(preset));
-        }
+        const { defaultOpen = true } = preset;
+        if (defaultOpen) acc.push(genCollapsePanelKey(preset));
         return acc;
       }, []),
     [presetsValue],

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | destroyTooltipOnHide | Whether destroy popover when hidden | `boolean` | false | 5.7.0 |
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | Whether to show popup | boolean | - | |
-| presets | Preset colors | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | `defaultCollapsed: 5.11.0` |
+| presets | Preset colors | `{ label: ReactNode, colors: Array<string \| Color>, defaultOpen?: boolean }[]` | - | `defaultOpen: 5.11.0` |
 | placement | Placement of popup | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -54,7 +54,7 @@ group:
 | destroyTooltipOnHide | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color>, defaultCollapsed?: boolean }[]` | - | `defaultCollapsed: 5.11.0` |
+| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color>, defaultOpen?: boolean }[]` | - | `defaultOpen: 5.11.0` |
 | placement | 弹出窗口的位置 | `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | `bottomLeft` | |
 | panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -14,8 +14,9 @@ export interface PresetsItem {
   /**
    * Whether the initial state is collapsed
    * @since 5.11.0
+   * @default true
    */
-  defaultCollapsed?: boolean;
+  defaultOpen?: boolean;
 }
 export type TriggerType = 'click' | 'hover';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     refactor(color-picker): rename `defaultCollapsed` => `defaultOpen`      |
| 🇨🇳 Chinese |    重构 color-picker Api   `defaultCollapsed` => `defaultOpen`     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a678d5e</samp>

Rename `defaultCollapsed` prop to `defaultOpen` and reverse its value for color picker presets. Update the component logic, interface, and documentation accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a678d5e</samp>

*  Rename and reverse the boolean value of the `defaultCollapsed` prop for the color picker presets to `defaultOpen` ([link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-aa06460351e8630f305cf6509e8137984e0f167ab2560da22874033189234fb4L251-R251), [link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L51-R52), [link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-83dba3026e7dc41ad64d3a2f4d484eeb085f0c3798dc2316fbb90d23520fca6eL17-R19))
*  Update the English and Chinese documentation of the color picker API to reflect the new prop name and default value of `defaultOpen` and add a version annotation ([link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-819859f3d30fc8ec12a8ef1b55ac1d75b4b1d600eb1cee989efd5af57255b560L56-R56), [link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-9d1ff106a032e484c8f982279c4e1295d23f69904a26e020e99310c446e93249L57-R57))
*  Add a fallback value of `true` for the `defaultOpen` prop in the `ColorPresets` component ([link](https://github.com/ant-design/ant-design/pull/45655/files?diff=unified&w=0#diff-8d2a305db0c4945017603df77e97b2bf27dbde09aef2a8e2c2f7d10e67a3a822L51-R52))
