### PR TITLE
WIP: fix react16 case

### DIFF
--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -57,8 +57,6 @@ export interface SliderBaseProps {
 
   styles?: RcSliderProps['styles'];
   classNames?: RcSliderProps['classNames'];
-  onFocus?: React.FocusEventHandler<HTMLDivElement>;
-  onBlur?: React.FocusEventHandler<HTMLDivElement>;
 
   // Deprecated
   /** @deprecated `tooltipPrefixCls` is deprecated. Please use `tooltip.prefixCls` instead. */
@@ -221,26 +219,18 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
     const open =
       tooltipOpen ?? legacyTooltipVisible ?? (tooltipOpen === undefined && isTipFormatter);
 
-    const passedProps = {
-      ...node.props,
-      onMouseEnter: () => toggleTooltipOpen(index, true),
-      onMouseLeave: () => toggleTooltipOpen(index, false),
-      onFocus: (e: React.FocusEvent<HTMLDivElement>) => {
-        toggleTooltipOpen(index, true);
-        restProps.onFocus?.(e);
-      },
-      onBlur: (e: React.FocusEvent<HTMLDivElement>) => {
-        toggleTooltipOpen(index, false);
-        restProps.onBlur?.(e);
-      },
+    const onOpenChange = (newOpen: boolean) => {
+      toggleTooltipOpen(index, newOpen);
     };
 
     return (
       <SliderTooltip
+        trigger={['hover', 'focus']}
         {...tooltipProps}
         prefixCls={getPrefixCls('tooltip', customizeTooltipPrefixCls ?? legacyTooltipPrefixCls)}
         title={mergedTipFormatter ? mergedTipFormatter(info.value) : ''}
         open={open}
+        onOpenChange={onOpenChange}
         placement={getTooltipPlacement(tooltipPlacement ?? legacyTooltipPlacement, vertical)}
         key={index}
         overlayClassName={`${prefixCls}-tooltip`}
@@ -248,7 +238,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
           getTooltipPopupContainer || legacyGetTooltipPopupContainer || getPopupContainer
         }
       >
-        {React.cloneElement(node, passedProps)}
+        {node}
       </SliderTooltip>
     );
   };


### PR DESCRIPTION
This reverts commit b888f69152e133187719cf7854d748e01a2fd47b.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c61d4f5</samp>

Simplify tooltip visibility logic and remove unnecessary cloning for `Slider` component. Use `onOpenChange` prop of `SliderTooltip` to control tooltip display.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c61d4f5</samp>

* Remove `onFocus` and `onBlur` props from `SliderBaseProps` interface, as they are not used to control tooltip visibility ([link](https://github.com/ant-design/ant-design/pull/45668/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL60-L61))
* Simplify tooltip visibility logic by passing `onOpenChange` prop to `SliderTooltip` component, which wraps the slider handle or range node ([link](https://github.com/ant-design/ant-design/pull/45668/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL224-R233), [link](https://github.com/ant-design/ant-design/pull/45668/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL251-R241))
* Avoid unnecessary cloning and spreading of props by rendering the node element directly as a child of `SliderTooltip` ([link](https://github.com/ant-design/ant-design/pull/45668/files?diff=unified&w=0#diff-e22f49aefe1d843861233ab733153b481833065466913b5a9ef2fb2cd47e5a7dL251-R241))
