### PR TITLE
fix(Image): using chinese language in image components API's table

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -51,7 +51,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 
 ### PreviewType
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | visible | Whether the preview dialog is visible or not | boolean | - | - |
 | src | Custom preview src | string | - | 4.10.0 |
@@ -72,7 +72,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 
 ## PreviewGroup
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | preview | Preview config, `disabled` when false | boolean \| [PreviewGroupType](#previewgrouptype) | true | 4.6.0 [PreviewGroupType](#previewgrouptype):4.7.0 |
 | items | Preview items | string[] \| { src: string, crossOrigin: string, ... }[] | - | 5.7.0 |
@@ -80,7 +80,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 
 ### PreviewGroupType
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | visible | Whether the preview dialog is visible or not | boolean | - | - |
 | getContainer | The mounted node for preview dialog but still display at fullScreen | string \| HTMLElement \| (() => HTMLElement) \| false | - | 4.8.0 |
@@ -99,7 +99,7 @@ Other attributes [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/El
 | imageRender | Custom preview content | (originalNode: React.ReactElement, info: { transform: [TransformType](#transformtype), current: number }) => React.ReactNode | - | 5.7.0 |
 | onTransform | Callback when the transform of image changed | { transform: [TransformType](#transformtype), action: [TransformAction](#transformaction) } | - | 5.7.0 |
 | onChange | Callback when switch preview image | (current: number, prevCurrent: number) => void | - | 5.3.0 |
-| onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean, current: number) => void | - | current 参数 5.3.0 |
+| onVisibleChange | Callback when `visible` changed | (visible: boolean, prevVisible: boolean, current: number) => void | - | current Property 5.3.0 |
 
 ## Interface
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

In Image component, some api tables have Chinese header.

![image](https://github.com/ant-design/ant-design/assets/62149413/271c6000-a982-44e0-97f8-631738e13179)


### 📝 Changelog

Now all api tables in image component have English header when language of site is English.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a7c434</samp>

Improved English documentation for `Image` component. Translated and updated property table in `components/image/index.en-US.md`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a7c434</samp>

*  Translate table headers from Chinese to English in `components/image/index.en-US.md` ([link](https://github.com/ant-design/ant-design/pull/45673/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L54-R54), [link](https://github.com/ant-design/ant-design/pull/45673/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L75-R75), [link](https://github.com/ant-design/ant-design/pull/45673/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L83-R83))
*  Replace Chinese word "参数" with English word "Property" in `onVisibleChange` description in `components/image/index.en-US.md` ([link](https://github.com/ant-design/ant-design/pull/45673/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2L102-R102))
