### PR TITLE
fix: notification style width

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { IconType } from './interface';
 import useStyle from './style';
+import PurePanelStyle from './style/pure-panel';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,
@@ -99,6 +100,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   return (
     <div className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className)}>
+      <PurePanelStyle prefixCls={prefixCls} />
       <Notice
         {...restProps}
         prefixCls={prefixCls}

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -313,6 +313,7 @@ describe('notification', () => {
 
     expect(document.querySelectorAll('[role="status"]').length).toBe(1);
   });
+
   it('should hide close btn when closeIcon setting to null or false', async () => {
     notification.config({
       closeIcon: undefined,
@@ -347,5 +348,23 @@ describe('notification', () => {
     expect(document.querySelectorAll('.custom .custom-close-icon').length).toBe(1);
     expect(document.querySelectorAll('.with-null .ant-notification-notice-close').length).toBe(0);
     expect(document.querySelectorAll('.with-false .ant-notification-notice-close').length).toBe(0);
+  });
+
+  it('style.width could be overrided', async () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        duration: 0,
+        style: {
+          width: 600,
+        },
+        className: 'with-style',
+      });
+    });
+    await awaitPromise();
+    expect(document.querySelector('.with-style')).toHaveStyle({ width: '600px' });
+    expect(
+      document.querySelector('.ant-notification-notice-wrapper:has(.width-style)'),
+    ).toHaveStyle({ width: '' });
   });
 });

--- a/components/notification/demo/basic.tsx
+++ b/components/notification/demo/basic.tsx
@@ -9,7 +9,6 @@ const openNotification = () => {
     onClick: () => {
       console.log('Notification Clicked!');
     },
-    style: { width: 600 },
   });
 };
 const App: React.FC = () => (

--- a/components/notification/demo/basic.tsx
+++ b/components/notification/demo/basic.tsx
@@ -9,6 +9,7 @@ const openNotification = () => {
     onClick: () => {
       console.log('Notification Clicked!');
     },
+    style: { width: 600 },
   });
 };
 const App: React.FC = () => (

--- a/components/notification/style/pure-panel.ts
+++ b/components/notification/style/pure-panel.ts
@@ -1,0 +1,20 @@
+import { genSubStyleComponent } from '../../theme/internal';
+import { prepareComponentToken, genNoticeStyle, prepareNotificationToken } from '.';
+
+export default genSubStyleComponent(
+  ['Notification', 'PurePanel'],
+  (token) => {
+    const noticeCls = `${token.componentCls}-notice`;
+    const notificationToken = prepareNotificationToken(token);
+
+    return {
+      [`${noticeCls}-pure-panel`]: {
+        ...genNoticeStyle(notificationToken),
+        width: notificationToken.width,
+        maxWidth: `calc(100vw - ${notificationToken.notificationMarginEdge * 2}px)`,
+        margin: 0,
+      },
+    };
+  },
+  prepareComponentToken,
+);

--- a/components/notification/style/stack.ts
+++ b/components/notification/style/stack.ts
@@ -88,7 +88,6 @@ const genStackStyle: GenerateStyle<NotificationToken> = (token) => {
       [`& > ${componentCls}-notice-wrapper`]: {
         '&:not(:nth-last-child(-n + 1))': {
           opacity: 1,
-          width: token.width,
           overflow: 'unset',
           color: 'inherit',
           pointerEvents: 'auto',

--- a/package.json
+++ b/package.json
@@ -329,11 +329,11 @@
   "size-limit": [
     {
       "path": "./dist/antd.min.js",
-      "limit": "401 KiB"
+      "limit": "402 KiB"
     },
     {
       "path": "./dist/antd-with-locales.min.js",
-      "limit": "460 KiB"
+      "limit": "461 KiB"
     }
   ],
   "title": "Ant Design",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/45678
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Notification that `style.width` not work.        |
| 🇨🇳 Chinese |     修复 Notification 组件设置 `style.width` 无效的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6914e4</samp>

This pull request adds a new feature to the notification component, allowing it to use a pure panel style. It also introduces a theme system using alias tokens and refactors the style generation functions. It updates the test and demo files accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6914e4</samp>

*  Add a new feature of pure panel style for the notification component ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccR14), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-8b66e26e1dc3ab97c7faf1e4f2d015c5b42d580fce0dd4c3043b7253bcdb83ccR103), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-cda3e92a534cf8b3f7539418f8e3d0e1ea4eeb84b1fbd303c43af9084685909dR1-R20))
*  Refactor the style generation functions to use the theme system and extract the common style for the notice element ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L4-R4), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L36-R36), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L52-L53), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L63-R62), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965R71-R72), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L175-R185), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L239-R284), [link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L279-R292))
*  Remove the redundant width property from the stack style function in `components/notification/style/stack.ts` ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-afcb3078a4ca46e4c23d5a6292b9d6bddc597e289711b77fc319bad238d5b85fL91))
*  Add a test case to check the style.width prop can override the default width of the notification component in `components/notification/__tests__/index.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690R352-R369))
*  Add the style prop to the demo code in `components/notification/demo/basic.tsx` to show how to customize the notification component ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-d59d1752076873d64b9180b5fa4b4f1d317a292dc58d85b0052e0385c32e89cfR12))
*  Add an empty line to separate the test cases in `components/notification/__tests__/index.test.tsx` for readability ([link](https://github.com/ant-design/ant-design/pull/45681/files?diff=unified&w=0#diff-ed8976c7e832d9befa4199cc192b025c91cb3ff525a3649834d7545fdd89f690R316))
