### PR TITLE
refactor: segmented support css var

### DIFF
--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -10,6 +10,7 @@ import { ConfigContext } from '../config-provider';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export type { SegmentedValue } from 'rc-segmented';
 
@@ -57,7 +58,8 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) 
   const { getPrefixCls, direction, segmented } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('segmented', customizePrefixCls);
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   // ===================== Size =====================
   const mergedSize = useSize(customSize);
@@ -97,7 +99,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) 
 
   const mergedStyle: React.CSSProperties = { ...segmented?.style, ...style };
 
-  return wrapSSR(
+  return wrapCSSVar(
     <RcSegmented
       {...restProps}
       className={cls}

--- a/components/segmented/style/cssVar.ts
+++ b/components/segmented/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Segmented', prepareComponentToken);

--- a/components/segmented/style/index.tsx
+++ b/components/segmented/style/index.tsx
@@ -1,7 +1,8 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { resetComponent, textEllipsis } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import { unit } from '@ant-design/cssinjs';
 
 export interface ComponentToken {
   /**
@@ -39,8 +40,8 @@ export interface ComponentToken {
 interface SegmentedToken extends FullToken<'Segmented'> {
   segmentedPadding: number;
   segmentedBgColor: string;
-  segmentedPaddingHorizontal: number;
-  segmentedPaddingHorizontalSM: number;
+  segmentedPaddingHorizontal: number | string;
+  segmentedPaddingHorizontalSM: number | string;
 }
 
 // ============================== Mixins ==============================
@@ -69,6 +70,19 @@ const segmentedTextEllipsisCss: CSSObject = {
 // ============================== Styles ==============================
 const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken) => {
   const { componentCls } = token;
+
+  const labelHeight = token
+    .calc(token.controlHeight)
+    .sub(token.calc(token.segmentedPadding).mul(2))
+    .equal();
+  const labelHeightLG = token
+    .calc(token.controlHeightLG)
+    .sub(token.calc(token.segmentedPadding).mul(2))
+    .equal();
+  const labelHeightSM = token
+    .calc(token.controlHeightSM)
+    .sub(token.calc(token.segmentedPadding).mul(2))
+    .equal();
 
   return {
     [componentCls]: {
@@ -148,15 +162,15 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
         },
 
         '&-label': {
-          minHeight: token.controlHeight - token.segmentedPadding * 2,
-          lineHeight: `${token.controlHeight - token.segmentedPadding * 2}px`,
-          padding: `0 ${token.segmentedPaddingHorizontal}px`,
+          minHeight: labelHeight,
+          lineHeight: unit(labelHeight),
+          padding: `0 ${unit(token.segmentedPaddingHorizontal)}`,
           ...segmentedTextEllipsisCss,
         },
 
         // syntactic sugar to add `icon` for Segmented Item
         '&-icon + *': {
-          marginInlineStart: token.marginSM / 2,
+          marginInlineStart: token.calc(token.marginSM).div(2).equal(),
         },
 
         '&-input': {
@@ -179,7 +193,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
         insetInlineStart: 0,
         width: 0,
         height: '100%',
-        padding: `${token.paddingXXS}px 0`,
+        padding: `${unit(token.paddingXXS)} 0`,
         borderRadius: token.borderRadiusSM,
 
         [`& ~ ${componentCls}-item:not(${componentCls}-item-selected):not(${componentCls}-item-disabled)::after`]:
@@ -192,9 +206,9 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
       [`&${componentCls}-lg`]: {
         borderRadius: token.borderRadiusLG,
         [`${componentCls}-item-label`]: {
-          minHeight: token.controlHeightLG - token.segmentedPadding * 2,
-          lineHeight: `${token.controlHeightLG - token.segmentedPadding * 2}px`,
-          padding: `0 ${token.segmentedPaddingHorizontal}px`,
+          minHeight: labelHeightLG,
+          lineHeight: unit(labelHeightLG),
+          padding: `0 ${unit(token.segmentedPaddingHorizontal)}`,
           fontSize: token.fontSizeLG,
         },
         [`${componentCls}-item, ${componentCls}-thumb`]: {
@@ -205,9 +219,9 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
       [`&${componentCls}-sm`]: {
         borderRadius: token.borderRadiusSM,
         [`${componentCls}-item-label`]: {
-          minHeight: token.controlHeightSM - token.segmentedPadding * 2,
-          lineHeight: `${token.controlHeightSM - token.segmentedPadding * 2}px`,
-          padding: `0 ${token.segmentedPaddingHorizontalSM}px`,
+          minHeight: labelHeightSM,
+          lineHeight: unit(labelHeightSM),
+          padding: `0 ${unit(token.segmentedPaddingHorizontalSM)}`,
         },
         [`${componentCls}-item, ${componentCls}-thumb`]: {
           borderRadius: token.borderRadiusXS,
@@ -228,28 +242,30 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Segmented'> = (token) => {
+  const { colorTextLabel, colorText, colorFillSecondary, colorBgElevated, colorFill } = token;
+  return {
+    itemColor: colorTextLabel,
+    itemHoverColor: colorText,
+    itemHoverBg: colorFillSecondary,
+    itemSelectedBg: colorBgElevated,
+    itemActiveBg: colorFill,
+    itemSelectedColor: colorText,
+  };
+};
+
 export default genComponentStyleHook(
   'Segmented',
   (token) => {
-    const { lineWidth, lineWidthBold, colorBgLayout } = token;
+    const { lineWidth, lineWidthBold, colorBgLayout, calc } = token;
 
     const segmentedToken = mergeToken<SegmentedToken>(token, {
       segmentedPadding: lineWidthBold,
       segmentedBgColor: colorBgLayout,
-      segmentedPaddingHorizontal: token.controlPaddingHorizontal - lineWidth,
-      segmentedPaddingHorizontalSM: token.controlPaddingHorizontalSM - lineWidth,
+      segmentedPaddingHorizontal: calc(token.controlPaddingHorizontal).sub(lineWidth).equal(),
+      segmentedPaddingHorizontalSM: calc(token.controlPaddingHorizontalSM).sub(lineWidth).equal(),
     });
     return [genSegmentedStyle(segmentedToken)];
   },
-  (token) => {
-    const { colorTextLabel, colorText, colorFillSecondary, colorBgElevated, colorFill } = token;
-    return {
-      itemColor: colorTextLabel,
-      itemHoverColor: colorText,
-      itemHoverBg: colorFillSecondary,
-      itemSelectedBg: colorBgElevated,
-      itemActiveBg: colorFill,
-      itemSelectedColor: colorText,
-    };
-  },
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Segmented support css variables.       |
| 🇨🇳 Chinese |        Segmented 组件支持 CSS 变量。   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3b66a9</samp>

This pull request adds a new hook `useCSSVar` to manage CSS variables for the Segmented component and its children. It also refactors the component style to use the `@ant-design/cssinjs` package and the `wrapCSSVar` function. These changes improve the component's compatibility with different themes and units.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3b66a9</samp>

*  Add `useCSSVar` hook to register and apply CSS variables for Segmented component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-ebd8faa5a5bf1be6e4c8194463292b96763487683b149b15e9dccce9f9f63a45R13), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-fea11d7869c0c8f8f0f266686298afe16e360cf0502e0b9e373634296b540c3cR1-R4))
*  Replace `wrapSSR` function with `wrapCSSVar` function, which wraps component with CSS variable provider and calls `useCSSVar` hook ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-ebd8faa5a5bf1be6e4c8194463292b96763487683b149b15e9dccce9f9f63a45L60-R62), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-ebd8faa5a5bf1be6e4c8194463292b96763487683b149b15e9dccce9f9f63a45L100-R102))
*  Import `unit` function from `@ant-design/cssinjs` package to convert values to valid CSS units ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL3-R5))
*  Modify type of `segmentedPaddingHorizontal` and `segmentedPaddingHorizontalSM` properties in `SegmentedToken` interface to allow string values ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL42-R44))
*  Calculate label height for different sizes based on token values using `calc` and `equal` methods from token ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dR74-R86))
*  Apply `unit` function to padding and margin values in `genSegmentedStyle` function to ensure valid CSS units ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL151-R167), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL159-R173), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL182-R196), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL195-R211), [link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL208-R224))
*  Extract default token preparer for Segmented component into `prepareComponentToken` function, which returns item color and background properties based on token values ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL231-R270))
*  Apply `calc` and `equal` methods to `controlPaddingHorizontal` and `controlPaddingHorizontalSM` values in `prepareComponentToken` function to return valid CSS values for `segmentedPaddingHorizontal` and `segmentedPaddingHorizontalSM` properties ([link](https://github.com/ant-design/ant-design/pull/45716/files?diff=unified&w=0#diff-d8755e0c6400f3ca89c70784447555131c3adf13dab1289bbd756666784ac06dL231-R270))
