### PR TITLE
fix: component token should work

### DIFF
--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { act } from 'react-dom/test-utils';
 import { StyleProvider, createCache, extractStyle } from '@ant-design/cssinjs';
 import message from '..';
@@ -270,5 +270,33 @@ describe('message.hooks', () => {
 
     const styleText = extractStyle(cache, true);
     expect(styleText).not.toContain('.ant-message');
+  });
+
+  it('component fontSize should work', () => {
+    const Demo = () => {
+      const [api, holder] = message.useMessage();
+
+      useEffect(() => {
+        api.info({
+          content: <div />,
+          className: 'fontSize',
+        });
+      }, []);
+
+      return (
+        <ConfigProvider theme={{ components: { Message: { fontSize: 20 } } }}>
+          {holder}
+        </ConfigProvider>
+      );
+    };
+
+    render(<Demo />);
+
+    const msg = document.querySelector('.fontSize');
+
+    expect(msg).toBeTruthy();
+    expect(msg).toHaveStyle({
+      fontSize: '20px',
+    });
   });
 });

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -170,7 +170,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
           });
           flush(component, mergedComponentToken);
           return [
-            options.resetStyle === false ? null : genCommonStyle(token, prefixCls),
+            options.resetStyle === false ? null : genCommonStyle(mergedToken, prefixCls),
             styleInterpolation,
           ];
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close https://github.com/ant-design/ant-design/issues/45718
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Message that token specified in component scope not work.        |
| 🇨🇳 Chinese |      修复 Message 组件在组件范围设置全局 token 无效的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02ba7c2</samp>

Fixed a theme bug and added a test for the `message` component. The bug affected the common style generation for components using the `ConfigProvider` context. The test checked the `fontSize` prop of the `message` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02ba7c2</samp>

* Fix `genComponentStyleHook` function to use `mergedToken` for theme overrides ([link](https://github.com/ant-design/ant-design/pull/45721/files?diff=unified&w=0#diff-e6843e3f6d078c2e0c399d9f79c5e0591073abc571cab4c1e71a9fac531baeacL173-R173))
* Add test case for `fontSize` prop of `message` component ([link](https://github.com/ant-design/ant-design/pull/45721/files?diff=unified&w=0#diff-3eaeb0809a3cf8c5be4961df7b85ee6fa0e1cf8b3a54afbe0121a76f39a41abcR274-R301))
* Import `useEffect` hook from React in `hooks.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/45721/files?diff=unified&w=0#diff-3eaeb0809a3cf8c5be4961df7b85ee6fa0e1cf8b3a54afbe0121a76f39a41abcL2-R2))
