### PR TITLE
refactor: select support css var

### DIFF
--- a/components/config-provider/hooks/useCSSVarCls.ts
+++ b/components/config-provider/hooks/useCSSVarCls.ts
@@ -1,0 +1,9 @@
+import { useToken } from '../../theme/internal';
+
+const useCSSVarCls = (prefixCls: string) => {
+  const [, , , , cssVar] = useToken();
+
+  return cssVar ? `${prefixCls}-css-var` : '';
+};
+
+export default useCSSVarCls;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -26,6 +26,7 @@ import useCSSVar from './style/cssVar';
 import useBuiltinPlacements from './useBuiltinPlacements';
 import useIcons from './useIcons';
 import useShowArrow from './useShowArrow';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 type RawValue = string | number;
 
@@ -118,12 +119,12 @@ const InternalSelect = <
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
-  const rootCls = `${prefixCls}-root`;
   const direction = propDirection ?? contextDirection;
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
   const [, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(rootPrefixCls);
   const wrapCSSVar = useCSSVar(rootCls);
 
   const mode = React.useMemo(() => {

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -26,7 +26,6 @@ import useCSSVar from './style/cssVar';
 import useBuiltinPlacements from './useBuiltinPlacements';
 import useIcons from './useIcons';
 import useShowArrow from './useShowArrow';
-import { useToken } from '../theme/internal';
 
 type RawValue = string | number;
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -22,9 +22,11 @@ import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import useBuiltinPlacements from './useBuiltinPlacements';
 import useIcons from './useIcons';
 import useShowArrow from './useShowArrow';
+import { useToken } from '../theme/internal';
 
 type RawValue = string | number;
 
@@ -117,11 +119,13 @@ const InternalSelect = <
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
+  const rootCls = `${prefixCls}-root`;
   const direction = propDirection ?? contextDirection;
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const mode = React.useMemo(() => {
     const { mode: m } = props as InternalSelectProps<OptionType>;
@@ -181,12 +185,13 @@ const InternalSelect = <
     'itemIcon',
   ]);
 
-  const rcSelectRtlDropdownClassName = classNames(
+  const mergedPopupClassName = classNames(
     popupClassName || dropdownClassName,
     {
       [`${prefixCls}-dropdown-${direction}`]: direction === 'rtl',
     },
     rootClassName,
+    rootCls,
     hashId,
   );
 
@@ -209,6 +214,7 @@ const InternalSelect = <
     select?.className,
     className,
     rootClassName,
+    rootCls,
     hashId,
   );
 
@@ -245,7 +251,7 @@ const InternalSelect = <
   const [zIndex] = useZIndex('SelectLike', props.dropdownStyle?.zIndex as number);
 
   // ====================== Render =======================
-  return wrapSSR(
+  return wrapCSSVar(
     <RcSelect<ValueType, OptionType>
       ref={ref}
       virtual={virtual}
@@ -268,7 +274,7 @@ const InternalSelect = <
       notFoundContent={mergedNotFound}
       className={mergedClassName}
       getPopupContainer={getPopupContainer || getContextPopupContainer}
-      dropdownClassName={rcSelectRtlDropdownClassName}
+      dropdownClassName={mergedPopupClassName}
       disabled={mergedDisabled}
       dropdownStyle={{
         ...props?.dropdownStyle,

--- a/components/select/style/cssVar.ts
+++ b/components/select/style/cssVar.ts
@@ -1,0 +1,8 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Select', prepareComponentToken, {
+  unitless: {
+    optionLineHeight: true,
+  },
+});

--- a/components/select/style/dropdown.tsx
+++ b/components/select/style/dropdown.tsx
@@ -142,7 +142,7 @@ const genSingleStyle: GenerateStyle<SelectToken> = (token) => {
             },
 
             '&-grouped': {
-              paddingInlineStart: token.controlPaddingHorizontal * 2,
+              paddingInlineStart: token.calc(token.controlPaddingHorizontal).mul(2).equal(),
             },
           },
         },

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -105,6 +105,10 @@ export interface ComponentToken {
    * @descEN Border color of multiple tag when disabled
    */
   multipleItemBorderColorDisabled: string;
+  /**
+   * @internal
+   */
+  showArrowPaddingInlineEnd: number;
 }
 
 export interface SelectToken extends FullToken<'Select'> {
@@ -481,6 +485,7 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     multipleSelectorBgDisabled: colorBgContainerDisabled,
     multipleItemColorDisabled: colorTextDisabled,
     multipleItemBorderColorDisabled: 'transparent',
+    showArrowPaddingInlineEnd: Math.ceil(token.fontSize * 1.25),
   };
 };
 

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -2,11 +2,12 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import type { CSSProperties } from 'react';
 import { resetComponent, resetIcon, textEllipsis } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genDropdownStyle from './dropdown';
 import genMultipleStyle from './multiple';
 import genSingleStyle from './single';
+import { unit } from '@ant-design/cssinjs';
 
 export interface ComponentToken {
   /**
@@ -108,7 +109,7 @@ export interface ComponentToken {
 
 export interface SelectToken extends FullToken<'Select'> {
   rootPrefixCls: string;
-  inputPaddingHorizontalBase: number;
+  inputPaddingHorizontalBase: number | string;
   multipleSelectItemHeight: number;
   selectHeight: number;
 }
@@ -120,7 +121,7 @@ const genSelectorStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
   return {
     position: 'relative',
     backgroundColor: selectorBg,
-    border: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+    border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
     transition: `all ${token.motionDurationMid} ${token.motionEaseInOut}`,
 
     input: {
@@ -192,7 +193,7 @@ const genStatusStyle = (
 
           [`${componentCls}-focused& ${componentCls}-selector`]: {
             borderColor: borderActiveColor,
-            boxShadow: `0 0 0 ${controlOutlineWidth}px ${outlineColor}`,
+            boxShadow: `0 0 0 ${unit(controlOutlineWidth)} ${outlineColor}`,
             outline: 0,
           },
         },
@@ -273,7 +274,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
         insetInlineStart: 'auto',
         insetInlineEnd: inputPaddingHorizontalBase,
         height: token.fontSizeIcon,
-        marginTop: -token.fontSizeIcon / 2,
+        marginTop: token.calc(token.fontSizeIcon).mul(-1).div(2).equal(),
         color: token.colorTextQuaternary,
         fontSize: token.fontSizeIcon,
         lineHeight: 1,
@@ -314,7 +315,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
         display: 'inline-block',
         width: token.fontSizeIcon,
         height: token.fontSizeIcon,
-        marginTop: -token.fontSizeIcon / 2,
+        marginTop: token.calc(token.fontSizeIcon).mul(-1).div(2).equal(),
         color: token.colorTextQuaternary,
         fontSize: token.fontSizeIcon,
         fontStyle: 'normal',
@@ -346,7 +347,11 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
     // ========================= Feedback ==========================
     [`${componentCls}-has-feedback`]: {
       [`${componentCls}-clear`]: {
-        insetInlineEnd: inputPaddingHorizontalBase + token.fontSize + token.paddingXS,
+        insetInlineEnd: token
+          .calc(inputPaddingHorizontalBase)
+          .add(token.fontSize)
+          .add(token.paddingXS)
+          .equal(),
       },
     },
   };
@@ -437,59 +442,59 @@ const genSelectStyle: GenerateStyle<SelectToken> = (token) => {
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
+  const {
+    fontSize,
+    lineHeight,
+    controlHeight,
+    controlPaddingHorizontal,
+    zIndexPopupBase,
+    colorText,
+    fontWeightStrong,
+    controlItemBgActive,
+    controlItemBgHover,
+    colorBgContainer,
+    colorFillSecondary,
+    controlHeightLG,
+    controlHeightSM,
+    colorBgContainerDisabled,
+    colorTextDisabled,
+  } = token;
+
+  return {
+    zIndexPopup: zIndexPopupBase + 50,
+    optionSelectedColor: colorText,
+    optionSelectedFontWeight: fontWeightStrong,
+    optionSelectedBg: controlItemBgActive,
+    optionActiveBg: controlItemBgHover,
+    optionPadding: `${(controlHeight - fontSize * lineHeight) / 2}px ${controlPaddingHorizontal}px`,
+    optionFontSize: fontSize,
+    optionLineHeight: lineHeight,
+    optionHeight: controlHeight,
+    selectorBg: colorBgContainer,
+    clearBg: colorBgContainer,
+    singleItemHeightLG: controlHeightLG,
+    multipleItemBg: colorFillSecondary,
+    multipleItemBorderColor: 'transparent',
+    multipleItemHeight: controlHeightSM,
+    multipleItemHeightLG: controlHeight,
+    multipleSelectorBgDisabled: colorBgContainerDisabled,
+    multipleItemColorDisabled: colorTextDisabled,
+    multipleItemBorderColorDisabled: 'transparent',
+  };
+};
+
 export default genComponentStyleHook(
   'Select',
   (token, { rootPrefixCls }) => {
     const selectToken: SelectToken = mergeToken<SelectToken>(token, {
       rootPrefixCls,
-      inputPaddingHorizontalBase: token.paddingSM - 1,
+      inputPaddingHorizontalBase: token.calc(token.paddingSM).sub(1).equal(),
       multipleSelectItemHeight: token.multipleItemHeight,
       selectHeight: token.controlHeight,
     });
 
     return [genSelectStyle(selectToken)];
   },
-  (token) => {
-    const {
-      fontSize,
-      lineHeight,
-      controlHeight,
-      controlPaddingHorizontal,
-      zIndexPopupBase,
-      colorText,
-      fontWeightStrong,
-      controlItemBgActive,
-      controlItemBgHover,
-      colorBgContainer,
-      colorFillSecondary,
-      controlHeightLG,
-      controlHeightSM,
-      colorBgContainerDisabled,
-      colorTextDisabled,
-    } = token;
-
-    return {
-      zIndexPopup: zIndexPopupBase + 50,
-      optionSelectedColor: colorText,
-      optionSelectedFontWeight: fontWeightStrong,
-      optionSelectedBg: controlItemBgActive,
-      optionActiveBg: controlItemBgHover,
-      optionPadding: `${
-        (controlHeight - fontSize * lineHeight) / 2
-      }px ${controlPaddingHorizontal}px`,
-      optionFontSize: fontSize,
-      optionLineHeight: lineHeight,
-      optionHeight: controlHeight,
-      selectorBg: colorBgContainer,
-      clearBg: colorBgContainer,
-      singleItemHeightLG: controlHeightLG,
-      multipleItemBg: colorFillSecondary,
-      multipleItemBorderColor: 'transparent',
-      multipleItemHeight: controlHeightSM,
-      multipleItemHeightLG: controlHeight,
-      multipleSelectorBgDisabled: colorBgContainerDisabled,
-      multipleItemColorDisabled: colorTextDisabled,
-      multipleItemBorderColorDisabled: 'transparent',
-    };
-  },
+  prepareComponentToken,
 );

--- a/components/select/style/multiple.tsx
+++ b/components/select/style/multiple.tsx
@@ -6,18 +6,15 @@ import { unit } from '@ant-design/cssinjs';
 
 const FIXED_ITEM_MARGIN = 2;
 
-const getSelectItemStyle = (token: SelectToken): readonly [number | string, number | string] => {
+const getSelectItemStyle = (token: SelectToken): number | string => {
   const { multipleSelectItemHeight, selectHeight, lineWidth } = token;
-  // const selectItemDist = (selectHeight - multipleSelectItemHeight) / 2 - borderWidth;
-  // const selectItemMargin = Math.ceil(selectItemDist / 2);
   const selectItemDist = token
     .calc(selectHeight)
     .sub(multipleSelectItemHeight)
     .div(2)
     .sub(lineWidth)
     .equal();
-  const selectItemMargin = token.calc(selectItemDist).div(2).equal();
-  return [selectItemDist, selectItemMargin] as const;
+  return selectItemDist;
 };
 
 function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
@@ -26,7 +23,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
 
   const selectItemHeight = token.multipleSelectItemHeight;
-  const [selectItemDist] = getSelectItemStyle(token);
+  const selectItemDist = getSelectItemStyle(token);
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
@@ -228,8 +225,6 @@ const genMultipleStyle = (token: SelectToken): CSSInterpolation => {
     borderRadiusSM: token.borderRadius,
   });
 
-  const [, smSelectItemMargin] = getSelectItemStyle(token);
-
   return [
     genSizeStyle(token),
     // ======================== Small ========================
@@ -244,7 +239,7 @@ const genMultipleStyle = (token: SelectToken): CSSInterpolation => {
 
         // https://github.com/ant-design/ant-design/issues/29559
         [`${componentCls}-selection-search`]: {
-          marginInlineStart: smSelectItemMargin,
+          marginInlineStart: 2, // Magic Number
         },
       },
     },

--- a/components/select/style/multiple.tsx
+++ b/components/select/style/multiple.tsx
@@ -2,16 +2,21 @@ import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import type { SelectToken } from '.';
 import { resetIcon } from '../../style';
 import { mergeToken } from '../../theme/internal';
+import { unit } from '@ant-design/cssinjs';
 
 const FIXED_ITEM_MARGIN = 2;
 
-const getSelectItemStyle = ({
-  multipleSelectItemHeight,
-  selectHeight,
-  lineWidth: borderWidth,
-}: SelectToken): readonly [number, number] => {
-  const selectItemDist = (selectHeight - multipleSelectItemHeight) / 2 - borderWidth;
-  const selectItemMargin = Math.ceil(selectItemDist / 2);
+const getSelectItemStyle = (token: SelectToken): readonly [number | string, number | string] => {
+  const { multipleSelectItemHeight, selectHeight, lineWidth } = token;
+  // const selectItemDist = (selectHeight - multipleSelectItemHeight) / 2 - borderWidth;
+  // const selectItemMargin = Math.ceil(selectItemDist / 2);
+  const selectItemDist = token
+    .calc(selectHeight)
+    .sub(multipleSelectItemHeight)
+    .div(2)
+    .sub(lineWidth)
+    .equal();
+  const selectItemMargin = token.calc(selectItemDist).div(2).equal();
   return [selectItemDist, selectItemMargin] as const;
 };
 
@@ -56,7 +61,9 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         alignItems: 'center',
         height: '100%',
         // Multiple is little different that horizontal is follow the vertical
-        padding: `${selectItemDist - FIXED_ITEM_MARGIN}px ${FIXED_ITEM_MARGIN * 2}px`,
+        padding: `${unit(token.calc(selectItemDist).sub(FIXED_ITEM_MARGIN).equal())} ${unit(
+          token.calc(FIXED_ITEM_MARGIN).mul(2).equal(),
+        )}`,
         borderRadius: token.borderRadius,
 
         [`${componentCls}-show-search&`]: {
@@ -71,8 +78,8 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         '&:after': {
           display: 'inline-block',
           width: 0,
-          margin: `${FIXED_ITEM_MARGIN}px 0`,
-          lineHeight: `${selectItemHeight}px`,
+          margin: `${unit(FIXED_ITEM_MARGIN)} 0`,
+          lineHeight: unit(selectItemHeight),
           visibility: 'hidden',
           content: '"\\a0"',
         },
@@ -82,7 +89,10 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         &${componentCls}-show-arrow ${componentCls}-selector,
         &${componentCls}-allow-clear ${componentCls}-selector
       `]: {
-        paddingInlineEnd: token.fontSizeIcon + token.controlPaddingHorizontal,
+        paddingInlineEnd: token
+          .calc(token.fontSizeIcon)
+          .add(token.controlPaddingHorizontal)
+          .equal(),
       },
 
       // ======================== Selections ========================
@@ -95,15 +105,17 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         height: selectItemHeight,
         marginTop: FIXED_ITEM_MARGIN,
         marginBottom: FIXED_ITEM_MARGIN,
-        lineHeight: `${selectItemHeight - token.lineWidth * 2}px`,
+        lineHeight: unit(
+          token.calc(selectItemHeight).sub(token.calc(token.lineWidth).mul(2)).equal(),
+        ),
         background: token.multipleItemBg,
-        border: `${token.lineWidth}px ${token.lineType} ${token.multipleItemBorderColor}`,
+        border: `${unit(token.lineWidth)} ${token.lineType} ${token.multipleItemBorderColor}`,
         borderRadius: token.borderRadiusSM,
         cursor: 'default',
         transition: `font-size ${token.motionDurationSlow}, line-height ${token.motionDurationSlow}, height ${token.motionDurationSlow}`,
-        marginInlineEnd: FIXED_ITEM_MARGIN * 2,
+        marginInlineEnd: token.calc(FIXED_ITEM_MARGIN).mul(2).equal(),
         paddingInlineStart: token.paddingXS,
-        paddingInlineEnd: token.paddingXS / 2,
+        paddingInlineEnd: token.calc(token.paddingXS).div(2).equal(),
 
         [`${componentCls}-disabled&`]: {
           color: token.multipleItemColorDisabled,
@@ -114,7 +126,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         // It's ok not to do this, but 24px makes bottom narrow in view should adjust
         '&-content': {
           display: 'inline-block',
-          marginInlineEnd: token.paddingXS / 2,
+          marginInlineEnd: token.calc(token.paddingXS).div(2).equal(),
           overflow: 'hidden',
           whiteSpace: 'pre', // fix whitespace wrapping. custom tags display all whitespace within.
           textOverflow: 'ellipsis',
@@ -157,7 +169,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         display: 'inline-flex',
         position: 'relative',
         maxWidth: '100%',
-        marginInlineStart: token.inputPaddingHorizontalBase - selectItemDist,
+        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
 
         [`
           &-input,
@@ -165,7 +177,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         `]: {
           height: selectItemHeight,
           fontFamily: token.fontFamily,
-          lineHeight: `${selectItemHeight}px`,
+          lineHeight: unit(selectItemHeight),
           transition: `all ${token.motionDurationSlow}`,
         },
 
@@ -227,7 +239,7 @@ const genMultipleStyle = (token: SelectToken): CSSInterpolation => {
     {
       [`${componentCls}-multiple${componentCls}-sm`]: {
         [`${componentCls}-selection-placeholder`]: {
-          insetInline: token.controlPaddingHorizontalSM - token.lineWidth,
+          insetInline: token.calc(token.controlPaddingHorizontalSM).sub(token.lineWidth).equal(),
         },
 
         // https://github.com/ant-design/ant-design/issues/29559

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -2,13 +2,18 @@ import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import type { SelectToken } from '.';
 import { mergeToken } from '../../theme/internal';
+import { unit } from '@ant-design/cssinjs';
 
 function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
   const { componentCls, inputPaddingHorizontalBase, borderRadius } = token;
 
-  const selectHeightWithoutBorder = token.controlHeight - token.lineWidth * 2;
+  const selectHeightWithoutBorder = token
+    .calc(token.controlHeight)
+    .sub(token.calc(token.lineWidth).mul(2))
+    .equal();
 
-  const selectionItemPadding = Math.ceil(token.fontSize * 1.25);
+  // const selectionItemPadding = Math.ceil(token.fontSize * 1.25);
+  const selectionItemPadding = token.calc(token.fontSize).mul(1.25).equal();
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
@@ -41,7 +46,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           ${componentCls}-selection-placeholder
         `]: {
           padding: 0,
-          lineHeight: `${selectHeightWithoutBorder}px`,
+          lineHeight: unit(selectHeightWithoutBorder),
           transition: `all ${token.motionDurationSlow}, visibility 0s`,
           alignSelf: 'center',
         },
@@ -85,14 +90,14 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         [`${componentCls}-selector`]: {
           width: '100%',
           height: '100%',
-          padding: `0 ${inputPaddingHorizontalBase}px`,
+          padding: `0 ${unit(inputPaddingHorizontalBase)}`,
 
           [`${componentCls}-selection-search-input`]: {
             height: selectHeightWithoutBorder,
           },
 
           '&:after': {
-            lineHeight: `${selectHeightWithoutBorder}px`,
+            lineHeight: unit(selectHeightWithoutBorder),
           },
         },
       },
@@ -112,7 +117,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
             position: 'absolute',
             insetInlineStart: 0,
             insetInlineEnd: 0,
-            padding: `0 ${inputPaddingHorizontalBase}px`,
+            padding: `0 ${unit(inputPaddingHorizontalBase)}`,
 
             '&:after': {
               display: 'none',
@@ -127,7 +132,10 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
 export default function genSingleStyle(token: SelectToken): CSSInterpolation {
   const { componentCls } = token;
 
-  const inputPaddingHorizontalSM = token.controlPaddingHorizontalSM - token.lineWidth;
+  const inputPaddingHorizontalSM = token
+    .calc(token.controlPaddingHorizontalSM)
+    .sub(token.lineWidth)
+    .equal();
 
   return [
     genSizeStyle(token),
@@ -152,19 +160,22 @@ export default function genSingleStyle(token: SelectToken): CSSInterpolation {
           },
 
           [`${componentCls}-selector`]: {
-            padding: `0 ${inputPaddingHorizontalSM}px`,
+            padding: `0 ${unit(inputPaddingHorizontalSM)}`,
           },
 
           // With arrow should provides `padding-right` to show the arrow
           [`&${componentCls}-show-arrow ${componentCls}-selection-search`]: {
-            insetInlineEnd: inputPaddingHorizontalSM + token.fontSize * 1.5,
+            insetInlineEnd: token
+              .calc(inputPaddingHorizontalSM)
+              .add(token.calc(token.fontSize).mul(1.5))
+              .equal(),
           },
 
           [`
             &${componentCls}-show-arrow ${componentCls}-selection-item,
             &${componentCls}-show-arrow ${componentCls}-selection-placeholder
           `]: {
-            paddingInlineEnd: token.fontSize * 1.5,
+            paddingInlineEnd: token.calc(token.fontSize).mul(1.5).equal(),
           },
         },
       },

--- a/components/select/style/single.tsx
+++ b/components/select/style/single.tsx
@@ -12,9 +12,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
     .sub(token.calc(token.lineWidth).mul(2))
     .equal();
 
-  // const selectionItemPadding = Math.ceil(token.fontSize * 1.25);
-  const selectionItemPadding = token.calc(token.fontSize).mul(1.25).equal();
-
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
   return {
@@ -75,7 +72,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         &${componentCls}-show-arrow ${componentCls}-selection-item,
         &${componentCls}-show-arrow ${componentCls}-selection-placeholder
       `]: {
-        paddingInlineEnd: selectionItemPadding,
+        paddingInlineEnd: token.showArrowPaddingInlineEnd,
       },
 
       // Opacity selection if open

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -292,6 +292,11 @@ export type CSSVarRegisterProps = {
 export const genCSSVarRegister = <C extends OverrideComponent>(
   component: C,
   getDefaultToken: GetDefaultToken<C>,
+  options?: {
+    unitless?: {
+      [key in ComponentTokenKey<C>]: boolean;
+    };
+  },
 ) => {
   const CSSVarRegister: FC<CSSVarRegisterProps> = ({ rootCls, cssVar }) => {
     const [, realToken] = useToken();
@@ -302,6 +307,7 @@ export const genCSSVarRegister = <C extends OverrideComponent>(
         key: cssVar?.key!,
         unitless: {
           ...unitless,
+          ...options?.unitless,
           zIndexPopup: true,
         },
         ignore,


### PR DESCRIPTION
- feat: css var (#45589)
- refactor: Tooltip, Popover, Dropdown, Tour support css var (#45705)
- refactor: segmented support css var (#45716)
- refactor: select support css var

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Select support css variables.        |
| 🇨🇳 Chinese |       Select 组件支持 CSS 变量。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bacf950</samp>

This pull request adds CSS variables support to the `Select` component and refactors its style objects to use the `@ant-design/cssinjs` library. It also enhances the `genCSSVarRegister` function to handle unitless properties and creates a new file `./style/cssVar.ts` to export the hook for registering the CSS variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bacf950</samp>

*  Wrap `RcSelect` component with CSS variables using `useCSSVar` hook and `rootCls` class name ([link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L25-R29), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L120-R128), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L184-R188), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R194), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0R217), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L248-R254), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-cf9c6a6fcee364e93144b7afa91b8ff8b85e8bab46a1b602752c25b6c8de55d0L271-R277), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-6807efde7996890597453ae80cd4a5d1f126c896134917f6655f14686c0ee6f0R1-R8))
* Replace arithmetic operators with `calc` and `mul`, `sub`, `div`, `add` methods of token object to support CSS variables in style calculations ([link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-1ac56226dc98c9cd8451c23362f258c0066440108456cb021cfb575da749ea0eL145-R145), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L123-R124), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L195-R196), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L276-R277), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L317-R318), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L349-R354), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L452-R499), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L59-R66), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L85-R95), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L98-R118), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L117-R129), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L160-R172), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L230-R242), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L44-R49), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L130-R138), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L155-R171), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L167-R178))
* Add `unit` function to numeric values in style object to ensure consistency of unit ([link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L5-R10), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L111-R112), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L5-R19), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L74-R82), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-bdbff67724f9cb38a989e08057fac4b1dbbffcb715ecb8597db624ffd72f3ab5L168-R180), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L5-R16), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L88-R93), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L95-R100), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L115-R120), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-d074c411bd6636664ae405c3b7a1744f68b0d236d82b2adbef155746711ec8a2L155-R171))
* Add `prepareComponentToken` function to generate default token object for `Select` component based on global token object ([link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804R445-R486), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-fb13b068af82cbea071823b11603de9a83d853246b809a2e9b9ba45fac54f804L445-R492))
* Add optional `options` parameter to `genCSSVarRegister` function to specify unitless properties of component token ([link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8R295-R299), [link](https://github.com/ant-design/ant-design/pull/45727/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8R310))
