### PR TITLE
[Off-topic] feat: supplemental valuePropName logic, improving DX

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -52,6 +52,11 @@ export interface CheckboxProps extends AbstractCheckboxProps<CheckboxChangeEvent
   indeterminate?: boolean;
 }
 
+type CompoundedComponent = React.ForwardRefExoticComponent<CheckboxProps> & {
+  /** @internal */
+  __ANT_CHECKBOX: boolean;
+};
+
 const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProps> = (
   props,
   ref,
@@ -163,10 +168,14 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
   );
 };
 
-const Checkbox = React.forwardRef<CheckboxRef, CheckboxProps>(InternalCheckbox);
+const Checkbox = React.forwardRef<CheckboxRef, CheckboxProps>(
+  InternalCheckbox,
+) as CompoundedComponent;
 
 if (process.env.NODE_ENV !== 'production') {
   Checkbox.displayName = 'Checkbox';
 }
+
+Checkbox.__ANT_CHECKBOX = true;
 
 export default Checkbox;

--- a/components/checkbox/__tests__/checkbox.test.tsx
+++ b/components/checkbox/__tests__/checkbox.test.tsx
@@ -36,4 +36,8 @@ describe('Checkbox', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('have static property for type detecting', () => {
+    expect(Checkbox.__ANT_CHECKBOX).toBeTruthy();
+  });
 });

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -268,6 +268,24 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
     variables = { ...variables, ...messageVariables };
   }
 
+  /**
+   * For historical reasons, some components (<Switch />, <Checkbox />) within a Form required developers to explicitly specify controlled props.
+   * We have decided to take care of this by default, improving DX.
+   * https://github.com/ant-design/ant-design/issues/20803#issuecomment-601626759
+   */
+  let mergedValuePropName = 'value';
+  const _anyMergedChildren: any = mergedChildren;
+  if (
+    !Array.isArray(_anyMergedChildren) && // not list
+    _anyMergedChildren?.type &&
+    (_anyMergedChildren.type.__ANT_SWITCH || _anyMergedChildren.type.__ANT_CHECKBOX)
+  ) {
+    mergedValuePropName = 'checked';
+  }
+
+  // allow developer overwrite
+  mergedValuePropName = props.valuePropName ?? mergedValuePropName;
+
   // >>>>> With Field
   return wrapSSR(
     <Field
@@ -276,6 +294,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
       trigger={trigger}
       validateTrigger={mergedValidateTrigger}
       onMetaChange={onMetaChange}
+      valuePropName={mergedValuePropName}
     >
       {(control, renderMeta, context: FormInstance<Values>) => {
         const mergedName = toArray(name).length && renderMeta ? renderMeta.name : [];
@@ -391,7 +410,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
 
           childNode = (
             <MemoInput
-              value={mergedControl[props.valuePropName || 'value']}
+              value={mergedControl[mergedValuePropName]}
               update={mergedChildren}
               childProps={watchingChildProps}
             >

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2102,4 +2102,48 @@ describe('Form', () => {
     expect(container.querySelector('.ant-input-number-suffix')).toBeTruthy();
     expect(container.querySelector('.ant-input-number-focused')).toBeTruthy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/20803#issuecomment-601626759
+  it('without explicitly passing `valuePropName`', async () => {
+    const submit = jest.fn();
+    const Demo = () => (
+      <Form
+        initialValues={{
+          foo: true,
+          boo: false,
+        }}
+        onFinish={submit}
+      >
+        <Form.Item label="Switch" name="foo">
+          <Switch />
+        </Form.Item>
+        <Form.Item label="Checkbox" name="boo">
+          <Checkbox />
+        </Form.Item>
+        <button type="submit">Submit</button>
+      </Form>
+    );
+
+    const { container, getByRole } = render(<Demo />);
+
+    await waitFakeTimer();
+
+    expect(container.querySelectorAll('.ant-switch.ant-switch-checked').length).toBeTruthy();
+    expect(getByRole('checkbox')).not.toBeChecked();
+
+    fireEvent.click(getByRole('checkbox'));
+
+    expect(getByRole('checkbox')).toBeChecked();
+
+    const submitButton = getByRole('button');
+    expect(submitButton).toBeTruthy();
+    fireEvent.click(submitButton);
+
+    await waitFakeTimer();
+
+    expect(submit).toHaveBeenCalledWith({
+      foo: true,
+      boo: true,
+    });
+  });
 });

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ import Modal from '../../modal';
 import Radio from '../../radio';
 import Select from '../../select';
 import Slider from '../../slider';
-import Switch from '../../switch';
+import Switch, { type SwitchProps } from '../../switch';
 import TreeSelect from '../../tree-select';
 import Upload from '../../upload';
 import type { NamePath } from '../interface';
@@ -2145,5 +2145,35 @@ describe('Form', () => {
       foo: true,
       boo: true,
     });
+  });
+
+  it('even though, but should work', async () => {
+    const OverwriteSwitch = Object.assign(
+      (props: SwitchProps & { myChecked?: boolean }) => {
+        // eslint-disable-next-line
+        const { checked: _, /** omit */ myChecked, ...rest } = props;
+        return <Switch checked={myChecked} {...rest} />;
+      },
+      {
+        // There are always people with ulterior motives!
+        __ANT_SWITCH: true,
+      },
+    );
+
+    const Demo = ({ valuePropName }: any) => (
+      <Form initialValues={{ foo: true }}>
+        <Form.Item label="Switch" name="foo" valuePropName={valuePropName}>
+          <OverwriteSwitch />
+        </Form.Item>
+      </Form>
+    );
+
+    const { container, rerender } = render(<Demo />);
+
+    expect(container.querySelectorAll('.ant-switch.ant-switch-checked').length).toBeFalsy();
+
+    rerender(<Demo valuePropName="myChecked" />);
+
+    expect(container.querySelectorAll('.ant-switch.ant-switch-checked').length).toBeTruthy();
   });
 });

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -54,4 +54,8 @@ describe('Radio', () => {
     );
     expect(getByRole('radio')).not.toBeDisabled();
   });
+
+  it('have static property for type detecting', () => {
+    expect(Radio.__ANT_RADIO).toBeTruthy();
+  });
 });

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -44,4 +44,8 @@ describe('Switch', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('have static property for type detecting', () => {
+    expect(Switch.__ANT_SWITCH).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/20803#issuecomment-601626759

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

改进表单中使用 antd 的 `<Switch />`, `<Checkbox />` 组件时，需要开发者显式设置 `valuePropName` 才能正常工作。经常会忘记 :(

**解决方案**：默认在组件上加一个标识，帮助开发者处理掉这件事~。 :)

**补充**

文档不需要做更新，保留之前 demo 显式传递 `valuePropName` 避免开发者在低版本使用会困惑。个人感觉 changelog 也不需要体现

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      feat: supplemental valuePropName logic, improving DX     |
| 🇨🇳 Chinese |      改进 `valuePropName` 逻辑，提升开发者体验     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d25977c</samp>

This pull request adds static properties to the custom `Switch`, `Checkbox`, and `Radio` components from Ant Design, to enable type detecting and custom logic for form integration. It also updates the `FormItem` component to automatically detect the value prop name for these components, and adds test cases to verify the functionality.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d25977c</samp>

*  Add static properties `__ANT_CHECKBOX`, `__ANT_RADIO`, and `__ANT_SWITCH` to the custom components `Checkbox`, `Radio`, and `Switch` from Ant Design, and use them to detect the type of the child component in the `FormItem` component ([link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R55-R59), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L166-R173), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R179-R180), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-a6b316e6fad7ff1ce27a055149bfabd92c61a26de376a178e67ab0e9104ff27bR57-R60), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-4feb281b1afcaebccf16ab91979c44b50216808bb6bdf8587c3c0e31261b8d85R47-R50))
*  Define a new type `CompoundedComponent` that extends the `React.ForwardRefExoticComponent` type with a boolean property `__ANT_CHECKBOX`, and use it to annotate the `Checkbox` component ([link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R55-R59), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L166-R173))
*  Add a new block of code to the `InternalFormItem` function in the `FormItem` component that automatically assigns the appropriate value prop name (`value` or `checked`) based on the static properties of the child component, and pass it to the `FormItemContext.Provider` component and the `MemoInput` component ([link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR271-R288), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeR297), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-ca241b27784d31abb99a7d491adda5dd50f6969f7d25389fb3513d267835f3aeL394-R413))
*  Add test cases to check that the `Checkbox`, `Radio`, and `Switch` components have the static properties and that the `FormItem` component works correctly with them without explicitly passing the `valuePropName` prop ([link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-670fc06a0ecc91fa35c2a39dfb4995f9a513625e697a23aee8b7445d3ad507baR39-R42), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR2105-R2148), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-a6b316e6fad7ff1ce27a055149bfabd92c61a26de376a178e67ab0e9104ff27bR57-R60), [link](https://github.com/ant-design/ant-design/pull/45730/files?diff=unified&w=0#diff-4feb281b1afcaebccf16ab91979c44b50216808bb6bdf8587c3c0e31261b8d85R47-R50))
