### PR TITLE
feat(switch): support for value and defaultValue props

### DIFF
--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2110,30 +2110,27 @@ describe('Form', () => {
       <Form
         initialValues={{
           foo: true,
-          boo: false,
         }}
         onFinish={submit}
       >
         <Form.Item label="Switch" name="foo">
           <Switch />
         </Form.Item>
-        <Form.Item label="Checkbox" name="boo">
-          <Checkbox />
-        </Form.Item>
         <button type="submit">Submit</button>
       </Form>
     );
 
-    const { container, getByRole } = render(<Demo />);
+    const { getByRole } = render(<Demo />);
 
     await waitFakeTimer();
 
-    expect(container.querySelectorAll('.ant-switch.ant-switch-checked').length).toBeTruthy();
-    expect(getByRole('checkbox')).not.toBeChecked();
+    const switchNode = getByRole('switch');
 
-    fireEvent.click(getByRole('checkbox'));
+    expect(switchNode).toBeTruthy();
+    expect(switchNode).toBeChecked();
 
-    expect(getByRole('checkbox')).toBeChecked();
+    fireEvent.click(switchNode);
+    expect(switchNode).not.toBeChecked();
 
     const submitButton = getByRole('button');
     expect(submitButton).toBeTruthy();
@@ -2142,8 +2139,7 @@ describe('Form', () => {
     await waitFakeTimer();
 
     expect(submit).toHaveBeenCalledWith({
-      foo: true,
-      boo: true,
+      foo: false,
     });
   });
 });

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2102,4 +2102,48 @@ describe('Form', () => {
     expect(container.querySelector('.ant-input-number-suffix')).toBeTruthy();
     expect(container.querySelector('.ant-input-number-focused')).toBeTruthy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/20803#issuecomment-601626759
+  it('without explicitly passing `valuePropName`', async () => {
+    const submit = jest.fn();
+    const Demo = () => (
+      <Form
+        initialValues={{
+          foo: true,
+          boo: false,
+        }}
+        onFinish={submit}
+      >
+        <Form.Item label="Switch" name="foo">
+          <Switch />
+        </Form.Item>
+        <Form.Item label="Checkbox" name="boo">
+          <Checkbox />
+        </Form.Item>
+        <button type="submit">Submit</button>
+      </Form>
+    );
+
+    const { container, getByRole } = render(<Demo />);
+
+    await waitFakeTimer();
+
+    expect(container.querySelectorAll('.ant-switch.ant-switch-checked').length).toBeTruthy();
+    expect(getByRole('checkbox')).not.toBeChecked();
+
+    fireEvent.click(getByRole('checkbox'));
+
+    expect(getByRole('checkbox')).toBeChecked();
+
+    const submitButton = getByRole('button');
+    expect(submitButton).toBeTruthy();
+    fireEvent.click(submitButton);
+
+    await waitFakeTimer();
+
+    expect(submit).toHaveBeenCalledWith({
+      foo: true,
+      boo: true,
+    });
+  });
 });

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('Switch', () => {
     jest.useRealTimers();
   });
 
-  it('warning if set `value`', () => {
+  it.skip('warning if set `value`', () => {
     resetWarned();
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -43,5 +43,37 @@ describe('Switch', () => {
       'Warning: [antd: Switch] `value` is not a valid prop, do you mean `checked`?',
     );
     errorSpy.mockRestore();
+  });
+
+  it('should be controlled by value', () => {
+    const mockChangeHandler = jest.fn();
+
+    const { getByRole } = render(<Switch value onChange={mockChangeHandler} />);
+
+    const switchNode = getByRole('switch');
+    expect(switchNode).toBeTruthy();
+    expect(getByRole('switch')).toBeChecked();
+
+    fireEvent.click(switchNode);
+
+    expect(mockChangeHandler).toHaveBeenCalledWith(false, expect.anything());
+    // controlled component, so still true after click
+    expect(getByRole('switch')).toBeChecked();
+  });
+
+  it('should be uncontrolled by defaultValue', () => {
+    const mockChangeHandler = jest.fn();
+
+    const { getByRole } = render(<Switch defaultValue onChange={mockChangeHandler} />);
+
+    const switchNode = getByRole('switch');
+    expect(switchNode).toBeTruthy();
+    expect(getByRole('switch')).toBeChecked();
+
+    fireEvent.click(switchNode);
+
+    expect(mockChangeHandler).toHaveBeenCalledWith(false, expect.anything());
+    // uncontrolled component, so false after click
+    expect(getByRole('switch')).not.toBeChecked();
   });
 });

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -4,7 +4,6 @@ import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
-import { resetWarned } from '../../_util/warning';
 
 jest.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => true;
@@ -31,18 +30,6 @@ describe('Switch', () => {
     expect(document.querySelector('.ant-wave')).toBeTruthy();
     jest.clearAllTimers();
     jest.useRealTimers();
-  });
-
-  it.skip('warning if set `value`', () => {
-    resetWarned();
-
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const props = { value: true } as any;
-    render(<Switch {...props} />);
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Switch] `value` is not a valid prop, do you mean `checked`?',
-    );
-    errorSpy.mockRestore();
   });
 
   it('should be controlled by value', () => {

--- a/components/switch/index.en-US.md
+++ b/components/switch/index.en-US.md
@@ -29,19 +29,21 @@ Switching Selector.
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| autoFocus | Whether get focus when component mounted | boolean | false |
-| checked | Determine whether the Switch is checked | boolean | false |
-| checkedChildren | The content to be shown when the state is checked | ReactNode | - |
-| className | The additional class to Switch | string | - |
-| defaultChecked | Whether to set the initial state | boolean | false |
-| disabled | Disable switch | boolean | false |
-| loading | Loading state of switch | boolean | false |
-| size | The size of the Switch, options: `default` `small` | string | `default` |
-| unCheckedChildren | The content to be shown when the state is unchecked | ReactNode | - |
-| onChange | Trigger when the checked state is changing | function(checked: boolean, event: Event) | - |
-| onClick | Trigger when clicked | function(checked: boolean, event: Event) | - |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| autoFocus | Whether get focus when component mounted | boolean | false |  |
+| checked | Determine whether the Switch is checked | boolean | false |  |
+| checkedChildren | The content to be shown when the state is checked | ReactNode | - |  |
+| className | The additional class to Switch | string | - |  |
+| defaultChecked | Whether to set the initial state | boolean | false |  |
+| defaultValue | Alias for `defaultChecked` | boolean | - | 5.12.0 |
+| disabled | Disable switch | boolean | false |  |
+| loading | Loading state of switch | boolean | false |  |
+| size | The size of the Switch, options: `default` `small` | string | `default` |  |
+| unCheckedChildren | The content to be shown when the state is unchecked | ReactNode | - |  |
+| value | Alias for `checked` | boolean | - | 5.12.0 |
+| onChange | Trigger when the checked state is changing | function(checked: boolean, event: Event) | - |  |
+| onClick | Trigger when clicked | function(checked: boolean, event: Event) | - |  |
 
 ## Methods
 

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -3,12 +3,12 @@ import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
 import RcSwitch from 'rc-switch';
 
-import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
 import useStyle from './style';
+import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
 export type SwitchSize = 'small' | 'default';
 export type SwitchChangeEventHandler = (
@@ -24,6 +24,16 @@ export interface SwitchProps {
   rootClassName?: string;
   checked?: boolean;
   defaultChecked?: boolean;
+  /**
+   * Alias for `checked`.
+   * @since 5.12.0
+   */
+  value?: boolean;
+  /**
+   * Alias for `defaultChecked`.
+   * @since 5.12.0
+   */
+  defaultValue?: boolean;
   onChange?: SwitchChangeEventHandler;
   onClick?: SwitchClickEventHandler;
   checkedChildren?: React.ReactNode;
@@ -53,18 +63,18 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => 
     className,
     rootClassName,
     style,
+    checked: checkedProp,
+    value,
+    defaultChecked: defaultCheckedProp,
+    defaultValue,
+    onChange,
     ...restProps
   } = props;
 
-  if (process.env.NODE_ENV !== 'production') {
-    const warning = devUseWarning('Switch');
-
-    warning(
-      'checked' in props || !('value' in props),
-      'usage',
-      '`value` is not a valid prop, do you mean `checked`?',
-    );
-  }
+  const [checked, setChecked] = useMergedState<boolean>(false, {
+    value: checkedProp ?? value,
+    defaultValue: defaultCheckedProp ?? defaultValue,
+  });
 
   const { getPrefixCls, direction, switch: SWITCH } = React.useContext(ConfigContext);
 
@@ -99,10 +109,17 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => 
 
   const mergedStyle: React.CSSProperties = { ...SWITCH?.style, ...style };
 
+  const changeHandler: SwitchChangeEventHandler = (...args) => {
+    setChecked(args[0]);
+    onChange?.(...args);
+  };
+
   return wrapSSR(
     <Wave component="Switch">
       <RcSwitch
         {...restProps}
+        checked={checked}
+        onChange={changeHandler}
         prefixCls={prefixCls}
         className={classes}
         style={mergedStyle}

--- a/components/switch/index.zh-CN.md
+++ b/components/switch/index.zh-CN.md
@@ -30,19 +30,21 @@ demo:
 
 通用属性参考：[通用属性](/docs/react/common-props)
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| autoFocus | 组件自动获取焦点 | boolean | false |
-| checked | 指定当前是否选中 | boolean | false |
-| checkedChildren | 选中时的内容 | ReactNode | - |
-| className | Switch 器类名 | string | - |
-| defaultChecked | 初始是否选中 | boolean | false |
-| disabled | 是否禁用 | boolean | false |
-| loading | 加载中的开关 | boolean | false |
-| size | 开关大小，可选值：`default` `small` | string | `default` |
-| unCheckedChildren | 非选中时的内容 | ReactNode | - |
-| onChange | 变化时的回调函数 | function(checked: boolean, event: Event) | - |
-| onClick | 点击时的回调函数 | function(checked: boolean, event: Event) | - |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| autoFocus | 组件自动获取焦点 | boolean | false |  |
+| checked | 指定当前是否选中 | boolean | false |  |
+| checkedChildren | 选中时的内容 | ReactNode | - |  |
+| className | Switch 器类名 | string | - |  |
+| defaultChecked | 初始是否选中 | boolean | false |  |
+| defaultValue | `defaultChecked` 的别名 | boolean | - | 5.12.0 |
+| disabled | 是否禁用 | boolean | false |  |
+| loading | 加载中的开关 | boolean | false |  |
+| size | 开关大小，可选值：`default` `small` | string | `default` |  |
+| unCheckedChildren | 非选中时的内容 | ReactNode | - |  |
+| value | `checked` 的别名 | boolean | - | 5.12.0 |
+| onChange | 变化时的回调函数 | function(checked: boolean, event: Event) | - |  |
+| onClick | 点击时的回调函数 | function(checked: boolean, event: Event) | - |  |
 
 ## 方法
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Off-topic：https://github.com/ant-design/ant-design/pull/45730#discussion_r1387392199

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     `<Switch />` support for `value` and `defaultValue` props      |
| 🇨🇳 Chinese |     `<Switch />` 支持  `value` and `defaultValue` 属性      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4051400</samp>

This pull request adds a new feature to the `Switch` component, allowing it to accept `value` and `defaultValue` props as aliases for `checked` and `defaultChecked` props. It also updates the test cases and the API documentation for the `Switch` component in both English and Chinese. This feature aims to improve the compatibility and usability of the `Switch` component when used inside a `Form` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4051400</samp>

*  Add new `value` and `defaultValue` props to the Switch component as aliases for the `checked` and `defaultChecked` props, respectively ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-1a8d26d95d4a78ff5bf4e933e749fc9449d8065feeb62948d87bb88bdcb3d2e3L32-R46), [link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03R27-R36), [link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-55185d2701b5fae2292303db00692e1ab773d0485be91dba607ffe4ec297dee5L33-R47))
*  Use the `useMergedState` hook from the `rc-util` library to handle the merged state of the four props in the Switch component function ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03R11), [link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L56-R78), [link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L102-R122))
*  Remove the unused import of the `devUseWarning` function and the warning logic for the `value` prop from the Switch component file ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L6), [link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-e6cc84da9314e7733f7658f68135d16dbc896ce22ec302e43189778cc134cf03L56-R78))
*  Add two new test cases to verify the controlled and uncontrolled behavior of the Switch component with the new props ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-4feb281b1afcaebccf16ab91979c44b50216808bb6bdf8587c3c0e31261b8d85R47-R78))
*  Skip the existing test case that warns if the `value` prop is set, as it is no longer relevant ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-4feb281b1afcaebccf16ab91979c44b50216808bb6bdf8587c3c0e31261b8d85L36-R36))
*  Add a new test case to verify that the Switch component can work without the `valuePropName` prop inside a Form.Item ([link](https://github.com/ant-design/ant-design/pull/45747/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR2105-R2144))
