### PR TITLE
fix: Upload should show remove icon when showRemoveIcon is specified to true explicitly

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -376,6 +376,10 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     downloadIcon,
   } = typeof showUploadList === 'boolean' ? ({} as ShowUploadListInterface) : showUploadList;
 
+  // use showRemoveIcon if it is specified explicitly
+  const realShowRemoveIcon =
+    typeof showRemoveIcon === 'undefined' ? !mergedDisabled : !!showRemoveIcon;
+
   const renderUploadList = (button?: React.ReactNode, buttonVisible?: boolean) => {
     if (!showUploadList) {
       return button;
@@ -389,7 +393,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
         onPreview={onPreview}
         onDownload={onDownload}
         onRemove={handleRemove}
-        showRemoveIcon={!mergedDisabled && showRemoveIcon}
+        showRemoveIcon={realShowRemoveIcon}
         showPreviewIcon={showPreviewIcon}
         showDownloadIcon={showDownloadIcon}
         removeIcon={removeIcon}

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -579,6 +579,34 @@ describe('Upload List', () => {
     unmount();
   });
 
+  // https://github.com/ant-design/ant-design/issues/27519
+  // https://github.com/ant-design/ant-design/issues/45735
+  it('should show remove icon when showRemoveIcon is true', () => {
+    const list = [
+      {
+        name: 'image',
+        status: 'uploading',
+        uid: '-4',
+        url: 'https://cdn.xxx.com/aaa',
+      },
+    ];
+
+    const { container: wrapper, unmount } = render(
+      <Upload
+        listType="picture"
+        defaultFileList={list as UploadProps['defaultFileList']}
+        showUploadList={{
+          showRemoveIcon: true,
+        }}
+        disabled
+      >
+        <button type="button">upload</button>
+      </Upload>,
+    );
+    expect(wrapper.querySelector('.anticon-delete')).toBeTruthy();
+    unmount();
+  });
+
   it('should support custom onClick in custom icon', async () => {
     const handleRemove = jest.fn();
     const handleChange = jest.fn();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
- close https://github.com/ant-design/ant-design/issues/27519
- close https://github.com/ant-design/ant-design/issues/45735

ref https://github.com/ant-design/ant-design/pull/16786

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Upload should show remove icon when `showRemoveIcon` is specified to true explicitly.         |
| 🇨🇳 Chinese |  修复 Upload 显式指定 `showRemoveIcon: true` 时删除图标未显示的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 202d7b3</samp>

Fix a bug where the remove icon was not showing for disabled upload components. Update `components/upload/Upload.tsx` and add a test case in `components/upload/__tests__/uploadlist.test.tsx` to reflect the fix.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 202d7b3</samp>

* Fix bug where remove icon was not showing when upload component was disabled but `showRemoveIcon` prop was true (#27519, #45735)
  - Introduce new variable `realShowRemoveIcon` to compute whether to show remove icon for each file based on `showRemoveIcon` and `mergedDisabled` props ([link](https://github.com/ant-design/ant-design/pull/45752/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dR379-R382))
  - Use `realShowRemoveIcon` in `UploadList` component props instead of `!mergedDisabled && showRemoveIcon` expression ([link](https://github.com/ant-design/ant-design/pull/45752/files?diff=unified&w=0#diff-a2e7152a9f97730a600f9bda0bf15029cce0148818a6ee8d2a037fafc101427dL392-R396))
  - Add test case to verify that remove icon is shown when `showRemoveIcon` is true and upload component is disabled (`components/upload/__tests__/uploadlist.test.tsx`, [link](https://github.com/ant-design/ant-design/pull/45752/files?diff=unified&w=0#diff-be2aa30e7597e9d996e3b0573a8f2f34568cbb899f203b3d270c95105132b390R582-R609))
