### PR TITLE
fix: Description children missing key

### DIFF
--- a/components/descriptions/__tests__/hooks.test.tsx
+++ b/components/descriptions/__tests__/hooks.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Descriptions from '..';
+import { render } from '../../../tests/utils';
+import useBreakpoint from '../../grid/hooks/useBreakpoint';
+import useItems from '../hooks/useItems';
+
+describe('Descriptions.Hooks', () => {
+  it('Should Descriptions not throw react key prop error in jsx mode', () => {
+    const Demo = () => {
+      const screens = useBreakpoint();
+      const items = useItems(
+        screens,
+        undefined,
+        <Descriptions.Item key="bamboo" label="UserName">
+          Bamboo
+        </Descriptions.Item>,
+      );
+
+      return <p>{(items[0] as any).key}</p>;
+    };
+
+    const { container } = render(<Demo />);
+    expect(container.querySelector('p')?.textContent).toBe('bamboo');
+  });
+});

--- a/components/descriptions/hooks/useItems.ts
+++ b/components/descriptions/hooks/useItems.ts
@@ -6,7 +6,7 @@ import { matchScreen, type ScreenMap } from '../../_util/responsiveObserver';
 
 // Convert children into items
 const transChildren2Items = (childNodes?: React.ReactNode) =>
-  toArray(childNodes).map((node) => ({ ...node?.props }));
+  toArray(childNodes).map((node) => ({ ...node?.props, key: node.key }));
 
 export default function useItems(
   screens: ScreenMap,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Descriptions use `children` structure missing the Descriptions.Item `key` prop.        |
| 🇨🇳 Chinese |   修复 Descriptions 使用 `children` 结构语法糖时，会丢失 Descriptions.Item 的 `key` 的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22c9eaa</samp>

This pull request fixes a react key prop error in the `Descriptions` component when using jsx mode. It adds a test case for the `useItems` hook and modifies the `transChildren2Items` function in `components/descriptions/hooks/useItems.ts` to preserve the `key` prop of the `Descriptions.Item` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22c9eaa</samp>

* Preserve the `key` prop of the `Descriptions.Item` component to avoid react key prop error and identify the component ([link](https://github.com/ant-design/ant-design/pull/45757/files?diff=unified&w=0#diff-753321f9ada9303e96dd54c0eb16876870bc246cdfd280037108d10d4aeceddbL9-R9))
* Add a test case for the `useItems` hook to check that it does not throw a react key prop error when using jsx mode to render the `Descriptions.Item` component ([link](https://github.com/ant-design/ant-design/pull/45757/files?diff=unified&w=0#diff-b2c618ff245d14ccc4b37bd6551e66340ffb1d75aae3b0567a870e46f5982504R1-R26))
