### PR TITLE
refactor: Input support css var

### DIFF
--- a/components/input/Group.tsx
+++ b/components/input/Group.tsx
@@ -7,6 +7,7 @@ import { ConfigContext } from '../config-provider';
 import type { FormItemStatusContextProps } from '../form/context';
 import { FormItemInputContext } from '../form/context';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface GroupProps {
   className?: string;
@@ -26,7 +27,8 @@ const Group: React.FC<GroupProps> = (props) => {
   const { prefixCls: customizePrefixCls, className } = props;
   const prefixCls = getPrefixCls('input-group', customizePrefixCls);
   const inputPrefixCls = getPrefixCls('input');
-  const [wrapSSR, hashId] = useStyle(inputPrefixCls);
+  const [, hashId] = useStyle(inputPrefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
   const cls = classNames(
     prefixCls,
     {
@@ -55,7 +57,7 @@ const Group: React.FC<GroupProps> = (props) => {
     warning.deprecated(false, 'Input.Group', 'Space.Compact');
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <span
       className={cls}
       style={props.style}

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -17,7 +17,9 @@ import { FormItemInputContext, NoFormStyle } from '../form/context';
 import { NoCompactStyle, useCompactItemContext } from '../space/Compact';
 import useRemovePasswordTimeout from './hooks/useRemovePasswordTimeout';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import { hasPrefixSuffix } from './utils';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 export interface InputFocusOptions extends FocusOptions {
   cursor?: 'start' | 'end' | 'all';
@@ -94,7 +96,9 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const inputRef = useRef<InputRef>(null);
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const cssVarCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(cssVarCls);
 
   // ===================== Compact Item =====================
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
@@ -164,7 +168,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     mergedAllowClear = { clearIcon: <CloseCircleFilled /> };
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <RcInput
       ref={composeRef(ref, inputRef)}
       prefixCls={prefixCls}
@@ -177,7 +181,14 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       styles={{ ...input?.styles, ...styles }}
       suffix={suffixNode}
       allowClear={mergedAllowClear}
-      className={classNames(className, rootClassName, compactItemClassnames, input?.className)}
+      className={classNames(
+        className,
+        rootClassName,
+        cssVarCls,
+        hashId,
+        compactItemClassnames,
+        input?.className,
+      )}
       onChange={handleChange}
       addonAfter={
         addonAfter && (

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -17,6 +17,8 @@ import { FormItemInputContext } from '../form/context';
 import type { InputFocusOptions } from './Input';
 import { triggerFocus } from './Input';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 export interface TextAreaProps extends Omit<RcTextAreaProps, 'suffix'> {
   bordered?: boolean;
@@ -83,14 +85,16 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   }
 
   // ===================== Style =====================
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const cssVarCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(cssVarCls);
 
-  return wrapSSR(
+  return wrapCSSVar(
     <RcTextArea
       {...rest}
       disabled={mergedDisabled}
       allowClear={mergedAllowClear}
-      className={classNames(className, rootClassName)}
+      className={classNames(cssVarCls, className, rootClassName)}
       classes={{
         affixWrapper: classNames(
           `${prefixCls}-textarea-affix-wrapper`,

--- a/components/input/style/cssVar.ts
+++ b/components/input/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { initComponentToken } from '.';
+
+export default genCSSVarRegister('Input', initComponentToken);

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -3,7 +3,7 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import { clearFix, resetComponent } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import type { GlobalToken } from '../../theme/interface';
-import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
+import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import { unit } from '@ant-design/cssinjs';
 
@@ -1045,7 +1045,7 @@ export function initInputToken(token: GlobalToken): SharedInputToken {
   });
 }
 
-export const initComponentToken: GetDefaultToken<'Input'> = (token) => {
+export const initComponentToken = (token: GlobalToken): SharedComponentToken => {
   const {
     controlHeight,
     fontSize,

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -3,8 +3,9 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import { clearFix, resetComponent } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import type { GlobalToken } from '../../theme/interface';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import { unit } from '@ant-design/cssinjs';
 
 export interface SharedComponentToken {
   /**
@@ -135,7 +136,7 @@ const genInputLargeStyle = (token: InputToken): CSSObject => {
   const { paddingBlockLG, fontSizeLG, lineHeightLG, borderRadiusLG, paddingInlineLG } = token;
 
   return {
-    padding: `${paddingBlockLG}px ${paddingInlineLG}px`,
+    padding: `${unit(paddingBlockLG)} ${unit(paddingInlineLG)}`,
     fontSize: fontSizeLG,
     lineHeight: lineHeightLG,
     borderRadius: borderRadiusLG,
@@ -143,7 +144,7 @@ const genInputLargeStyle = (token: InputToken): CSSObject => {
 };
 
 export const genInputSmallStyle = (token: InputToken): CSSObject => ({
-  padding: `${token.paddingBlockSM}px ${token.paddingInlineSM}px`,
+  padding: `${unit(token.paddingBlockSM)} ${unit(token.paddingInlineSM)}`,
   borderRadius: token.borderRadiusSM,
 });
 
@@ -207,7 +208,7 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
   display: 'inline-block',
   width: '100%',
   minWidth: 0,
-  padding: `${token.paddingBlock}px ${token.paddingInline}px`,
+  padding: `${unit(token.paddingBlock)} ${unit(token.paddingInline)}`,
   color: token.colorText,
   fontSize: token.fontSize,
   lineHeight: token.lineHeight,
@@ -331,26 +332,28 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
 
       '&-addon': {
         position: 'relative',
-        padding: `0 ${token.paddingInline}px`,
+        padding: `0 ${unit(token.paddingInline)}`,
         color: token.colorText,
         fontWeight: 'normal',
         fontSize: token.fontSize,
         textAlign: 'center',
         backgroundColor: token.addonBg,
-        border: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+        border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
         borderRadius: token.borderRadius,
         transition: `all ${token.motionDurationSlow}`,
         lineHeight: 1,
 
         // Reset Select's style in addon
         [`${antCls}-select`]: {
-          margin: `-${token.paddingBlock + 1}px -${token.paddingInline}px`,
+          margin: `${unit(token.calc(token.paddingBlock).add(1).mul(-1).equal())} ${unit(
+            token.calc(token.paddingInline).mul(-1).equal(),
+          )}`,
 
           [`&${antCls}-select-single:not(${antCls}-select-customize-input):not(${antCls}-pagination-size-changer)`]:
             {
               [`${antCls}-select-selector`]: {
                 backgroundColor: 'inherit',
-                border: `${token.lineWidth}px ${token.lineType} transparent`,
+                border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
                 boxShadow: 'none',
               },
             },
@@ -364,7 +367,7 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
 
         // https://github.com/ant-design/ant-design/issues/31333
         [`${antCls}-cascader-picker`]: {
-          margin: `-9px -${token.paddingInline}px`,
+          margin: `-9px ${unit(token.calc(token.paddingInline).mul(-1).equal())}`,
           backgroundColor: 'transparent',
           [`${antCls}-cascader-input`]: {
             textAlign: 'start',
@@ -488,7 +491,7 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
       },
 
       '& > *:not(:last-child)': {
-        marginInlineEnd: -token.lineWidth,
+        marginInlineEnd: token.calc(token.lineWidth).mul(-1).equal(),
         borderInlineEndWidth: token.lineWidth,
       },
 
@@ -546,7 +549,7 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
       },
 
       [`${componentCls}-group-wrapper + ${componentCls}-group-wrapper`]: {
-        marginInlineStart: -token.lineWidth,
+        marginInlineStart: token.calc(token.lineWidth).mul(-1).equal(),
         [`${componentCls}-affix-wrapper`]: {
           borderRadius: 0,
         },
@@ -571,10 +574,14 @@ export const genInputGroupStyle = (token: InputToken): CSSObject => {
 };
 
 const genInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
-  const { componentCls, controlHeightSM, lineWidth } = token;
+  const { componentCls, controlHeightSM, lineWidth, calc } = token;
 
   const FIXED_CHROME_COLOR_HEIGHT = 16;
-  const colorSmallPadding = (controlHeightSM - lineWidth * 2 - FIXED_CHROME_COLOR_HEIGHT) / 2;
+  const colorSmallPadding = calc(controlHeightSM)
+    .sub(calc(lineWidth).mul(2))
+    .sub(FIXED_CHROME_COLOR_HEIGHT)
+    .div(2)
+    .equal();
 
   return {
     [componentCls]: {
@@ -630,7 +637,7 @@ const genAllowClearStyle = (token: InputToken): CSSObject => {
       },
 
       '&-has-suffix': {
-        margin: `0 ${token.inputAffixPadding}px`,
+        margin: `0 ${unit(token.inputAffixPadding)}`,
       },
     },
   };
@@ -844,7 +851,7 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       // fix slight height diff in Firefox:
       // https://ant.design/components/auto-complete-cn/#components-auto-complete-demo-certain-category
       [`${componentCls}-lg`]: {
-        lineHeight: token.lineHeightLG - 0.0002,
+        lineHeight: token.calc(token.lineHeightLG).sub(0.0002).equal({ unit: false }),
       },
 
       [`> ${componentCls}-group`]: {
@@ -909,7 +916,7 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
         [`&:not(${componentCls}-compact-last-item)`]: {
           [`${componentCls}-group-addon`]: {
             [`${componentCls}-search-button`]: {
-              marginInlineEnd: -token.lineWidth,
+              marginInlineEnd: token.calc(token.lineWidth).mul(-1).equal(),
               borderRadius: 0,
             },
           },
@@ -953,7 +960,7 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
 
         [`${componentCls}-data-count`]: {
           position: 'absolute',
-          bottom: -token.fontSize * token.lineHeight,
+          bottom: token.calc(token.fontSize).mul(token.lineHeight).mul(-1).equal(),
           insetInlineEnd: 0,
           color: token.colorTextDescription,
           whiteSpace: 'nowrap',
@@ -1038,7 +1045,7 @@ export function initInputToken(token: GlobalToken): SharedInputToken {
   });
 }
 
-export const initComponentToken = (token: GlobalToken): SharedComponentToken => {
+export const initComponentToken: GetDefaultToken<'Input'> = (token) => {
   const {
     controlHeight,
     fontSize,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Input support css variables       |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e10e6e</samp>

This pull request adds CSS variables support to the input, input group, and text area components using custom hooks and the `@ant-design/cssinjs` library. It also refactors the styling code to use the `unit` and `calc` functions and the `GetDefaultToken` type from the `../../theme/internal` module. It affects the files `components/input/Group.tsx`, `components/input/Input.tsx`, `components/input/style/index.ts`, `components/input/TextArea.tsx`, and `components/input/style/cssVar.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e10e6e</samp>

*  Register and use CSS variables for the input and text area components using custom hooks ([link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-9eb09be52eccb23eca0f8a281decb1e31a260e19b5176de99aef059c5abfb3c6R10), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-9eb09be52eccb23eca0f8a281decb1e31a260e19b5176de99aef059c5abfb3c6L29-R31), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-9eb09be52eccb23eca0f8a281decb1e31a260e19b5176de99aef059c5abfb3c6L58-R60), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL20-R22), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL97-R101), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL167-R171), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-1ff27196463317207b642a68f149b39ccfedafbeceb1a8dd59ff7a03674c06aaL180-R191), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089R20-R21), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-e38236283d4b2ff8417dfed931e619e2652dffcf55a9d22125fc8d2c8c16e089L86-R97), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-58ce4df545c9b597884be78eac743dcf2fdbb7c3523e5a2974456606dd4b70e1R1-R4))
* Convert numeric values to CSS units using the `unit` function from `@ant-design/cssinjs` in the `style/index.ts` file ([link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL6-R8), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL138-R139), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL146-R147), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL210-R211), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL334-R335), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL340-R341), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL347-R350), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL353-R356), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL367-R370), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL633-R640))
* Perform arithmetic operations on CSS variables using the `calc` method of the `token` object in the `style/index.ts` file ([link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL491-R494), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL549-R552), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL574-R584), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL847-R854), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL912-R919), [link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL956-R963))
* Change the type of the `initComponentToken` function from `(token: GlobalToken) => SharedComponentToken` to `GetDefaultToken<'Input'>` in the `style/index.ts` file ([link](https://github.com/ant-design/ant-design/pull/45782/files?diff=unified&w=0#diff-3a34112b09233455996fb191066f04b1c3fa01878e9400af4ca8a1dcf6c0106aL1041-R1048))
