### PR TITLE
feat: list support cssVar

### DIFF
--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -13,6 +13,7 @@ import Pagination from '../pagination';
 import type { SpinProps } from '../spin';
 import Spin from '../spin';
 import Item from './Item';
+import useCSSVar from './style/cssVar';
 
 // CSSINJS
 import { ListContext } from './context';
@@ -143,7 +144,8 @@ function List<T>({
   const prefixCls = getPrefixCls('list', customizePrefixCls);
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   let loadingProp = loading;
   if (typeof loadingProp === 'boolean') {
@@ -284,7 +286,7 @@ function List<T>({
     [JSON.stringify(grid), itemLayout],
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <ListContext.Provider value={contextValue}>
       <div style={{ ...list?.style, ...style }} className={classString} {...rest}>
         {(paginationPosition === 'top' || paginationPosition === 'both') && paginationContent}

--- a/components/list/style/cssVar.ts
+++ b/components/list/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('List', prepareComponentToken);

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -301,7 +301,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             width: lineWidth,
             height: token
               .calc(token.fontHeight)
-              .sub(token.calc(token.marginXXS).mul(2).equal())
+              .sub(token.calc(token.marginXXS).mul(2))
               .equal(),
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -65,7 +65,6 @@ export interface ComponentToken {
 interface ListToken extends FullToken<'List'> {
   listBorderedCls: string;
   minHeight: number;
-  itemActionSplitHeight: number | string;
 }
 
 const genBorderedStyle = (token: ListToken): CSSObject => {
@@ -180,7 +179,6 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     avatarMarginRight,
     titleMarginBottom,
     descriptionFontSize,
-    itemActionSplitHeight,
   } = token;
 
   const alignCls: any = {};
@@ -301,7 +299,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            height: itemActionSplitHeight,
+            height: token.fontHeight,
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },
@@ -424,7 +422,6 @@ export const prepareComponentToken: GetDefaultToken<'List'> = (token) => ({
   avatarMarginRight: token.padding,
   titleMarginBottom: token.paddingSM,
   descriptionFontSize: token.fontSize,
-  itemActionSplitHeight: Math.ceil(token.fontSize * token.lineHeight) - token.marginXXS * 2,
 });
 
 // ============================== Export ==============================

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -299,7 +299,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            height: token.fontHeight,
+            height: token.calc(token.fontHeight).sub(token.calc(token.marginXXS).mul(2)).equal(),
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -299,7 +299,10 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            height: token.calc(token.fontHeight).sub(token.calc(token.marginXXS).mul(2)).equal(),
+            height: token
+              .calc(token.fontHeight)
+              .sub(token.calc(token.marginXXS).mul(2).equal())
+              .equal(),
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -65,6 +65,7 @@ export interface ComponentToken {
 interface ListToken extends FullToken<'List'> {
   listBorderedCls: string;
   minHeight: number;
+  itemActionSplitHeight: number | string;
 }
 
 const genBorderedStyle = (token: ListToken): CSSObject => {
@@ -179,6 +180,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     avatarMarginRight,
     titleMarginBottom,
     descriptionFontSize,
+    itemActionSplitHeight,
   } = token;
 
   const alignCls: any = {};
@@ -299,11 +301,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            // todo Math.ceil(token.fontSize * token.lineHeight) - token.marginXXS * 2
-            height: token
-              .calc(token.fontSize)
-              .mul(token.lineHeight)
-              .sub(token.calc(token.marginXXS).mul(2)),
+            height: itemActionSplitHeight,
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },
@@ -426,6 +424,7 @@ export const prepareComponentToken: GetDefaultToken<'List'> = (token) => ({
   avatarMarginRight: token.padding,
   titleMarginBottom: token.paddingSM,
   descriptionFontSize: token.fontSize,
+  itemActionSplitHeight: Math.ceil(token.fontSize * token.lineHeight) - token.marginXXS * 2,
 });
 
 // ============================== Export ==============================

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -1,7 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 import type { CSSProperties } from 'react';
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -80,14 +80,14 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
   } = token;
   return {
     [`${listBorderedCls}`]: {
-      border: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+      border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
       borderRadius: borderRadiusLG,
       [`${componentCls}-header,${componentCls}-footer,${componentCls}-item`]: {
         paddingInline: paddingLG,
       },
 
       [`${componentCls}-pagination`]: {
-        margin: `${margin}px ${marginLG}px`,
+        margin: `${unit(margin)} ${unit(marginLG)}`,
       },
     },
     [`${listBorderedCls}${componentCls}-sm`]: {
@@ -144,7 +144,7 @@ const genResponsiveStyle = (token: ListToken): CSSObject => {
           },
 
           [`${componentCls}-item-extra`]: {
-            margin: `auto auto ${margin}px`,
+            margin: `auto auto ${unit(margin)}`,
           },
         },
       },
@@ -251,7 +251,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
           },
 
           [`${componentCls}-item-meta-title`]: {
-            margin: `0 0 ${token.marginXXS}px 0`,
+            margin: `0 0 ${unit(token.marginXXS)} 0`,
             color: colorText,
             fontSize: token.fontSize,
             lineHeight: token.lineHeight,
@@ -283,7 +283,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
           [`& > li`]: {
             position: 'relative',
             display: 'inline-block',
-            padding: `0 ${paddingXS}px`,
+            padding: `0 ${unit(paddingXS)}`,
             color: colorTextDescription,
             fontSize: token.fontSize,
             lineHeight: token.lineHeight,
@@ -299,7 +299,11 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            height: Math.ceil(token.fontSize * token.lineHeight) - token.marginXXS * 2,
+            // todo Math.ceil(token.fontSize * token.lineHeight) - token.marginXXS * 2
+            height: token
+              .calc(token.fontSize)
+              .mul(token.lineHeight)
+              .sub(token.calc(token.marginXXS).mul(2)),
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },
@@ -307,7 +311,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
       },
 
       [`${componentCls}-empty`]: {
-        padding: `${padding}px 0`,
+        padding: `${unit(padding)} 0`,
         color: colorTextDescription,
         fontSize: token.fontSizeSM,
         textAlign: 'center',
@@ -361,7 +365,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
         marginInlineStart: 'auto',
 
         '> li': {
-          padding: `0 ${padding}px`,
+          padding: `0 ${unit(padding)}`,
 
           [`&:first-child`]: {
             paddingInlineStart: 0,
@@ -371,7 +375,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     },
 
     [`${componentCls}-split ${componentCls}-item`]: {
-      borderBlockEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+      borderBlockEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
 
       [`&:last-child`]: {
         borderBlockEnd: 'none',
@@ -379,17 +383,17 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     },
 
     [`${componentCls}-split ${componentCls}-header`]: {
-      borderBlockEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+      borderBlockEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
     },
     [`${componentCls}-split${componentCls}-empty ${componentCls}-footer`]: {
-      borderTop: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+      borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
     },
     [`${componentCls}-loading ${componentCls}-spin-nested-loading`]: {
       minHeight: controlHeight,
     },
     [`${componentCls}-split${componentCls}-something-after-last-item ${antCls}-spin-container > ${componentCls}-items > ${componentCls}-item:last-child`]:
       {
-        borderBlockEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+        borderBlockEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
       },
     [`${componentCls}-lg ${componentCls}-item`]: {
       padding: itemPaddingLG,
@@ -408,6 +412,22 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'List'> = (token) => ({
+  contentWidth: 220,
+  itemPadding: `${unit(token.paddingContentVertical)} 0`,
+  itemPaddingSM: `${unit(token.paddingContentVerticalSM)} ${unit(token.paddingContentHorizontal)}`,
+  itemPaddingLG: `${unit(token.paddingContentVerticalLG)} ${unit(
+    token.paddingContentHorizontalLG,
+  )}`,
+  headerBg: 'transparent',
+  footerBg: 'transparent',
+  emptyTextPadding: token.padding,
+  metaMarginBottom: token.padding,
+  avatarMarginRight: token.padding,
+  titleMarginBottom: token.paddingSM,
+  descriptionFontSize: token.fontSize,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'List',
@@ -419,17 +439,5 @@ export default genComponentStyleHook(
 
     return [genBaseStyle(listToken), genBorderedStyle(listToken), genResponsiveStyle(listToken)];
   },
-  (token) => ({
-    contentWidth: 220,
-    itemPadding: `${token.paddingContentVertical}px 0`,
-    itemPaddingSM: `${token.paddingContentVerticalSM}px ${token.paddingContentHorizontal}px`,
-    itemPaddingLG: `${token.paddingContentVerticalLG}px ${token.paddingContentHorizontalLG}px`,
-    headerBg: 'transparent',
-    footerBg: 'transparent',
-    emptyTextPadding: token.padding,
-    metaMarginBottom: token.padding,
-    avatarMarginRight: token.padding,
-    titleMarginBottom: token.paddingSM,
-    descriptionFontSize: token.fontSize,
-  }),
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | list support css variable theme |
| 🇨🇳 Chinese | 列表支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 957e6e2</samp>

This pull request enhances the List component to support CSS variables for theming. It introduces a new `useCSSVar` hook that registers and applies the theme tokens as CSS variables. It also refactors the List style to use the `unit` and `token` methods from the `@ant-design/cssinjs` package.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 957e6e2</samp>

*  Add `useCSSVar` hook to register and apply CSS variables for List component based on theme tokens ([link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2R16), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L146-R148), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-015bf7609c9e2715aacae53f1bbf8779c3f64b720462e1efc033b8d2711cd9e2L287-R289), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-414ef311d1d3a1bb819449722ba7262737028220ad44180298ea0280a39c53d8R1-R4))
*  Use `unit` function to convert numeric values to CSS units in List styles ([link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L1-R4), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L83-R83), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L90-R90), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L147-R147), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L254-R254), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L286-R286), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L302-R306), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L310-R314), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L364-R368), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L374-R378), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L382-R389), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L392-R396))
*  Add `prepareComponentToken` function to return default token values for List component in CSS units ([link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4R415-R430), [link](https://github.com/ant-design/ant-design/pull/45795/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L422-R442))
