### PR TITLE
feat: message support cssVar

### DIFF
--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -10,6 +10,8 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { NoticeType } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 export const TypeIcon = {
   info: <InfoCircleFilled />,
@@ -47,12 +49,14 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
   const [, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
-  return (
+  return wrapCSSVar(
     <Notice
       {...restProps}
       prefixCls={prefixCls}
-      className={classNames(className, hashId, `${prefixCls}-notice-pure-panel`)}
+      className={classNames(className, hashId, `${prefixCls}-notice-pure-panel`, rootCls)}
       eventKey="pure"
       duration={null}
       content={
@@ -60,7 +64,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
           {content}
         </PureContent>
       }
-    />
+    />,
   );
 };
 

--- a/components/message/style/cssVar.ts
+++ b/components/message/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Message', prepareComponentToken);

--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -1,9 +1,10 @@
 // deps-lint-skip-all
+import type { CSSProperties } from 'react';
 import type { CSSObject } from '@ant-design/cssinjs';
 import { Keyframes } from '@ant-design/cssinjs';
-import type { CSSProperties } from 'react';
+
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 /** Component only token. Which will handle additional calculation of alias token */
@@ -184,6 +185,14 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
   ];
 };
 
+export const prepareComponentToken: GetDefaultToken<'Message'> = (token) => ({
+  zIndexPopup: token.zIndexPopupBase + 10,
+  contentBg: token.colorBgElevated,
+  contentPadding: `${(token.controlHeightLG - token.fontSize * token.lineHeight) / 2}px ${
+    token.paddingSM
+  }px`,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Message',
@@ -194,11 +203,5 @@ export default genComponentStyleHook(
     });
     return [genMessageStyle(combinedToken)];
   },
-  (token) => ({
-    zIndexPopup: token.zIndexPopupBase + 10,
-    contentBg: token.colorBgElevated,
-    contentPadding: `${(token.controlHeightLG - token.fontSize * token.lineHeight) / 2}px ${
-      token.paddingSM
-    }px`,
-  }),
+  prepareComponentToken,
 );

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -19,6 +19,7 @@ import type {
 import { PureContent } from './PurePanel';
 import useStyle from './style';
 import { getMotion, wrapPromiseFn } from './util';
+import useCSSVar from './style/cssVar';
 
 const DEFAULT_OFFSET = 8;
 const DEFAULT_DURATION = 3;
@@ -37,10 +38,11 @@ interface HolderRef extends NotificationAPI {
 
 const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
   const [, hashId] = useStyle(prefixCls);
-  return (
+  const wrapCSSVar = useCSSVar(prefixCls);
+  return wrapCSSVar(
     <NotificationProvider classNames={{ list: hashId, notice: hashId }}>
       {children}
-    </NotificationProvider>
+    </NotificationProvider>,
   );
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | message support css variable theme |
| 🇨🇳 Chinese | 消息支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ddead7</samp>

The pull request enhances the `message` component to use CSS variables for theming and styling. It refactors the `style` module and adds a new `cssVar.ts` file to generate and register the CSS variables. It also applies custom hooks to the `message` component and its subcomponents to use the CSS variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ddead7</samp>

*  Add hooks to register and use CSS variables for the `Message` component ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dR13-R14), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-cfae8427b441f2db9bc6c6dd586fa4687194d660217c91a6ffa242ac67617988R1-R4), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR188-R195), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R22), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L40-R45))
  - Create a new file `cssVar.ts` in the `style` module that exports a default function to generate a hook for registering the CSS variables ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-cfae8427b441f2db9bc6c6dd586fa4687194d660217c91a6ffa242ac67617988R1-R4))
  - Use the `genCSSVarRegister` and `prepareComponentToken` helpers from the `theme` module to provide the default token values and the hook logic ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-cfae8427b441f2db9bc6c6dd586fa4687194d660217c91a6ffa242ac67617988R1-R4), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfR188-R195))
  - Import the `useCSSVar` hook from the `style` module in the `PurePanel` and `useMessage` files ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dR13-R14), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571R22))
  - Wrap the `Notice` and `NotificationProvider` components with the `useCSSVar` hook to inject the CSS variables into the DOM ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL50-R59), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-f10caed8565868c030122bf62fb528a8d5675950cc705dca494d31375faea571L40-R45))
*  Add a root class name to the `PurePanel` component using the `useCSSVarCls` hook ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dR13-R14), [link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL50-R59))
  - Import the `useCSSVarCls` hook from the `config-provider` module in the `PurePanel` file ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dR13-R14))
  - Use the `useCSSVarCls` hook to generate a root class name based on the prefix class name ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL50-R59))
  - Add the root class name to the `className` prop of the `Notice` component ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL50-R59))
*  Update the import statements in the `style` module ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL2-R7))
  - Add the `GetDefaultToken` type from the `theme` module and remove the unused types ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL2-R7))
  - Move the `CSSProperties` type from the `react` module to the top of the import list ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-8af0be282a46c48f41d0fd430f9b0f81669ae42e3e93d0da8dfd635c6f24b7dfL2-R7))
*  Format the code in the `PurePanel` file using Prettier ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL63-R67))
  - Add a comma after the `Notice` component and move the closing parenthesis to the next line ([link](https://github.com/ant-design/ant-design/pull/45797/files?diff=unified&w=0#diff-5ef9527bc03ddb415b005c0e9154e9e3a14d907149770c69f4ac3312ff9a1e8dL63-R67))
