### PR TITLE
refactor: empty support css var

### DIFF
--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -6,6 +6,7 @@ import DefaultEmptyImg from './empty';
 import SimpleEmptyImg from './simple';
 
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 const defaultEmptyImg = <DefaultEmptyImg />;
 const simpleEmptyImg = <SimpleEmptyImg />;
@@ -45,7 +46,8 @@ const Empty: CompoundedComponent = ({
   const { getPrefixCls, direction, empty } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('empty', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const [locale] = useLocale('Empty');
 
@@ -60,7 +62,7 @@ const Empty: CompoundedComponent = ({
     imageNode = image;
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div
       className={classNames(
         hashId,

--- a/components/empty/style/cssVar.ts
+++ b/components/empty/style/cssVar.ts
@@ -1,0 +1,3 @@
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('Empty', null);

--- a/components/empty/style/index.ts
+++ b/components/empty/style/index.ts
@@ -7,8 +7,8 @@ export interface ComponentToken {}
 
 interface EmptyToken extends FullToken<'Empty'> {
   emptyImgCls: string;
-  emptyImgHeight: number;
-  emptyImgHeightSM: number;
+  emptyImgHeight: number | string;
+  emptyImgHeightSM: number | string;
   emptyImgHeightMD: number;
 }
 
@@ -76,13 +76,13 @@ const genSharedEmptyStyle: GenerateStyle<EmptyToken> = (token): CSSObject => {
 
 // ============================== Export ==============================
 export default genComponentStyleHook('Empty', (token) => {
-  const { componentCls, controlHeightLG } = token;
+  const { componentCls, controlHeightLG, calc } = token;
 
   const emptyToken: EmptyToken = mergeToken<EmptyToken>(token, {
     emptyImgCls: `${componentCls}-img`,
-    emptyImgHeight: controlHeightLG * 2.5,
+    emptyImgHeight: calc(controlHeightLG).mul(2.5).equal(),
     emptyImgHeightMD: controlHeightLG,
-    emptyImgHeightSM: controlHeightLG * 0.875,
+    emptyImgHeightSM: calc(controlHeightLG).mul(0.875).equal(),
   });
 
   return [genSharedEmptyStyle(emptyToken)];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
#45618 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Empty support css variables. |
| 🇨🇳 Chinese | Empty 组件支持 CSS 变量。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b5cf65</samp>

This pull request refactors the `Empty` component to use CSS variables for theme customization and responsive styling. It introduces a new hook `useCSSVar` and a provider component `CSSVarProvider` to manage the CSS variables. It also modifies the `Empty` component's style file to support different height values for the empty image.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b5cf65</samp>

*  Refactor `Empty` component to use CSS variables for theming and styling ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82R9), [link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L48-R50), [link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L63-R65), [link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-deb80d6a7fd9c29fcf53403d2d5f33e740b95cbe38de500cdad03c7f7472ab13R1-R3))
  - Import `useCSSVar` hook from `components/empty/style/cssVar.ts` ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82R9))
  - Replace `wrapSSR` function with `wrapCSSVar` function that provides CSS variables ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L48-R50), [link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L63-R65))
  - Destructure `hashId` from `useStyle` hook to scope CSS variables ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-cdd6df3e3e88506f22edfd2adc91a15baaefdb9f2054e24aeee178c8491c3a82L48-R50))
  - Create `useCSSVar` hook with `genCSSVarRegister` function that registers and updates CSS variables ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-deb80d6a7fd9c29fcf53403d2d5f33e740b95cbe38de500cdad03c7f7472ab13R1-R3))
*  Update `EmptyToken` interface and `genSharedEmptyStyle` function to allow string values for image height properties ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fL10-R11), [link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fL79-R85))
  - Accept either number or string for `emptyImgHeight`, `emptyImgHeightSM`, and `emptyImgHeightMD` properties ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fL10-R11))
  - Use `calc` function and `equal` method to create and convert calc expressions for image height properties ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fL79-R85))
  - Use CSS variables for image height properties in shared style ([link](https://github.com/ant-design/ant-design/pull/45802/files?diff=unified&w=0#diff-19c1cff28e07550d90710c508705cef57f4ccd89959a0db8b1b452e6c6e8173fL79-R85))
