### PR TITLE
feat: tabs support cssVar

### DIFF
--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -14,6 +14,8 @@ import type { SizeType } from '../config-provider/SizeContext';
 import useAnimateConfig from './hooks/useAnimateConfig';
 import useLegacyItems from './hooks/useLegacyItems';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import TabPane, { type TabPaneProps } from './TabPane';
 
 export type TabsType = 'line' | 'card' | 'editable-card';
@@ -53,7 +55,10 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
   const { prefixCls: customizePrefixCls, moreIcon = <EllipsisOutlined /> } = otherProps;
   const { direction, tabs, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+
+  const wrapCSSVar = useCSSVar(rootCls);
 
   let editable: EditableConfig | undefined;
   if (type === 'editable-card') {
@@ -86,7 +91,7 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
 
   const mergedStyle: React.CSSProperties = { ...tabs?.style, ...style };
 
-  return wrapSSR(
+  return wrapCSSVar(
     <RcTabs
       direction={direction}
       getPopupContainer={getPopupContainer}
@@ -104,8 +109,9 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
         className,
         rootClassName,
         hashId,
+        rootCls,
       )}
-      popupClassName={classNames(popupClassName, hashId)}
+      popupClassName={classNames(popupClassName, hashId, rootCls)}
       style={mergedStyle}
       editable={editable}
       moreIcon={moreIcon}

--- a/components/tabs/style/cssVar.ts
+++ b/components/tabs/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Tabs', prepareComponentToken);

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -565,7 +565,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
         order: 0,
         marginRight: {
           _skip_check_: true,
-          value: -token.lineWidth,
+          value: token.calc(token.lineWidth).mul(-1).equal(),
         },
         borderRight: {
           _skip_check_: true,
@@ -700,7 +700,7 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
         flex: 'none',
         marginRight: {
           _skip_check_: true,
-          value: -token.marginXXS,
+          value: token.calc(token.marginXXS).mul(-1).equal(),
         },
         marginLeft: {
           _skip_check_: true,

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -126,11 +126,6 @@ export interface ComponentToken {
    * @descEN Gutter of card tab
    */
   cardGutter: number;
-  /**
-   * @desc 卡片标签的行高
-   * @descEN height of card tab
-   */
-  tabsCardLineHeight: number | string;
 }
 
 export interface TabsToken extends FullToken<'Tabs'> {
@@ -1043,7 +1038,6 @@ export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
     itemHoverColor: token.colorPrimaryHover,
     itemActiveColor: token.colorPrimaryActive,
     cardGutter: token.marginXXS / 2,
-    tabsCardLineHeight: Math.round(token.fontSize * token.lineHeight),
   };
 };
 

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -436,7 +436,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
     [`${componentCls}-bottom`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         order: 1,
-        marginTop: `${unit(margin)}`,
+        marginTop: margin,
         marginBottom: 0,
 
         '&::before': {

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -1,6 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import { genFocusStyle, resetComponent, textEllipsis } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genMotionStyle from './motion';
 
@@ -125,6 +126,11 @@ export interface ComponentToken {
    * @descEN Gutter of card tab
    */
   cardGutter: number;
+  /**
+   * @desc 卡片标签的行高
+   * @descEN height of card tab
+   */
+  tabsCardLineHeight: number | string;
 }
 
 export interface TabsToken extends FullToken<'Tabs'> {
@@ -154,7 +160,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           margin: 0,
           padding: tabsCardPadding,
           background: cardBg,
-          border: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
+          border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           transition: `all ${token.motionDurationSlow} ${token.motionEaseInOut}`,
         },
 
@@ -174,7 +180,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           [`${componentCls}-tab + ${componentCls}-tab`]: {
             marginLeft: {
               _skip_check_: true,
-              value: `${cardGutter}px`,
+              value: unit(cardGutter),
             },
           },
         },
@@ -183,7 +189,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-top`]: {
         [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
-            borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
+            borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
           },
 
           [`${componentCls}-tab-active`]: {
@@ -195,7 +201,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-bottom`]: {
         [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
-            borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
+            borderRadius: `0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
           },
 
           [`${componentCls}-tab-active`]: {
@@ -208,7 +214,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-left, &${componentCls}-right`]: {
         [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
           [`${componentCls}-tab + ${componentCls}-tab`]: {
-            marginTop: `${cardGutter}px`,
+            marginTop: unit(cardGutter),
           },
         },
       },
@@ -218,7 +224,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           [`${componentCls}-tab`]: {
             borderRadius: {
               _skip_check_: true,
-              value: `${token.borderRadiusLG}px 0 0 ${token.borderRadiusLG}px`,
+              value: `${unit(token.borderRadiusLG)} 0 0 ${unit(token.borderRadiusLG)}`,
             },
           },
 
@@ -236,7 +242,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           [`${componentCls}-tab`]: {
             borderRadius: {
               _skip_check_: true,
-              value: `0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px 0`,
+              value: `0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0`,
             },
           },
 
@@ -274,7 +280,7 @@ const genDropdownStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
       [`${componentCls}-dropdown-menu`]: {
         maxHeight: token.tabsDropdownHeight,
         margin: 0,
-        padding: `${dropdownEdgeChildVerticalPadding}px 0`,
+        padding: `${unit(dropdownEdgeChildVerticalPadding)} 0`,
         overflowX: 'hidden',
         overflowY: 'auto',
         textAlign: {
@@ -294,7 +300,7 @@ const genDropdownStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
           alignItems: 'center',
           minWidth: token.tabsDropdownWidth,
           margin: 0,
-          padding: `${token.paddingXXS}px ${token.paddingSM}px`,
+          padding: `${unit(token.paddingXXS)} ${unit(token.paddingSM)}`,
           color: token.colorText,
           fontWeight: 'normal',
           fontSize: token.fontSize,
@@ -368,7 +374,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
             _skip_check_: true,
             value: 0,
           },
-          borderBottom: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
+          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           content: "''",
         },
 
@@ -430,7 +436,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
     [`${componentCls}-bottom`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         order: 1,
-        marginTop: `${margin}px`,
+        marginTop: `${unit(margin)}`,
         marginBottom: 0,
 
         '&::before': {
@@ -451,7 +457,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
     [`${componentCls}-left, ${componentCls}-right`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         flexDirection: 'column',
-        minWidth: token.controlHeight * 1.25,
+        minWidth: token.calc(token.controlHeight).mul(1.25).equal(),
 
         // >>>>>>>>>>> Tab
         [`${componentCls}-tab`]: {
@@ -527,11 +533,11 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
       [`> ${componentCls}-content-holder, > div > ${componentCls}-content-holder`]: {
         marginLeft: {
           _skip_check_: true,
-          value: `-${token.lineWidth}px`,
+          value: `-${unit(token.lineWidth)}`,
         },
         borderLeft: {
           _skip_check_: true,
-          value: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+          value: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
         },
 
         [`> ${componentCls}-content > ${componentCls}-tabpane`]: {
@@ -563,7 +569,7 @@ const genPositionStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject
         },
         borderRight: {
           _skip_check_: true,
-          value: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+          value: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
         },
 
         [`> ${componentCls}-content > ${componentCls}-tabpane`]: {
@@ -615,19 +621,19 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
         },
         [`&${componentCls}-bottom`]: {
           [`> ${componentCls}-nav ${componentCls}-tab`]: {
-            borderRadius: `0 0 ${token.borderRadius}px ${token.borderRadius}px`,
+            borderRadius: `0 0 ${unit(token.borderRadius)} ${unit(token.borderRadius)}`,
           },
         },
         [`&${componentCls}-top`]: {
           [`> ${componentCls}-nav ${componentCls}-tab`]: {
-            borderRadius: `${token.borderRadius}px ${token.borderRadius}px 0 0`,
+            borderRadius: `${unit(token.borderRadius)} ${unit(token.borderRadius)} 0 0`,
           },
         },
         [`&${componentCls}-right`]: {
           [`> ${componentCls}-nav ${componentCls}-tab`]: {
             borderRadius: {
               _skip_check_: true,
-              value: `0 ${token.borderRadius}px ${token.borderRadius}px 0`,
+              value: `0 ${unit(token.borderRadius)} ${unit(token.borderRadius)} 0`,
             },
           },
         },
@@ -635,7 +641,7 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           [`> ${componentCls}-nav ${componentCls}-tab`]: {
             borderRadius: {
               _skip_check_: true,
-              value: `${token.borderRadius}px 0 0 ${token.borderRadius}px`,
+              value: `${unit(token.borderRadius)} 0 0 ${unit(token.borderRadius)}`,
             },
           },
         },
@@ -777,18 +783,18 @@ const genRtlStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
             },
             marginLeft: {
               _skip_check_: true,
-              value: `${token.marginSM}px`,
+              value: unit(token.marginSM),
             },
           },
 
           [`${componentCls}-tab-remove`]: {
             marginRight: {
               _skip_check_: true,
-              value: `${token.marginXS}px`,
+              value: unit(token.marginXS),
             },
             marginLeft: {
               _skip_check_: true,
-              value: `-${token.marginXXS}px`,
+              value: `-${unit(token.marginXXS)}`,
             },
 
             [iconCls]: {
@@ -926,7 +932,7 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
               _skip_check_: true,
               value: 0,
             },
-            height: token.controlHeightLG / 8,
+            height: token.calc(token.controlHeightLG).div(8).equal(),
             transform: 'translateY(100%)',
             content: "''",
           },
@@ -938,10 +944,10 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
             _skip_check_: true,
             value: cardGutter,
           },
-          padding: `0 ${token.paddingXS}px`,
+          padding: `0 ${unit(token.paddingXS)}`,
           background: 'transparent',
-          border: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
-          borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
+          border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
+          borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
           outline: 'none',
           cursor: 'pointer',
           color: token.colorText,
@@ -1005,23 +1011,55 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
+  const cardHeight = token.controlHeightLG;
+
+  return {
+    zIndexPopup: token.zIndexPopupBase + 50,
+    cardBg: token.colorFillAlter,
+    cardHeight,
+    // Initialize with empty string, because cardPadding will be calculated with cardHeight by default.
+    cardPadding: `${
+      (cardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
+    }px ${token.padding}px`,
+    cardPaddingSM: `${token.paddingXXS * 1.5}px ${token.padding}px`,
+    cardPaddingLG: `${token.paddingXS}px ${token.padding}px ${token.paddingXXS * 1.5}px`,
+    titleFontSize: token.fontSize,
+    titleFontSizeLG: token.fontSizeLG,
+    titleFontSizeSM: token.fontSize,
+    inkBarColor: token.colorPrimary,
+    horizontalMargin: `0 0 ${token.margin}px 0`,
+    horizontalItemGutter: 32, // Fixed Value
+    // Initialize with empty string, because horizontalItemMargin will be calculated with horizontalItemGutter by default.
+    horizontalItemMargin: ``,
+    horizontalItemMarginRTL: ``,
+    horizontalItemPadding: `${token.paddingSM}px 0`,
+    horizontalItemPaddingSM: `${token.paddingXS}px 0`,
+    horizontalItemPaddingLG: `${token.padding}px 0`,
+    verticalItemPadding: `${token.paddingXS}px ${token.paddingLG}px`,
+    verticalItemMargin: `${token.margin}px 0 0 0`,
+    itemColor: token.colorText,
+    itemSelectedColor: token.colorPrimary,
+    itemHoverColor: token.colorPrimaryHover,
+    itemActiveColor: token.colorPrimaryActive,
+    cardGutter: token.marginXXS / 2,
+    tabsCardLineHeight: Math.round(token.fontSize * token.lineHeight),
+  };
+};
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Tabs',
   (token) => {
     const tabsToken = mergeToken<TabsToken>(token, {
       // `cardPadding` is empty by default, so we could calculate with dynamic `cardHeight`
-      tabsCardPadding:
-        token.cardPadding ||
-        `${
-          (token.cardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
-        }px ${token.padding}px`,
+      tabsCardPadding: token.cardPadding,
       dropdownEdgeChildVerticalPadding: token.paddingXXS,
       tabsActiveTextShadow: '0 0 0.25px currentcolor',
       tabsDropdownHeight: 200,
       tabsDropdownWidth: 120,
-      tabsHorizontalItemMargin: `0 0 0 ${token.horizontalItemGutter}px`,
-      tabsHorizontalItemMarginRTL: `0 0 0 ${token.horizontalItemGutter}px`,
+      tabsHorizontalItemMargin: `0 0 0 ${unit(token.horizontalItemGutter)}`,
+      tabsHorizontalItemMarginRTL: `0 0 0 ${unit(token.horizontalItemGutter)}`,
     });
 
     return [
@@ -1034,36 +1072,5 @@ export default genComponentStyleHook(
       genMotionStyle(tabsToken),
     ];
   },
-  (token) => {
-    const cardHeight = token.controlHeightLG;
-
-    return {
-      zIndexPopup: token.zIndexPopupBase + 50,
-      cardBg: token.colorFillAlter,
-      cardHeight,
-      // Initialize with empty string, because cardPadding will be calculated with cardHeight by default.
-      cardPadding: ``,
-      cardPaddingSM: `${token.paddingXXS * 1.5}px ${token.padding}px`,
-      cardPaddingLG: `${token.paddingXS}px ${token.padding}px ${token.paddingXXS * 1.5}px`,
-      titleFontSize: token.fontSize,
-      titleFontSizeLG: token.fontSizeLG,
-      titleFontSizeSM: token.fontSize,
-      inkBarColor: token.colorPrimary,
-      horizontalMargin: `0 0 ${token.margin}px 0`,
-      horizontalItemGutter: 32, // Fixed Value
-      // Initialize with empty string, because horizontalItemMargin will be calculated with horizontalItemGutter by default.
-      horizontalItemMargin: ``,
-      horizontalItemMarginRTL: ``,
-      horizontalItemPadding: `${token.paddingSM}px 0`,
-      horizontalItemPaddingSM: `${token.paddingXS}px 0`,
-      horizontalItemPaddingLG: `${token.padding}px 0`,
-      verticalItemPadding: `${token.paddingXS}px ${token.paddingLG}px`,
-      verticalItemMargin: `${token.margin}px 0 0 0`,
-      itemColor: token.colorText,
-      itemSelectedColor: token.colorPrimary,
-      itemHoverColor: token.colorPrimaryHover,
-      itemActiveColor: token.colorPrimaryActive,
-      cardGutter: token.marginXXS / 2,
-    };
-  },
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | tabs support css variable theme |
| 🇨🇳 Chinese | 标签页支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fd6677</samp>

This pull request enhances the tabs component with CSS variables support and refactors its style code. It adds custom hooks and a provider component to enable dynamic theming and customization of the tabs component and its dropdown menu. It also improves the consistency and compatibility of the CSS variables and calculations by using the `@ant-design/cssinjs` package and extracting common functions to separate files.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fd6677</samp>

*  Import and use custom hooks for registering and applying CSS variables for the tabs component ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adR17-R18), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL56-R62), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL89-R94), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-29d06a1647b854ac9e4eff3f5e9f5b25dca5e02a92ddde121a1af24940c767adL107-R114), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-0d8e0ae6ba41e2ef504286c8ca0332f966027ec81ad2b75a3e196ae922b0f52eR1-R4), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7R1014-R1049))
*  Wrap numeric token values with the `unit` function to convert them to CSS units ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L157-R163), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L177-R183), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L186-R192), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L198-R204), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L211-R217), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L221-R227), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L239-R245), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L277-R283), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L297-R303), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L371-R377), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L433-R439), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L454-R460), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L530-R540), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L566-R572), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L618-R629), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L630-R636), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L638-R644), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L780-R786), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L787-R797), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L941-R950))
*  Replace some token values with the `token.calc` function to create CSS calculation expressions ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L454-R460), [link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L929-R935))
*  Add a new token property `tabsCardLineHeight` to the `ComponentToken` interface ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7R129-R133))
*  Replace the `token.cardPadding` value with the `token.tabsCardPadding` value, which is calculated from the `token.cardPadding` value if it is empty ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L1014-R1062))
*  Update the imports in the `style/index.ts` file, replacing the `FullToken` type with the `GetDefaultToken` type and removing the `genComponentStyleHook` import ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L1-R4))
*  Simplify the `genComponentStyleHook` function call by using the `prepareComponentToken` function instead of a function expression ([link](https://github.com/ant-design/ant-design/pull/45803/files?diff=unified&w=0#diff-d2d317a91ba62030532018942e2f2e91ffc533b238fb8017b7bea62d4ac428a7L1037-R1075))
