### PR TITLE
feat: transfer support cssVar

### DIFF
--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -23,6 +23,7 @@ import List from './list';
 import Operation from './operation';
 import Search from './search';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export type { TransferListProps } from './list';
 export type { TransferOperationProps } from './operation';
@@ -151,7 +152,8 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('transfer', customizePrefixCls);
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   // Fill record with `key`
   const [mergedDataSource, leftDataSource, rightDataSource] = useData(
@@ -419,7 +421,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   const [leftTitle, rightTitle] = getTitles(listLocale);
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls} style={{ ...transfer?.style, ...style }}>
       <List<KeyWise<RecordType>>
         prefixCls={`${prefixCls}-list`}

--- a/components/transfer/style/cssVar.ts
+++ b/components/transfer/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Transfer', prepareComponentToken);

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -38,7 +38,6 @@ export interface ComponentToken {
 
 interface TransferToken extends FullToken<'Transfer'> {
   transferHeaderVerticalPadding: number;
-  emptyImageLineHeight: number;
 }
 
 const genTransferCustomizeStyle: GenerateStyle<TransferToken> = (
@@ -324,7 +323,7 @@ const genTransferStyle: GenerateStyle<TransferToken> = (token: TransferToken): C
     marginXXS,
     fontSizeIcon,
     colorBgContainerDisabled,
-    emptyImageLineHeight,
+    fontHeight,
   } = token;
 
   return {
@@ -368,7 +367,7 @@ const genTransferStyle: GenerateStyle<TransferToken> = (token: TransferToken): C
         // headerHeight / 2 - Math.round(fontSize * lineHeight)
         maxHeight: token
           .calc(token.calc(headerHeight).div(2).equal())
-          .sub(emptyImageLineHeight)
+          .sub(fontHeight)
           .equal(),
       },
     },
@@ -395,7 +394,6 @@ export const prepareComponentToken: GetDefaultToken<'Transfer'> = (token) => {
     itemHeight: controlHeight,
     itemPaddingBlock: (controlHeight - fontHeight) / 2,
     transferHeaderVerticalPadding: Math.ceil((controlHeightLG - lineWidth - fontHeight) / 2),
-    emptyImageLineHeight: Math.round(fontSize * lineHeight),
   };
 };
 

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -1,6 +1,6 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 import { resetComponent, resetIcon, textEllipsis } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -38,6 +38,7 @@ export interface ComponentToken {
 
 interface TransferToken extends FullToken<'Transfer'> {
   transferHeaderVerticalPadding: number;
+  emptyImageLineHeight: number;
 }
 
 const genTransferCustomizeStyle: GenerateStyle<TransferToken> = (
@@ -70,7 +71,7 @@ const genTransferCustomizeStyle: GenerateStyle<TransferToken> = (
         },
 
         [`${tableCls}-pagination${tableCls}-pagination`]: {
-          margin: `${margin}px 0 ${marginXXS}px`,
+          margin: `${unit(margin)} 0 ${unit(marginXXS)}`,
         },
       },
 
@@ -140,7 +141,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     flexDirection: 'column',
     width: listWidth,
     height: listHeight,
-    border: `${lineWidth}px ${lineType} ${colorBorder}`,
+    border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
     borderRadius: token.borderRadiusLG,
 
     '&-with-pagination': {
@@ -160,13 +161,13 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       alignItems: 'center',
       height: headerHeight,
       // border-top is on the transfer dom. We should minus 1px for this
-      padding: `${
-        transferHeaderVerticalPadding - lineWidth
-      }px ${paddingSM}px ${transferHeaderVerticalPadding}px`,
+      padding: `${unit(token.calc(transferHeaderVerticalPadding).sub(lineWidth).equal())} ${unit(
+        paddingSM,
+      )} ${unit(transferHeaderVerticalPadding)}`,
       color: colorText,
       background: colorBgContainer,
-      borderBottom: `${lineWidth}px ${lineType} ${colorSplit}`,
-      borderRadius: `${borderRadiusLG}px ${borderRadiusLG}px 0 0`,
+      borderBottom: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
+      borderRadius: `${unit(borderRadiusLG)} ${unit(borderRadiusLG)} 0 0`,
 
       '> *:not(:last-child)': {
         marginInlineEnd: 4, // This is magic and fixed number, DO NOT use token since it may change.
@@ -221,7 +222,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
         display: 'flex',
         alignItems: 'center',
         minHeight: itemHeight,
-        padding: `${itemPaddingBlock}px ${paddingSM}px`,
+        padding: `${unit(itemPaddingBlock)} ${unit(paddingSM)}`,
         transition: `all ${motionDurationSlow}`,
 
         '> *:not(:last-child)': {
@@ -250,7 +251,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
 
           '&::after': {
             position: 'absolute',
-            inset: `-${itemPaddingBlock}px -50%`,
+            inset: `-${unit(itemPaddingBlock)} -50%`,
             content: '""',
           },
         },
@@ -285,9 +286,9 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     },
 
     '&-pagination': {
-      padding: `${token.paddingXS}px 0`,
+      padding: `${unit(token.paddingXS)} 0`,
       textAlign: 'end',
-      borderTop: `${lineWidth}px ${lineType} ${colorSplit}`,
+      borderTop: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
 
       [`${antCls}-pagination-options`]: {
         paddingInlineEnd: token.paddingXS,
@@ -303,7 +304,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     },
 
     '&-footer': {
-      borderTop: `${lineWidth}px ${lineType} ${colorSplit}`,
+      borderTop: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
     },
 
     // fix: https://github.com/ant-design/ant-design/issues/44489
@@ -322,9 +323,8 @@ const genTransferStyle: GenerateStyle<TransferToken> = (token: TransferToken): C
     marginXS,
     marginXXS,
     fontSizeIcon,
-    fontSize,
-    lineHeight,
     colorBgContainerDisabled,
+    emptyImageLineHeight,
   } = token;
 
   return {
@@ -348,7 +348,7 @@ const genTransferStyle: GenerateStyle<TransferToken> = (token: TransferToken): C
         flex: 'none',
         flexDirection: 'column',
         alignSelf: 'center',
-        margin: `0 ${marginXS}px`,
+        margin: `0 ${unit(marginXS)}`,
         verticalAlign: 'middle',
 
         [`${antCls}-btn`]: {
@@ -365,7 +365,11 @@ const genTransferStyle: GenerateStyle<TransferToken> = (token: TransferToken): C
       },
 
       [`${antCls}-empty-image`]: {
-        maxHeight: headerHeight / 2 - Math.round(fontSize * lineHeight),
+        // headerHeight / 2 - Math.round(fontSize * lineHeight)
+        maxHeight: token
+          .calc(token.calc(headerHeight).div(2).equal())
+          .sub(emptyImageLineHeight)
+          .equal(),
       },
     },
   };
@@ -380,15 +384,26 @@ const genTransferRTLStyle: GenerateStyle<TransferToken> = (token: TransferToken)
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Transfer'> = (token) => {
+  const { fontSize, lineHeight, controlHeight, controlHeightLG, lineWidth } = token;
+  const fontHeight = Math.round(fontSize * lineHeight);
+  return {
+    listWidth: 180,
+    listHeight: 200,
+    listWidthLG: 250,
+    headerHeight: controlHeightLG,
+    itemHeight: controlHeight,
+    itemPaddingBlock: (controlHeight - fontHeight) / 2,
+    transferHeaderVerticalPadding: Math.ceil((controlHeightLG - lineWidth - fontHeight) / 2),
+    emptyImageLineHeight: Math.round(fontSize * lineHeight),
+  };
+};
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Transfer',
   (token) => {
-    const { fontSize, lineHeight, lineWidth, controlHeightLG } = token;
-    const fontHeight = Math.round(fontSize * lineHeight);
-    const transferToken = mergeToken<TransferToken>(token, {
-      transferHeaderVerticalPadding: Math.ceil((controlHeightLG - lineWidth - fontHeight) / 2),
-    });
+    const transferToken = mergeToken<TransferToken>(token);
 
     return [
       genTransferStyle(transferToken),
@@ -397,16 +412,5 @@ export default genComponentStyleHook(
       genTransferRTLStyle(transferToken),
     ];
   },
-  (token) => {
-    const { fontSize, lineHeight, controlHeight, controlHeightLG } = token;
-    const fontHeight = Math.round(fontSize * lineHeight);
-    return {
-      listWidth: 180,
-      listHeight: 200,
-      listWidthLG: 250,
-      headerHeight: controlHeightLG,
-      itemHeight: controlHeight,
-      itemPaddingBlock: (controlHeight - fontHeight) / 2,
-    };
-  },
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | transfer support css variable theme |
| 🇨🇳 Chinese | 穿梭框支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b223818</samp>

This pull request enhances the transfer component by using CSS variables to adapt to different themes. It adds a new hook `useCSSVar` and a new component `CSSVarProvider` to manage the CSS variables, and refactors the style generation code to use theme-related functions and avoid hard-coded values. It also updates the `index.tsx` and `style/index.ts` files to use these new features.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b223818</samp>

*  Add `useCSSVar` hook to register and update CSS variables for transfer component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-b1508fd5c579390b9a5dbae856db6319cbd6da68249efebd454aab0a3bb81fe7R1-R4), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdR26), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdL154-R156), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdL422-R424))
*  Replace `wrapSSR` function with `wrapCSSVar` function to wrap component with `CSSVarProvider` that provides CSS variables to children ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdL154-R156), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-16f601b16a2f3b1d448af36a6b569c1d47bf9e2c351318a3b986c42fcbc5b7fdL422-R424))
*  Import `unit` function from `@ant-design/cssinjs` module to convert numeric values to CSS units with default unit being `px` ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL1-R3))
*  Import `GetDefaultToken` type from theme internal module to define `prepareComponentToken` function that returns default token for transfer component ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL1-R3))
*  Use `unit` function to convert various values to CSS units in `genTransferCustomizeStyle`, `genTransferListStyle`, and `genTransferStyle` functions ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL73-R74), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL143-R144), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL163-R170), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL224-R225), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL253-R254), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL288-R291), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL306-R307), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL351-R351), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL368-R372))
*  Add `emptyImageLineHeight` property to `TransferToken` interface and use it to calculate maximum height of empty image in transfer component ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbR41), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL325-R327), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL368-R372))
*  Remove unused and redundant properties from token destructuring in `genTransferStyle` and `genComponentStyleHook` functions ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL325-R327), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL383-R406), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL400-R415))
*  Replace inline calculation of default token for transfer component with `prepareComponentToken` function in `genComponentStyleHook` function ([link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL383-R406), [link](https://github.com/ant-design/ant-design/pull/45804/files?diff=unified&w=0#diff-d9d90f3711c4b10ecac467dc5d915fd5e15d8398916ed340a5ca70968394f2cbL400-R415))
