### PR TITLE
feat: Flex support cssVar

### DIFF
--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -7,6 +7,7 @@ import { ConfigContext } from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import type { FlexProps } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import createFlexClassNames from './utils';
 
 const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
@@ -31,7 +32,8 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('flex', customizePrefixCls);
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const mergedVertical = vertical ?? ctxFlex?.vertical;
 
@@ -59,7 +61,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     mergedStyle.gap = gap;
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <Component
       ref={ref}
       className={mergedCls}

--- a/components/flex/style/cssVar.ts
+++ b/components/flex/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Flex'>('Flex', prepareComponentToken);

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -1,5 +1,4 @@
 import type { CSSInterpolation } from '@ant-design/cssinjs';
-import { unit } from '@ant-design/cssinjs';
 
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -1,6 +1,7 @@
 import type { CSSInterpolation } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import { alignItemsValues, flexWrapValues, justifyContentValues } from '../utils';
 
@@ -16,21 +17,21 @@ export interface FlexToken extends FullToken<'Flex'> {
    * @desc 控制元素的小间隙。
    * @descEN Control the small gap of the element.
    */
-  flexGapSM: number;
+  flexGapSM: number | string;
   /**
    * @nameZH 间隙
    * @nameEN Gap
    * @desc 控制元素的间隙。
    * @descEN Control the gap of the element.
    */
-  flexGap: number;
+  flexGap: number | string;
   /**
    * @nameZH 大间隙
    * @nameEN Large Gap
    * @desc 控制元素的大间隙。
    * @descEN Control the large gap of the element.
    */
-  flexGapLG: number;
+  flexGapLG: number | string;
 }
 
 const genFlexStyle: GenerateStyle<FlexToken> = (token) => {
@@ -56,13 +57,13 @@ const genFlexGapStyle: GenerateStyle<FlexToken> = (token) => {
   return {
     [componentCls]: {
       '&-gap-small': {
-        gap: token.flexGapSM,
+        gap: unit(token.flexGapSM),
       },
       '&-gap-middle': {
-        gap: token.flexGap,
+        gap: unit(token.flexGap),
       },
       '&-gap-large': {
-        gap: token.flexGapLG,
+        gap: unit(token.flexGapLG),
       },
     },
   };
@@ -95,11 +96,21 @@ const genJustifyContentStyle: GenerateStyle<FlexToken> = (token) => {
   return justifyStyle;
 };
 
+export const prepareComponentToken: GetDefaultToken<'Flex'> = (token) => {
+  const { paddingXS, padding, paddingLG } = token;
+  return {
+    flexGapSM: unit(paddingXS),
+    flexGap: unit(padding),
+    flexGapLG: unit(paddingLG),
+  };
+};
+
 export default genComponentStyleHook<'Flex'>('Flex', (token) => {
+  const { paddingXS, padding, paddingLG } = token;
   const flexToken = mergeToken<FlexToken>(token, {
-    flexGapSM: token.paddingXS,
-    flexGap: token.padding,
-    flexGapLG: token.paddingLG,
+    flexGapSM: unit(paddingXS),
+    flexGap: unit(padding),
+    flexGapLG: unit(paddingLG),
   });
   return [
     genFlexStyle(flexToken),

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -17,21 +17,21 @@ export interface FlexToken extends FullToken<'Flex'> {
    * @desc 控制元素的小间隙。
    * @descEN Control the small gap of the element.
    */
-  flexGapSM: number | string;
+  flexGapSM: number;
   /**
    * @nameZH 间隙
    * @nameEN Gap
    * @desc 控制元素的间隙。
    * @descEN Control the gap of the element.
    */
-  flexGap: number | string;
+  flexGap: number;
   /**
    * @nameZH 大间隙
    * @nameEN Large Gap
    * @desc 控制元素的大间隙。
    * @descEN Control the large gap of the element.
    */
-  flexGapLG: number | string;
+  flexGapLG: number;
 }
 
 const genFlexStyle: GenerateStyle<FlexToken> = (token) => {

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -57,13 +57,13 @@ const genFlexGapStyle: GenerateStyle<FlexToken> = (token) => {
   return {
     [componentCls]: {
       '&-gap-small': {
-        gap: unit(token.flexGapSM),
+        gap: token.flexGapSM,
       },
       '&-gap-middle': {
-        gap: unit(token.flexGap),
+        gap: token.flexGap,
       },
       '&-gap-large': {
-        gap: unit(token.flexGapLG),
+        gap: token.flexGapLG,
       },
     },
   };
@@ -96,27 +96,24 @@ const genJustifyContentStyle: GenerateStyle<FlexToken> = (token) => {
   return justifyStyle;
 };
 
-export const prepareComponentToken: GetDefaultToken<'Flex'> = (token) => {
-  const { paddingXS, padding, paddingLG } = token;
-  return {
-    flexGapSM: unit(paddingXS),
-    flexGap: unit(padding),
-    flexGapLG: unit(paddingLG),
-  };
-};
+export const prepareComponentToken: GetDefaultToken<'Flex'> = () => ({});
 
-export default genComponentStyleHook<'Flex'>('Flex', (token) => {
-  const { paddingXS, padding, paddingLG } = token;
-  const flexToken = mergeToken<FlexToken>(token, {
-    flexGapSM: unit(paddingXS),
-    flexGap: unit(padding),
-    flexGapLG: unit(paddingLG),
-  });
-  return [
-    genFlexStyle(flexToken),
-    genFlexGapStyle(flexToken),
-    genFlexWrapStyle(flexToken),
-    genAlignItemsStyle(flexToken),
-    genJustifyContentStyle(flexToken),
-  ];
-});
+export default genComponentStyleHook<'Flex'>(
+  'Flex',
+  (token) => {
+    const { paddingXS, padding, paddingLG } = token;
+    const flexToken = mergeToken<FlexToken>(token, {
+      flexGapSM: unit(paddingXS),
+      flexGap: unit(padding),
+      flexGapLG: unit(paddingLG),
+    });
+    return [
+      genFlexStyle(flexToken),
+      genFlexGapStyle(flexToken),
+      genFlexWrapStyle(flexToken),
+      genAlignItemsStyle(flexToken),
+      genJustifyContentStyle(flexToken),
+    ];
+  },
+  prepareComponentToken,
+);

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -57,13 +57,13 @@ const genFlexGapStyle: GenerateStyle<FlexToken> = (token) => {
   return {
     [componentCls]: {
       '&-gap-small': {
-        gap: token.flexGapSM,
+        gap: unit(token.flexGapSM),
       },
       '&-gap-middle': {
-        gap: token.flexGap,
+        gap: unit(token.flexGap),
       },
       '&-gap-large': {
-        gap: token.flexGapLG,
+        gap: unit(token.flexGapLG),
       },
     },
   };
@@ -103,9 +103,9 @@ export default genComponentStyleHook<'Flex'>(
   (token) => {
     const { paddingXS, padding, paddingLG } = token;
     const flexToken = mergeToken<FlexToken>(token, {
-      flexGapSM: unit(paddingXS),
-      flexGap: unit(padding),
-      flexGapLG: unit(paddingLG),
+      flexGapSM: paddingXS,
+      flexGap: padding,
+      flexGapLG: paddingLG,
     });
     return [
       genFlexStyle(flexToken),

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -57,13 +57,13 @@ const genFlexGapStyle: GenerateStyle<FlexToken> = (token) => {
   return {
     [componentCls]: {
       '&-gap-small': {
-        gap: unit(token.flexGapSM),
+        gap: token.flexGapSM,
       },
       '&-gap-middle': {
-        gap: unit(token.flexGap),
+        gap: token.flexGap,
       },
       '&-gap-large': {
-        gap: unit(token.flexGapLG),
+        gap: token.flexGapLG,
       },
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Flex support cssVar |
| 🇨🇳 Chinese | feat: Flex 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be38ffc</samp>

This pull request enhances the Flex component with CSS variable support and gap unit flexibility. It adds a `useCSSVar` hook and a `wrapCSSVar` function to `components/flex/index.tsx` and `components/flex/style/cssVar.ts`, and refactors the gap properties to use the `unit` function in `components/flex/style/index.ts`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be38ffc</samp>

*  Add `useCSSVar` hook to register and apply CSS variables for Flex component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-45e789193fd221f1b3b5011163fa049a6979d74beeed4c4332141410de92b5c3R1-R4), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-cea2f22573af518c55b2f15e06b7036fba976af8df45c0dc0e0b74eb5f91f6d4R10), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-cea2f22573af518c55b2f15e06b7036fba976af8df45c0dc0e0b74eb5f91f6d4L34-R36), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-cea2f22573af518c55b2f15e06b7036fba976af8df45c0dc0e0b74eb5f91f6d4L62-R64))
*  Replace `wrapSSR` function with `wrapCSSVar` function to wrap Flex component with CSS variable provider for both server-side and client-side rendering ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-cea2f22573af518c55b2f15e06b7036fba976af8df45c0dc0e0b74eb5f91f6d4L34-R36), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-cea2f22573af518c55b2f15e06b7036fba976af8df45c0dc0e0b74eb5f91f6d4L62-R64))
*  Move `index.ts` file from `style` folder to root folder of Flex component to simplify import path and align with convention ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL2-R4))
*  Allow `flexGapSM`, `flexGap`, and `flexGapLG` properties of `FlexToken` interface to accept either number or string to support both pixel and relative units for Flex gap ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL19-R20), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL26-R27), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL33-R34))
*  Use `unit` function to convert numeric values of `flexGapSM`, `flexGap`, and `flexGapLG` properties to CSS units in `genFlexGapStyle` function and `prepareComponentToken` function ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL59-R66), [link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL98-R113))
*  Pass `prepareComponentToken` function to `useCSSVar` hook to generate CSS variables for Flex component ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL98-R113))
*  Use `unit` function to convert numeric values of `flexGapSM`, `flexGap`, and `flexGapLG` properties to CSS units in `genComponentStyleHook` function ([link](https://github.com/ant-design/ant-design/pull/45805/files?diff=unified&w=0#diff-623c3df51cd5ea52d992660be5725570778e24166525a55d44caba483cf539aeL98-R113))