### PR TITLE
docs: update Next.js docs

### DIFF
--- a/docs/react/server-side-rendering.en-US.md
+++ b/docs/react/server-side-rendering.en-US.md
@@ -16,13 +16,14 @@ There are two options for server-side rendering styles, each with advantages and
 Use `@ant-design/cssinjs` to extract style:
 
 ```tsx
+import React from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import type Entity from '@ant-design/cssinjs/es/Cache';
 import { renderToString } from 'react-dom/server';
 
-export default () => {
+const App = () => {
   // SSR Render
-  const cache = createCache();
-
+  const cache = React.useMemo<Entity>(() => createCache(), []);
   const html = renderToString(
     <StyleProvider cache={cache}>
       <MyApp />
@@ -34,17 +35,19 @@ export default () => {
 
   // Mix with style
   return `
-<!DOCTYPE html>
-<html>
-  <head>
-    ${styleText}
-  </head>
-  <body>
-    <div id="root">${html}</div>
-  </body>
-</html>
-`;
+    <!DOCTYPE html>
+    <html>
+      <head>
+        ${styleText}
+      </head>
+      <body>
+        <div id="root">${html}</div>
+      </body>
+    </html>
+  `;
 };
+
+export default App;
 ```
 
 ## Whole Export
@@ -89,8 +92,8 @@ If you want to use mixed themes or custom themes, you can use the following scri
 
 ```tsx
 import fs from 'fs';
-import { extractStyle } from '@ant-design/static-style-extract';
 import React from 'react';
+import { extractStyle } from '@ant-design/static-style-extract';
 import { ConfigProvider } from 'antd';
 
 const outputPath = './public/antd.min.css';
@@ -155,6 +158,7 @@ Then, you just need to import this file into the `pages/_app.tsx` file:
 ```tsx
 import { StyleProvider } from '@ant-design/cssinjs';
 import type { AppProps } from 'next/app';
+
 import '../public/antd.min.css'; // add this line
 import '../styles/globals.css';
 
@@ -237,8 +241,8 @@ More about static-style-extract, see [static-style-extract](https://github.com/a
 import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import type Entity from '@ant-design/cssinjs/lib/Cache';
 import { extractStyle } from '@ant-design/cssinjs';
+import type Entity from '@ant-design/cssinjs/lib/Cache';
 
 export type DoExtraStyleOptions = {
   cache: Entity;
@@ -280,9 +284,10 @@ Export on demand using the above tools in `_document.tsx`
 
 ```tsx
 // _document.tsx
-import { StyleProvider, createCache } from '@ant-design/cssinjs';
+import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import type { DocumentContext } from 'next/document';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
+
 import { doExtraStyle } from '../scripts/genAntdCss';
 
 export default class MyDocument extends Document {

--- a/docs/react/server-side-rendering.zh-CN.md
+++ b/docs/react/server-side-rendering.zh-CN.md
@@ -16,13 +16,14 @@ tag: New
 使用 `@ant-design/cssinjs` 将所需样式抽离：
 
 ```tsx
+import React from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import type Entity from '@ant-design/cssinjs/es/Cache';
 import { renderToString } from 'react-dom/server';
 
-export default () => {
+const App = () => {
   // SSR Render
-  const cache = createCache();
-
+  const cache = React.useMemo<Entity>(() => createCache(), []);
   const html = renderToString(
     <StyleProvider cache={cache}>
       <MyApp />
@@ -34,17 +35,19 @@ export default () => {
 
   // Mix with style
   return `
-<!DOCTYPE html>
-<html>
-  <head>
-    ${styleText}
-  </head>
-  <body>
-    <div id="root">${html}</div>
-  </body>
-</html>
-`;
+    <!DOCTYPE html>
+    <html>
+      <head>
+        ${styleText}
+      </head>
+      <body>
+        <div id="root">${html}</div>
+      </body>
+    </html>
+  `;
 };
+
+export default App;
 ```
 
 ## 整体导出
@@ -89,8 +92,8 @@ fs.writeFileSync(outputPath, css);
 
 ```tsx
 import fs from 'fs';
-import { extractStyle } from '@ant-design/static-style-extract';
 import React from 'react';
+import { extractStyle } from '@ant-design/static-style-extract';
 import { ConfigProvider } from 'antd';
 
 const outputPath = './public/antd.min.css';
@@ -155,6 +158,7 @@ fs.writeFileSync(outputPath, css);
 ```tsx
 import { StyleProvider } from '@ant-design/cssinjs';
 import type { AppProps } from 'next/app';
+
 import '../public/antd.min.css'; // 添加这行
 import '../styles/globals.css';
 
@@ -237,8 +241,8 @@ const cssText = extractStyle((node) => (
 import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import type Entity from '@ant-design/cssinjs/lib/Cache';
 import { extractStyle } from '@ant-design/cssinjs';
+import type Entity from '@ant-design/cssinjs/lib/Cache';
 
 export type DoExtraStyleOptions = {
   cache: Entity;
@@ -280,9 +284,10 @@ export function doExtraStyle({
 
 ```tsx
 // _document.tsx
-import { StyleProvider, createCache } from '@ant-design/cssinjs';
+import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import type { DocumentContext } from 'next/document';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
+
 import { doExtraStyle } from '../scripts/genAntdCss';
 
 export default class MyDocument extends Document {

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -67,16 +67,20 @@ If you are using the App Router in Next.js and using antd as your component libr
 
 import React from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
-// if you are using Next.js 14, use below import instead. More info: https://github.com/ant-design/ant-design/issues/45567
-// import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs/lib';
 import type Entity from '@ant-design/cssinjs/es/Cache';
 import { useServerInsertedHTML } from 'next/navigation';
 
 const StyledComponentsRegistry = ({ children }: React.PropsWithChildren) => {
   const cache = React.useMemo<Entity>(() => createCache(), []);
-  useServerInsertedHTML(() => (
-    <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
-  ));
+  const isServerInserted = React.useRef<boolean>(false);
+  useServerInsertedHTML(() => {
+    // avoid duplicate css insert
+    if (isServerInserted.current) {
+      return;
+    }
+    isServerInserted.current = true;
+    return <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />;
+  });
   return <StyleProvider cache={cache}>{children}</StyleProvider>;
 };
 

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -33,9 +33,8 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```tsx
-'use client';
+'use client'; // If used in Pages Router, is no need to add "use client"
 
-// If used in Pages Router, is no need to add "use client"
 import React from 'react';
 import { Button } from 'antd';
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -67,16 +67,20 @@ export default Home;
 
 import React from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
-// 如果您使用的是 Next.js 14，请改用下面的导入。更多信息： https://github.com/ant-design/ant-design/issues/45567
-// import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs/lib';
 import type Entity from '@ant-design/cssinjs/es/Cache';
 import { useServerInsertedHTML } from 'next/navigation';
 
 const StyledComponentsRegistry = ({ children }: React.PropsWithChildren) => {
   const cache = React.useMemo<Entity>(() => createCache(), []);
-  useServerInsertedHTML(() => (
-    <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
-  ));
+  const isServerInserted = React.useRef<boolean>(false);
+  useServerInsertedHTML(() => {
+    // 避免 css 重复插入
+    if (isServerInserted.current) {
+      return;
+    }
+    isServerInserted.current = true;
+    return <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />;
+  });
   return <StyleProvider cache={cache}>{children}</StyleProvider>;
 };
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -33,9 +33,8 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```tsx
-'use client';
+'use client'; // 如果是在 Pages Router 中使用，则不需要添加 "use client"
 
-// 如果是在 Pages Router 中使用，则不需要添加 "use client"
 import React from 'react';
 import { Button } from 'antd';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | docs: update Next.js docs |
| 🇨🇳 Chinese | docs: update Next.js docs |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8706fe8</samp>

This pull request improves the documentation for server-side rendering and Next.js integration with Ant Design. It fixes some errors, updates some examples, and synchronizes the English and Chinese versions. It also addresses a style bug in `use-with-next.en-US.md`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8706fe8</samp>

*  Add React import, App component and Entity type to inline style examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132L19-R26), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4L19-R26))
*  Add export default App and indent HTML template in inline style examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132L37-R50), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4L37-R50))
*  Swap the order of React and extractStyle imports in whole export examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132L92-R96), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4L92-R96))
*  Fix markdown syntax error by adding an empty code block in whole export examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132R161), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4R161))
*  Swap the order of extractStyle and Entity imports in extract on demand examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132L240-R245), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4L240-R245))
*  Add a blank line between imports and doExtraStyle function in extract on demand examples in both English and Chinese documents ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-fb14d202bae9942d931d5bc23e403272164c27e27ae7e8cafe75da866c9c1132L283-R290), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-d075c199614f1086c766a83821a217cc494c698e0ac6b7c8cbfe8b53602bedd4L283-R290))
*  Remove comment about Next.js 14 in use with Next.js documents in both languages ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L70-L71), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L70-L71))
*  Add useRef hook and condition to avoid duplicate css insertion in use with Next.js documents in both languages ([link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L77-R83), [link](https://github.com/ant-design/ant-design/pull/45811/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L77-R83))
