### PR TITLE
Update docs about Next.js 14 with antd

### DIFF
--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -65,18 +65,24 @@ If you are using the App Router in Next.js and using antd as your component libr
 ```tsx
 'use client';
 
-import React from 'react';
+import React, { useRef }  from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
-// if you are using Next.js 14, use below import instead. More info: https://github.com/ant-design/ant-design/issues/45567
-// import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs/lib';
 import type Entity from '@ant-design/cssinjs/es/Cache';
 import { useServerInsertedHTML } from 'next/navigation';
 
 const StyledComponentsRegistry = ({ children }: React.PropsWithChildren) => {
   const cache = React.useMemo<Entity>(() => createCache(), []);
-  useServerInsertedHTML(() => (
-    <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
-  ));
+  const isInsert = useRef(false);
+
+  useServerInsertedHTML(() => {
+    // avoid duplicate css insert
+    // refs: https://github.com/vercel/next.js/discussions/49354#discussioncomment-6279917
+    if (isInsert.current) return;
+    isInsert.current = true;
+
+    return <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
+  })
+
   return <StyleProvider cache={cache}>{children}</StyleProvider>;
 };
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -65,18 +65,24 @@ export default Home;
 ```tsx
 'use client';
 
-import React from 'react';
+import React, { useRef }  from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
-// 如果您使用的是 Next.js 14，请改用下面的导入。更多信息： https://github.com/ant-design/ant-design/issues/45567
-// import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs/lib';
 import type Entity from '@ant-design/cssinjs/es/Cache';
 import { useServerInsertedHTML } from 'next/navigation';
 
 const StyledComponentsRegistry = ({ children }: React.PropsWithChildren) => {
   const cache = React.useMemo<Entity>(() => createCache(), []);
-  useServerInsertedHTML(() => (
-    <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
-  ));
+  const isInsert = useRef(false);
+
+  useServerInsertedHTML(() => {
+    // 避免重复的CSS插入
+    // 参考文献：https://github.com/vercel/next.js/discussions/49354#discussioncomment-6279917
+    if (isInsert.current) return;
+    isInsert.current = true;
+
+    return <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache, true) }} />
+  })
+
   return <StyleProvider cache={cache}>{children}</StyleProvider>;
 };
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [X] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/45567

### 💡 Background and solution

Update docs, so other developers won't be confused

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Updated docs about usage antd with Next.js 14      |
| 🇨🇳 Chinese |    更新了有关使用 antd 和 Next.js 14 的文档       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfcac7d</samp>

Improved the documentation and code examples for using Ant Design with Next.js. Fixed some bugs and added some features to handle CSS insertion and style mismatch.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfcac7d</samp>

* Remove unnecessary import of `@ant-design/cssinjs/lib` and add `useRef` hook to store CSS insertion flag for Next.js 14 compatibility ([link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L68-R69), [link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L68-R69))
* Modify `useServerInsertedHTML` hook to check CSS insertion flag and prevent duplicate CSS insertion when navigating between pages ([link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L77-R85), [link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L77-R85))
* Add and translate comments to explain the reason for the hook modification and provide a reference to the related discussion on Next.js GitHub ([link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L77-R85), [link](https://github.com/ant-design/ant-design/pull/45812/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L77-R85))
