### PR TITLE
feat: tree support cssVar

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -10,6 +10,7 @@ import type { DataNode, Key } from 'rc-tree/lib/interface';
 import initCollapseMotion from '../_util/motion';
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import dropIndicatorRender from './utils/dropIndicator';
 import SwitcherIconCom from './utils/iconUtil';
 
@@ -193,7 +194,8 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     dropIndicatorRender,
   };
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const draggableConfig = React.useMemo(() => {
     if (!draggable) {
@@ -229,7 +231,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     />
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <RcTree
       itemHeight={20}
       ref={ref}

--- a/components/tree/style/cssVar.ts
+++ b/components/tree/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Tree', prepareComponentToken);

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -1,10 +1,11 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
 import { genFocusOutline, resetComponent } from '../../style';
 import { genCollapseMotion } from '../../style/motion';
-import type { AliasToken, DerivativeToken, FullToken } from '../../theme/internal';
+import type { AliasToken, DerivativeToken, FullToken, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import type { CSSUtil } from '../../theme/util/genComponentStyleHook';
 
 export interface TreeSharedToken {
   /**
@@ -78,7 +79,7 @@ const getDropIndicatorStyle = (prefixCls: string, token: DerivativeToken) => ({
       width: 8,
       height: 8,
       backgroundColor: 'transparent',
-      border: `${token.lineWidthBold}px solid ${token.colorPrimary}`,
+      border: `${unit(token.lineWidthBold)} solid ${token.colorPrimary}`,
       borderRadius: '50%',
       content: '""',
     },
@@ -89,7 +90,7 @@ const getDropIndicatorStyle = (prefixCls: string, token: DerivativeToken) => ({
 type TreeToken = FullToken<'Tree'> & {
   treeCls: string;
   treeNodeCls: string;
-  treeNodePadding: number;
+  treeNodePadding: number | string;
 };
 
 export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => {
@@ -161,7 +162,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeNodeCls}`]: {
         display: 'flex',
         alignItems: 'flex-start',
-        padding: `0 0 ${treeNodePadding}px 0`,
+        padding: `0 0 ${unit(treeNodePadding)} 0`,
         outline: 'none',
 
         '&-rtl': {
@@ -194,7 +195,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             // https://github.com/ant-design/ant-design/issues/41915
             flexShrink: 0,
             width: titleHeight,
-            lineHeight: `${titleHeight}px`,
+            lineHeight: `${unit(titleHeight)}`,
             textAlign: 'center',
             visibility: 'visible',
             opacity: 0.2,
@@ -237,7 +238,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         alignSelf: 'stretch',
         width: titleHeight,
         margin: 0,
-        lineHeight: `${titleHeight}px`,
+        lineHeight: `${unit(titleHeight)}`,
         textAlign: 'center',
         cursor: 'pointer',
         userSelect: 'none',
@@ -269,7 +270,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           '&:before': {
             position: 'absolute',
             top: 0,
-            insetInlineEnd: titleHeight / 2,
+            insetInlineEnd: token.calc(titleHeight).div(2).equal(),
             bottom: -treeNodePadding,
             marginInlineStart: -1,
             borderInlineEnd: `1px solid ${token.colorBorder}`,
@@ -278,8 +279,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
           '&:after': {
             position: 'absolute',
-            width: (titleHeight / 2) * 0.8,
-            height: titleHeight / 2,
+            width: token.calc(token.calc(titleHeight).div(2).equal()).mul(0.8).equal(),
+            height: token.calc(titleHeight).div(2).equal(),
             borderBottom: `1px solid ${token.colorBorder}`,
             content: '""',
           },
@@ -301,9 +302,9 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         zIndex: 'auto',
         minHeight: titleHeight,
         margin: 0,
-        padding: `0 ${token.paddingXS / 2}px`,
+        padding: `0 ${unit(token.calc(token.paddingXS).div(2).equal())}`,
         color: 'inherit',
-        lineHeight: `${titleHeight}px`,
+        lineHeight: `${unit(titleHeight)}`,
         background: 'transparent',
         borderRadius: token.borderRadius,
         cursor: 'pointer',
@@ -322,7 +323,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           display: 'inline-block',
           width: titleHeight,
           height: titleHeight,
-          lineHeight: `${titleHeight}px`,
+          lineHeight: `${unit(titleHeight)}`,
           textAlign: 'center',
           verticalAlign: 'top',
 
@@ -339,7 +340,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
       // ==================== Draggable =====================
       [`${treeCls}-node-content-wrapper`]: {
-        lineHeight: `${titleHeight}px`,
+        lineHeight: `${unit(titleHeight)}`,
         userSelect: 'none',
 
         ...getDropIndicatorStyle(prefixCls, token),
@@ -362,7 +363,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             '&:before': {
               position: 'absolute',
               top: 0,
-              insetInlineEnd: titleHeight / 2,
+              insetInlineEnd: token.calc(titleHeight).div(2).equal(),
               bottom: -treeNodePadding,
               borderInlineEnd: `1px solid ${token.colorBorder}`,
               content: '""',
@@ -393,7 +394,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             '&:before': {
               top: 'auto !important',
               bottom: 'auto !important',
-              height: `${titleHeight / 2}px !important`,
+              height: `${unit(token.calc(titleHeight).div(2).equal())} !important`,
             },
           },
         },
@@ -489,12 +490,12 @@ export const genDirectoryStyle = (token: TreeToken): CSSObject => {
 // ============================== Merged ==============================
 export const genTreeStyle = (
   prefixCls: string,
-  token: AliasToken & TreeSharedToken,
+  token: AliasToken & TreeSharedToken & CSSUtil,
 ): CSSInterpolation => {
   const treeCls = `.${prefixCls}`;
   const treeNodeCls = `${treeCls}-treenode`;
 
-  const treeNodePadding = token.paddingXS / 2;
+  const treeNodePadding = token.calc(token.paddingXS).div(2).equal();
 
   const treeToken = mergeToken<TreeToken>(token, {
     treeCls,
@@ -520,6 +521,16 @@ export const initComponentToken = (token: AliasToken): TreeSharedToken => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Tree'> = (token) => {
+  const { colorTextLightSolid, colorPrimary } = token;
+
+  return {
+    ...initComponentToken(token),
+    directoryNodeSelectedColor: colorTextLightSolid,
+    directoryNodeSelectedBg: colorPrimary,
+  };
+};
+
 export default genComponentStyleHook(
   'Tree',
   (token, { prefixCls }) => [
@@ -529,13 +540,5 @@ export default genComponentStyleHook(
     genTreeStyle(prefixCls, token),
     genCollapseMotion(token),
   ],
-  (token) => {
-    const { colorTextLightSolid, colorPrimary } = token;
-
-    return {
-      ...initComponentToken(token),
-      directoryNodeSelectedColor: colorTextLightSolid,
-      directoryNodeSelectedBg: colorPrimary,
-    };
-  },
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | tree support css variable theme |
| 🇨🇳 Chinese | 树形控件支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9871c7c</samp>

This pull request refactors the Tree component to use CSS variables for styling, based on the theme token. It introduces a new `useCSSVar` hook that registers and applies the CSS variables for the component. It also updates the component style to use the `@ant-design/cssinjs` package and the `CSSUtil` type.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9871c7c</samp>

*  Add the `useCSSVar` hook to register and apply CSS variables for the Tree component based on the theme token ([link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-979269ee9a18699fa0bd3a875795130af5580d965ed2cc09235bf135278a442eR1-R4), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R13), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6L196-R198), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6L232-R234))
*  Import and use the `unit` function from the `@ant-design/cssinjs` package to convert numeric values to CSS units in the Tree style ([link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L2-R8), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L81-R82), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L164-R165), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L197-R198), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L240-R241), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L304-R307), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L325-R326), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L342-R343), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L396-R397))
*  Import and use the `token.calc` method from the `CSSUtil` type to perform CSS calculations based on the theme token in the Tree style ([link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L2-R8), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L272-R273), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L281-R283), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L365-R366), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L492-R498))
*  Modify the `TreeToken` type to allow the `treeNodePadding` property to be either a number or a string to support CSS variables ([link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L92-R93))
*  Add the `prepareComponentToken` function to abstract the logic of preparing the component token based on the theme token and reuse it for other components ([link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010R524-R533), [link](https://github.com/ant-design/ant-design/pull/45813/files?diff=unified&w=0#diff-a96220c0f9da1159b455aa953a94877f481fb369b795771cca99d3910d880010L532-R543))
