### PR TITLE
fix: QRCode style.padding should work

### DIFF
--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -29,12 +29,12 @@ Array [
         >
           <div
             class="ant-qrcode ant-qrcode-borderless"
-            style="background-color: transparent;"
+            style="width: 160px; height: 160px; background-color: transparent;"
           >
             <canvas
-              height="134"
-              style="height: 134px; width: 134px;"
-              width="134"
+              height="160"
+              style="height: 160px; width: 160px;"
+              width="160"
             />
           </div>
         </div>
@@ -55,12 +55,12 @@ exports[`renders components/qr-code/demo/base.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -89,12 +89,12 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -103,12 +103,12 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
   >
     <div
       class="ant-qrcode"
-      style="background-color: rgb(245, 245, 245);"
+      style="width: 160px; height: 160px; background-color: rgb(245, 245, 245);"
     >
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -191,7 +191,7 @@ Array [
   </div>,
   <div
     class="ant-qrcode"
-    style="background-color: transparent;"
+    style="width: 160px; height: 160px; background-color: transparent;"
   >
     <canvas
       height="160"
@@ -214,12 +214,12 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
 >
   <div
     class="ant-qrcode"
-    style="margin-bottom: 16px; background-color: rgb(255, 255, 255);"
+    style="margin-bottom: 16px; width: 160px; height: 160px; background-color: rgb(255, 255, 255);"
   >
     <canvas
-      height="134"
-      style="height: 134px; width: 134px;"
-      width="134"
+      height="160"
+      style="height: 160px; width: 160px;"
+      width="160"
     />
   </div>
   <button
@@ -239,12 +239,12 @@ exports[`renders components/qr-code/demo/errorlevel.tsx extend context correctly
 Array [
   <div
     class="ant-qrcode"
-    style="margin-bottom: 16px; background-color: transparent;"
+    style="margin-bottom: 16px; width: 160px; height: 160px; background-color: transparent;"
   >
     <canvas
-      height="134"
-      style="height: 134px; width: 134px;"
-      width="134"
+      height="160"
+      style="height: 160px; width: 160px;"
+      width="160"
     />
   </div>,
   <div
@@ -320,12 +320,12 @@ exports[`renders components/qr-code/demo/errorlevel.tsx extend context correctly
 exports[`renders components/qr-code/demo/icon.tsx extend context correctly 1`] = `
 <div
   class="ant-qrcode"
-  style="background-color: transparent;"
+  style="width: 160px; height: 160px; background-color: transparent;"
 >
   <canvas
-    height="134"
-    style="height: 134px; width: 134px;"
-    width="134"
+    height="160"
+    style="height: 160px; width: 160px;"
+    width="160"
   />
   <img
     src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
@@ -346,7 +346,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <div
         class="ant-qrcode-mask"
@@ -375,9 +375,9 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
         </div>
       </div>
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -386,7 +386,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <div
         class="ant-qrcode-mask"
@@ -429,9 +429,9 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
         </button>
       </div>
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -449,12 +449,12 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <canvas
-        height="134"
-        style="height: 134px; width: 134px;"
-        width="134"
+        height="160"
+        style="height: 160px; width: 160px;"
+        width="160"
       />
     </div>
   </div>
@@ -463,12 +463,12 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="background-color: transparent;"
+      style="width: 160px; height: 160px; background-color: transparent;"
     >
       <svg
-        height="134"
+        height="160"
         viewBox="0 0 25 25"
-        width="134"
+        width="160"
       >
         <path
           d="M0,0 h25v25H0z"

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -33,7 +33,6 @@ Array [
           >
             <canvas
               height="160"
-              style="height: 160px; width: 160px;"
               width="160"
             />
           </div>
@@ -59,7 +58,6 @@ exports[`renders components/qr-code/demo/base.tsx extend context correctly 1`] =
     >
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>
@@ -93,7 +91,6 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
     >
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>
@@ -107,7 +104,6 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
     >
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>
@@ -195,7 +191,6 @@ Array [
   >
     <canvas
       height="160"
-      style="height: 160px; width: 160px;"
       width="160"
     />
     <img
@@ -218,7 +213,6 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
   >
     <canvas
       height="160"
-      style="height: 160px; width: 160px;"
       width="160"
     />
   </div>
@@ -243,7 +237,6 @@ Array [
   >
     <canvas
       height="160"
-      style="height: 160px; width: 160px;"
       width="160"
     />
   </div>,
@@ -324,7 +317,6 @@ exports[`renders components/qr-code/demo/icon.tsx extend context correctly 1`] =
 >
   <canvas
     height="160"
-    style="height: 160px; width: 160px;"
     width="160"
   />
   <img
@@ -376,7 +368,6 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
       </div>
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>
@@ -430,7 +421,6 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
       </div>
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>
@@ -453,7 +443,6 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
     >
       <canvas
         height="160"
-        style="height: 160px; width: 160px;"
         width="160"
       />
     </div>

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -29,7 +29,7 @@ Array [
         >
           <div
             class="ant-qrcode ant-qrcode-borderless"
-            style="width: 160px; height: 160px; background-color: transparent;"
+            style="background-color: transparent;"
           >
             <canvas
               height="134"
@@ -55,7 +55,7 @@ exports[`renders components/qr-code/demo/base.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <canvas
         height="134"
@@ -89,7 +89,7 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <canvas
         height="134"
@@ -103,7 +103,7 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: rgb(245, 245, 245);"
+      style="background-color: rgb(245, 245, 245);"
     >
       <canvas
         height="134"
@@ -191,12 +191,12 @@ Array [
   </div>,
   <div
     class="ant-qrcode"
-    style="width: 160px; height: 160px; background-color: transparent;"
+    style="background-color: transparent;"
   >
     <canvas
-      height="134"
-      style="height: 134px; width: 134px;"
-      width="134"
+      height="160"
+      style="height: 160px; width: 160px;"
+      width="160"
     />
     <img
       src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
@@ -214,7 +214,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
 >
   <div
     class="ant-qrcode"
-    style="margin-bottom: 16px; width: 160px; height: 160px; background-color: rgb(255, 255, 255);"
+    style="margin-bottom: 16px; background-color: rgb(255, 255, 255);"
   >
     <canvas
       height="134"
@@ -239,7 +239,7 @@ exports[`renders components/qr-code/demo/errorlevel.tsx extend context correctly
 Array [
   <div
     class="ant-qrcode"
-    style="margin-bottom: 16px; width: 160px; height: 160px; background-color: transparent;"
+    style="margin-bottom: 16px; background-color: transparent;"
   >
     <canvas
       height="134"
@@ -320,7 +320,7 @@ exports[`renders components/qr-code/demo/errorlevel.tsx extend context correctly
 exports[`renders components/qr-code/demo/icon.tsx extend context correctly 1`] = `
 <div
   class="ant-qrcode"
-  style="width: 160px; height: 160px; background-color: transparent;"
+  style="background-color: transparent;"
 >
   <canvas
     height="134"
@@ -346,7 +346,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <div
         class="ant-qrcode-mask"
@@ -386,7 +386,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <div
         class="ant-qrcode-mask"
@@ -449,7 +449,7 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <canvas
         height="134"
@@ -463,7 +463,7 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
   >
     <div
       class="ant-qrcode"
-      style="width: 160px; height: 160px; background-color: transparent;"
+      style="background-color: transparent;"
     >
       <svg
         height="134"

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -18,12 +18,12 @@ exports[`renders components/qr-code/demo/base.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -50,12 +50,12 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -64,12 +64,12 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:#f5f5f5"
+      style="width:160px;height:160px;background-color:#f5f5f5"
     >
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -150,7 +150,7 @@ Array [
   </div>,
   <div
     class="ant-qrcode"
-    style="background-color:transparent"
+    style="width:160px;height:160px;background-color:transparent"
   >
     <canvas
       height="160"
@@ -171,12 +171,12 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
 >
   <div
     class="ant-qrcode"
-    style="margin-bottom:16px;background-color:#fff"
+    style="margin-bottom:16px;width:160px;height:160px;background-color:#fff"
   >
     <canvas
-      height="134"
-      style="height:134px;width:134px"
-      width="134"
+      height="160"
+      style="height:160px;width:160px"
+      width="160"
     />
   </div>
   <button
@@ -194,12 +194,12 @@ exports[`renders components/qr-code/demo/errorlevel.tsx correctly 1`] = `
 Array [
   <div
     class="ant-qrcode"
-    style="margin-bottom:16px;background-color:transparent"
+    style="margin-bottom:16px;width:160px;height:160px;background-color:transparent"
   >
     <canvas
-      height="134"
-      style="height:134px;width:134px"
-      width="134"
+      height="160"
+      style="height:160px;width:160px"
+      width="160"
     />
   </div>,
   <div
@@ -273,12 +273,12 @@ Array [
 exports[`renders components/qr-code/demo/icon.tsx correctly 1`] = `
 <div
   class="ant-qrcode"
-  style="background-color:transparent"
+  style="width:160px;height:160px;background-color:transparent"
 >
   <canvas
-    height="134"
-    style="height:134px;width:134px"
-    width="134"
+    height="160"
+    style="height:160px;width:160px"
+    width="160"
   />
   <img
     src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
@@ -297,7 +297,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <div
         class="ant-qrcode-mask"
@@ -326,9 +326,9 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
         </div>
       </div>
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -337,7 +337,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <div
         class="ant-qrcode-mask"
@@ -380,9 +380,9 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
         </button>
       </div>
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -398,12 +398,12 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <canvas
-        height="134"
-        style="height:134px;width:134px"
-        width="134"
+        height="160"
+        style="height:160px;width:160px"
+        width="160"
       />
     </div>
   </div>
@@ -412,12 +412,12 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="background-color:transparent"
+      style="width:160px;height:160px;background-color:transparent"
     >
       <svg
-        height="134"
+        height="160"
         viewBox="0 0 25 25"
-        width="134"
+        width="160"
       >
         <path
           d="M0,0 h25v25H0z"

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -18,7 +18,7 @@ exports[`renders components/qr-code/demo/base.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <canvas
         height="134"
@@ -50,7 +50,7 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <canvas
         height="134"
@@ -64,7 +64,7 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:#f5f5f5"
+      style="background-color:#f5f5f5"
     >
       <canvas
         height="134"
@@ -150,12 +150,12 @@ Array [
   </div>,
   <div
     class="ant-qrcode"
-    style="width:160px;height:160px;background-color:transparent"
+    style="background-color:transparent"
   >
     <canvas
-      height="134"
-      style="height:134px;width:134px"
-      width="134"
+      height="160"
+      style="height:160px;width:160px"
+      width="160"
     />
     <img
       src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
@@ -171,7 +171,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
 >
   <div
     class="ant-qrcode"
-    style="margin-bottom:16px;width:160px;height:160px;background-color:#fff"
+    style="margin-bottom:16px;background-color:#fff"
   >
     <canvas
       height="134"
@@ -194,7 +194,7 @@ exports[`renders components/qr-code/demo/errorlevel.tsx correctly 1`] = `
 Array [
   <div
     class="ant-qrcode"
-    style="margin-bottom:16px;width:160px;height:160px;background-color:transparent"
+    style="margin-bottom:16px;background-color:transparent"
   >
     <canvas
       height="134"
@@ -273,7 +273,7 @@ Array [
 exports[`renders components/qr-code/demo/icon.tsx correctly 1`] = `
 <div
   class="ant-qrcode"
-  style="width:160px;height:160px;background-color:transparent"
+  style="background-color:transparent"
 >
   <canvas
     height="134"
@@ -297,7 +297,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <div
         class="ant-qrcode-mask"
@@ -337,7 +337,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <div
         class="ant-qrcode-mask"
@@ -398,7 +398,7 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <canvas
         height="134"
@@ -412,7 +412,7 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
   >
     <div
       class="ant-qrcode"
-      style="width:160px;height:160px;background-color:transparent"
+      style="background-color:transparent"
     >
       <svg
         height="134"

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -22,7 +22,6 @@ exports[`renders components/qr-code/demo/base.tsx correctly 1`] = `
     >
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>
@@ -54,7 +53,6 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
     >
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>
@@ -68,7 +66,6 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
     >
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>
@@ -154,7 +151,6 @@ Array [
   >
     <canvas
       height="160"
-      style="height:160px;width:160px"
       width="160"
     />
     <img
@@ -175,7 +171,6 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
   >
     <canvas
       height="160"
-      style="height:160px;width:160px"
       width="160"
     />
   </div>
@@ -198,7 +193,6 @@ Array [
   >
     <canvas
       height="160"
-      style="height:160px;width:160px"
       width="160"
     />
   </div>,
@@ -277,7 +271,6 @@ exports[`renders components/qr-code/demo/icon.tsx correctly 1`] = `
 >
   <canvas
     height="160"
-    style="height:160px;width:160px"
     width="160"
   />
   <img
@@ -327,7 +320,6 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
       </div>
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>
@@ -381,7 +373,6 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
       </div>
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>
@@ -402,7 +393,6 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
     >
       <canvas
         height="160"
-        style="height:160px;width:160px"
         width="160"
       />
     </div>

--- a/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,12 +6,12 @@ exports[`QRCode test should correct render 1`] = `
 <div>
   <div
     class="ant-qrcode"
-    style="background-color: transparent;"
+    style="width: 160px; height: 160px; background-color: transparent;"
   >
     <canvas
-      height="134"
-      style="height: 134px; width: 134px;"
-      width="134"
+      height="160"
+      style="height: 160px; width: 160px;"
+      width="160"
     />
   </div>
 </div>

--- a/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`QRCode test should correct render 1`] = `
   >
     <canvas
       height="160"
-      style="height: 160px; width: 160px;"
       width="160"
     />
   </div>

--- a/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`QRCode test should correct render 1`] = `
 <div>
   <div
     class="ant-qrcode"
-    style="width: 160px; height: 160px; background-color: transparent;"
+    style="background-color: transparent;"
   >
     <canvas
       height="134"

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -88,4 +88,21 @@ describe('QRCode test', () => {
     );
     errSpy.mockRestore();
   });
+
+  it('style.padding should works', () => {
+    const { container: container1 } = render(<QRCode value="test" size={200} />);
+    expect(container1.querySelector('canvas')).toHaveStyle('width: 174px; height: 174px');
+    const { container: container2 } = render(
+      <QRCode value="test" size={200} style={{ padding: 0 }} />,
+    );
+    expect(container2.querySelector('canvas')).toHaveStyle('width: 200px; height: 200px');
+    const { container: container3 } = render(
+      <QRCode value="test" size={200} style={{ padding: '2px' }} />,
+    );
+    expect(container3.querySelector('canvas')).toHaveStyle('width: 198px; height: 198px');
+    const { container: container4 } = render(
+      <QRCode value="test" size={200} style={{ padding: '2px 2px' }} />,
+    );
+    expect(container4.querySelector('canvas')).toHaveStyle('width: 198px; height: 198px');
+  });
 });

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -39,9 +39,7 @@ describe('QRCode test', () => {
 
   it('support custom size', () => {
     const { container } = render(<QRCode value="test" size={100} />);
-    const wrapper = container.querySelector<HTMLDivElement>('.ant-qrcode');
-    expect(wrapper?.style?.width).toBe('100px');
-    expect(wrapper?.style?.height).toBe('100px');
+    expect(container.querySelector('canvas')).toHaveStyle('width: 100px; height: 100px');
   });
 
   it('support refresh', () => {
@@ -90,19 +88,8 @@ describe('QRCode test', () => {
   });
 
   it('style.padding should works', () => {
-    const { container: container1 } = render(<QRCode value="test" size={200} />);
-    expect(container1.querySelector('canvas')).toHaveStyle('width: 174px; height: 174px');
-    const { container: container2 } = render(
-      <QRCode value="test" size={200} style={{ padding: 0 }} />,
-    );
-    expect(container2.querySelector('canvas')).toHaveStyle('width: 200px; height: 200px');
-    const { container: container3 } = render(
-      <QRCode value="test" size={200} style={{ padding: '2px' }} />,
-    );
-    expect(container3.querySelector('canvas')).toHaveStyle('width: 198px; height: 198px');
-    const { container: container4 } = render(
-      <QRCode value="test" size={200} style={{ padding: '2px 2px' }} />,
-    );
-    expect(container4.querySelector('canvas')).toHaveStyle('width: 198px; height: 198px');
+    const { container } = render(<QRCode value="test" size={200} style={{ padding: '2px' }} />);
+    expect(container.querySelector('.ant-qrcode')).toHaveStyle('padding: 2px');
+    expect(container.querySelector('canvas')).toHaveStyle('width: 200px; height: 200px');
   });
 });

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -39,7 +39,7 @@ describe('QRCode test', () => {
 
   it('support custom size', () => {
     const { container } = render(<QRCode value="test" size={100} />);
-    expect(container.querySelector('canvas')).toHaveStyle('width: 100px; height: 100px');
+    expect(container.querySelector('.ant-qrcode')).toHaveStyle('width: 100px; height: 100px');
   });
 
   it('support refresh', () => {
@@ -85,11 +85,5 @@ describe('QRCode test', () => {
       'Warning: [antd: QRCode] ErrorLevel `L` is not recommended to be used with `icon`, for scanning result would be affected by low level.',
     );
     errSpy.mockRestore();
-  });
-
-  it('style.padding should works', () => {
-    const { container } = render(<QRCode value="test" size={200} style={{ padding: '2px' }} />);
-    expect(container.querySelector('.ant-qrcode')).toHaveStyle('padding: 2px');
-    expect(container.querySelector('canvas')).toHaveStyle('width: 200px; height: 200px');
   });
 });

--- a/components/qr-code/index.en-US.md
+++ b/components/qr-code/index.en-US.md
@@ -43,7 +43,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | scanned text | string | - |
 | type | render type | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | include image url (only image link are supported) | string | - |
-| size | QRCode size | number | 128 |
+| size | QRCode size | number | 134 |
 | iconSize | include image size | number | 32 |
 | color | QRCode Color | string | `#000` |
 | bgColor | QRCode Background Color | string | `transparent` | 5.5.0 |

--- a/components/qr-code/index.en-US.md
+++ b/components/qr-code/index.en-US.md
@@ -43,7 +43,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | scanned text | string | - |
 | type | render type | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | include image url (only image link are supported) | string | - |
-| size | QRCode size | number | 134 |
+| size | QRCode size | number | 160 |
 | iconSize | include image size | number | 32 |
 | color | QRCode Color | string | `#000` |
 | bgColor | QRCode Background Color | string | `transparent` | 5.5.0 |

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -45,9 +45,21 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     excavate: true,
   };
 
+  const getQrCodePadding = (): number => {
+    const defaultPadding = (token.paddingSM + token.lineWidth) * 2;
+    if (typeof style?.padding === 'number') {
+      return style?.padding;
+    }
+    if (typeof style?.padding === 'string') {
+      const paddingInNumber = parseInt(style?.padding || '', 10);
+      return typeof paddingInNumber === 'number' ? paddingInNumber : defaultPadding;
+    }
+    return defaultPadding;
+  };
+
   const qrCodeProps = {
     value,
-    size: size - (token.paddingSM + token.lineWidth) * 2,
+    size: size - getQrCodePadding(),
     level: errorLevel,
     bgColor,
     fgColor: color,

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -19,7 +19,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     value,
     type = 'canvas',
     icon = '',
-    size = 134,
+    size = 160,
     iconSize = 40,
     color = token.colorText,
     errorLevel = 'M',
@@ -77,7 +77,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   });
 
   return wrapSSR(
-    <div style={{ ...style, backgroundColor: bgColor }} className={cls}>
+    <div style={{ ...style, width: size, height: size, backgroundColor: bgColor }} className={cls}>
       {status !== 'active' && (
         <div className={`${prefixCls}-mask`}>
           {status === 'loading' && <Spin />}

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -19,7 +19,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     value,
     type = 'canvas',
     icon = '',
-    size = 160,
+    size = 134,
     iconSize = 40,
     color = token.colorText,
     errorLevel = 'M',
@@ -45,21 +45,9 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     excavate: true,
   };
 
-  const getQrCodePadding = (): number => {
-    const defaultPadding = (token.paddingSM + token.lineWidth) * 2;
-    if (typeof style?.padding === 'number') {
-      return style?.padding;
-    }
-    if (typeof style?.padding === 'string') {
-      const paddingInNumber = parseInt(style?.padding || '', 10);
-      return typeof paddingInNumber === 'number' ? paddingInNumber : defaultPadding;
-    }
-    return defaultPadding;
-  };
-
   const qrCodeProps = {
     value,
-    size: size - getQrCodePadding(),
+    size,
     level: errorLevel,
     bgColor,
     fgColor: color,
@@ -89,7 +77,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   });
 
   return wrapSSR(
-    <div style={{ ...style, width: size, height: size, backgroundColor: bgColor }} className={cls}>
+    <div style={{ ...style, backgroundColor: bgColor }} className={cls}>
       {status !== 'active' && (
         <div className={`${prefixCls}-mask`}>
           {status === 'loading' && <Spin />}

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -51,6 +51,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     level: errorLevel,
     bgColor,
     fgColor: color,
+    style: { width: undefined, height: undefined },
     imageSettings: icon ? imageSettings : undefined,
   };
 

--- a/components/qr-code/index.zh-CN.md
+++ b/components/qr-code/index.zh-CN.md
@@ -44,7 +44,7 @@ tag: New
 | value | 扫描后的文本 | string | - |
 | type | 渲染类型 | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | 二维码中图片的地址（目前只支持图片地址） | string | - |
-| size | 二维码大小 | number | 134 |
+| size | 二维码大小 | number | 160 |
 | iconSize | 二维码中图片的大小 | number | 40 |
 | color | 二维码颜色 | string | `#000` |
 | bgColor | 二维码背景颜色 | string | `transparent` | 5.5.0 |

--- a/components/qr-code/index.zh-CN.md
+++ b/components/qr-code/index.zh-CN.md
@@ -44,7 +44,7 @@ tag: New
 | value | 扫描后的文本 | string | - |
 | type | 渲染类型 | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | 二维码中图片的地址（目前只支持图片地址） | string | - |
-| size | 二维码大小 | number | 160 |
+| size | 二维码大小 | number | 134 |
 | iconSize | 二维码中图片的大小 | number | 40 |
 | color | 二维码颜色 | string | `#000` |
 | bgColor | 二维码背景颜色 | string | `transparent` | 5.5.0 |

--- a/components/qr-code/style/index.ts
+++ b/components/qr-code/style/index.ts
@@ -14,7 +14,7 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
   return {
     [componentCls]: {
       ...resetComponent(token),
-      display: 'inline-flex',
+      display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       padding: token.paddingSM,
@@ -23,6 +23,7 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
       border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
       position: 'relative',
       overflow: 'hidden',
+
       [`& > ${componentCls}-mask`]: {
         position: 'absolute',
         insetBlockStart: 0,
@@ -42,6 +43,14 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
           color: token.QRCodeExpiredTextColor,
         },
       },
+
+      '> canvas': {
+        alignSelf: 'stretch',
+        flex: 'auto',
+        width: 'auto !important',
+        height: 'auto !important',
+      },
+
       '&-icon': {
         marginBlockEnd: token.marginXS,
         fontSize: token.controlHeight,

--- a/components/qr-code/style/index.ts
+++ b/components/qr-code/style/index.ts
@@ -14,7 +14,7 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
   return {
     [componentCls]: {
       ...resetComponent(token),
-      display: 'flex',
+      display: 'inline-flex',
       justifyContent: 'center',
       alignItems: 'center',
       padding: token.paddingSM,
@@ -22,8 +22,6 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
       borderRadius: token.borderRadiusLG,
       border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
       position: 'relative',
-      width: '100%',
-      height: '100%',
       overflow: 'hidden',
       [`& > ${componentCls}-mask`]: {
         position: 'absolute',

--- a/components/qr-code/style/index.ts
+++ b/components/qr-code/style/index.ts
@@ -47,8 +47,7 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
       '> canvas': {
         alignSelf: 'stretch',
         flex: 'auto',
-        width: 'auto !important',
-        height: 'auto !important',
+        minWidth: 0,
       },
 
       '&-icon': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/45801

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
这个修改后，将可以通过

```
<QRCode style={{ padding: 0 }} />
```

或者 

```csss
.ant-qrcode {
  padding: 0;
}
```

修改默认的 padding。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix QRCode `style.padding` is not working.        |
| 🇨🇳 Chinese |  修复 QRCode 设置 `style.padding` 时无效的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3070be8</samp>

This pull request fixes a bug in the `QRCode` component that ignored the `style.padding` prop. It adds a helper function to handle different padding formats and a test case to verify the component's behavior.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3070be8</samp>

* Fix a bug where QRCode component did not respect the `style.padding` prop ([link](https://github.com/ant-design/ant-design/pull/45815/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL48-R60), [link](https://github.com/ant-design/ant-design/pull/45815/files?diff=unified&w=0#diff-4896c04327b3bb6deed0f183db828e97759872133c0bbd3aa5a1591c0f878bc8R91-R103))
  - Use a helper function `getQrCodePadding` to calculate the padding value from different types and formats of the prop in `components/qr-code/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45815/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL48-R60))
  - Add a test case for the `style.padding` prop in `components/qr-code/__tests__/index.test.tsx` to check the width and height of the canvas element with different values of padding ([link](https://github.com/ant-design/ant-design/pull/45815/files?diff=unified&w=0#diff-4896c04327b3bb6deed0f183db828e97759872133c0bbd3aa5a1591c0f878bc8R91-R103))
