### PR TITLE
feat: Typography support cssVar

### DIFF
--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -8,6 +8,7 @@ import type { DirectionType } from '../config-provider';
 import type { TextAreaRef } from '../input/TextArea';
 import TextArea from '../input/TextArea';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 interface EditableProps {
   prefixCls: string;
@@ -115,7 +116,8 @@ const Editable: React.FC<EditableProps> = (props) => {
 
   const textClassName = component ? `${prefixCls}-${component}` : '';
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const textAreaClassName = classNames(
     prefixCls,
@@ -128,7 +130,7 @@ const Editable: React.FC<EditableProps> = (props) => {
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={textAreaClassName} style={style}>
       <TextArea
         ref={ref}

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -6,6 +6,7 @@ import { devUseWarning } from '../_util/warning';
 import type { ConfigConsumerProps, DirectionType } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface TypographyProps<C extends keyof JSX.IntrinsicElements>
   extends React.HTMLAttributes<HTMLElement> {
@@ -64,7 +65,8 @@ const Typography = React.forwardRef<
   const prefixCls = getPrefixCls('typography', customizePrefixCls);
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const componentClassName = classNames(
     prefixCls,
@@ -79,7 +81,7 @@ const Typography = React.forwardRef<
 
   const mergedStyle: React.CSSProperties = { ...typography?.style, ...style };
 
-  return wrapSSR(
+  return wrapCSSVar(
     // @ts-expect-error: Expression produces a union type that is too complex to represent.
     <Component className={componentClassName} style={mergedStyle} ref={mergedRef} {...restProps}>
       {children}

--- a/components/typography/style/cssVar.ts
+++ b/components/typography/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Typography', prepareComponentToken);

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -1,5 +1,5 @@
 import { operationUnit } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook } from '../../theme/internal';
 import {
   getCopyableStyles,
@@ -129,12 +129,14 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Typography'> = () => ({
+  titleMarginTop: '1.2em',
+  titleMarginBottom: '0.5em',
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Typography',
   (token) => [genTypographyStyle(token)],
-  () => ({
-    titleMarginTop: '1.2em',
-    titleMarginBottom: '0.5em',
-  }),
+  prepareComponentToken,
 );

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -194,8 +194,8 @@ export const getEditableStyles: GenerateStyle<TypographyToken, CSSObject> = (tok
       position: 'relative',
 
       'div&': {
-        insetInlineStart: -token.paddingSM,
-        marginTop: -inputShift,
+        insetInlineStart: token.calc(token.paddingSM).mul(-1).equal(),
+        marginTop: token.calc(inputShift).mul(-1).equal(),
         marginBottom: `calc(1em - ${unit(inputShift)})`,
       },
 

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -8,7 +8,7 @@
 }
 */
 import { gold } from '@ant-design/colors';
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 import type { TypographyToken } from '.';
 import { operationUnit } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
@@ -196,12 +196,12 @@ export const getEditableStyles: GenerateStyle<TypographyToken, CSSObject> = (tok
       'div&': {
         insetInlineStart: -token.paddingSM,
         marginTop: -inputShift,
-        marginBottom: `calc(1em - ${inputShift}px)`,
+        marginBottom: `calc(1em - ${unit(inputShift)})`,
       },
 
       [`${componentCls}-edit-content-confirm`]: {
         position: 'absolute',
-        insetInlineEnd: token.marginXS + 2,
+        insetInlineEnd: token.calc(token.marginXS).add(2).equal(),
         insetBlockEnd: token.marginXS,
         color: token.colorTextDescription,
         // default style


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Typography support css variable theme |
| 🇨🇳 Chinese | 排版支持 css 变量主题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7e8659</samp>

This pull request improves the typography component by using CSS variables for the style and refactoring the code to use the `useCSSVar` hook and the `@ant-design/cssinjs` library. It also removes unnecessary code and enhances the compatibility with server-side rendering.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7e8659</samp>

* Create and use a custom hook `useCSSVar` to register and apply CSS variables for the typography component based on the theme token ([link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7R11), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7L118-R120), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b4d5a52a105014379c0063fc5cdfc20c3bab6fc0f9e2a6abc9b57364ef4ba5b7L131-R133), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b876734b2f41ebc0a47dca5b8a06d9cfd09a0489c33414ab138415a648854fe6R9), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b876734b2f41ebc0a47dca5b8a06d9cfd09a0489c33414ab138415a648854fe6L67-R69), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-b876734b2f41ebc0a47dca5b8a06d9cfd09a0489c33414ab138415a648854fe6L82-R84), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-0d88c59a08f6b420a939773ed7d143d969d1e2517fb3c8721af1620f57bd010fR1-R4))
* Extract the default token values for the typography component into a separate function `prepareComponentToken` and export it from `index.ts` ([link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-5a240a9ef14a2b1b72305e8e80f82a5cda99bf30cbc7be62220048199465a64aL2-R2), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-5a240a9ef14a2b1b72305e8e80f82a5cda99bf30cbc7be62220048199465a64aL132-R141))
* Use the `unit` function from `@ant-design/cssinjs` and the `calc` method of the token to convert and manipulate CSS values in the `getEditableStyles` function ([link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-5e2c2184e054706f99691f617b33901f0929824030ce7847ac693ad475154775L11-R11), [link](https://github.com/ant-design/ant-design/pull/45818/files?diff=unified&w=0#diff-5e2c2184e054706f99691f617b33901f0929824030ce7847ac693ad475154775L199-R204))
