### PR TITLE
refactor: Progress support css var

### DIFF
--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -13,6 +13,7 @@ import Circle from './Circle';
 import Line from './Line';
 import Steps from './Steps';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import { getSize, getSuccessPercent, validProgress } from './utils';
 
 export const ProgressTypes = ['line', 'circle', 'dashboard'] as const;
@@ -97,7 +98,8 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     progress: progressStyle,
   } = React.useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('progress', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const progressInfo = React.useMemo<React.ReactNode>(() => {
     if (!showInfo) {
@@ -190,7 +192,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div
       ref={ref}
       style={{ ...progressStyle?.style, ...style }}

--- a/components/progress/style/cssVar.ts
+++ b/components/progress/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Progress', prepareComponentToken);

--- a/components/progress/style/index.tsx
+++ b/components/progress/style/index.tsx
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -30,11 +30,16 @@ export interface ComponentToken {
    * @descEN Text size of circular progress bar
    */
   circleTextFontSize: string;
+  /**
+   * @desc 圆形进度条图标大小
+   * @descEN Icon size of circular progress bar
+   */
+  circleIconFontSize: string;
 }
 
 interface ProgressToken extends FullToken<'Progress'> {
-  progressStepMinWidth: number;
-  progressStepMarginInlineEnd: number;
+  progressStepMinWidth: number | string;
+  progressStepMarginInlineEnd: number | string;
   progressActiveMotionDuration: string;
 }
 
@@ -84,8 +89,8 @@ const genBaseStyle: GenerateStyle<ProgressToken> = (token) => {
 
       [`&${progressCls}-show-info`]: {
         [`${progressCls}-outer`]: {
-          marginInlineEnd: `calc(-2em - ${token.marginXS}px)`,
-          paddingInlineEnd: `calc(2em + ${token.paddingXS}px)`,
+          marginInlineEnd: `calc(-2em - ${unit(token.marginXS)})`,
+          paddingInlineEnd: `calc(2em + ${unit(token.paddingXS)})`,
         },
       },
 
@@ -219,7 +224,7 @@ const genCircleStyle: GenerateStyle<ProgressToken> = (token) => {
         transform: 'translateY(-50%)',
 
         [iconPrefixCls]: {
-          fontSize: `${token.fontSize / token.fontSizeSM}em`,
+          fontSize: token.circleIconFontSize,
         },
       },
 
@@ -285,10 +290,19 @@ const genSmallLine: GenerateStyle<ProgressToken> = (token: ProgressToken): CSSOb
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Progress'> = (token) => ({
+  circleTextColor: token.colorText,
+  defaultColor: token.colorInfo,
+  remainingColor: token.colorFillSecondary,
+  lineBorderRadius: 100, // magic for capsule shape, should be a very large number
+  circleTextFontSize: '1em',
+  circleIconFontSize: `${token.fontSize / token.fontSizeSM}em`,
+});
+
 export default genComponentStyleHook(
   'Progress',
   (token) => {
-    const progressStepMarginInlineEnd = token.marginXXS / 2;
+    const progressStepMarginInlineEnd = token.calc(token.marginXXS).div(2).equal();
 
     const progressToken = mergeToken<ProgressToken>(token, {
       progressStepMarginInlineEnd,
@@ -303,11 +317,5 @@ export default genComponentStyleHook(
       genSmallLine(progressToken),
     ];
   },
-  (token) => ({
-    circleTextColor: token.colorText,
-    defaultColor: token.colorInfo,
-    remainingColor: token.colorFillSecondary,
-    lineBorderRadius: 100, // magic for capsule shape, should be a very large number
-    circleTextFontSize: '1em',
-  }),
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Progress support css variables |
| 🇨🇳 Chinese | Progress 组件支持 css 变量 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f8c823</samp>

This pull request refactors the progress component to use CSS variables for styling, instead of inline styles. It uses a new hook `useCSSVar` that registers and applies the CSS variables based on the `ComponentToken` interface from `@ant-design/cssinjs`. It also updates the style files to use the `unit` function and the `ComponentToken` interface for consistency and flexibility.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f8c823</samp>

*  Import and use `useCSSVar` hook to register and apply CSS variables for progress component ([link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddR16), [link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL100-R102), [link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-faba3b9fef75b1f2b3c50badd4cb81e9d9a3ac66376bcf8e3059ed5cc1c8c1ddL193-R195), [link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-91d2d5e8d0a641c508f7a064f0a6766362cf540b1d4176df4898bb9c4e27f083R1-R4))
*  Add and use `unit` function to convert numeric values to CSS units ([link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL2-R4), [link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL87-R93))
*  Add and use `circleIconFontSize` token to set icon size of circular progress bar ([link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL33-R42), [link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL222-R227))
*  Use `token.calc` and `equal` methods to create and convert CSS calculation expression for `progressStepMarginInlineEnd` token ([link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL288-R305))
*  Export and use `prepareComponentToken` function to get default token values for progress component ([link](https://github.com/ant-design/ant-design/pull/45821/files?diff=unified&w=0#diff-d7dfdb1325cba1b48db16a294c75327b9b61bc15b9ef1526c581ed1cfbf88e9cL306-R320))
