### PR TITLE
feat: Avatar support cssVar

### DIFF
--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -12,6 +12,7 @@ import useBreakpoint from '../grid/hooks/useBreakpoint';
 import type { AvatarContextType, AvatarSize } from './AvatarContext';
 import AvatarContext from './AvatarContext';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface AvatarProps {
   /** Shape of avatar, options: `circle`, `square` */
@@ -144,7 +145,8 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
   }
 
   const prefixCls = getPrefixCls('avatar', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const sizeCls = classNames({
     [`${prefixCls}-lg`]: size === 'large',
@@ -234,7 +236,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
   delete others.onError;
   delete others.gap;
 
-  return wrapSSR(
+  return wrapCSSVar(
     <span
       {...others}
       style={{ ...sizeStyle, ...responsiveSizeStyle, ...avatar?.style, ...others.style }}

--- a/components/avatar/style/cssVar.ts
+++ b/components/avatar/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Avatar'>('Avatar', prepareComponentToken);

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -1,6 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -79,13 +80,13 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
 
   // Avatar size style
   const avatarSizeStyle = (size: number, fontSize: number, radius: number): CSSObject => ({
-    width: size,
-    height: size,
-    lineHeight: `${size - lineWidth * 2}px`,
+    width: unit(size),
+    height: unit(size),
+    lineHeight: unit(token.calc(size).sub(token.calc(lineWidth).mul(2)).equal()),
     borderRadius: '50%',
 
     [`&${componentCls}-square`]: {
-      borderRadius: radius,
+      borderRadius: unit(radius),
     },
 
     [`${componentCls}-string`]: {
@@ -98,7 +99,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     },
 
     [`&${componentCls}-icon`]: {
-      fontSize,
+      fontSize: unit(fontSize),
       [`> ${iconCls}`]: {
         margin: 0,
       },
@@ -116,7 +117,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
       textAlign: 'center',
       verticalAlign: 'middle',
       background: avatarBg,
-      border: `${lineWidth}px ${lineType} transparent`,
+      border: `${unit(lineWidth)} ${unit(lineType)} transparent`,
 
       [`&-image`]: {
         background: 'transparent',
@@ -158,14 +159,40 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
       },
 
       [`> *:not(:first-child)`]: {
-        marginInlineStart: groupOverlapping,
+        marginInlineStart: unit(groupOverlapping),
       },
     },
     [`${componentCls}-group-popover`]: {
       [`${componentCls} + ${componentCls}`]: {
-        marginInlineStart: groupSpace,
+        marginInlineStart: unit(groupSpace),
       },
     },
+  };
+};
+
+export const prepareComponentToken: GetDefaultToken<'Avatar'> = (token) => {
+  const {
+    controlHeight,
+    controlHeightLG,
+    controlHeightSM,
+    fontSize,
+    fontSizeLG,
+    fontSizeXL,
+    fontSizeHeading3,
+    marginXS,
+    marginXXS,
+    colorBorderBg,
+  } = token;
+  return {
+    containerSize: controlHeight,
+    containerSizeLG: controlHeightLG,
+    containerSizeSM: controlHeightSM,
+    textFontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
+    textFontSizeLG: fontSizeHeading3,
+    textFontSizeSM: fontSize,
+    groupSpace: marginXXS,
+    groupOverlapping: -marginXS,
+    groupBorderColor: colorBorderBg,
   };
 };
 
@@ -179,33 +206,5 @@ export default genComponentStyleHook(
     });
     return [genBaseStyle(avatarToken), genGroupStyle(avatarToken)];
   },
-  (token) => {
-    const {
-      controlHeight,
-      controlHeightLG,
-      controlHeightSM,
-
-      fontSize,
-      fontSizeLG,
-      fontSizeXL,
-      fontSizeHeading3,
-
-      marginXS,
-      marginXXS,
-      colorBorderBg,
-    } = token;
-    return {
-      containerSize: controlHeight,
-      containerSizeLG: controlHeightLG,
-      containerSizeSM: controlHeightSM,
-
-      textFontSize: Math.round((fontSizeLG + fontSizeXL) / 2),
-      textFontSizeLG: fontSizeHeading3,
-      textFontSizeSM: fontSize,
-
-      groupSpace: marginXXS,
-      groupOverlapping: -marginXS,
-      groupBorderColor: colorBorderBg,
-    };
-  },
+  prepareComponentToken,
 );

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -76,13 +76,14 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     borderRadiusSM,
     lineWidth,
     lineType,
+    calc,
   } = token;
 
   // Avatar size style
   const avatarSizeStyle = (size: number, fontSize: number, radius: number): CSSObject => ({
     width: unit(size),
     height: unit(size),
-    lineHeight: unit(token.calc(size).sub(token.calc(lineWidth).mul(2)).equal()),
+    lineHeight: calc(size).sub(calc(lineWidth).mul(2)).equal(),
     borderRadius: '50%',
 
     [`&${componentCls}-square`]: {

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -81,13 +81,13 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
 
   // Avatar size style
   const avatarSizeStyle = (size: number, fontSize: number, radius: number): CSSObject => ({
-    width: unit(size),
-    height: unit(size),
-    lineHeight: calc(size).sub(calc(lineWidth).mul(2)).equal(),
+    width: size,
+    height: size,
+    lineHeight: unit(calc(size).sub(calc(lineWidth).mul(2)).equal()),
     borderRadius: '50%',
 
     [`&${componentCls}-square`]: {
-      borderRadius: unit(radius),
+      borderRadius: radius,
     },
 
     [`${componentCls}-string`]: {
@@ -100,7 +100,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
     },
 
     [`&${componentCls}-icon`]: {
-      fontSize: unit(fontSize),
+      fontSize,
       [`> ${iconCls}`]: {
         margin: 0,
       },
@@ -160,12 +160,12 @@ const genGroupStyle: GenerateStyle<AvatarToken> = (token) => {
       },
 
       [`> *:not(:first-child)`]: {
-        marginInlineStart: unit(groupOverlapping),
+        marginInlineStart: groupOverlapping,
       },
     },
     [`${componentCls}-group-popover`]: {
       [`${componentCls} + ${componentCls}`]: {
-        marginInlineStart: unit(groupSpace),
+        marginInlineStart: groupSpace,
       },
     },
   };

--- a/components/avatar/style/index.ts
+++ b/components/avatar/style/index.ts
@@ -117,7 +117,7 @@ const genBaseStyle: GenerateStyle<AvatarToken> = (token) => {
       textAlign: 'center',
       verticalAlign: 'middle',
       background: avatarBg,
-      border: `${unit(lineWidth)} ${unit(lineType)} transparent`,
+      border: `${unit(lineWidth)} ${lineType} transparent`,
 
       [`&-image`]: {
         background: 'transparent',
@@ -196,7 +196,7 @@ export const prepareComponentToken: GetDefaultToken<'Avatar'> = (token) => {
   };
 };
 
-export default genComponentStyleHook(
+export default genComponentStyleHook<'Avatar'>(
   'Avatar',
   (token) => {
     const { colorTextLightSolid, colorTextPlaceholder } = token;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Avatar support cssVar |
| 🇨🇳 Chinese | feat: Avatar 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1a360d</samp>

This pull request updates the Avatar component to use the new theme token system and CSS variables. It adds a new hook `useCSSVar` to register and apply the CSS variables, and refactors the component style to use the `@ant-design/cssinjs` package. It also removes the unnecessary `wrapSSR` function.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c1a360d</samp>

*  Add `useCSSVar` hook to register and apply CSS variables for Avatar component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efR15), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-07fe0a043813b9b3e3ffa3d9b67504ca3c411adfe6551a27003ed0fe87943d8bR1-R4), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L172-R199))
*  Use `useCSSVar` hook in Avatar component with `prefixCls` and `hashId` arguments to scope and identify CSS variables ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL147-R149), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL237-R239))
*  Replace `wrapSSR` function with `wrapCSSVar` function to handle server-side rendering of Avatar component with CSS variables ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-a9110968bd15226a58d0270285b7d34c0c37c415a6e5ca231c84fb3fb82ef9efL237-R239))
*  Import `unit` function and `GetDefaultToken` type from external modules to convert token values to CSS units and type the component token function ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L1-R4))
*  Use `unit` function in `avatarSizeStyle` and `genGroupStyle` functions to apply CSS units to `size`, `fontSize`, `radius`, `lineHeight`, `lineWidth`, `groupSpace`, and `groupOverlapping` values ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L82-R89), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L101-R102), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L119-R120), [link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L161-R167))
*  Simplify `genComponentStyleHook` call by using `prepareComponentToken` function as second argument instead of repeating the same logic ([link](https://github.com/ant-design/ant-design/pull/45824/files?diff=unified&w=0#diff-9bae49959a354c48caf848def36049b3c0d1e929e594370e57fc1a40c8a10f38L182-R209))
