### PR TITLE
feat: support popupBg and darkPopupBg

### DIFF
--- a/Untitled-1.css
+++ b/Untitled-1.css
@@ -1,0 +1,1824 @@
+﻿:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'],
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  font-size: 14px;
+  box-sizing: border-box;
+}
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu']::after,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu']::after {
+  box-sizing: border-box;
+}
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class^='ant-menu'],
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class^='ant-menu'],
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class*=' ant-menu'],
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class*=' ant-menu'] {
+  box-sizing: border-box;
+}
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class^='ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class^='ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class*=' ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class*=' ant-menu']::before,
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class^='ant-menu']::after,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class^='ant-menu']::after,
+:where(.css-dev-only-do-not-override-1adbn6x)[class^='ant-menu'] [class*=' ant-menu']::after,
+:where(.css-dev-only-do-not-override-1adbn6x)[class*=' ant-menu'] [class*=' ant-menu']::after {
+  box-sizing: border-box;
+}
+:where(.css-dev-only-do-not-override-1adbn6x) .ant-menu::before {
+  display: table;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x) .ant-menu::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x) .ant-menu-hidden {
+  display: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-hidden {
+  display: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  color: rgba(0, 0, 0, 0.88);
+  font-size: 14px;
+  line-height: 0;
+  list-style: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  margin-bottom: 0;
+  padding-inline-start: 0;
+  outline: none;
+  transition: width 0.3s cubic-bezier(0.2, 0, 0, 1) 0s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu::before {
+  display: table;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu ul,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-overflow {
+  display: flex;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-overflow .ant-menu-item {
+  flex: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title {
+  border-radius: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-group-title {
+  padding: 8px 16px;
+  font-size: 14px;
+  line-height: 1.5714285714285714;
+  transition: all 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-submenu {
+  transition:
+    border-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-inline {
+  transition:
+    border-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    padding 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu .ant-menu-sub {
+  cursor: initial;
+  transition:
+    background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-title-content {
+  transition: color 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-title-content
+  > .ant-typography-ellipsis-single-line {
+  display: inline;
+  vertical-align: unset;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item a::before {
+  position: absolute;
+  inset: 0;
+  background-color: transparent;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-divider {
+  overflow: hidden;
+  line-height: 0;
+  border-color: rgba(5, 5, 5, 0.06);
+  border-style: solid;
+  border-width: 0;
+  border-top-width: 1px;
+  margin-block: 1px;
+  padding: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-divider-dashed {
+  border-style: dashed;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title {
+  position: relative;
+  display: block;
+  margin: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    border-color 0.3s,
+    background 0.3s,
+    padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title .anticon {
+  min-width: 14px;
+  font-size: 14px;
+  transition:
+    font-size 0.2s cubic-bezier(0.215, 0.61, 0.355, 1),
+    margin 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    color 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .ant-menu-item-icon + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .anticon + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title .anticon + span {
+  margin-inline-start: 10px;
+  opacity: 1;
+  transition:
+    opacity 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    margin 0.3s,
+    color 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-title .ant-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+  font-style: normal;
+  line-height: 0;
+  text-align: center;
+  text-transform: none;
+  vertical-align: -0.125em;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .ant-menu-item-icon > *,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  > * {
+  line-height: 1;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item .ant-menu-item-icon svg,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  svg {
+  display: inline-block;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item.ant-menu-item-only-child
+  > .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-title.ant-menu-item-only-child
+  > .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item.ant-menu-item-only-child
+  > .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-title.ant-menu-item-only-child
+  > .ant-menu-item-icon {
+  margin-inline-end: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-disabled {
+  background: none !important;
+  cursor: not-allowed;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-disabled::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-disabled::after {
+  border-color: transparent !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-item-disabled a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-disabled a {
+  color: inherit !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item-disabled
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-disabled
+  > .ant-menu-submenu-title {
+  color: inherit !important;
+  cursor: not-allowed;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item-group
+  .ant-menu-item-group-list {
+  margin: 0;
+  padding: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item-group
+  .ant-menu-item-group-list
+  .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-item-group
+  .ant-menu-item-group-list
+  .ant-menu-submenu-title {
+  padding-inline: 28px 16px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup {
+  position: absolute;
+  z-index: 1050;
+  border-radius: 8px;
+  box-shadow: none;
+  transform-origin: 0 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup.ant-menu-submenu {
+  background: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup::before {
+  position: absolute;
+  inset: -7px 0 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-rightTop::before {
+  top: 0;
+  inset-inline-start: -7px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-leftTop,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-bottomRight,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu {
+  transform-origin: 100% 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-leftBottom,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-topRight,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu {
+  transform-origin: 100% 100%;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-rightBottom,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-topLeft,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu {
+  transform-origin: 0 100%;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-bottomLeft,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-rightTop,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu {
+  transform-origin: 0 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-leftTop,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-leftBottom {
+  padding-inline-end: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-rightTop,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-rightBottom {
+  padding-inline-start: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-topRight,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-topLeft {
+  padding-bottom: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-bottomRight,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-placement-bottomLeft {
+  padding-top: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu {
+  border-radius: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-submenu-title {
+  position: relative;
+  display: block;
+  margin: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    border-color 0.3s,
+    background 0.3s,
+    padding 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-item .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .anticon {
+  min-width: 14px;
+  font-size: 14px;
+  transition:
+    font-size 0.2s cubic-bezier(0.215, 0.61, 0.355, 1),
+    margin 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    color 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .anticon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .anticon
+  + span {
+  margin-inline-start: 10px;
+  opacity: 1;
+  transition:
+    opacity 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    margin 0.3s,
+    color 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+  font-style: normal;
+  line-height: 0;
+  text-align: center;
+  text-transform: none;
+  vertical-align: -0.125em;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .ant-menu-item-icon
+  > *,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  > * {
+  line-height: 1;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item
+  .ant-menu-item-icon
+  svg,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title
+  .ant-menu-item-icon
+  svg {
+  display: inline-block;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item.ant-menu-item-only-child
+  > .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title.ant-menu-item-only-child
+  > .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item.ant-menu-item-only-child
+  > .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title.ant-menu-item-only-child
+  > .ant-menu-item-icon {
+  margin-inline-end: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-disabled {
+  background: none !important;
+  cursor: not-allowed;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item-disabled::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-disabled::after {
+  border-color: transparent !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item-disabled
+  a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-disabled
+  a {
+  color: inherit !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-item-disabled
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-disabled
+  > .ant-menu-submenu-title {
+  color: inherit !important;
+  cursor: not-allowed;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-expand-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-submenu-arrow {
+  position: absolute;
+  top: 50%;
+  inset-inline-end: 16px;
+  width: 10px;
+  color: currentcolor;
+  transform: translateY(-50%);
+  transition:
+    transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-arrow::before,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-arrow::after {
+  position: absolute;
+  width: 6px;
+  height: 1.5px;
+  background-color: currentcolor;
+  border-radius: 6px;
+  transition:
+    background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    top 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-arrow::before {
+  transform: rotate(45deg) translateY(-2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-arrow::after {
+  transform: rotate(-45deg) translateY(2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu > .ant-menu .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu
+  > .ant-menu-submenu-title {
+  border-radius: 4px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu
+  > .ant-menu
+  .ant-menu-submenu-title::after {
+  transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-expand-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-arrow {
+  position: absolute;
+  top: 50%;
+  inset-inline-end: 16px;
+  width: 10px;
+  color: currentcolor;
+  transform: translateY(-50%);
+  transition:
+    transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-arrow::before,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-arrow::after {
+  position: absolute;
+  width: 6px;
+  height: 1.5px;
+  background-color: currentcolor;
+  border-radius: 6px;
+  transition:
+    background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    top 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+    color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-arrow::before {
+  transform: rotate(45deg) translateY(-2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-menu-submenu-arrow::after {
+  transform: rotate(-45deg) translateY(2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  .ant-menu-submenu-arrow::before,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-submenu-arrow::before {
+  transform: rotate(-45deg) translateX(2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  .ant-menu-submenu-arrow::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-submenu-arrow::after {
+  transform: rotate(45deg) translateX(-2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-open.ant-menu-submenu-inline
+  > .ant-menu-submenu-title
+  > .ant-menu-submenu-arrow {
+  transform: translateY(-2px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-open.ant-menu-submenu-inline
+  > .ant-menu-submenu-title
+  > .ant-menu-submenu-arrow::after {
+  transform: rotate(-45deg) translateX(-2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu
+  .ant-menu-submenu-open.ant-menu-submenu-inline
+  > .ant-menu-submenu-title
+  > .ant-menu-submenu-arrow::before {
+  transform: rotate(45deg) translateX(2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-layout-header .ant-menu {
+  line-height: inherit;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal {
+  line-height: 46px;
+  border: 0;
+  border-bottom: 1px solid rgba(5, 5, 5, 0.06);
+  box-shadow: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal::after {
+  display: block;
+  clear: both;
+  height: 0;
+  content: '\20';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-submenu {
+  position: relative;
+  display: inline-block;
+  vertical-align: bottom;
+  padding-inline: 16px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal > .ant-menu-item:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal > .ant-menu-item-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal
+  > .ant-menu-submenu
+  .ant-menu-submenu-title:hover {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-submenu-title {
+  transition:
+    border-color 0.3s,
+    background 0.3s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-horizontal .ant-menu-submenu-arrow {
+  display: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical.ant-menu-root {
+  box-shadow: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical .ant-menu-item {
+  position: relative;
+  overflow: hidden;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical .ant-menu-submenu-title {
+  height: 40px;
+  line-height: 40px;
+  padding-inline: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-inline: 4px;
+  margin-block: 4px;
+  width: calc(100% - 8px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title {
+  height: 40px;
+  line-height: 40px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline
+  .ant-menu-item-group-list
+  .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical
+  .ant-menu-item-group-list
+  .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-vertical .ant-menu-submenu-title {
+  padding-inline-end: 34px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup .ant-menu-vertical {
+  box-shadow:
+    0 6px 16px 0 rgba(0, 0, 0, 0.08),
+    0 3px 6px -4px rgba(0, 0, 0, 0.12),
+    0 9px 28px 8px rgba(0, 0, 0, 0.05);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  .ant-menu-item {
+  position: relative;
+  overflow: hidden;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  .ant-menu-submenu-title {
+  height: 40px;
+  line-height: 40px;
+  padding-inline: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-inline: 4px;
+  margin-block: 4px;
+  width: calc(100% - 8px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title {
+  height: 40px;
+  line-height: 40px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  .ant-menu-item-group-list
+  .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical
+  .ant-menu-submenu-title {
+  padding-inline-end: 34px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical.ant-menu-sub {
+  min-width: 160px;
+  max-height: calc(100vh - 100px);
+  padding: 0;
+  overflow: hidden;
+  border-inline-end: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-popup
+  .ant-menu-vertical.ant-menu-sub:not([class*='-active']) {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline {
+  width: 100%;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root
+  .ant-menu-submenu-title {
+  display: flex;
+  align-items: center;
+  transition:
+    border-color 0.3s,
+    background 0.3s,
+    padding 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root
+  .ant-menu-item
+  > .ant-menu-title-content,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root
+  .ant-menu-submenu-title
+  > .ant-menu-title-content {
+  flex: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root .ant-menu-item > *,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline.ant-menu-root
+  .ant-menu-submenu-title
+  > * {
+  flex: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-sub.ant-menu-inline {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline
+  .ant-menu-sub.ant-menu-inline
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title {
+  height: 40px;
+  line-height: 40px;
+  list-style-position: inside;
+  list-style-type: disc;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline
+  .ant-menu-sub.ant-menu-inline
+  .ant-menu-item-group-title {
+  padding-inline-start: 32px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline .ant-menu-item {
+  height: 40px;
+  line-height: 40px;
+  list-style-position: inside;
+  list-style-type: disc;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed {
+  width: 80px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed.ant-menu-root
+  .ant-menu-item
+  > .ant-menu-inline-collapsed-noicon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed.ant-menu-root
+  .ant-menu-submenu
+  .ant-menu-submenu-title
+  > .ant-menu-inline-collapsed-noicon {
+  font-size: 16px;
+  text-align: center;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title {
+  inset-inline-start: 0;
+  padding-inline: calc(50% - 8px - 4px);
+  text-overflow: clip;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item
+  .ant-menu-submenu-arrow,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .ant-menu-submenu-arrow,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-submenu-arrow,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-submenu-arrow,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item
+  .ant-menu-submenu-expand-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .ant-menu-submenu-expand-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-submenu-expand-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-submenu-expand-icon {
+  opacity: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed > .ant-menu-item .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .anticon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .anticon {
+  margin: 0;
+  font-size: 16px;
+  line-height: 40px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .ant-menu-item-icon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item
+  .anticon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-item
+  .anticon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-item-group
+  > .ant-menu-item-group-list
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .anticon
+  + span,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed
+  > .ant-menu-submenu
+  > .ant-menu-submenu-title
+  .anticon
+  + span {
+  display: inline-block;
+  opacity: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed .anticon {
+  display: inline-block;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed-tooltip {
+  pointer-events: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed-tooltip .ant-menu-item-icon,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed-tooltip .anticon {
+  display: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed-tooltip a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed-tooltip a:hover {
+  color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-inline-collapsed .ant-menu-item-group-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-inline: 8px;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu {
+  color: rgba(0, 0, 0, 0.88);
+  background: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-root:focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-root:focus-visible {
+  outline: 4px solid #91caff;
+  outline-offset: 1px;
+  transition:
+    outline-offset 0s,
+    outline 0s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-group-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-group-title {
+  color: rgba(0, 0, 0, 0.45);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-submenu-selected
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-submenu-selected
+  > .ant-menu-submenu-title {
+  color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-submenu-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-submenu-disabled {
+  color: rgba(0, 0, 0, 0.25) !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected)
+  > .ant-menu-submenu-title:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected)
+  > .ant-menu-submenu-title:hover {
+  color: rgba(0, 0, 0, 0.88);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):active {
+  background-color: #e6f4ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:active {
+  background-color: #e6f4ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item-danger {
+  color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item-danger.ant-menu-item:hover:not(.ant-menu-item-selected):not(
+    .ant-menu-submenu-selected
+  ),
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-danger.ant-menu-item:hover:not(.ant-menu-item-selected):not(
+    .ant-menu-submenu-selected
+  ) {
+  color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item-danger.ant-menu-item:active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-danger.ant-menu-item:active {
+  background: #fff2f0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item a:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item a:hover {
+  color: inherit;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item-selected {
+  color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item-selected.ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-selected.ant-menu-item-danger {
+  color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-selected a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item-selected a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-selected a:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-selected
+  a:hover {
+  color: inherit;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light > .ant-menu .ant-menu-item-selected {
+  background-color: #e6f4ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item-selected.ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item-selected.ant-menu-item-danger {
+  background-color: #fff2f0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-item:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  .ant-menu-submenu-title:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu
+  .ant-menu-submenu-title:not(.ant-menu-item-disabled):focus-visible {
+  outline: 4px solid #91caff;
+  outline-offset: 1px;
+  transition:
+    outline-offset 0s,
+    outline 0s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-submenu > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-submenu
+  > .ant-menu {
+  background-color: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-submenu-popup > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-submenu-popup
+  > .ant-menu {
+  background-color: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-popup > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-popup
+  > .ant-menu {
+  background-color: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu {
+  top: 1px;
+  margin-top: -1px;
+  margin-bottom: 0;
+  border-radius: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu::after {
+  position: absolute;
+  inset-inline: 16px;
+  bottom: 0;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-open {
+  background: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-open::after {
+  border-bottom-width: 2px;
+  border-bottom-color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected {
+  color: #1677ff;
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected:hover {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-horizontal
+  > .ant-menu-submenu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected::after {
+  border-bottom-width: 2px;
+  border-bottom-color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-root.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-root.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-root.ant-menu-vertical,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-root.ant-menu-vertical {
+  border-inline-end: 1px solid rgba(5, 5, 5, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline
+  .ant-menu-sub.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-sub.ant-menu-inline {
+  background: rgba(0, 0, 0, 0.02);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item {
+  position: relative;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item::after {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  border-inline-end: 0px solid #1677ff;
+  transform: scaleY(0.0001);
+  opacity: 0;
+  transition:
+    transform 0.2s cubic-bezier(0.215, 0.61, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline
+  .ant-menu-item.ant-menu-item-danger::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item.ant-menu-item-danger::after {
+  border-inline-end-color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline
+  .ant-menu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light.ant-menu-inline
+  .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-light
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item-selected::after {
+  transform: scaleY(1);
+  opacity: 1;
+  transition:
+    transform 0.2s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu {
+  color: rgba(255, 255, 255, 0.65);
+  background: #001529;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-root:focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-root:focus-visible {
+  outline: 4px solid #91caff;
+  outline-offset: 1px;
+  transition:
+    outline-offset 0s,
+    outline 0s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-group-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-group-title {
+  color: rgba(255, 255, 255, 0.65);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-submenu-selected
+  > .ant-menu-submenu-title,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-submenu-selected
+  > .ant-menu-submenu-title {
+  color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-submenu-disabled,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-submenu-disabled {
+  color: rgba(255, 255, 255, 0.25) !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected)
+  > .ant-menu-submenu-title:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-selected):not(.ant-menu-submenu-selected)
+  > .ant-menu-submenu-title:hover {
+  color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):hover {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-item:not(.ant-menu-item-selected):active {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:hover {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu:not(.ant-menu-horizontal)
+  .ant-menu-submenu-title:active {
+  background-color: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-danger {
+  color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item-danger.ant-menu-item:hover:not(.ant-menu-item-selected):not(
+    .ant-menu-submenu-selected
+  ),
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item-danger.ant-menu-item:hover:not(.ant-menu-item-selected):not(
+    .ant-menu-submenu-selected
+  ) {
+  color: #ff7875;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item-danger.ant-menu-item:active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item-danger.ant-menu-item:active {
+  background: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item a:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item a:hover {
+  color: inherit;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-selected {
+  color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item-selected.ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item-selected.ant-menu-item-danger {
+  color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-selected a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-selected a,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-selected a:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item-selected
+  a:hover {
+  color: inherit;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu .ant-menu-item-selected {
+  background-color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item-selected.ant-menu-item-danger,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item-selected.ant-menu-item-danger {
+  background-color: #ff4d4f;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-item:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-item:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  .ant-menu-submenu-title:not(.ant-menu-item-disabled):focus-visible,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu
+  .ant-menu-submenu-title:not(.ant-menu-item-disabled):focus-visible {
+  outline: 4px solid #91caff;
+  outline-offset: 1px;
+  transition:
+    outline-offset 0s,
+    outline 0s;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-submenu > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-submenu
+  > .ant-menu {
+  background-color: #000c17;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-submenu-popup > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-submenu-popup
+  > .ant-menu {
+  background-color: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-popup > .ant-menu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu.ant-menu-popup > .ant-menu {
+  background-color: #ffffff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark > .ant-menu.ant-menu-horizontal {
+  border-bottom: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal > .ant-menu-submenu,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu {
+  top: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  border-radius: 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu::after {
+  position: absolute;
+  inset-inline: 16px;
+  bottom: 0;
+  border-bottom: 0px solid transparent;
+  transition: border-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-open,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-open {
+  background: transparent;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu:hover::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-active::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-open::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-open::after {
+  border-bottom-width: 0;
+  border-bottom-color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-selected,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected {
+  color: #fff;
+  background-color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-selected:hover,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected:hover {
+  background-color: #1677ff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-horizontal
+  > .ant-menu-submenu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-horizontal
+  > .ant-menu-submenu-selected::after {
+  border-bottom-width: 0;
+  border-bottom-color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-root.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-root.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-root.ant-menu-vertical,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-root.ant-menu-vertical {
+  border-inline-end: 0px solid rgba(5, 5, 5, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline
+  .ant-menu-sub.ant-menu-inline,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-sub.ant-menu-inline {
+  background: #000c17;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline .ant-menu-item,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item {
+  position: relative;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline .ant-menu-item::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item::after {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  border-inline-end: 0px solid #fff;
+  transform: scaleY(0.0001);
+  opacity: 0;
+  transition:
+    transform 0.2s cubic-bezier(0.215, 0.61, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
+  content: '';
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline
+  .ant-menu-item.ant-menu-item-danger::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item.ant-menu-item-danger::after {
+  border-inline-end-color: #fff;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline
+  .ant-menu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark.ant-menu-inline
+  .ant-menu-item-selected::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-dark
+  > .ant-menu.ant-menu-inline
+  .ant-menu-item-selected::after {
+  transform: scaleY(1);
+  opacity: 1;
+  transition:
+    transform 0.2s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-rtl {
+  direction: rtl;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-rtl {
+  transform-origin: 100% 0;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-rtl.ant-menu-vertical
+  .ant-menu-submenu-arrow::before,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-rtl
+  .ant-menu-vertical
+  .ant-menu-submenu-arrow::before {
+  transform: rotate(-45deg) translateY(-2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-rtl.ant-menu-vertical
+  .ant-menu-submenu-arrow::after,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu-submenu-rtl
+  .ant-menu-vertical
+  .ant-menu-submenu-arrow::after {
+  transform: rotate(45deg) translateY(2.5px);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-motion-collapse-legacy {
+  overflow: hidden;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-motion-collapse-legacy-active {
+  transition:
+    height 0.2s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.645, 0.045, 0.355, 1) !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-menu .ant-motion-collapse {
+  overflow: hidden;
+  transition:
+    height 0.2s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.2s cubic-bezier(0.645, 0.045, 0.355, 1) !important;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-appear {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-leave {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-enter.ant-slide-up-enter-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-appear.ant-slide-up-appear-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antSlideUpIn;
+  animation-play-state: running;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-leave.ant-slide-up-leave-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antSlideUpOut;
+  animation-play-state: running;
+  pointer-events: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-appear {
+  transform: scale(0);
+  transform-origin: 0% 0%;
+  opacity: 0;
+  animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-enter-prepare,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-appear-prepare {
+  transform: scale(1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-up-leave {
+  animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-appear {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-leave {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-enter.ant-slide-down-enter-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-appear.ant-slide-down-appear-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antSlideDownIn;
+  animation-play-state: running;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-leave.ant-slide-down-leave-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antSlideDownOut;
+  animation-play-state: running;
+  pointer-events: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-appear {
+  transform: scale(0);
+  transform-origin: 0% 0%;
+  opacity: 0;
+  animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-enter-prepare,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-appear-prepare {
+  transform: scale(1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-slide-down-leave {
+  animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-appear {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-leave {
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+  animation-play-state: paused;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-enter.ant-zoom-big-enter-active,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-appear.ant-zoom-big-appear-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antZoomBigIn;
+  animation-play-state: running;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-leave.ant-zoom-big-leave-active {
+  animation-name: css-dev-only-do-not-override-1adbn6x-antZoomBigOut;
+  animation-play-state: running;
+  pointer-events: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-enter,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-appear {
+  transform: scale(0);
+  opacity: 0;
+  animation-timing-function: cubic-bezier(0.08, 0.82, 0.17, 1);
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-enter-prepare,
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-appear-prepare {
+  transform: none;
+}
+:where(.css-dev-only-do-not-override-1adbn6x).ant-zoom-big-leave {
+  animation-timing-function: cubic-bezier(0.78, 0.14, 0.15, 0.86);
+}

--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1227,6 +1227,740 @@ exports[`renders components/menu/demo/component-token.tsx extend context correct
       </div>
     </div>
   </div>
+  <div
+    class="ant-space-item"
+  >
+    <ul
+      class="ant-menu ant-menu-root ant-menu-vertical ant-menu-dark ant-menu-inline-collapsed"
+      data-menu-list="true"
+      role="menu"
+      tabindex="0"
+    >
+      <li
+        class="ant-menu-item ant-menu-item-selected"
+        data-menu-id="rc-menu-uuid-test-1"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="pie-chart"
+          class="anticon anticon-pie-chart ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="pie-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M864 518H506V160c0-4.4-3.6-8-8-8h-26a398.46 398.46 0 00-282.8 117.1 398.19 398.19 0 00-85.7 127.1A397.61 397.61 0 0072 552a398.46 398.46 0 00117.1 282.8c36.7 36.7 79.5 65.6 127.1 85.7A397.61 397.61 0 00472 952a398.46 398.46 0 00282.8-117.1c36.7-36.7 65.6-79.5 85.7-127.1A397.61 397.61 0 00872 552v-26c0-4.4-3.6-8-8-8zM705.7 787.8A331.59 331.59 0 01470.4 884c-88.1-.4-170.9-34.9-233.2-97.2C174.5 724.1 140 640.7 140 552c0-88.7 34.5-172.1 97.2-234.8 54.6-54.6 124.9-87.9 200.8-95.5V586h364.3c-7.7 76.3-41.3 147-96.6 201.8zM952 462.4l-2.6-28.2c-8.5-92.1-49.4-179-115.2-244.6A399.4 399.4 0 00589 74.6L560.7 72c-4.7-.4-8.7 3.2-8.7 7.9V464c0 4.4 3.6 8 8 8l384-1c4.7 0 8.4-4 8-8.6zm-332.2-58.2V147.6a332.24 332.24 0 01166.4 89.8c45.7 45.6 77 103.6 90 166.1l-256.4.7z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 1
+        </span>
+      </li>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 1
+          </div>
+        </div>
+      </div>
+      <li
+        class="ant-menu-item"
+        data-menu-id="rc-menu-uuid-test-2"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="desktop"
+          class="anticon anticon-desktop ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="desktop"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M928 140H96c-17.7 0-32 14.3-32 32v496c0 17.7 14.3 32 32 32h380v112H304c-8.8 0-16 7.2-16 16v48c0 4.4 3.6 8 8 8h432c4.4 0 8-3.6 8-8v-48c0-8.8-7.2-16-16-16H548V700h380c17.7 0 32-14.3 32-32V172c0-17.7-14.3-32-32-32zm-40 488H136V212h752v416z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 2
+        </span>
+      </li>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 2
+          </div>
+        </div>
+      </div>
+      <li
+        class="ant-menu-item"
+        data-menu-id="rc-menu-uuid-test-3"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="container"
+          class="anticon anticon-container ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="container"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M832 64H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V96c0-17.7-14.3-32-32-32zm-40 824H232V687h97.9c11.6 32.8 32 62.3 59.1 84.7 34.5 28.5 78.2 44.3 123 44.3s88.5-15.7 123-44.3c27.1-22.4 47.5-51.9 59.1-84.7H792v-63H643.6l-5.2 24.7C626.4 708.5 573.2 752 512 752s-114.4-43.5-126.5-103.3l-5.2-24.7H232V136h560v752zM320 341h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8zm0 160h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 3
+        </span>
+      </li>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 3
+          </div>
+        </div>
+      </div>
+      <li
+        class="ant-menu-submenu ant-menu-submenu-vertical ant-menu-submenu-open"
+        role="none"
+      >
+        <div
+          aria-controls="rc-menu-uuid-test-sub1-popup"
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="ant-menu-submenu-title"
+          data-menu-id="rc-menu-uuid-test-sub1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            aria-label="mail"
+            class="anticon anticon-mail ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="mail"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M928 160H96c-17.7 0-32 14.3-32 32v640c0 17.7 14.3 32 32 32h832c17.7 0 32-14.3 32-32V192c0-17.7-14.3-32-32-32zm-40 110.8V792H136V270.8l-27.6-21.5 39.3-50.5 42.8 33.3h643.1l42.8-33.3 39.3 50.5-27.7 21.5zM833.6 232L512 482 190.4 232l-42.8-33.3-39.3 50.5 27.6 21.5 341.6 265.6a55.99 55.99 0 0068.7 0L888 270.8l27.6-21.5-39.3-50.5-42.7 33.2z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            Navigation One
+          </span>
+          <i
+            class="ant-menu-submenu-arrow"
+          />
+        </div>
+        <div
+          class="ant-menu-submenu ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-menu-submenu-popup ant-menu ant-menu-dark ant-menu-submenu-placement-rightTop"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            class="ant-menu ant-menu-sub ant-menu-vertical"
+            data-menu-list="true"
+            id="rc-menu-uuid-test-sub1-popup"
+            role="menu"
+          >
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-5"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 5
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-6"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 6
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-7"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 7
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-8"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 8
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+          </ul>
+        </div>
+      </li>
+      <li
+        class="ant-menu-submenu ant-menu-submenu-vertical"
+        role="none"
+      >
+        <div
+          aria-controls="rc-menu-uuid-test-sub2-popup"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="ant-menu-submenu-title"
+          data-menu-id="rc-menu-uuid-test-sub2"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            aria-label="appstore"
+            class="anticon anticon-appstore ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="appstore"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M464 144H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H212V212h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H612V212h200v200zM464 544H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H212V612h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H612V612h200v200z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            Navigation Two
+          </span>
+          <i
+            class="ant-menu-submenu-arrow"
+          />
+        </div>
+        <div
+          class="ant-menu-submenu ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-menu-submenu-popup ant-menu ant-menu-dark ant-menu-submenu-placement-rightTop"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            class="ant-menu ant-menu-sub ant-menu-vertical"
+            data-menu-list="true"
+            id="rc-menu-uuid-test-sub2-popup"
+            role="menu"
+          >
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-9"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 9
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              class="ant-menu-item ant-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-10"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-menu-title-content"
+              >
+                Option 10
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              class="ant-menu-submenu ant-menu-submenu-vertical"
+              role="none"
+            >
+              <div
+                aria-controls="rc-menu-uuid-test-sub3-popup"
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="ant-menu-submenu-title"
+                data-menu-id="rc-menu-uuid-test-sub3"
+                role="menuitem"
+                tabindex="-1"
+              >
+                <span
+                  class="ant-menu-title-content"
+                >
+                  Submenu
+                </span>
+                <i
+                  class="ant-menu-submenu-arrow"
+                />
+              </div>
+              <div
+                class="ant-menu-submenu ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-menu-submenu-popup ant-menu ant-menu-dark ant-menu-submenu-placement-rightTop"
+                style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+              >
+                <ul
+                  class="ant-menu ant-menu-sub ant-menu-vertical"
+                  data-menu-list="true"
+                  id="rc-menu-uuid-test-sub3-popup"
+                  role="menu"
+                >
+                  <li
+                    class="ant-menu-item ant-menu-item-only-child"
+                    data-menu-id="rc-menu-uuid-test-11"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <span
+                      class="ant-menu-title-content"
+                    >
+                      Option 11
+                    </span>
+                  </li>
+                  <div
+                    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+                    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+                  >
+                    <div
+                      class="ant-tooltip-arrow"
+                      style="position: absolute; top: 0px; left: 0px;"
+                    />
+                    <div
+                      class="ant-tooltip-content"
+                    >
+                      <div
+                        class="ant-tooltip-inner"
+                        role="tooltip"
+                      />
+                    </div>
+                  </div>
+                  <li
+                    class="ant-menu-item ant-menu-item-only-child"
+                    data-menu-id="rc-menu-uuid-test-12"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    <span
+                      class="ant-menu-title-content"
+                    >
+                      Option 12
+                    </span>
+                  </li>
+                  <div
+                    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+                    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+                  >
+                    <div
+                      class="ant-tooltip-arrow"
+                      style="position: absolute; top: 0px; left: 0px;"
+                    />
+                    <div
+                      class="ant-tooltip-content"
+                    >
+                      <div
+                        class="ant-tooltip-inner"
+                        role="tooltip"
+                      />
+                    </div>
+                  </div>
+                </ul>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+    <div
+      aria-hidden="true"
+      style="display: none;"
+    >
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 1
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 2
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          >
+            Option 3
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; top: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            role="tooltip"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
@@ -422,6 +422,191 @@ exports[`renders components/menu/demo/component-token.tsx correctly 1`] = `
       style="display:none"
     />
   </div>
+  <div
+    class="ant-space-item"
+  >
+    <ul
+      class="ant-menu ant-menu-root ant-menu-vertical ant-menu-dark ant-menu-inline-collapsed"
+      data-menu-list="true"
+      role="menu"
+      tabindex="0"
+    >
+      <li
+        class="ant-menu-item ant-menu-item-selected"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="pie-chart"
+          class="anticon anticon-pie-chart ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="pie-chart"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M864 518H506V160c0-4.4-3.6-8-8-8h-26a398.46 398.46 0 00-282.8 117.1 398.19 398.19 0 00-85.7 127.1A397.61 397.61 0 0072 552a398.46 398.46 0 00117.1 282.8c36.7 36.7 79.5 65.6 127.1 85.7A397.61 397.61 0 00472 952a398.46 398.46 0 00282.8-117.1c36.7-36.7 65.6-79.5 85.7-127.1A397.61 397.61 0 00872 552v-26c0-4.4-3.6-8-8-8zM705.7 787.8A331.59 331.59 0 01470.4 884c-88.1-.4-170.9-34.9-233.2-97.2C174.5 724.1 140 640.7 140 552c0-88.7 34.5-172.1 97.2-234.8 54.6-54.6 124.9-87.9 200.8-95.5V586h364.3c-7.7 76.3-41.3 147-96.6 201.8zM952 462.4l-2.6-28.2c-8.5-92.1-49.4-179-115.2-244.6A399.4 399.4 0 00589 74.6L560.7 72c-4.7-.4-8.7 3.2-8.7 7.9V464c0 4.4 3.6 8 8 8l384-1c4.7 0 8.4-4 8-8.6zm-332.2-58.2V147.6a332.24 332.24 0 01166.4 89.8c45.7 45.6 77 103.6 90 166.1l-256.4.7z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 1
+        </span>
+      </li>
+      <li
+        class="ant-menu-item"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="desktop"
+          class="anticon anticon-desktop ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="desktop"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M928 140H96c-17.7 0-32 14.3-32 32v496c0 17.7 14.3 32 32 32h380v112H304c-8.8 0-16 7.2-16 16v48c0 4.4 3.6 8 8 8h432c4.4 0 8-3.6 8-8v-48c0-8.8-7.2-16-16-16H548V700h380c17.7 0 32-14.3 32-32V172c0-17.7-14.3-32-32-32zm-40 488H136V212h752v416z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 2
+        </span>
+      </li>
+      <li
+        class="ant-menu-item"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span
+          aria-label="container"
+          class="anticon anticon-container ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="container"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M832 64H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V96c0-17.7-14.3-32-32-32zm-40 824H232V687h97.9c11.6 32.8 32 62.3 59.1 84.7 34.5 28.5 78.2 44.3 123 44.3s88.5-15.7 123-44.3c27.1-22.4 47.5-51.9 59.1-84.7H792v-63H643.6l-5.2 24.7C626.4 708.5 573.2 752 512 752s-114.4-43.5-126.5-103.3l-5.2-24.7H232V136h560v752zM320 341h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8zm0 160h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Option 3
+        </span>
+      </li>
+      <li
+        class="ant-menu-submenu ant-menu-submenu-vertical ant-menu-submenu-open"
+        role="none"
+      >
+        <div
+          aria-expanded="true"
+          aria-haspopup="true"
+          class="ant-menu-submenu-title"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            aria-label="mail"
+            class="anticon anticon-mail ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="mail"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M928 160H96c-17.7 0-32 14.3-32 32v640c0 17.7 14.3 32 32 32h832c17.7 0 32-14.3 32-32V192c0-17.7-14.3-32-32-32zm-40 110.8V792H136V270.8l-27.6-21.5 39.3-50.5 42.8 33.3h643.1l42.8-33.3 39.3 50.5-27.7 21.5zM833.6 232L512 482 190.4 232l-42.8-33.3-39.3 50.5 27.6 21.5 341.6 265.6a55.99 55.99 0 0068.7 0L888 270.8l27.6-21.5-39.3-50.5-42.7 33.2z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            Navigation One
+          </span>
+          <i
+            class="ant-menu-submenu-arrow"
+          />
+        </div>
+      </li>
+      <li
+        class="ant-menu-submenu ant-menu-submenu-vertical"
+        role="none"
+      >
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="ant-menu-submenu-title"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            aria-label="appstore"
+            class="anticon anticon-appstore ant-menu-item-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="appstore"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M464 144H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H212V212h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H612V212h200v200zM464 544H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H212V612h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H612V612h200v200z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-menu-title-content"
+          >
+            Navigation Two
+          </span>
+          <i
+            class="ant-menu-submenu-arrow"
+          />
+        </div>
+      </li>
+    </ul>
+    <div
+      aria-hidden="true"
+      style="display:none"
+    />
+  </div>
 </div>
 `;
 

--- a/components/menu/demo/component-token.tsx
+++ b/components/menu/demo/component-token.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import {
   AppstoreOutlined,
   ContainerOutlined,
@@ -6,7 +7,6 @@ import {
   PieChartOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import React, { useState } from 'react';
 import type { MenuProps } from 'antd';
 import { ConfigProvider, Menu, Space } from 'antd';
 
@@ -120,6 +120,7 @@ const App: React.FC = () => {
           components: {
             Menu: {
               horizontalItemBorderRadius: 6,
+              popupBg: 'red',
               horizontalItemHoverBg: '#f5f5f5',
             },
           },
@@ -136,6 +137,7 @@ const App: React.FC = () => {
               darkSubMenuItemBg: '#faad14',
               darkItemSelectedColor: '#ffccc7',
               darkItemSelectedBg: '#52c41a',
+              darkPopupBg: 'red',
             },
           },
         }}
@@ -149,6 +151,24 @@ const App: React.FC = () => {
           style={{
             width: 256,
           }}
+        />
+      </ConfigProvider>
+      <ConfigProvider
+        theme={{
+          components: {
+            Menu: {
+              darkPopupBg: 'red',
+            },
+          },
+        }}
+      >
+        <Menu
+          inlineCollapsed
+          defaultSelectedKeys={['1']}
+          defaultOpenKeys={['sub1']}
+          mode="inline"
+          theme="dark"
+          items={items2}
         />
       </ConfigProvider>
     </Space>

--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -1,6 +1,7 @@
+import type { CSSProperties } from 'react';
 import type { CSSObject } from '@ant-design/cssinjs';
 import { TinyColor } from '@ctrl/tinycolor';
-import type { CSSProperties } from 'react';
+
 import { clearFix, resetComponent, resetIcon } from '../../style';
 import { genCollapseMotion, initSlideMotion, initZoomMotion } from '../../style/motion';
 import type { FullToken, GenerateStyle, UseComponentStyleResult } from '../../theme/internal';
@@ -287,6 +288,12 @@ export interface ComponentToken {
   collapsedIconSize: number;
 
   // Dark
+  /**
+   * @desc 暗色模式下的浮层菜单的背景颜色
+   * @descEN The background color of the overlay menu in dark mode.
+   */
+  darkPopupBg: string;
+
   /**
    * @desc 暗色模式下的菜单项文字颜色
    * @descEN Color of menu item text in dark mode
@@ -814,6 +821,7 @@ export default (prefixCls: string, injectStyle: boolean): UseComponentStyleResul
         darkItemColor,
         darkDangerItemColor,
         darkItemBg,
+        darkPopupBg,
         darkSubMenuItemBg,
         darkItemSelectedColor,
         darkItemSelectedBg,
@@ -844,7 +852,7 @@ export default (prefixCls: string, injectStyle: boolean): UseComponentStyleResul
         groupTitleColor: darkGroupTitleColor,
         itemSelectedColor: darkItemSelectedColor,
         itemBg: darkItemBg,
-        popupBg: darkItemBg,
+        popupBg: darkPopupBg || darkItemBg,
         subMenuItemBg: darkSubMenuItemBg,
         itemActiveBg: 'transparent',
         itemSelectedBg: darkItemSelectedBg,
@@ -1000,6 +1008,7 @@ export default (prefixCls: string, injectStyle: boolean): UseComponentStyleResul
         darkItemColor: colorTextDark,
         darkDangerItemColor: colorError,
         darkItemBg: '#001529',
+        darkPopupBg: '#001529',
         darkSubMenuItemBg: '#000c17',
         darkItemSelectedColor: colorTextLightSolid,
         darkItemSelectedBg: colorPrimary,

--- a/components/menu/style/theme.tsx
+++ b/components/menu/style/theme.tsx
@@ -1,4 +1,5 @@
 import type { CSSInterpolation } from '@ant-design/cssinjs';
+
 import type { MenuToken } from '.';
 import { genFocusOutline } from '../../style';
 
@@ -156,6 +157,10 @@ const getThemeStyle = (token: MenuToken, themeSuffix: string): CSSInterpolation 
 
       [`&${componentCls}-submenu > ${componentCls}`]: {
         backgroundColor: menuSubMenuBg,
+      },
+
+      [`&${componentCls}-submenu-popup > ${componentCls}`]: {
+        backgroundColor: popupBg,
       },
 
       [`&${componentCls}-popup > ${componentCls}`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

procomponents 中默认是submenu 背景颜色是透明的，但是在 popup 中希望是跟随主题颜色，这个token 可以解决这个问题，区分 popup 和 平铺时的颜色

![image](https://github.com/ant-design/ant-design/assets/8186664/aeddd318-396a-4b80-8fa8-a21be26c6664)

![image](https://github.com/ant-design/ant-design/assets/8186664/e50e3018-2fb0-41af-9ead-0df85afe3176)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Menu support popupBg and darkPopupBg      |
| 🇨🇳 Chinese |   Menu  支持 popupBg 和   darkPopupBg  来修改浮层背景颜色     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b11ba1</samp>

This pull request enhances the Menu component's support for dark mode by introducing a new theme token `darkPopupBg` and a demo of how to use it with the ConfigProvider component. It also improves the code style and the appearance of the overlay menu.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b11ba1</samp>

*  Add and use darkPopupBg theme token for overlay menu in dark mode ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dR292-R297), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dR824), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dL847-R855), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dR1011), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR140), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR156-R173))
*  Add and use popupBg theme token for overlay menu in light mode ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR123), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR156-R173), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-803a82d9b4afa684620a38d6c44836f0b24b12205ef42ec80dba78aa28fe9829R162-R165))
*  Wrap Menu component with ConfigProvider component with custom theme in `component-token.tsx` demo file ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR156-R173))
*  Reorder imports and add blank line in style files for readability ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-f84706d0f4fb54c91e83f8dd7b34ce37f6015d56dc057385580b19473c8f1f7dL1-R4), [link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-803a82d9b4afa684620a38d6c44836f0b24b12205ef42ec80dba78aa28fe9829R2))
*  Remove duplicate import of React and useState in `component-token.tsx` demo file ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecL9))
*  Import React and useState in `component-token.tsx` demo file for ConfigProvider and state usage ([link](https://github.com/ant-design/ant-design/pull/45826/files?diff=unified&w=0#diff-4a752aeb2a4a9a264017cc0016b52b3a9899d088787990206ad98e833eb22cecR1))
