### PR TITLE
refactor: Timeline support css var

### DIFF
--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -5,6 +5,8 @@ import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 // CSSINJS
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type { TimelineItemProps } from './TimelineItem';
 import TimelineItem from './TimelineItem';
 import TimelineItemList from './TimelineItemList';
@@ -41,14 +43,16 @@ const Timeline: CompoundedComponent = (props) => {
   }
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const mergedItems: TimelineItemProps[] = useItems(items, children);
 
-  return wrapSSR(
+  return wrapCSSVar(
     <TimelineItemList
       {...restProps}
-      className={classNames(timeline?.className, className)}
+      className={classNames(timeline?.className, className, rootCls)}
       style={{ ...timeline?.style, ...style }}
       prefixCls={prefixCls}
       direction={direction}

--- a/components/timeline/style/cssVar.ts
+++ b/components/timeline/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Timeline', prepareComponentToken);

--- a/components/timeline/style/index.ts
+++ b/components/timeline/style/index.ts
@@ -1,6 +1,7 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -38,7 +39,7 @@ interface TimelineToken extends FullToken<'Timeline'> {
 }
 
 const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
-  const { componentCls } = token;
+  const { componentCls, calc } = token;
 
   return {
     [componentCls]: {
@@ -57,9 +58,9 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
         '&-tail': {
           position: 'absolute',
           insetBlockStart: token.itemHeadSize,
-          insetInlineStart: (token.itemHeadSize - token.tailWidth) / 2,
-          height: `calc(100% - ${token.itemHeadSize}px)`,
-          borderInlineStart: `${token.tailWidth}px ${token.lineType} ${token.tailColor}`,
+          insetInlineStart: calc(calc(token.itemHeadSize).sub(token.tailWidth)).div(2).equal(),
+          height: `calc(100% - ${unit(token.itemHeadSize)})`,
+          borderInlineStart: `${unit(token.tailWidth)} ${token.lineType} ${token.tailColor}`,
         },
 
         '&-pending': {
@@ -78,7 +79,7 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
           width: token.itemHeadSize,
           height: token.itemHeadSize,
           backgroundColor: token.dotBg,
-          border: `${token.dotBorderWidth}px ${token.lineType} transparent`,
+          border: `${unit(token.dotBorderWidth)} ${token.lineType} transparent`,
           borderRadius: '50%',
 
           '&-blue': {
@@ -104,8 +105,8 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
 
         '&-head-custom': {
           position: 'absolute',
-          insetBlockStart: token.itemHeadSize / 2,
-          insetInlineStart: token.itemHeadSize / 2,
+          insetBlockStart: calc(token.itemHeadSize).div(2).equal(),
+          insetInlineStart: calc(token.itemHeadSize).div(2).equal(),
           width: 'auto',
           height: 'auto',
           marginBlockStart: 0,
@@ -119,8 +120,11 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
 
         '&-content': {
           position: 'relative',
-          insetBlockStart: -(token.fontSize * token.lineHeight - token.fontSize) + token.lineWidth,
-          marginInlineStart: token.margin + token.itemHeadSize,
+          insetBlockStart: calc(calc(token.fontSize).mul(token.lineHeight).sub(token.fontSize))
+            .mul(-1)
+            .add(token.lineWidth)
+            .equal(),
+          marginInlineStart: calc(token.margin).add(token.itemHeadSize).equal(),
           marginInlineEnd: 0,
           marginBlockStart: 0,
           marginBlockEnd: 0,
@@ -133,7 +137,7 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
           },
 
           [`> ${componentCls}-item-content`]: {
-            minHeight: token.controlHeightLG * 1.2,
+            minHeight: calc(token.controlHeightLG).mul(1.2).equal(),
           },
         },
       },
@@ -147,24 +151,24 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
           },
 
           '&-head': {
-            marginInlineStart: `-${token.marginXXS}px`,
+            marginInlineStart: calc(token.marginXXS).mul(-1).equal(),
 
             '&-custom': {
-              marginInlineStart: token.tailWidth / 2,
+              marginInlineStart: calc(token.tailWidth).div(2).equal(),
             },
           },
 
           '&-left': {
             [`${componentCls}-item-content`]: {
-              insetInlineStart: `calc(50% - ${token.marginXXS}px)`,
-              width: `calc(50% - ${token.marginSM}px)`,
+              insetInlineStart: `calc(50% - ${unit(token.marginXXS)})`,
+              width: `calc(50% - ${unit(token.marginSM)})`,
               textAlign: 'start',
             },
           },
 
           '&-right': {
             [`${componentCls}-item-content`]: {
-              width: `calc(50% - ${token.marginSM}px)`,
+              width: `calc(50% - ${unit(token.marginSM)})`,
               margin: 0,
               textAlign: 'end',
             },
@@ -177,11 +181,13 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
           [`${componentCls}-item-tail,
             ${componentCls}-item-head,
             ${componentCls}-item-head-custom`]: {
-            insetInlineStart: `calc(100% - ${(token.itemHeadSize + token.tailWidth) / 2}px)`,
+            insetInlineStart: `calc(100% - ${unit(
+              calc(calc(token.itemHeadSize).add(token.tailWidth)).div(2).equal(),
+            )})`,
           },
 
           [`${componentCls}-item-content`]: {
-            width: `calc(100% - ${token.itemHeadSize + token.marginXS}px)`,
+            width: `calc(100% - ${unit(calc(token.itemHeadSize).add(token.marginXS).equal())})`,
           },
         },
       },
@@ -190,8 +196,8 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
         ${componentCls}-item-last
         ${componentCls}-item-tail`]: {
         display: 'block',
-        height: `calc(100% - ${token.margin}px)`,
-        borderInlineStart: `${token.tailWidth}px dotted ${token.tailColor}`,
+        height: `calc(100% - ${unit(token.margin)})`,
+        borderInlineStart: `${unit(token.tailWidth)} dotted ${token.tailColor}`,
       },
 
       [`&${componentCls}-reverse
@@ -204,27 +210,30 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
         [`${componentCls}-item-tail`]: {
           insetBlockStart: token.margin,
           display: 'block',
-          height: `calc(100% - ${token.margin}px)`,
-          borderInlineStart: `${token.tailWidth}px dotted ${token.tailColor}`,
+          height: `calc(100% - ${unit(token.margin)})`,
+          borderInlineStart: `${unit(token.tailWidth)} dotted ${token.tailColor}`,
         },
 
         [`${componentCls}-item-content`]: {
-          minHeight: token.controlHeightLG * 1.2,
+          minHeight: calc(token.controlHeightLG).mul(1.2).equal(),
         },
       },
 
       [`&${componentCls}-label`]: {
         [`${componentCls}-item-label`]: {
           position: 'absolute',
-          insetBlockStart: -(token.fontSize * token.lineHeight - token.fontSize) + token.tailWidth,
-          width: `calc(50% - ${token.marginSM}px)`,
+          insetBlockStart: calc(calc(token.fontSize).mul(token.lineHeight).sub(token.fontSize))
+            .mul(-1)
+            .add(token.tailWidth)
+            .equal(),
+          width: `calc(50% - ${unit(token.marginSM)})`,
           textAlign: 'end',
         },
 
         [`${componentCls}-item-right`]: {
           [`${componentCls}-item-label`]: {
-            insetInlineStart: `calc(50% + ${token.marginSM}px)`,
-            width: `calc(50% - ${token.marginSM}px)`,
+            insetInlineStart: `calc(50% + ${unit(token.marginSM)})`,
+            width: `calc(50% - ${unit(token.marginSM)})`,
             textAlign: 'start',
           },
         },
@@ -243,6 +252,14 @@ const genTimelineStyle: GenerateStyle<TimelineToken, CSSObject> = (token) => {
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Timeline'> = (token) => ({
+  tailColor: token.colorSplit,
+  tailWidth: token.lineWidthBold,
+  dotBorderWidth: token.wireframe ? token.lineWidthBold : token.lineWidth * 3,
+  dotBg: token.colorBgContainer,
+  itemPaddingBottom: token.padding * 1.25,
+});
+
 export default genComponentStyleHook(
   'Timeline',
   (token) => {
@@ -254,11 +271,5 @@ export default genComponentStyleHook(
 
     return [genTimelineStyle(timeLineToken)];
   },
-  (token) => ({
-    tailColor: token.colorSplit,
-    tailWidth: token.lineWidthBold,
-    dotBorderWidth: token.wireframe ? token.lineWidthBold : token.lineWidth * 3,
-    dotBg: token.colorBgContainer,
-    itemPaddingBottom: token.padding * 1.25,
-  }),
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Timeline support css variables |
| 🇨🇳 Chinese | Timeline 组件支持 css 变量 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e497b54</samp>

This pull request refactors the `Timeline` component to use CSS variables for styling, enabling dynamic theming and customization. It introduces new helpers and a function for registering the CSS variables, and modifies the style and component modules accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e497b54</samp>

*  Enable CSS variables for the `Timeline` component to support dynamic theming and customization ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dR8-R9), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dL44-R55), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-cd0c15c98fdf7495a752bc54f462a05b1c5ee80f8b1e9cdcdf4b281bea099c8fR1-R4), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602R255-R262), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L257-R274))
  - Import `useCSSVar` and `useCSSVarCls` hooks from `style` and `config-provider` modules ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dR8-R9))
  - Wrap the component with `CSSVarProvider` and add `rootCls` class name to `className` prop ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-3b72170fc4d783068393b0bcd87b541fcbf4eac0b0ccbc8ae237f06886da272dL44-R55))
  - Add `cssVar.ts` file in `style` module that exports a function to register the CSS variables ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-cd0c15c98fdf7495a752bc54f462a05b1c5ee80f8b1e9cdcdf4b281bea099c8fR1-R4))
  - Refactor the function that prepares the component token to a separate function `prepareComponentToken` in `style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602R255-R262), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L257-R274))
*  Use `calc` and `unit` helpers to perform calculations and generate valid CSS values with CSS variables ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L41-R42), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L60-R63), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L81-R82), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L107-R109), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L122-R127), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L136-R140), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L150-R157), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L159-R164), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L167-R171), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L180-R190), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L193-R200), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L207-R218), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L219-R229), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L226-R236))
  - Add `calc` property to `TimelineToken` interface that returns a `CSSCalc` object ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L41-R42))
  - Replace plain arithmetic expressions with `calc` helper that uses `CSSCalc` class ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L60-R63), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L107-R109), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L122-R127), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L150-R157), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L180-R190), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L207-R218), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L219-R229))
  - Use `unit` helper to convert numbers to CSS unit strings ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L81-R82), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L136-R140), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L159-R164), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L167-R171), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L180-R190), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L193-R200), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L207-R218), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L219-R229), [link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L226-R236))
*  Import `GetDefaultToken` type from `theme` module to define the type of the function that prepares the component token ([link](https://github.com/ant-design/ant-design/pull/45831/files?diff=unified&w=0#diff-033ff0b0fb35d11b0031fce6bb9dba6e8d00910e9dbf81a620c42f904a18d602L2-R4))
