### PR TITLE
feat: Calendar support cssVar

### DIFF
--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -121,7 +121,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
     const calendarPrefixCls = `${prefixCls}-calendar`;
 
     const [, hashId] = useStyle(prefixCls);
-    const wrapCSSVar = useCSSVar(prefixCls);
+    const wrapCSSVar = useCSSVar(calendarPrefixCls);
 
     const today = generateConfig.getNow();
 

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -16,6 +16,7 @@ import { useLocale } from '../locale';
 import CalendarHeader from './Header';
 import enUS from './locale/en_US';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 type InjectDefaultProps<Props> = Omit<
   Props,
@@ -119,7 +120,8 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
     const calendarPrefixCls = `${prefixCls}-calendar`;
 
-    const [wrapSSR, hashId] = useStyle(prefixCls);
+    const [, hashId] = useStyle(prefixCls);
+    const wrapCSSVar = useCSSVar(prefixCls);
 
     const today = generateConfig.getNow();
 
@@ -281,7 +283,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
       }
     };
 
-    return wrapSSR(
+    return wrapCSSVar(
       <div
         className={classNames(
           calendarPrefixCls,

--- a/components/calendar/style/cssVar.ts
+++ b/components/calendar/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('Calendar', prepareComponentToken);

--- a/components/calendar/style/index.ts
+++ b/components/calendar/style/index.ts
@@ -1,4 +1,6 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
+
 import type { PanelComponentToken, PickerPanelToken } from '../../date-picker/style';
 import {
   genPanelStyle,
@@ -6,7 +8,7 @@ import {
   initPickerPanelToken,
 } from '../../date-picker/style';
 import { resetComponent } from '../../style';
-import type { FullToken } from '../../theme/internal';
+import type { FullToken, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -62,7 +64,7 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
       [`${calendarCls}-header`]: {
         display: 'flex',
         justifyContent: 'flex-end',
-        padding: `${token.paddingSM}px 0`,
+        padding: `${unit(token.paddingSM)} 0`,
 
         [`${calendarCls}-year-select`]: {
           minWidth: token.yearControlWidth,
@@ -79,13 +81,13 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
     [`${calendarCls} ${componentCls}-panel`]: {
       background: fullPanelBg,
       border: 0,
-      borderTop: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+      borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
       borderRadius: 0,
       [`${componentCls}-month-panel, ${componentCls}-date-panel`]: {
         width: 'auto',
       },
       [`${componentCls}-body`]: {
-        padding: `${token.paddingXS}px 0`,
+        padding: `${unit(token.paddingXS)} 0`,
       },
       [`${componentCls}-content`]: {
         width: '100%',
@@ -98,14 +100,14 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
         paddingInlineStart: token.paddingXS,
       },
       [`${componentCls}-panel`]: {
-        borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
+        borderRadius: `0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
       },
       [`${componentCls}-content`]: {
         height: token.miniContentHeight,
         th: {
           height: 'auto',
           padding: 0,
-          lineHeight: `${token.weekHeight}px`,
+          lineHeight: `${unit(token.weekHeight)}`,
         },
       },
       [`${componentCls}-cell::before`]: {
@@ -127,7 +129,7 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
             height: 'auto',
             paddingInlineEnd: token.paddingSM,
             paddingBottom: token.paddingXXS,
-            lineHeight: `${token.weekHeight}px`,
+            lineHeight: `${unit(token.weekHeight)}`,
           },
         },
       },
@@ -161,14 +163,14 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
         display: 'block',
         width: 'auto',
         height: 'auto',
-        margin: `0 ${token.marginXS / 2}px`,
-        padding: `${token.paddingXS / 2}px ${token.paddingXS}px 0`,
+        margin: `0 ${unit(token.calc(token.marginXS).div(2).equal())}`,
+        padding: `${unit(token.calc(token.paddingXS).div(2).equal())} ${unit(token.paddingXS)} 0`,
         border: 0,
-        borderTop: `${token.lineWidthBold}px ${token.lineType} ${token.colorSplit}`,
+        borderTop: `${unit(token.lineWidthBold)} ${token.lineType} ${token.colorSplit}`,
         borderRadius: 0,
         transition: `background ${token.motionDurationSlow}`,
         '&-value': {
-          lineHeight: `${token.dateValueHeight}px`,
+          lineHeight: `${unit(token.dateValueHeight)}`,
           transition: `color ${token.motionDurationSlow}`,
         },
         '&-content': {
@@ -188,7 +190,7 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
         },
       },
     },
-    [`@media only screen and (max-width: ${token.screenXS}px) `]: {
+    [`@media only screen and (max-width: ${unit(token.screenXS)}) `]: {
       [`${calendarCls}`]: {
         [`${calendarCls}-header`]: {
           display: 'block',
@@ -196,7 +198,7 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
             width: '50%',
           },
           [`${calendarCls}-month-select`]: {
-            width: `calc(50% - ${token.paddingXS}px)`,
+            width: `calc(50% - ${unit(token.paddingXS)})`,
           },
           [`${calendarCls}-mode-switch`]: {
             width: '100%',
@@ -213,6 +215,15 @@ export const genCalendarStyles = (token: CalendarToken): CSSObject => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Calendar'> = (token) => ({
+  fullBg: token.colorBgContainer,
+  fullPanelBg: token.colorBgContainer,
+  itemActiveBg: token.controlItemBgActive,
+  yearControlWidth: 80,
+  monthControlWidth: 70,
+  miniContentHeight: 256,
+});
+
 export default genComponentStyleHook(
   'Calendar',
   (token) => {
@@ -225,20 +236,17 @@ export default genComponentStyleHook(
         calendarCls,
         pickerCellInnerCls: `${token.componentCls}-cell-inner`,
         dateValueHeight: token.controlHeightSM,
-        weekHeight: token.controlHeightSM * 0.75,
-        dateContentHeight:
-          (token.fontSizeSM * token.lineHeightSM + token.marginXS) * 3 + token.lineWidth * 2,
+        weekHeight: token.calc(token.controlHeightSM).mul(0.75).equal() as number,
+        dateContentHeight: token
+          .calc(token.calc(token.fontHeightSM).add(token.marginXS).equal())
+          .mul(3)
+          .add(token.lineWidth)
+          .mul(2)
+          .equal() as number,
       },
     );
 
     return [genCalendarStyles(calendarToken)];
   },
-  (token) => ({
-    fullBg: token.colorBgContainer,
-    fullPanelBg: token.colorBgContainer,
-    itemActiveBg: token.controlItemBgActive,
-    yearControlWidth: 80,
-    monthControlWidth: 70,
-    miniContentHeight: 256,
-  }),
+  prepareComponentToken,
 );

--- a/components/calendar/style/index.ts
+++ b/components/calendar/style/index.ts
@@ -238,10 +238,9 @@ export default genComponentStyleHook(
         dateValueHeight: token.controlHeightSM,
         weekHeight: token.calc(token.controlHeightSM).mul(0.75).equal() as number,
         dateContentHeight: token
-          .calc(token.calc(token.fontHeightSM).add(token.marginXS).equal())
+          .calc(token.calc(token.fontHeightSM).add(token.marginXS))
           .mul(3)
-          .add(token.lineWidth)
-          .mul(2)
+          .add(token.calc(token.lineWidth).mul(2))
           .equal() as number,
       },
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- #45618 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Calendar support cssVar       |
| 🇨🇳 Chinese |    日历组件支持 css 变量       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73b4070</samp>

This pull request refactors the calendar component to use CSS variables for theming, instead of static styles. It introduces a new hook `useCSSVar` that handles the registration and update of the CSS variables based on the theme token. It also updates the component's style file to use the theme token system and the `@ant-design/cssinjs` library.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73b4070</samp>

*  Generate and use a custom hook for registering and updating CSS variables for the calendar component based on the theme token ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2R19), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L122-R124), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L284-R286), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-2cc1bcdf491496d5b42c2b5be2158d39e18ba2bb626260237284a87be965a8aaR1-R4), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544R218-R226))
  * Import the `useCSSVar` hook from `./style/cssVar` in `components/calendar/generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2R19))
  * Destructure the `hashId` from the `useStyle` hook and call the `useCSSVar` hook with the `prefixCls` as the argument in `components/calendar/generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L122-R124))
  * Replace the `wrapSSR` function with the `wrapCSSVar` function returned by the `useCSSVar` hook in `components/calendar/generateCalendar.tsx` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-841e97dfb23daba72a34ee15810c8b36da6464eba16e120739ec6c9636f94fb2L284-R286))
  * Create a new file `components/calendar/style/cssVar.ts` that exports the `useCSSVar` hook as the default export ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-2cc1bcdf491496d5b42c2b5be2158d39e18ba2bb626260237284a87be965a8aaR1-R4))
  * Generate the `useCSSVar` hook by calling the `genCSSVarRegister` function from `../../theme/internal` with the component name and the `prepareComponentToken` function as the arguments in `components/calendar/style/cssVar.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-2cc1bcdf491496d5b42c2b5be2158d39e18ba2bb626260237284a87be965a8aaR1-R4), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544R218-R226))
  * Define the `prepareComponentToken` function that takes a theme token and returns a default token for the calendar component in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544R218-R226))
* Convert the numeric token values to CSS unit strings with the `unit` function from `@ant-design/cssinjs` and replace the hard-coded numeric values with the `token.calc` function in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544R2-R3), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L9-R11), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L65-R67), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L82-R84), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L88-R90), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L101-R103), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L108-R110), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L130-R132), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L164-R173), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L191-R193), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L199-R201), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L228-R245), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L236-R251))
  * Import the `unit` function and the `GetDefaultToken` type from `@ant-design/cssinjs` and `../../theme/internal` respectively in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544R2-R3), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L9-R11))
  * Wrap the `token.paddingSM`, `token.lineWidth`, `token.paddingXS`, `token.borderRadiusLG`, `token.weekHeight`, `token.marginXS`, `token.lineWidthBold`, `token.dateValueHeight`, and `token.screenXS` values with the `unit` function in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L65-R67), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L82-R84), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L88-R90), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L101-R103), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L108-R110), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L130-R132), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L164-R173), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L191-R193), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L199-R201))
  * Replace the hard-coded numeric values for the `weekHeight` and `dateContentHeight` properties with the `token.calc` function in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L228-R245), [link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L236-R251))
  * Replace the inline function that returns the default token for the calendar component with the `prepareComponentToken` function in `components/calendar/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45835/files?diff=unified&w=0#diff-301b86a4e3e8d0c690868d2f70adcef037741d8db81cdad1dcc989a4c8be0544L236-R251))
