### PR TITLE
feat: Card support cssVar

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react';
 import classNames from 'classnames';
 import type { Tab } from 'rc-tabs/lib/interface';
 import omit from 'rc-util/lib/omit';
-import * as React from 'react';
+
 import { ConfigContext } from '../config-provider';
 import useSize from '../config-provider/hooks/useSize';
 import Skeleton from '../skeleton';
@@ -9,6 +10,7 @@ import type { TabsProps } from '../tabs';
 import Tabs from '../tabs';
 import Grid from './Grid';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export type CardType = 'inner';
 export type CardSize = 'default' | 'small';
@@ -98,7 +100,8 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   }, [children]);
 
   const prefixCls = getPrefixCls('card', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const loadingBlock = (
     <Skeleton loading active paragraph={{ rows: 4 }} title={false}>
@@ -171,7 +174,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
   const mergedStyle: React.CSSProperties = { ...card?.style, ...style };
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div ref={ref} {...divProps} className={classString} style={mergedStyle}>
       {head}
       {coverDom}

--- a/components/card/style/cssVar.ts
+++ b/components/card/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('Card', prepareComponentToken);

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -1,7 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 
 import { clearFix, resetComponent, textEllipsis } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -72,13 +72,13 @@ const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     flexDirection: 'column',
     minHeight: headerHeight,
     marginBottom: -1, // Fix card grid overflow bug: https://gw.alipayobjects.com/zos/rmsportal/XonYxBikwpgbqIQBeuhk.png
-    padding: `0 ${cardPaddingBase}px`,
+    padding: `0 ${unit(cardPaddingBase)}`,
     color: token.colorTextHeading,
     fontWeight: token.fontWeightStrong,
     fontSize: token.headerFontSize,
     background: token.headerBg,
-    borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorBorderSecondary}`,
-    borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
+    borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
+    borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
 
     ...clearFix(),
 
@@ -111,7 +111,7 @@ const genCardHeadStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       fontSize: token.fontSize,
 
       '&-bar': {
-        borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorBorderSecondary}`,
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
       },
     },
   };
@@ -126,11 +126,11 @@ const genCardGridStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     border: 0,
     borderRadius: 0,
     boxShadow: `
-      ${lineWidth}px 0 0 0 ${colorBorderSecondary},
-      0 ${lineWidth}px 0 0 ${colorBorderSecondary},
-      ${lineWidth}px ${lineWidth}px 0 0 ${colorBorderSecondary},
-      ${lineWidth}px 0 0 0 ${colorBorderSecondary} inset,
-      0 ${lineWidth}px 0 0 ${colorBorderSecondary} inset;
+      ${unit(lineWidth)} 0 0 0 ${colorBorderSecondary},
+      0 ${unit(lineWidth)} 0 0 ${colorBorderSecondary},
+      ${unit(lineWidth)} ${unit(lineWidth)} 0 0 ${colorBorderSecondary},
+      ${unit(lineWidth)} 0 0 0 ${colorBorderSecondary} inset,
+      0 ${unit(lineWidth)} 0 0 ${colorBorderSecondary} inset;
     `,
     transition: `all ${token.motionDurationMid}`,
 
@@ -157,9 +157,9 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     padding: 0,
     listStyle: 'none',
     background: actionsBg,
-    borderTop: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
+    borderTop: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
     display: 'flex',
-    borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px `,
+    borderRadius: `0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
     ...clearFix(),
 
     '& > li': {
@@ -170,7 +170,7 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       '> span': {
         position: 'relative',
         display: 'block',
-        minWidth: token.cardActionsIconSize * 2,
+        minWidth: token.calc(token.cardActionsIconSize).mul(2).equal(),
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         cursor: 'pointer',
@@ -184,7 +184,7 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
           display: 'inline-block',
           width: '100%',
           color: token.colorTextDescription,
-          lineHeight: `${token.fontSize * token.lineHeight}px`,
+          lineHeight: unit(token.fontHeight),
           transition: `color ${token.motionDurationMid}`,
 
           '&:hover': {
@@ -194,12 +194,12 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
         [`> ${iconCls}`]: {
           fontSize: cardActionsIconSize,
-          lineHeight: `${cardActionsIconSize * token.lineHeight}px`,
+          lineHeight: unit(token.calc(cardActionsIconSize).mul(token.lineHeight).equal()),
         },
       },
 
       '&:not(:last-child)': {
-        borderInlineEnd: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
+        borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
       },
     },
   };
@@ -207,7 +207,7 @@ const genCardActionsStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
 // ============================== Meta ==============================
 const genCardMetaStyle: GenerateStyle<CardToken> = (token): CSSObject => ({
-  margin: `-${token.marginXXS}px 0`,
+  margin: `${unit(token.calc(token.marginXXS).mul(-1).equal())} 0`,
   display: 'flex',
   ...clearFix(),
 
@@ -242,7 +242,7 @@ const genCardTypeInnerStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
   return {
     [`${componentCls}-head`]: {
-      padding: `0 ${cardPaddingBase}px`,
+      padding: `0 ${unit(cardPaddingBase)}`,
       background: colorFillAlter,
 
       '&-title': {
@@ -251,7 +251,7 @@ const genCardTypeInnerStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-body`]: {
-      padding: `${token.padding}px ${cardPaddingBase}px`,
+      padding: `${unit(token.padding)} ${unit(cardPaddingBase)}`,
     },
   };
 };
@@ -306,7 +306,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
       [`${componentCls}-body`]: {
         padding: cardPaddingBase,
-        borderRadius: ` 0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
+        borderRadius: ` 0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
         ...clearFix(),
       },
 
@@ -319,7 +319,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         },
 
         [`img, img + ${antCls}-image-mask`]: {
-          borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0`,
+          borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
         },
       },
 
@@ -329,7 +329,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-bordered`]: {
-      border: `${token.lineWidth}px ${token.lineType} ${colorBorderSecondary}`,
+      border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
 
       [`${componentCls}-cover`]: {
         marginTop: -1,
@@ -349,15 +349,15 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-contain-grid`]: {
-      borderRadius: `${token.borderRadiusLG}px ${token.borderRadiusLG}px 0 0 `,
+      borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0 `,
       [`${componentCls}-body`]: {
         display: 'flex',
         flexWrap: 'wrap',
       },
 
       [`&:not(${componentCls}-loading) ${componentCls}-body`]: {
-        marginBlockStart: -token.lineWidth,
-        marginInlineStart: -token.lineWidth,
+        marginBlockStart: token.calc(token.lineWidth).mul(-1).equal(),
+        marginInlineStart: token.calc(token.lineWidth).mul(-1).equal(),
         padding: 0,
       },
     },
@@ -389,7 +389,7 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     [`${componentCls}-small`]: {
       [`> ${componentCls}-head`]: {
         minHeight: headerHeightSM,
-        padding: `0 ${cardPaddingSM}px`,
+        padding: `0 ${unit(cardPaddingSM)}`,
         fontSize: headerFontSizeSM,
 
         [`> ${componentCls}-head-wrapper`]: {
@@ -415,6 +415,18 @@ const genCardSizeStyle: GenerateStyle<CardToken> = (token): CSSObject => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Card'> = (token) => ({
+  headerBg: 'transparent',
+  headerFontSize: token.fontSizeLG,
+  headerFontSizeSM: token.fontSize,
+  headerHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
+  headerHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
+  actionsBg: token.colorBgContainer,
+  actionsLiMargin: `${token.paddingSM}px 0`,
+  tabsMarginBottom: -token.padding - token.lineWidth,
+  extraColor: token.colorText,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Card',
@@ -435,15 +447,5 @@ export default genComponentStyleHook(
       genCardSizeStyle(cardToken),
     ];
   },
-  (token) => ({
-    headerBg: 'transparent',
-    headerFontSize: token.fontSizeLG,
-    headerFontSizeSM: token.fontSize,
-    headerHeight: token.fontSizeLG * token.lineHeightLG + token.padding * 2,
-    headerHeightSM: token.fontSize * token.lineHeight + token.paddingXS * 2,
-    actionsBg: token.colorBgContainer,
-    actionsLiMargin: `${token.paddingSM}px 0`,
-    tabsMarginBottom: -token.padding - token.lineWidth,
-    extraColor: token.colorText,
-  }),
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- #45618
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Card support cssVar        |
| 🇨🇳 Chinese |    卡片组件支持 css 变量       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce42131</samp>

The pull request refactors the Card component to use CSS variables for theming and styling, instead of hard-coded values. It introduces a new `useCSSVar` hook and a `./style/cssVar` module to create and register the CSS variables. It also uses the `@ant-design/cssinjs` package to simplify the CSS value generation and enable theme customization.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce42131</samp>

*  Import `useCSSVar` hook from `./style/cssVar` module and replace `wrapSSR` function with `wrapCSSVar` function in `Card.tsx` to enable CSS variables for dynamic theming and styling ([link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL1-R5),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dR13),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL101-R104),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-813df59a15a41639208b93aa1ea9a9a25f6e5aaff04bebfe7bbdb774a84c2a3dL174-R177))
* Create `./style/cssVar` module to export `useCSSVar` hook and define default values of CSS variables based on theme token using `prepareComponentToken` function ([link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-148e6d6325f5535204572f6f8589774375292599bcb36a991c79d4f69fc9acf7R1-R4))
* Import `unit` function from `@ant-design/cssinjs` package and use it to simplify CSS value generation for `Card` component in `style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L1-R4),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L75-R81),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L114-R114),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L129-R133),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L160-R162),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L173-R173),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L187-R187),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L197-R202),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L210-R210),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L245-R245),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L254-R254),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L309-R309),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L322-R322),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L332-R332),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L352-R352),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L359-R360),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L392-R392))
* Import `token.calc` function from `@ant-design/cssinjs` package and use it to perform arithmetic operations on theme token values in `style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L173-R173),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L197-R202),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L210-R210),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L359-R360))
* Move `prepareComponentToken` function from `style/index.ts` to `./style/cssVar` module and import it from there to avoid duplication and improve readability ([link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8R418-R429),[link](https://github.com/ant-design/ant-design/pull/45836/files?diff=unified&w=0#diff-9f1c82b699dc6a75d6cc843d4e766527920ce050e82dddbb008e23a99906f8b8L438-R450))
