### PR TITLE
refactor: skeleton support css var

### DIFF
--- a/components/skeleton/Avatar.tsx
+++ b/components/skeleton/Avatar.tsx
@@ -5,6 +5,7 @@ import { ConfigContext } from '../config-provider';
 import type { SkeletonElementProps } from './Element';
 import Element from './Element';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface AvatarProps extends Omit<SkeletonElementProps, 'shape'> {
   shape?: 'circle' | 'square';
@@ -21,7 +22,8 @@ const SkeletonAvatar: React.FC<AvatarProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const otherProps = omit(props, ['prefixCls', 'className']);
   const cls = classNames(
@@ -35,7 +37,7 @@ const SkeletonAvatar: React.FC<AvatarProps> = (props) => {
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls}>
       <Element prefixCls={`${prefixCls}-avatar`} shape={shape} size={size} {...otherProps} />
     </div>,

--- a/components/skeleton/Button.tsx
+++ b/components/skeleton/Button.tsx
@@ -6,6 +6,7 @@ import type { SkeletonElementProps } from './Element';
 import Element from './Element';
 
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface SkeletonButtonProps extends Omit<SkeletonElementProps, 'size'> {
   size?: 'large' | 'small' | 'default';
@@ -23,7 +24,8 @@ const SkeletonButton: React.FC<SkeletonButtonProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const otherProps = omit(props, ['prefixCls']);
   const cls = classNames(
@@ -38,7 +40,7 @@ const SkeletonButton: React.FC<SkeletonButtonProps> = (props) => {
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls}>
       <Element prefixCls={`${prefixCls}-button`} size={size} {...otherProps} />
     </div>,

--- a/components/skeleton/Image.tsx
+++ b/components/skeleton/Image.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { SkeletonElementProps } from './Element';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface SkeletonImageProps extends Omit<SkeletonElementProps, 'size' | 'shape'> {}
 
@@ -13,7 +14,8 @@ const SkeletonImage: React.FC<SkeletonImageProps> = (props) => {
   const { prefixCls: customizePrefixCls, className, rootClassName, style, active } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
   const cls = classNames(
     prefixCls,
     `${prefixCls}-element`,
@@ -25,7 +27,7 @@ const SkeletonImage: React.FC<SkeletonImageProps> = (props) => {
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls}>
       <div className={classNames(`${prefixCls}-image`, className)} style={style}>
         <svg

--- a/components/skeleton/Input.tsx
+++ b/components/skeleton/Input.tsx
@@ -6,6 +6,7 @@ import type { SkeletonElementProps } from './Element';
 import Element from './Element';
 
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface SkeletonInputProps extends Omit<SkeletonElementProps, 'size' | 'shape'> {
   size?: 'large' | 'small' | 'default';
@@ -23,7 +24,8 @@ const SkeletonInput: React.FC<SkeletonInputProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const otherProps = omit(props, ['prefixCls']);
   const cls = classNames(
@@ -38,7 +40,7 @@ const SkeletonInput: React.FC<SkeletonInputProps> = (props) => {
     hashId,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls}>
       <Element prefixCls={`${prefixCls}-input`} size={size} {...otherProps} />
     </div>,

--- a/components/skeleton/Node.tsx
+++ b/components/skeleton/Node.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { SkeletonElementProps } from './Element';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface SkeletonNodeProps extends Omit<SkeletonElementProps, 'size' | 'shape'> {
   fullSize?: boolean;
@@ -21,7 +22,8 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const cls = classNames(
     prefixCls,
@@ -36,7 +38,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
 
   const content = children ?? <DotChartOutlined />;
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls}>
       <div className={classNames(`${prefixCls}-image`, className)} style={style}>
         {content}

--- a/components/skeleton/Skeleton.tsx
+++ b/components/skeleton/Skeleton.tsx
@@ -14,6 +14,7 @@ import type { SkeletonTitleProps } from './Title';
 import Title from './Title';
 
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 /* This only for skeleton internal. */
 type SkeletonAvatarProps = Omit<AvatarProps, 'active'>;
@@ -103,7 +104,8 @@ const Skeleton: React.FC<SkeletonProps> & CompoundedComponent = (props) => {
 
   const { getPrefixCls, direction, skeleton } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   if (loading || !('loading' in props)) {
     const hasAvatar = !!avatar;
@@ -174,7 +176,7 @@ const Skeleton: React.FC<SkeletonProps> & CompoundedComponent = (props) => {
       hashId,
     );
 
-    return wrapSSR(
+    return wrapCSSVar(
       <div className={cls} style={{ ...skeleton?.style, ...style }}>
         {avatarNode}
         {contentNode}

--- a/components/skeleton/style/cssVar.ts
+++ b/components/skeleton/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Skeleton', prepareComponentToken);

--- a/components/skeleton/style/index.tsx
+++ b/components/skeleton/style/index.tsx
@@ -1,7 +1,8 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import { Keyframes, unit } from '@ant-design/cssinjs';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
+import type { CSSUtil } from '../../theme/util/genComponentStyleHook';
 
 export type ComponentToken = {
   /** @deprecated use gradientFromColor instead. */
@@ -56,18 +57,18 @@ interface SkeletonToken extends FullToken<'Skeleton'> {
   skeletonButtonCls: string;
   skeletonInputCls: string;
   skeletonImageCls: string;
-  imageSizeBase: number;
+  imageSizeBase: number | string;
   skeletonLoadingBackground: string;
   skeletonLoadingMotionDuration: string;
   borderRadius: number;
 }
 
-const genSkeletonElementCommonSize = (size: number): CSSObject => ({
+const genSkeletonElementCommonSize = (size: number | string): CSSObject => ({
   height: size,
-  lineHeight: `${size}px`,
+  lineHeight: unit(size),
 });
 
-const genSkeletonElementAvatarSize = (size: number): CSSObject => ({
+const genSkeletonElementAvatarSize = (size: number | string): CSSObject => ({
   width: size,
   ...genSkeletonElementCommonSize(size),
 });
@@ -80,10 +81,9 @@ const genSkeletonColor = (token: SkeletonToken): CSSObject => ({
   animationTimingFunction: 'ease',
   animationIterationCount: 'infinite',
 });
-
-const genSkeletonElementInputSize = (size: number): CSSObject => ({
-  width: size * 5,
-  minWidth: size * 5,
+const genSkeletonElementInputSize = (size: number, calc: CSSUtil['calc']): CSSObject => ({
+  width: calc(size).mul(5).equal(),
+  minWidth: calc(size).mul(5).equal(),
   ...genSkeletonElementCommonSize(size),
 });
 
@@ -117,6 +117,7 @@ const genSkeletonElementInput = (token: SkeletonToken): CSSObject => {
     controlHeightLG,
     controlHeightSM,
     gradientFromColor,
+    calc,
   } = token;
   return {
     [`${skeletonInputCls}`]: {
@@ -124,26 +125,26 @@ const genSkeletonElementInput = (token: SkeletonToken): CSSObject => {
       verticalAlign: 'top',
       background: gradientFromColor,
       borderRadius: borderRadiusSM,
-      ...genSkeletonElementInputSize(controlHeight),
+      ...genSkeletonElementInputSize(controlHeight, calc),
     },
 
     [`${skeletonInputCls}-lg`]: {
-      ...genSkeletonElementInputSize(controlHeightLG),
+      ...genSkeletonElementInputSize(controlHeightLG, calc),
     },
 
     [`${skeletonInputCls}-sm`]: {
-      ...genSkeletonElementInputSize(controlHeightSM),
+      ...genSkeletonElementInputSize(controlHeightSM, calc),
     },
   };
 };
 
-const genSkeletonElementImageSize = (size: number): CSSObject => ({
+const genSkeletonElementImageSize = (size: number | string): CSSObject => ({
   width: size,
   ...genSkeletonElementCommonSize(size),
 });
 
 const genSkeletonElementImage = (token: SkeletonToken): CSSObject => {
-  const { skeletonImageCls, imageSizeBase, gradientFromColor, borderRadiusSM } = token;
+  const { skeletonImageCls, imageSizeBase, gradientFromColor, borderRadiusSM, calc } = token;
   return {
     [`${skeletonImageCls}`]: {
       display: 'flex',
@@ -152,14 +153,14 @@ const genSkeletonElementImage = (token: SkeletonToken): CSSObject => {
       verticalAlign: 'top',
       background: gradientFromColor,
       borderRadius: borderRadiusSM,
-      ...genSkeletonElementImageSize(imageSizeBase * 2),
+      ...genSkeletonElementImageSize(calc(imageSizeBase).mul(2).equal()),
       [`${skeletonImageCls}-path`]: {
         fill: '#bfbfbf',
       },
       [`${skeletonImageCls}-svg`]: {
         ...genSkeletonElementImageSize(imageSizeBase),
-        maxWidth: imageSizeBase * 4,
-        maxHeight: imageSizeBase * 4,
+        maxWidth: calc(imageSizeBase).mul(4).equal(),
+        maxHeight: calc(imageSizeBase).mul(4).equal(),
       },
       [`${skeletonImageCls}-svg${skeletonImageCls}-svg-circle`]: {
         borderRadius: '50%',
@@ -188,9 +189,9 @@ const genSkeletonElementButtonShape = (
   };
 };
 
-const genSkeletonElementButtonSize = (size: number): CSSObject => ({
-  width: size * 2,
-  minWidth: size * 2,
+const genSkeletonElementButtonSize = (size: number, calc: CSSUtil['calc']): CSSObject => ({
+  width: calc(size).mul(2).equal(),
+  minWidth: calc(size).mul(2).equal(),
   ...genSkeletonElementCommonSize(size),
 });
 
@@ -202,6 +203,7 @@ const genSkeletonElementButton = (token: SkeletonToken): CSSObject => {
     controlHeightLG,
     controlHeightSM,
     gradientFromColor,
+    calc,
   } = token;
   return {
     [`${skeletonButtonCls}`]: {
@@ -209,19 +211,19 @@ const genSkeletonElementButton = (token: SkeletonToken): CSSObject => {
       verticalAlign: 'top',
       background: gradientFromColor,
       borderRadius: borderRadiusSM,
-      width: controlHeight * 2,
-      minWidth: controlHeight * 2,
-      ...genSkeletonElementButtonSize(controlHeight),
+      width: calc(controlHeight).mul(2).equal(),
+      minWidth: calc(controlHeight).mul(2).equal(),
+      ...genSkeletonElementButtonSize(controlHeight, calc),
     },
     ...genSkeletonElementButtonShape(token, controlHeight, skeletonButtonCls),
 
     [`${skeletonButtonCls}-lg`]: {
-      ...genSkeletonElementButtonSize(controlHeightLG),
+      ...genSkeletonElementButtonSize(controlHeightLG, calc),
     },
     ...genSkeletonElementButtonShape(token, controlHeightLG, `${skeletonButtonCls}-lg`),
 
     [`${skeletonButtonCls}-sm`]: {
-      ...genSkeletonElementButtonSize(controlHeightSM),
+      ...genSkeletonElementButtonSize(controlHeightSM, calc),
     },
     ...genSkeletonElementButtonShape(token, controlHeightSM, `${skeletonButtonCls}-sm`),
   };
@@ -369,10 +371,26 @@ const genBaseStyle: GenerateStyle<SkeletonToken> = (token: SkeletonToken) => {
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Skeleton'> = (token) => {
+  const { colorFillContent, colorFill } = token;
+  const gradientFromColor = colorFillContent;
+  const gradientToColor = colorFill;
+  return {
+    color: gradientFromColor,
+    colorGradientEnd: gradientToColor,
+    gradientFromColor,
+    gradientToColor,
+    titleHeight: token.controlHeight / 2,
+    blockRadius: token.borderRadiusSM,
+    paragraphMarginTop: token.marginLG + token.marginXXS,
+    paragraphLiHeight: token.controlHeight / 2,
+  };
+};
+
 export default genComponentStyleHook(
   'Skeleton',
   (token) => {
-    const { componentCls } = token;
+    const { componentCls, calc } = token;
 
     const skeletonToken = mergeToken<SkeletonToken>(token, {
       skeletonAvatarCls: `${componentCls}-avatar`,
@@ -381,28 +399,14 @@ export default genComponentStyleHook(
       skeletonButtonCls: `${componentCls}-button`,
       skeletonInputCls: `${componentCls}-input`,
       skeletonImageCls: `${componentCls}-image`,
-      imageSizeBase: token.controlHeight * 1.5,
+      imageSizeBase: calc(token.controlHeight).mul(1.5).equal(),
       borderRadius: 100, // Large number to make capsule shape
       skeletonLoadingBackground: `linear-gradient(90deg, ${token.gradientFromColor} 25%, ${token.gradientToColor} 37%, ${token.gradientFromColor} 63%)`,
       skeletonLoadingMotionDuration: '1.4s',
     });
     return [genBaseStyle(skeletonToken)];
   },
-  (token) => {
-    const { colorFillContent, colorFill } = token;
-    const gradientFromColor = colorFillContent;
-    const gradientToColor = colorFill;
-    return {
-      color: gradientFromColor,
-      colorGradientEnd: gradientToColor,
-      gradientFromColor,
-      gradientToColor,
-      titleHeight: token.controlHeight / 2,
-      blockRadius: token.borderRadiusSM,
-      paragraphMarginTop: token.marginLG + token.marginXXS,
-      paragraphLiHeight: token.controlHeight / 2,
-    };
-  },
+  prepareComponentToken,
   {
     deprecatedTokens: [
       ['color', 'gradientFromColor'],

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -70,7 +70,6 @@ async function checkCSSVar() {
     'result',
     'segmented',
     'select',
-    'skeleton',
     'slider',
     'space',
     'spin',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

#45618 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Skeleton support css variables. |
| 🇨🇳 Chinese | Skeleton 组件支持 CSS 变量。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ee1edf</samp>

This pull request refactors the skeleton component and its subcomponents to use CSS variables for styling, using a custom hook, a helper function, and a CSS variable register. This improves the compatibility and performance of the component in different environments, themes, and SSR rendering. It also removes some unnecessary code and enhances the support for CSS calculations and units. It updates the `check-cssinjs` script to reflect the changes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ee1edf</samp>

*  Refactor skeleton component to use CSS variables and calculations (F0-F6)
  - Import and use `useCSSVar` hook in skeleton subcomponents to register and apply CSS variables ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-88588038e617f86fd2c35792b9a1aa6c8a6f3dd97484c1af84d1d558791f0976R8), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-26ef3eaf23ff09d04f4db16a5eef6f271edce98479619a8837145d2e3a80d3f3R9), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-646e8fd7d44ba1e12431b032083b9008927f414e7242fe2ab8cd876a81068661R6), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-47c0923e91f623645207940e4c2f32e243ecf37173c56e42a9f9e53882cad040R9), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13R7), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-06af9cb647c92b123b921f7be2e4d7738eb2914d066a832bb4a5ac0b580a3c03R17))
  - Destructure and use `calc` function from `useStyle` hook in skeleton subcomponents to perform CSS calculations ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-88588038e617f86fd2c35792b9a1aa6c8a6f3dd97484c1af84d1d558791f0976L24-R26), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-26ef3eaf23ff09d04f4db16a5eef6f271edce98479619a8837145d2e3a80d3f3L26-R28), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-646e8fd7d44ba1e12431b032083b9008927f414e7242fe2ab8cd876a81068661L16-R18), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-47c0923e91f623645207940e4c2f32e243ecf37173c56e42a9f9e53882cad040L26-R28), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13L24-R26), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-06af9cb647c92b123b921f7be2e4d7738eb2914d066a832bb4a5ac0b580a3c03L106-R108))
  - Replace `wrapSSR` function with `wrapCSSVar` function in skeleton subcomponents to inject CSS variables into style attribute ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-88588038e617f86fd2c35792b9a1aa6c8a6f3dd97484c1af84d1d558791f0976L38-R40), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-26ef3eaf23ff09d04f4db16a5eef6f271edce98479619a8837145d2e3a80d3f3L41-R43), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-646e8fd7d44ba1e12431b032083b9008927f414e7242fe2ab8cd876a81068661L28-R30), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-47c0923e91f623645207940e4c2f32e243ecf37173c56e42a9f9e53882cad040L41-R43), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-4d98ce98fef18757740662c6491f7c957b3cec2d78fbbeb399afdee6cad1cd13L39-R41), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-06af9cb647c92b123b921f7be2e4d7738eb2914d066a832bb4a5ac0b580a3c03L177-R179))
  - Create `cssVar.ts` file in `style` folder to export a function that generates a CSS variable register for skeleton component ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-d5e7ead012d404e52d28b64bd92a616326e75919725886a77961bb37df195f42R1-R4))
  - Import `unit` and `calc` functions from `cssinjs` library and `GetDefaultToken` and `CSSUtil` types from `theme` folder in `style/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L2-R5))
  - Allow `imageSizeBase` property in `SkeletonToken` interface to be either number or string ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L59-R60))
  - Use `unit` function for `lineHeight` property in `genSkeletonElementCommonSize` function ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L65-R71))
  - Accept and use `calc` function as second argument in `genSkeletonElementInputSize`, `genSkeletonElementImageSize`, and `genSkeletonElementButtonSize` functions ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L83-R86), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L146-R147), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L191-R194))
  - Pass and use `calc` function for size-related properties in `genSkeletonElementInput`, `genSkeletonElementImage`, and `genSkeletonElementButton` functions ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811R120), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L127-R141), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L155-R156), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L161-R163), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811R206), [link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L212-R226))
  - Extract logic for preparing component token to a separate function called `prepareComponentToken` and export it ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L372-R393))
  - Use `calc` function for `imageSizeBase` property in `skeletonToken` object ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L384-R402))
  - Replace inline function for preparing component token with `prepareComponentToken` function ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-e9607dd76735d305ab98d05211d7ebaf400d805eb8c30e2e667b7b5f27814811L391-R409))
* Remove 'skeleton' string from `checkCSSVar` function in `scripts/check-cssinjs.tsx` to indicate that skeleton component uses CSS variables ([link](https://github.com/ant-design/ant-design/pull/45842/files?diff=unified&w=0#diff-5b054b9f47063e9b12b347b6e9bd669ad645226477f1d56fbdbc20afa54e109eL73))
