### PR TITLE
refacor: form css var

### DIFF
--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -9,6 +9,7 @@ import type { ValidateStatus } from './FormItem';
 import useDebounce from './hooks/useDebounce';
 
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 const EMPTY_LIST: React.ReactNode[] = [];
 
@@ -55,6 +56,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
   const baseClassName = `${prefixCls}-item-explain`;
 
   const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const collapseMotion: CSSMotionProps = useMemo(() => initCollapseMotion(prefixCls), [prefixCls]);
 
@@ -82,7 +84,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
     helpProps.id = `${fieldId}_help`;
   }
 
-  return (
+  return wrapCSSVar(
     <CSSMotion
       motionDeadline={collapseMotion.motionDeadline}
       motionName={`${prefixCls}-show-help`}
@@ -130,7 +132,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
           </div>
         );
       }}
-    </CSSMotion>
+    </CSSMotion>,
   );
 };
 

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -17,6 +17,7 @@ import useForm, { type FormInstance } from './hooks/useForm';
 import useFormWarning from './hooks/useFormWarning';
 import type { FormLabelAlign } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import ValidateMessagesContext from './validateMessagesContext';
 import type { FeedbackIcons } from './FormItem';
 
@@ -103,7 +104,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   const prefixCls = getPrefixCls('form', customizePrefixCls);
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const formClassName = classNames(
     prefixCls,
@@ -177,7 +179,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
     }
   };
 
-  return wrapSSR(
+  return wrapCSSVar(
     <DisabledContextProvider disabled={disabled}>
       <SizeContext.Provider value={mergedSize}>
         <FormProvider

--- a/components/form/style/cssVar.ts
+++ b/components/form/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Form', prepareComponentToken);

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -3,10 +3,11 @@ import type { CSSObject } from '@ant-design/cssinjs';
 
 import { resetComponent } from '../../style';
 import { genCollapseMotion, zoomIn } from '../../style/motion';
-import type { AliasToken, FullToken, GenerateStyle } from '../../theme/internal';
+import type { AliasToken, FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
 import genFormValidateMotionStyle from './explain';
+import { unit } from '@ant-design/cssinjs';
 
 export interface ComponentToken {
   /**
@@ -71,7 +72,7 @@ const resetForm = (token: AliasToken): CSSObject => ({
     fontSize: token.fontSizeLG,
     lineHeight: 'inherit',
     border: 0,
-    borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+    borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
   },
 
   label: {
@@ -107,7 +108,7 @@ const resetForm = (token: AliasToken): CSSObject => ({
   input[type='radio']:focus,
   input[type='checkbox']:focus`]: {
     outline: 0,
-    boxShadow: `0 0 0 ${token.controlOutlineWidth}px ${token.controlOutline}`,
+    boxShadow: `0 0 0 ${unit(token.controlOutlineWidth)} ${token.controlOutline}`,
   },
 
   // Adjust output element
@@ -223,7 +224,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 
         '&-wrap': {
           overflow: 'unset',
-          lineHeight: `${token.lineHeight} - 0.25em`,
+          lineHeight: token.fontHeight,
           whiteSpace: 'unset',
         },
 
@@ -515,7 +516,7 @@ const genVerticalStyle: GenerateStyle<FormToken> = (token) => {
       .${rootPrefixCls}-col-24${formItemCls}-label,
       .${rootPrefixCls}-col-xl-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
 
-    [`@media (max-width: ${token.screenXSMax}px)`]: [
+    [`@media (max-width: ${unit(token.screenXSMax)})`]: [
       makeVerticalLayout(token),
       {
         [componentCls]: {
@@ -524,19 +525,19 @@ const genVerticalStyle: GenerateStyle<FormToken> = (token) => {
       },
     ],
 
-    [`@media (max-width: ${token.screenSMMax}px)`]: {
+    [`@media (max-width: ${unit(token.screenSMMax)})`]: {
       [componentCls]: {
         [`.${rootPrefixCls}-col-sm-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
       },
     },
 
-    [`@media (max-width: ${token.screenMDMax}px)`]: {
+    [`@media (max-width: ${unit(token.screenMDMax)})`]: {
       [componentCls]: {
         [`.${rootPrefixCls}-col-md-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
       },
     },
 
-    [`@media (max-width: ${token.screenLGMax}px)`]: {
+    [`@media (max-width: ${unit(token.screenLGMax)})`]: {
       [componentCls]: {
         [`.${rootPrefixCls}-col-lg-24${formItemCls}-label`]: makeVerticalLayoutLabel(token),
       },
@@ -545,6 +546,18 @@ const genVerticalStyle: GenerateStyle<FormToken> = (token) => {
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Form'> = (token) => ({
+  labelRequiredMarkColor: token.colorError,
+  labelColor: token.colorTextHeading,
+  labelFontSize: token.fontSize,
+  labelHeight: token.controlHeight,
+  labelColonMarginInlineStart: token.marginXXS / 2,
+  labelColonMarginInlineEnd: token.marginXS,
+  itemMarginBottom: token.marginLG,
+  verticalLabelPadding: `0 0 ${token.paddingXS}px`,
+  verticalLabelMargin: 0,
+});
+
 export const prepareToken: (
   token: Parameters<GenStyleFn<'Form'>>[0],
   rootPrefixCls: string,
@@ -573,17 +586,7 @@ export default genComponentStyleHook(
       zoomIn,
     ];
   },
-  (token) => ({
-    labelRequiredMarkColor: token.colorError,
-    labelColor: token.colorTextHeading,
-    labelFontSize: token.fontSize,
-    labelHeight: token.controlHeight,
-    labelColonMarginInlineStart: token.marginXXS / 2,
-    labelColonMarginInlineEnd: token.marginXS,
-    itemMarginBottom: token.marginLG,
-    verticalLabelPadding: `0 0 ${token.paddingXS}px`,
-    verticalLabelMargin: 0,
-  }),
+  prepareComponentToken,
   {
     // Let From style before the Grid
     // ref https://github.com/ant-design/ant-design/issues/44386

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -224,7 +224,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 
         '&-wrap': {
           overflow: 'unset',
-          lineHeight: token.fontHeight,
+          lineHeight: `calc(${token.fontHeight} - 0.25em)`,
           whiteSpace: 'unset',
         },
 

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -224,7 +224,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 
         '&-wrap': {
           overflow: 'unset',
-          lineHeight: `calc(${unit(token.fontHeight)} - 0.25em)`,
+          lineHeight: token.lineHeight,
           whiteSpace: 'unset',
         },
 

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -224,7 +224,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 
         '&-wrap': {
           overflow: 'unset',
-          lineHeight: `calc(${token.fontHeight} - 0.25em)`,
+          lineHeight: `calc(${unit(token.fontHeight)} - 0.25em)`,
           whiteSpace: 'unset',
         },
 

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -47,7 +47,6 @@ async function checkCSSVar() {
     'drawer',
     'dropdown',
     'float-button',
-    'form',
     'grid',
     'icon',
     'image',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Form support css var.        |
| 🇨🇳 Chinese |        -   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b86ffa</samp>

This pull request adds support for CSS variables in the Form component and refactors its style code to improve consistency and reusability. It uses the `useCSSVar` hook and the `prepareComponentToken` function to register and apply the theme tokens, and wraps the Form providers and the error list animation with the `wrapCSSVar` function. It also updates the `checkCSSVar` script to reflect the new approach.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b86ffa</samp>

*  Add and use `useCSSVar` hook to register and apply CSS variables for the Form component based on the theme tokens ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-882ca2243b17a2c4a7dd71f424d5b9cb20793979210931c77a259ce8bace8248R12), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eR20), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-5b5b1c75316cff0d18268701fe106db3a8f6fcee408bf343a8ee6fd43f659127R1-R4))
*  Wrap JSX elements that need to use CSS variables with the `wrapCSSVar` function returned by the hook ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-882ca2243b17a2c4a7dd71f424d5b9cb20793979210931c77a259ce8bace8248R59), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-882ca2243b17a2c4a7dd71f424d5b9cb20793979210931c77a259ce8bace8248L85-R87), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-882ca2243b17a2c4a7dd71f424d5b9cb20793979210931c77a259ce8bace8248L133-R135), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL106-R108), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-8ccff6797d2e407d2113e4f8098d0a3fcf732670a048678a2e8ce80a28e4c80eL180-R182))
*  Export `prepareComponentToken` function from `./components/form/style/index.ts` to prepare the default token values for the Form component based on the theme tokens ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5R549-R560))
*  Pass `prepareComponentToken` function as the second argument to the `genComponentStyleHook` function and the `genCSSVarRegister` function to generate the `useStyle` hook and the `useCSSVar` hook for the Form component ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L576-R589), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-5b5b1c75316cff0d18268701fe106db3a8f6fcee408bf343a8ee6fd43f659127R1-R4))
*  Use `unit` function from `@ant-design/cssinjs` to convert numeric token values to CSS units in the `resetForm`, `genFormItemStyle`, and `genVerticalStyle` functions in `./components/form/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L74-R75), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L110-R111), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L226-R227), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L518-R519), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L527-R528), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L533-R534), [link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L539-R540))
*  Replace `token.lineHeight` with `token.fontHeight` in the `genFormItemStyle` function in `./components/form/style/index.ts` for the label text line height ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-beba95b8d13514e384968a2ecb8812753e1a7b7d716954f9cf52fb75907aa1f5L226-R227))
*  Remove 'form' string from the `checkCSSVar` function in `scripts/check-cssinjs.tsx` as the Form component has been updated to use the `useCSSVar` hook and the `prepareComponentToken` function ([link](https://github.com/ant-design/ant-design/pull/45849/files?diff=unified&w=0#diff-5b054b9f47063e9b12b347b6e9bd669ad645226477f1d56fbdbc20afa54e109eL50))
