### PR TITLE
feat: QRCode support cssVar

### DIFF
--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -11,6 +11,7 @@ import { useLocale } from '../locale';
 import Spin from '../spin';
 import { useToken } from '../theme/internal';
 import type { QRCodeProps, QRProps } from './interface';
+import useCSSVar from './style/cssVar';
 import useStyle from './style/index';
 
 const QRCode: React.FC<QRCodeProps> = (props) => {
@@ -34,7 +35,9 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   } = props;
   const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('qrcode', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const imageSettings: QRProps['imageSettings'] = {
     src: icon,
@@ -73,12 +76,15 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     return null;
   }
 
-  const cls = classNames(prefixCls, className, rootClassName, hashId, {
+  const mergedCls = classNames(prefixCls, className, rootClassName, hashId, {
     [`${prefixCls}-borderless`]: !bordered,
   });
 
-  return wrapSSR(
-    <div style={{ ...style, width: size, height: size, backgroundColor: bgColor }} className={cls}>
+  return wrapCSSVar(
+    <div
+      className={mergedCls}
+      style={{ ...style, width: size, height: size, backgroundColor: bgColor }}
+    >
       {status !== 'active' && (
         <div className={`${prefixCls}-mask`}>
           {status === 'loading' && <Spin />}

--- a/components/qr-code/style/cssVar.ts
+++ b/components/qr-code/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'QRCode'>('QRCode', prepareComponentToken);

--- a/components/qr-code/style/index.ts
+++ b/components/qr-code/style/index.ts
@@ -1,5 +1,7 @@
+import { unit } from '@ant-design/cssinjs';
+
 import { resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {}
@@ -10,7 +12,7 @@ interface QRCodeToken extends FullToken<'QRCode'> {
 }
 
 const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
-  const { componentCls } = token;
+  const { componentCls, lineWidth, lineType, colorSplit } = token;
   return {
     [componentCls]: {
       ...resetComponent(token),
@@ -20,7 +22,7 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
       padding: token.paddingSM,
       backgroundColor: token.colorWhite,
       borderRadius: token.borderRadiusLG,
-      border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+      border: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
       position: 'relative',
       overflow: 'hidden',
 
@@ -61,11 +63,16 @@ const genQRCodeStyle: GenerateStyle<QRCodeToken> = (token) => {
   };
 };
 
-export default genComponentStyleHook<'QRCode'>('QRCode', (token) =>
-  genQRCodeStyle(
-    mergeToken<QRCodeToken>(token, {
+export const prepareComponentToken: GetDefaultToken<'QRCode'> = () => ({});
+
+export default genComponentStyleHook<'QRCode'>(
+  'QRCode',
+  (token) => {
+    const mergedToken = mergeToken<QRCodeToken>(token, {
       QRCodeExpiredTextColor: 'rgba(0, 0, 0, 0.88)',
       QRCodeMaskBackgroundColor: 'rgba(255, 255, 255, 0.96)',
-    }),
-  ),
+    });
+    return genQRCodeStyle(mergedToken);
+  },
+  prepareComponentToken,
 );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: QRCode support cssVar |
| 🇨🇳 Chinese | feat: QRCode 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1c1be4</samp>

Refactored the QRCode component to use CSS variables for styling, based on token values defined in `style/index.ts`. Created a custom hook `useCSSVar` in `style/cssVar.ts` to register and update the CSS variables.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1c1be4</samp>

* Import `useCSSVar` hook from `./style/cssVar` to enable CSS variables for QRCode component ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaR14))
* Replace `wrapSSR` function with `wrapCSSVar` function to wrap QRCode component with CSS variables ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL37-R41), [link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL76-R87))
* Destructure `imageSettings` object to access `icon` property directly ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL37-R41))
* Rename `cls` variable to `mergedCls` to avoid confusion with `className` prop ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL76-R87))
* Move `style` prop to the end of `div` element to avoid overriding CSS variables ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-30eea37f943f85a55da5ca1786ff308fcbc33e8fc744029eedf600e8577bf2eaL76-R87))
* Create `cssVar.ts` file to export `useCSSVar` hook, which registers and updates CSS variables based on token values ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-1ab63b83df00d4ae8aa53da4babd5821682147f0c32fcf0b26980c67d0adc3cdR1-R4))
* Import `unit` function from `@ant-design/cssinjs` to convert token values to CSS units ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L1-R4))
* Import `GetDefaultToken` type from `../../theme/internal` to define type of `prepareComponentToken` function ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L1-R4))
* Add `lineWidth`, `lineType`, and `colorSplit` properties to `QRCodeToken` interface to define token values for border style ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L13-R15))
* Wrap `lineWidth`, `lineType`, and `colorSplit` values with `unit` function in style object ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L23-R25))
* Export `prepareComponentToken` function and pass it as third argument to `genComponentStyleHook` function ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L64-R77))
* Refactor `genQRCodeStyle` function to use `mergedToken` variable to store result of `mergeToken` function ([link](https://github.com/ant-design/ant-design/pull/45854/files?diff=unified&w=0#diff-8e8f9b96971f403f2f0cca32f79f0f23d9f4e25c1e8767a254ff0bf872c2bb91L64-R77))
