### PR TITLE
feat: Cascader support cssVar

### DIFF
--- a/components/cascader/Panel.tsx
+++ b/components/cascader/Panel.tsx
@@ -34,6 +34,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
 
   const [, hashId] = useStyle(cascaderPrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
+  const cascaderRootCls = useCSSVarCls(cascaderPrefixCls);
   usePanelStyle(cascaderPrefixCls);
 
   const isRtl = mergedDirection === 'rtl';
@@ -56,7 +57,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
       {...props}
       checkable={checkable}
       prefixCls={cascaderPrefixCls}
-      className={classNames(className, hashId, rootClassName, rootCls)}
+      className={classNames(className, hashId, rootClassName, rootCls, cascaderRootCls)}
       notFoundContent={mergedNotFoundContent}
       direction={mergedDirection}
       expandIcon={mergedExpandIcon}

--- a/components/cascader/Panel.tsx
+++ b/components/cascader/Panel.tsx
@@ -5,6 +5,7 @@ import type { PickType } from 'rc-cascader/lib/Panel';
 
 import type { CascaderProps } from '.';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useBase from './hooks/useBase';
 import useCheckable from './hooks/useCheckable';
 import useColumnIcons from './hooks/useColumnIcons';
@@ -32,6 +33,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
   );
 
   const [, hashId] = useStyle(cascaderPrefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
   usePanelStyle(cascaderPrefixCls);
 
   const isRtl = mergedDirection === 'rtl';
@@ -54,7 +56,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
       {...props}
       checkable={checkable}
       prefixCls={cascaderPrefixCls}
-      className={classNames(className, hashId, rootClassName)}
+      className={classNames(className, hashId, rootClassName, rootCls)}
       notFoundContent={mergedNotFoundContent}
       direction={mergedDirection}
       expandIcon={mergedExpandIcon}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -22,6 +22,7 @@ import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
@@ -213,8 +214,9 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
   const rootPrefixCls = getPrefixCls();
 
   const [, hashId] = useSelectStyle(prefixCls);
-  const wrapSelectCSSVar = useSelectCSSVar(prefixCls);
-  const wrapCascaderCSSVar = useCSSVar(cascaderPrefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapSelectCSSVar = useSelectCSSVar(rootCls);
+  const wrapCascaderCSSVar = useCSSVar(rootCls);
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
@@ -231,6 +233,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       [`${cascaderPrefixCls}-dropdown-rtl`]: mergedDirection === 'rtl',
     },
     rootClassName,
+    rootCls,
     hashId,
   );
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -36,6 +36,7 @@ import useBase from './hooks/useBase';
 import useCheckable from './hooks/useCheckable';
 import useColumnIcons from './hooks/useColumnIcons';
 import CascaderPanel from './Panel';
+import useStyle from './style';
 import useCSSVar from './style/cssVar';
 
 // Align the design since we use `rc-select` in root. This help:
@@ -214,9 +215,11 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
   const rootPrefixCls = getPrefixCls();
 
   const [, hashId] = useSelectStyle(prefixCls);
+  useStyle(cascaderPrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
+  const cascaderRootCls = useCSSVarCls(cascaderPrefixCls);
   const wrapSelectCSSVar = useSelectCSSVar(rootCls);
-  const wrapCascaderCSSVar = useCSSVar(rootCls);
+  const wrapCascaderCSSVar = useCSSVar(cascaderRootCls);
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
@@ -234,6 +237,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     },
     rootClassName,
     rootCls,
+    cascaderRootCls,
     hashId,
   );
 
@@ -316,6 +320,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
         className,
         rootClassName,
         rootCls,
+        cascaderRootCls,
         hashId,
       )}
       disabled={mergedDisabled}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -315,6 +315,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
         cascader?.className,
         className,
         rootClassName,
+        rootCls,
         hashId,
       )}
       disabled={mergedDisabled}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -12,6 +12,7 @@ import RcCascader from 'rc-cascader';
 import type { Placement } from 'rc-select/lib/BaseSelect';
 import omit from 'rc-util/lib/omit';
 
+import { useZIndex } from '../_util/hooks/useZIndex';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionName } from '../_util/motion';
 import genPurePanel from '../_util/PurePanel';
@@ -25,6 +26,7 @@ import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import useSelectStyle from '../select/style';
+import useSelectCSSVar from '../select/style/cssVar';
 import useBuiltinPlacements from '../select/useBuiltinPlacements';
 import useIcons from '../select/useIcons';
 import useShowArrow from '../select/useShowArrow';
@@ -33,8 +35,7 @@ import useBase from './hooks/useBase';
 import useCheckable from './hooks/useCheckable';
 import useColumnIcons from './hooks/useColumnIcons';
 import CascaderPanel from './Panel';
-import useStyle from './style';
-import { useZIndex } from '../_util/hooks/useZIndex';
+import useCSSVar from './style/cssVar';
 
 // Align the design since we use `rc-select` in root. This help:
 // - List search content will show all content
@@ -211,8 +212,9 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
 
   const rootPrefixCls = getPrefixCls();
 
-  const [wrapSelectSSR, hashId] = useSelectStyle(prefixCls);
-  const [wrapCascaderSSR] = useStyle(cascaderPrefixCls);
+  const [, hashId] = useSelectStyle(prefixCls);
+  const wrapSelectCSSVar = useSelectCSSVar(prefixCls);
+  const wrapCascaderCSSVar = useCSSVar(cascaderPrefixCls);
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
@@ -339,7 +341,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     />
   );
 
-  return wrapCascaderSSR(wrapSelectSSR(renderNode));
+  return wrapCascaderCSSVar(wrapSelectCSSVar(renderNode));
 }) as unknown as (<OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType>(
   props: React.PropsWithChildren<CascaderProps<OptionType>> & { ref?: React.Ref<CascaderRef> },
 ) => React.ReactElement) & {

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -1,4 +1,4 @@
-import type { CSSInterpolation } from '@ant-design/cssinjs';
+import { unit, type CSSInterpolation } from '@ant-design/cssinjs';
 
 import type { CascaderToken } from '.';
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
@@ -59,7 +59,7 @@ const getColumnsStyle: GenerateStyle<CascaderToken> = (token: CascaderToken): CS
           '-ms-overflow-style': '-ms-autohiding-scrollbar', // https://github.com/ant-design/ant-design/issues/11857
 
           '&:not(:last-child)': {
-            borderInlineEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           },
 
           '&-item': {

--- a/components/cascader/style/cssVar.ts
+++ b/components/cascader/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('Cascader', prepareComponentToken);

--- a/components/cascader/style/panel.ts
+++ b/components/cascader/style/panel.ts
@@ -1,4 +1,4 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 
 import { prepareComponentToken, type CascaderToken } from '.';
 import { genComponentStyleHook, type GenerateStyle } from '../../theme/internal';
@@ -13,7 +13,7 @@ const genPanelStyle: GenerateStyle<CascaderToken> = (token: CascaderToken): CSSO
       getColumnsStyle(token),
       {
         display: 'inline-flex',
-        border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+        border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
         borderRadius: token.borderRadiusLG,
         overflowX: 'auto',
         maxWidth: '100%',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- #45618 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Cascader support cssVar      |
| 🇨🇳 Chinese |     级联选择器支持 css 变量      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a60ec5c</samp>

This pull request refactors and updates the cascader component to use hooks, CSS variables, and the `@ant-design/cssinjs` package for better performance, compatibility, and maintainability. It also aligns the cascader style with the select component and simplifies the SSR logic.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a60ec5c</samp>

*  Import and use `useZIndex` hook to manage z-index of cascader and popups ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R15))
*  Import and use `useSelectCSSVar` hook to register and apply CSS variables for select component ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804R29))
*  Rename and move `useStyle` hook to `useCSSVar` and `style` folder for consistency and separation of concerns ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L36-R38))
*  Replace `wrapCascaderSSR` and `wrapSelectSSR` functions with `wrapCascaderCSSVar` and `wrapSelectCSSVar` functions to wrap component node with CSS variables and SSR logic ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L214-R217), [link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-4737f6ef564486c449ec019f2826176d8b8d186088e5e912ad06ad1919b2d804L342-R344))
*  Create `cssVar.ts` file to export function that registers and applies CSS variables for cascader component ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-ae8ea15c8edea2bfe3ea0c8c1b345c0eefe24f214370384e77cd0b850a185e2dR1-R4))
*  Import and use `unit` function from `@ant-design/cssinjs` package to convert numbers to CSS units ([link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-9d96d7e729614395a22c393efc9b29ee933f5b16d67972bab03f5c99898a9ceeL1-R1), [link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-9d96d7e729614395a22c393efc9b29ee933f5b16d67972bab03f5c99898a9ceeL62-R62), [link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-8a22481590f9bcba223f0f520b4dbe3b39d1e425b089aceb25c79ba64a3b7371L1-R1), [link](https://github.com/ant-design/ant-design/pull/45858/files?diff=unified&w=0#diff-8a22481590f9bcba223f0f520b4dbe3b39d1e425b089aceb25c79ba64a3b7371L16-R16))
