### PR TITLE
feat: Checkbox support cssvar

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -11,6 +11,7 @@ import DisabledContext from '../config-provider/DisabledContext';
 import { FormItemInputContext } from '../form/context';
 import GroupContext from './GroupContext';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export interface AbstractCheckboxProps<T> {
   prefixCls?: string;
@@ -104,7 +105,8 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
   }, [restProps.value]);
 
   const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const checkboxProps: CheckboxProps = { ...restProps };
   if (checkboxGroup && !skipGroup) {
@@ -140,7 +142,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     hashId,
   );
   const ariaChecked = indeterminate ? 'mixed' : undefined;
-  return wrapSSR(
+  return wrapCSSVar(
     <Wave component="Checkbox" disabled={mergedDisabled}>
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -134,6 +134,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     checkbox?.className,
     className,
     rootClassName,
+    rootCls,
     hashId,
   );
   const checkboxClass = classNames(

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { FormItemInputContext } from '../form/context';
 import GroupContext from './GroupContext';
 import useStyle from './style';
@@ -106,7 +107,8 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
 
   const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
   const [, hashId] = useStyle(prefixCls);
-  const wrapCSSVar = useCSSVar(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const checkboxProps: CheckboxProps = { ...restProps };
   if (checkboxGroup && !skipGroup) {

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
 
 import { ConfigContext } from '../config-provider';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type { CheckboxChangeEvent } from './Checkbox';
 import Checkbox from './Checkbox';
 import GroupContext from './GroupContext';
@@ -111,7 +112,8 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
   const groupPrefixCls = `${prefixCls}-group`;
 
   const [, hashId] = useStyle(prefixCls);
-  const wrapCSSVar = useCSSVar(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const domProps = omit(restProps, ['value', 'disabled']);
 

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -153,6 +153,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
     },
     className,
     rootClassName,
+    rootCls,
     hashId,
   );
   return wrapCSSVar(

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -7,6 +7,7 @@ import type { CheckboxChangeEvent } from './Checkbox';
 import Checkbox from './Checkbox';
 import GroupContext from './GroupContext';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export type CheckboxValueType = string | number | boolean;
 
@@ -109,7 +110,8 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
   const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
   const groupPrefixCls = `${prefixCls}-group`;
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const domProps = omit(restProps, ['value', 'disabled']);
 
@@ -151,7 +153,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
     rootClassName,
     hashId,
   );
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={classString} style={style} {...domProps} ref={ref}>
       <GroupContext.Provider value={context}>{childrenNode}</GroupContext.Provider>
     </div>,

--- a/components/checkbox/style/cssVar.ts
+++ b/components/checkbox/style/cssVar.ts
@@ -1,0 +1,3 @@
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('Checkbox', {});

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -1,3 +1,5 @@
+import { unit } from '@ant-design/cssinjs';
+
 import { genFocusOutline, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
@@ -102,7 +104,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           height: token.checkboxSize,
           direction: 'ltr',
           backgroundColor: token.colorBgContainer,
-          border: `${token.lineWidth}px ${token.lineType} ${token.colorBorder}`,
+          border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
           borderRadius: token.borderRadiusSM,
           borderCollapse: 'separate',
           transition: `all ${token.motionDurationSlow}`,
@@ -113,9 +115,9 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
             top: '50%',
             insetInlineStart: '21.5%',
             display: 'table',
-            width: (token.checkboxSize / 14) * 5,
-            height: (token.checkboxSize / 14) * 8,
-            border: `${token.lineWidthBold}px solid ${token.colorWhite}`,
+            width: token.calc(token.checkboxSize).div(14).mul(5).equal(),
+            height: token.calc(token.checkboxSize).div(14).mul(8).equal(),
+            border: `${unit(token.lineWidthBold)} solid ${token.colorWhite}`,
             borderTop: 0,
             borderInlineStart: 0,
             transform: 'rotate(45deg) scale(0) translate(-50%,-50%)',
@@ -195,8 +197,8 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
             '&:after': {
               top: '50%',
               insetInlineStart: '50%',
-              width: token.fontSizeLG / 2,
-              height: token.fontSizeLG / 2,
+              width: token.calc(token.fontSizeLG).div(2).equal(),
+              height: token.calc(token.fontSizeLG).div(2).equal(),
               backgroundColor: token.colorPrimary,
               border: 0,
               transform: 'translate(-50%, -50%) scale(1)',

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { AliasToken, DerivativeToken } from '../theme/internal';
 
 export { operationUnit } from './operationUnit';
@@ -128,7 +129,7 @@ export const genCommonStyle = (token: DerivativeToken, componentPrefixCls: strin
 };
 
 export const genFocusOutline = (token: AliasToken): CSSObject => ({
-  outline: `${token.lineWidthFocus}px solid ${token.colorPrimaryBorder}`,
+  outline: `${unit(token.lineWidthFocus)} solid ${token.colorPrimaryBorder}`,
   outlineOffset: 1,
   transition: 'outline-offset 0s, outline 0s',
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- #45618 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Checkbox support cssvar       |
| 🇨🇳 Chinese |     多选框支持 css 变量    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78289f1</samp>

This pull request refactors the Checkbox and Checkbox.Group components to use CSS variables for theming and styling. It introduces a new `useCSSVar` hook that manages the CSS variables and a new file `components/checkbox/style/cssVar.ts` that exports it. It also improves the consistency and customizability of the component's style by using the `unit` and `calc` functions from `@ant-design/cssinjs`.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78289f1</samp>

*  Replace `wrapSSR` with `wrapCSSVar` for Checkbox and Checkbox.Group components to use CSS variables instead of style tags for server-side rendering ([link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L107-R109), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86L143-R145), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L112-R114), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63L154-R156))
*  Create and export `useCSSVar` hook for Checkbox component in `cssVar.ts` file using `genCSSVarRegister` utility function ([link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-3dd83ffba2c18472c0e62ae7d7e3cf74750c07ec843fab598394579b9b2ce5adR1-R3))
*  Import and use `useCSSVar` hook in `Checkbox.tsx` and `Group.tsx` files to register and update CSS variables for Checkbox component and subcomponent ([link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-e5138148a71ae8aea8e59e4b8934815b003ff8836bbb6ca6dc91d41aef32ef86R14), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-d3e984f0984d6a44c780ab883b2f78b2df8029b1ce515d879e60879bb425fa63R10))
*  Import and use `unit` function from `@ant-design/cssinjs` library to convert numeric values to CSS unit strings in `genCheckboxStyle` and `genFocusOutline` functions ([link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efR1-R2), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL105-R107), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL116-R120), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL198-R201), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL2-R3), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-6ddd1e92016eb62920ed5a9e2a23fa555dc551e5c9a2e7c78c128919f357adaaL131-R132))
*  Use `token.calc` function to perform arithmetic operations on CSS variables in `genCheckboxStyle` function and return CSS calc expression strings ([link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL116-R120), [link](https://github.com/ant-design/ant-design/pull/45859/files?diff=unified&w=0#diff-c624f3acd6eb939a50b97d0fe9f815bd0dd657eb19797790a8e7b1755ee550efL198-R201))
