### PR TITLE
refactor: FloatButton support css var

### DIFF
--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -19,6 +19,7 @@ import type {
 } from './interface';
 import useStyle from './style';
 import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 export const floatButtonPrefixCls = 'float-btn';
 
@@ -39,12 +40,14 @@ const FloatButton = forwardRef<FloatButtonRef['nativeElement'], FloatButtonProps
   const groupShape = useContext<FloatButtonShape | undefined>(FloatButtonGroupContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
   const [, hashId] = useStyle(prefixCls);
-  const wrapCSSVar = useCSSVar(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const mergeShape = groupShape || shape;
 
   const classString = classNames(
     hashId,
+    rootCls,
     prefixCls,
     className,
     rootClassName,

--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -18,6 +18,7 @@ import type {
   FloatButtonShape,
 } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export const floatButtonPrefixCls = 'float-btn';
 
@@ -37,7 +38,8 @@ const FloatButton = forwardRef<FloatButtonRef['nativeElement'], FloatButtonProps
   const { getPrefixCls, direction } = useContext<ConfigConsumerProps>(ConfigContext);
   const groupShape = useContext<FloatButtonShape | undefined>(FloatButtonGroupContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const mergeShape = groupShape || shape;
 
@@ -92,7 +94,7 @@ const FloatButton = forwardRef<FloatButtonRef['nativeElement'], FloatButtonProps
     );
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     props.href ? (
       <a ref={ref} {...restProps} className={classString}>
         {buttonNode}

--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -13,6 +13,7 @@ import FloatButton, { floatButtonPrefixCls } from './FloatButton';
 import type { FloatButtonGroupProps, FloatButtonRef } from './interface';
 import useStyle from './style';
 import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
   const {
@@ -34,10 +35,11 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
   const { direction, getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
   const [, hashId] = useStyle(prefixCls);
-  const wrapCSSVar = useCSSVar(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
   const groupPrefixCls = `${prefixCls}-group`;
 
-  const groupCls = classNames(groupPrefixCls, hashId, className, {
+  const groupCls = classNames(groupPrefixCls, hashId, rootCls, className, {
     [`${groupPrefixCls}-rtl`]: direction === 'rtl',
     [`${groupPrefixCls}-${shape}`]: shape,
     [`${groupPrefixCls}-${shape}-shadow`]: !trigger,

--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -12,6 +12,7 @@ import { FloatButtonGroupProvider } from './context';
 import FloatButton, { floatButtonPrefixCls } from './FloatButton';
 import type { FloatButtonGroupProps, FloatButtonRef } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
   const {
@@ -32,7 +33,8 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
 
   const { direction, getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
   const groupPrefixCls = `${prefixCls}-group`;
 
   const groupCls = classNames(groupPrefixCls, hashId, className, {
@@ -104,7 +106,7 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
     );
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <FloatButtonGroupProvider value={shape}>
       <div ref={floatButtonGroupRef} className={groupCls} style={style} {...hoverAction}>
         {trigger && ['click', 'hover'].includes(trigger) ? (

--- a/components/float-button/style/cssVar.ts
+++ b/components/float-button/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('FloatButton', prepareComponentToken);

--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -10,11 +10,6 @@ import getOffset from '../util';
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
   /**
-   * @desc 按钮 z-index
-   * @descEN z-index of button
-   */
-  zIndexPopup: number;
-  /**
    * Offset of the badge dot in a circular button
    * @internal
    */
@@ -111,7 +106,7 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
   return {
     [groupPrefixCls]: {
       ...resetComponent(token),
-      zIndex: token.zIndexPopup,
+      zIndex: 99,
       display: 'block',
       border: 'none',
       position: 'fixed',
@@ -233,7 +228,7 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
       border: 'none',
       position: 'fixed',
       cursor: 'pointer',
-      zIndex: token.zIndexPopup,
+      zIndex: 99,
       // Do not remove the 'display: block' here.
       // Deleting it will cause marginBottom to become ineffective.
       // Ref: https://github.com/ant-design/ant-design/issues/44700
@@ -371,7 +366,6 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
 
 // ============================== Export ==============================
 export const prepareComponentToken: GetDefaultToken<'FloatButton'> = (token) => ({
-  zIndexPopup: token.zIndexPopupBase,
   dotOffsetInCircle: getOffset(token.controlHeightLG / 2),
   dotOffsetInSquare: getOffset(token.borderRadiusLG),
 });

--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -15,13 +15,13 @@ export interface ComponentToken {
    */
   zIndexPopup: number;
   /**
-   * @desc 圆形按钮中徽章点的偏移量
-   * @descEN Offset of the badge dot in a circular button
+   * Offset of the badge dot in a circular button
+   * @internal
    */
   dotOffsetInCircle: number;
   /**
-   * @desc 方形按钮中徽章点的偏移量
-   * @descEN Offset of the badge dot in a square button
+   * Offset of the badge dot in a square button
+   * @internal
    */
   dotOffsetInSquare: number;
 }

--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -1,15 +1,29 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 import { resetComponent } from '../../style';
 import { initFadeMotion } from '../../style/motion/fade';
 import { initMotion } from '../../style/motion/motion';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import getOffset from '../util';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
+  /**
+   * @desc 按钮 z-index
+   * @descEN z-index of button
+   */
   zIndexPopup: number;
+  /**
+   * @desc 圆形按钮中徽章点的偏移量
+   * @descEN Offset of the badge dot in a circular button
+   */
+  dotOffsetInCircle: number;
+  /**
+   * @desc 方形按钮中徽章点的偏移量
+   * @descEN Offset of the badge dot in a square button
+   */
+  dotOffsetInSquare: number;
 }
 
 type FloatButtonToken = FullToken<'FloatButton'> & {
@@ -18,12 +32,10 @@ type FloatButtonToken = FullToken<'FloatButton'> & {
   floatButtonHoverBackgroundColor: string;
   floatButtonFontSize: number;
   floatButtonSize: number;
-  floatButtonIconSize: number;
-  floatButtonBodySize: number;
+  floatButtonIconSize: number | string;
+  floatButtonBodySize: number | string;
   floatButtonBodyPadding: number;
-  badgeOffset: number;
-  dotOffsetInCircle: number;
-  dotOffsetInSquare: number;
+  badgeOffset: number | string;
 
   // Position
   floatButtonInsetBlockEnd: number;
@@ -35,7 +47,7 @@ const initFloatButtonGroupMotion = (token: FloatButtonToken) => {
   const groupPrefixCls = `${componentCls}-group`;
   const moveDownIn = new Keyframes('antFloatButtonMoveDownIn', {
     '0%': {
-      transform: `translate3d(0, ${floatButtonSize}px, 0)`,
+      transform: `translate3d(0, ${unit(floatButtonSize)}, 0)`,
       transformOrigin: '0 0',
       opacity: 0,
     },
@@ -53,7 +65,7 @@ const initFloatButtonGroupMotion = (token: FloatButtonToken) => {
       opacity: 1,
     },
     '100%': {
-      transform: `translate3d(0, ${floatButtonSize}px, 0)`,
+      transform: `translate3d(0, ${unit(floatButtonSize)}, 0)`,
       transformOrigin: '0 0',
       opacity: 0,
     },
@@ -93,12 +105,13 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
     borderRadiusSM,
     badgeOffset,
     floatButtonBodyPadding,
+    calc,
   } = token;
   const groupPrefixCls = `${componentCls}-group`;
   return {
     [groupPrefixCls]: {
       ...resetComponent(token),
-      zIndex: 99,
+      zIndex: token.zIndexPopup,
       display: 'block',
       border: 'none',
       position: 'fixed',
@@ -146,12 +159,12 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
           borderEndEndRadius: borderRadiusLG,
         },
         '&:not(:last-child)': {
-          borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
         },
         [`${antCls}-badge`]: {
           [`${antCls}-badge-count`]: {
-            top: -(floatButtonBodyPadding + badgeOffset),
-            insetInlineEnd: -(floatButtonBodyPadding + badgeOffset),
+            top: calc(calc(floatButtonBodyPadding).add(badgeOffset)).mul(-1).equal(),
+            insetInlineEnd: calc(calc(floatButtonBodyPadding).add(badgeOffset)).mul(-1).equal(),
           },
         },
       },
@@ -173,7 +186,7 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
             borderEndEndRadius: borderRadiusLG,
           },
           '&:not(:last-child)': {
-            borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+            borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           },
           [`${componentCls}-body`]: {
             width: token.floatButtonBodySize,
@@ -212,6 +225,7 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
     badgeOffset,
     dotOffsetInSquare,
     dotOffsetInCircle,
+    calc,
   } = token;
   return {
     [componentCls]: {
@@ -219,7 +233,7 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
       border: 'none',
       position: 'fixed',
       cursor: 'pointer',
-      zIndex: 99,
+      zIndex: token.zIndexPopup,
       // Do not remove the 'display: block' here.
       // Deleting it will cause marginBottom to become ineffective.
       // Ref: https://github.com/ant-design/ant-design/issues/44700
@@ -243,8 +257,8 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
         [`${antCls}-badge-count`]: {
           transform: 'translate(0, 0)',
           transformOrigin: 'center',
-          top: -badgeOffset,
-          insetInlineEnd: -badgeOffset,
+          top: calc(badgeOffset).mul(-1).equal(),
+          insetInlineEnd: calc(badgeOffset).mul(-1).equal(),
         },
       },
       [`${componentCls}-body`]: {
@@ -262,7 +276,9 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
           flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
-          padding: `${floatButtonBodyPadding / 2}px ${floatButtonBodyPadding}px`,
+          padding: `${unit(calc(floatButtonBodyPadding).div(2).equal())} ${unit(
+            floatButtonBodyPadding,
+          )}`,
           [`${componentCls}-icon`]: {
             textAlign: 'center',
             margin: 'auto',
@@ -321,7 +337,7 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
           [`${componentCls}-description`]: {
             display: 'flex',
             alignItems: 'center',
-            lineHeight: `${token.fontSizeLG}px`,
+            lineHeight: unit(token.fontSizeLG),
             color: token.colorText,
             fontSize: token.fontSizeSM,
           },
@@ -343,7 +359,7 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
           [`${componentCls}-description`]: {
             display: 'flex',
             alignItems: 'center',
-            lineHeight: `${token.fontSizeLG}px`,
+            lineHeight: unit(token.fontSizeLG),
             color: token.colorTextLightSolid,
             fontSize: token.fontSizeSM,
           },
@@ -354,41 +370,49 @@ const sharedFloatButtonStyle: GenerateStyle<FloatButtonToken, CSSObject> = (toke
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook<'FloatButton'>('FloatButton', (token) => {
-  const {
-    colorTextLightSolid,
-    colorBgElevated,
-    controlHeightLG,
-    marginXXL,
-    marginLG,
-    fontSize,
-    fontSizeIcon,
-    controlItemBgHover,
-    paddingXXS,
-    borderRadiusLG,
-  } = token;
-
-  const floatButtonToken = mergeToken<FloatButtonToken>(token, {
-    floatButtonBackgroundColor: colorBgElevated,
-    floatButtonColor: colorTextLightSolid,
-    floatButtonHoverBackgroundColor: controlItemBgHover,
-    floatButtonFontSize: fontSize,
-    floatButtonIconSize: fontSizeIcon * 1.5,
-    floatButtonSize: controlHeightLG,
-    floatButtonInsetBlockEnd: marginXXL,
-    floatButtonInsetInlineEnd: marginLG,
-    floatButtonBodySize: controlHeightLG - paddingXXS * 2,
-    // 这里的 paddingXXS 是简写，完整逻辑是 (controlHeightLG - (controlHeightLG - paddingXXS * 2)) / 2,
-    floatButtonBodyPadding: paddingXXS,
-    badgeOffset: paddingXXS * 1.5,
-    dotOffsetInCircle: getOffset(controlHeightLG / 2),
-    dotOffsetInSquare: getOffset(borderRadiusLG),
-  });
-
-  return [
-    floatButtonGroupStyle(floatButtonToken),
-    sharedFloatButtonStyle(floatButtonToken),
-    initFadeMotion(token),
-    initFloatButtonGroupMotion(floatButtonToken),
-  ];
+export const prepareComponentToken: GetDefaultToken<'FloatButton'> = (token) => ({
+  zIndexPopup: token.zIndexPopupBase,
+  dotOffsetInCircle: getOffset(token.controlHeightLG / 2),
+  dotOffsetInSquare: getOffset(token.borderRadiusLG),
 });
+
+export default genComponentStyleHook<'FloatButton'>(
+  'FloatButton',
+  (token) => {
+    const {
+      colorTextLightSolid,
+      colorBgElevated,
+      controlHeightLG,
+      marginXXL,
+      marginLG,
+      fontSize,
+      fontSizeIcon,
+      controlItemBgHover,
+      paddingXXS,
+      calc,
+    } = token;
+
+    const floatButtonToken = mergeToken<FloatButtonToken>(token, {
+      floatButtonBackgroundColor: colorBgElevated,
+      floatButtonColor: colorTextLightSolid,
+      floatButtonHoverBackgroundColor: controlItemBgHover,
+      floatButtonFontSize: fontSize,
+      floatButtonIconSize: calc(fontSizeIcon).mul(1.5).equal(),
+      floatButtonSize: controlHeightLG,
+      floatButtonInsetBlockEnd: marginXXL,
+      floatButtonInsetInlineEnd: marginLG,
+      floatButtonBodySize: calc(controlHeightLG).sub(calc(paddingXXS).mul(2)).equal(),
+      // 这里的 paddingXXS 是简写，完整逻辑是 (controlHeightLG - (controlHeightLG - paddingXXS * 2)) / 2,
+      floatButtonBodyPadding: paddingXXS,
+      badgeOffset: calc(paddingXXS).mul(1.5).equal(),
+    });
+
+    return [
+      floatButtonGroupStyle(floatButtonToken),
+      sharedFloatButtonStyle(floatButtonToken),
+      initFadeMotion(token),
+      initFloatButtonGroupMotion(floatButtonToken),
+    ];
+  },
+  prepareComponentToken,
+);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | FloatButton support css variables. |
| 🇨🇳 Chinese | FloatButton 组件支持 css 变量。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 808dbd3</samp>

This pull request refactors the float button component and its group variant to use CSS variables for styling and customization. It introduces a new hook `useCSSVar` and a new function `wrapCSSVar` to register and apply the CSS variables. It also enhances the style and customization of the component by using the `@ant-design/cssinjs` library and the `zIndexPopup` token value. It adds a new file `components/float-button/style/cssVar.ts` to export the `useCSSVar` hook.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 808dbd3</samp>

*  Replace `wrapSSR` function with `wrapCSSVar` function and destructure `hashId` from `useStyle` hook in `FloatButton` and `FloatButtonGroup` components to use CSS variables ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-28edfe59d92b75ce5389381bb8b05943da4ec4f6adc98fda85791009ff922d4bL40-R42),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-28edfe59d92b75ce5389381bb8b05943da4ec4f6adc98fda85791009ff922d4bL95-R97),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-e5d88d36fdd37df3e6d7bd4b14ab20798187137dd85d28acaee0a597cd9a09aeL35-R37),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-e5d88d36fdd37df3e6d7bd4b14ab20798187137dd85d28acaee0a597cd9a09aeL107-R109))
* Import `useCSSVar` hook from `./style/cssVar` in `FloatButton` and `FloatButtonGroup` components to register and use CSS variables ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-28edfe59d92b75ce5389381bb8b05943da4ec4f6adc98fda85791009ff922d4bR21),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-e5d88d36fdd37df3e6d7bd4b14ab20798187137dd85d28acaee0a597cd9a09aeR15))
* Add `components/float-button/style/cssVar.ts` file to export `useCSSVar` hook that uses `genCSSVarRegister` and `prepareComponentToken` functions to create a CSS variable provider and consumer for the float button component ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-ed436ba170837b14575a3b22024a0dc456409edfb9e4d7e4f62a443c3399abdeR1-R4))
* Use `unit` function from `@ant-design/cssinjs` to convert numeric token values to CSS unit strings in `initFloatButtonGroupMotion` and `sharedFloatButtonStyle` functions ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L38-R50),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L56-R68),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L149-R167),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L176-R189),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L265-R281),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L324-R340),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L346-R362))
* Use `calc` function from `@ant-design/cssinjs` to create CSS `calc` expressions for token values that accept custom CSS units or expressions in `floatButtonGroupStyle`, `sharedFloatButtonStyle`, and default export functions ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9R108),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9R228),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L246-R261),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L357-R418))
* Use `zIndexPopup` token value instead of hard-coded `99` value for `zIndex` property of `FloatButton` and `FloatButtonGroup` components ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L101-R114),[link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L222-R236))
* Add comments to `ComponentToken` interface to describe the meaning and usage of each token value ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L12-R26))
* Modify `FloatButtonToken` interface to make some token values accept either a number or a string, such as `floatButtonIconSize`, `floatButtonBodySize`, and `badgeOffset` ([link](https://github.com/ant-design/ant-design/pull/45861/files?diff=unified&w=0#diff-fc14ffe666c4ac5e79188e926f924116e9e8a9c57e2717b2a490d878b09e72d9L21-R38))
