### PR TITLE
feat: ColorPicker support cssVar

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -7,6 +7,7 @@ import type {
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
+import { useZIndex } from '../_util/hooks/useZIndex';
 import genPurePanel from '../_util/PurePanel';
 import { getStatusClassNames } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
@@ -30,6 +31,7 @@ import type {
   TriggerPlacement,
   TriggerType,
 } from './interface';
+import useCSSVar from './style/cssVar';
 import useStyle from './style/index';
 import { customizePrefixCls, genAlphaColor, generateColor, getAlphaColor } from './util';
 
@@ -133,7 +135,8 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   // ===================== Style =====================
   const mergedSize = useSize(customizeSize);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
   const mergeRootCls = classNames(rootClassName, rtlCls);
   const mergeCls = classNames(
@@ -232,7 +235,7 @@ const ColorPicker: CompoundedComponent = (props) => {
 
   // ============================ zIndex ============================
 
-  return wrapSSR(
+  return wrapCSSVar(
     <Popover
       style={styles?.popup}
       overlayInnerStyle={styles?.popupOverlayInner}

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -13,6 +13,7 @@ import { getStatusClassNames } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext, NoFormStyle } from '../form/context';
@@ -136,9 +137,10 @@ const ColorPicker: CompoundedComponent = (props) => {
   // ===================== Style =====================
   const mergedSize = useSize(customizeSize);
   const [, hashId] = useStyle(prefixCls);
-  const wrapCSSVar = useCSSVar(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
-  const mergeRootCls = classNames(rootClassName, rtlCls);
+  const mergeRootCls = classNames(rootClassName, rootCls, rtlCls);
   const mergeCls = classNames(
     getStatusClassNames(prefixCls, contextStatus),
     {

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -7,7 +7,6 @@ import type {
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
-import { useZIndex } from '../_util/hooks/useZIndex';
 import genPurePanel from '../_util/PurePanel';
 import { getStatusClassNames } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -152,7 +152,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     className,
     hashId,
   );
-  const mergePopupCls = classNames(prefixCls, rtlCls);
+  const mergePopupCls = classNames(prefixCls, mergeRootCls);
 
   const popupAllowCloseRef = useRef(true);
 

--- a/components/color-picker/style/color-block.ts
+++ b/components/color-picker/style/color-block.ts
@@ -1,4 +1,5 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { ColorPickerToken } from './index';
 
 /**
@@ -23,7 +24,7 @@ const genColorBlockStyle = (token: ColorPickerToken, size: number): CSSObject =>
       [`${componentCls}-color-block-inner`]: {
         width: '100%',
         height: '100%',
-        border: `${lineWidth}px solid ${colorFillSecondary}`,
+        border: `${unit(lineWidth)} solid ${colorFillSecondary}`,
         borderRadius: 'inherit',
       },
     },

--- a/components/color-picker/style/cssVar.ts
+++ b/components/color-picker/style/cssVar.ts
@@ -1,0 +1,3 @@
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister('ColorPicker', {});

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -1,4 +1,5 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genColorBlockStyle from './color-block';
@@ -27,7 +28,7 @@ export const genActiveStyle = (
 ) => ({
   borderInlineEndWidth: token.lineWidth,
   borderColor,
-  boxShadow: `0 0 0 ${token.controlOutlineWidth}px ${outlineColor}`,
+  boxShadow: `0 0 0 ${unit(token.controlOutlineWidth)} ${outlineColor}`,
   outline: 0,
 });
 
@@ -61,7 +62,7 @@ const genClearStyle = (
       width: size,
       height: size,
       borderRadius: borderRadiusSM,
-      border: `${lineWidth}px solid ${colorSplit}`,
+      border: `${unit(lineWidth)} solid ${colorSplit}`,
       position: 'relative',
       cursor: 'pointer',
       overflow: 'hidden',
@@ -188,7 +189,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           width: colorPickerWidth,
 
           '&-divider': {
-            margin: `${marginSM}px 0 ${marginXS}px`,
+            margin: `${unit(marginSM)} 0 ${unit(marginXS)}`,
           },
           [`${componentCls}-panel`]: {
             ...genPickerStyle(token),
@@ -206,17 +207,20 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           minWidth: controlHeight,
           height: controlHeight,
           borderRadius,
-          border: `${lineWidth}px solid ${colorBorder}`,
+          border: `${unit(lineWidth)} solid ${colorBorder}`,
           cursor: 'pointer',
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
           transition: `all ${motionDurationMid}`,
           background: colorBgElevated,
-          padding: paddingXXS - lineWidth,
+          padding: token.calc(paddingXXS).sub(lineWidth).equal(),
           [`${componentCls}-trigger-text`]: {
             marginInlineStart: marginXS,
-            marginInlineEnd: marginXS - (paddingXXS - lineWidth),
+            marginInlineEnd: token
+              .calc(marginXS)
+              .sub(token.calc(paddingXXS).sub(lineWidth))
+              .equal(),
             fontSize,
             color: colorText,
           },
@@ -262,7 +266,11 @@ export default genComponentStyleHook('ColorPicker', (token) => {
     colorPickerPresetColorSize: 18,
     colorPickerInsetShadow: `inset 0 0 1px 0 ${colorTextQuaternary}`,
     colorPickerSliderHeight,
-    colorPickerPreviewSize: colorPickerSliderHeight * 2 + marginSM,
+    colorPickerPreviewSize: token
+      .calc(colorPickerSliderHeight)
+      .mul(2)
+      .add(marginSM)
+      .equal() as number,
   });
 
   return [genColorPickerStyle(colorPickerToken)];

--- a/components/color-picker/style/input.ts
+++ b/components/color-picker/style/input.ts
@@ -1,4 +1,5 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { GenerateStyle } from '../../theme/internal';
 import type { ColorPickerToken } from './index';
 
@@ -36,7 +37,7 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-steppers${componentCls}-alpha-input`]: {
-        flex: `0 0 ${colorPickerAlphaInputWidth}px`,
+        flex: `0 0 ${unit(colorPickerAlphaInputWidth)}`,
         marginInlineStart: marginXXS,
       },
 
@@ -52,9 +53,9 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
             insetInlineEnd: 0,
           },
           [`${antCls}-select-selection-item`]: {
-            paddingInlineEnd: fontSizeIcon + marginXXS,
+            paddingInlineEnd: token.calc(fontSizeIcon).add(marginXXS).equal(),
             fontSize: fontSizeSM,
-            lineHeight: `${controlHeightSM}px`,
+            lineHeight: `${unit(controlHeightSM)}`,
           },
           [`${antCls}-select-item-option-content`]: {
             fontSize: fontSizeSM,
@@ -83,11 +84,11 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         },
         [`${componentCls}-hex-input${antCls}-input-affix-wrapper`]: {
           flex: 1,
-          padding: `0 ${paddingXS}px`,
+          padding: `0 ${unit(paddingXS)}`,
           [`${antCls}-input`]: {
             fontSize: fontSizeSM,
             textTransform: 'uppercase',
-            lineHeight: `${controlHeightSM - 2 * lineWidth}px`,
+            lineHeight: unit(token.calc(controlHeightSM).sub(token.calc(lineWidth).mul(2)).equal()),
           },
           [`${antCls}-input-prefix`]: {
             color: colorTextPlaceholder,

--- a/components/color-picker/style/picker.ts
+++ b/components/color-picker/style/picker.ts
@@ -1,4 +1,5 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { GenerateStyle } from '../../theme/internal';
 import { getTransBg } from './color-block';
 import type { ColorPickerToken } from './index';
@@ -21,7 +22,7 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
   return {
     [`${componentCls}-select`]: {
       [`${componentCls}-palette`]: {
-        minHeight: controlHeightLG * 4,
+        minHeight: token.calc(controlHeightLG).mul(4).equal(),
         overflow: 'hidden',
         borderRadius: borderRadiusSM,
       },
@@ -37,7 +38,7 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
     [`${componentCls}-handler`]: {
       width: colorPickerHandlerSize,
       height: colorPickerHandlerSize,
-      border: `${lineWidthBold}px solid ${colorBgElevated}`,
+      border: `${unit(lineWidthBold)} solid ${colorBgElevated}`,
       position: 'relative',
       borderRadius: '50%',
       cursor: 'pointer',
@@ -49,15 +50,15 @@ const genPickerStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
     },
 
     [`${componentCls}-slider`]: {
-      borderRadius: colorPickerSliderHeight / 2,
+      borderRadius: token.calc(colorPickerSliderHeight).div(2).equal(),
       [`${componentCls}-palette`]: {
         height: colorPickerSliderHeight,
       },
       [`${componentCls}-gradient`]: {
-        borderRadius: colorPickerSliderHeight / 2,
+        borderRadius: token.calc(colorPickerSliderHeight).div(2).equal(),
         boxShadow: colorPickerInsetShadow,
       },
-      '&-alpha': getTransBg(`${colorPickerSliderHeight}px`, token.colorFillSecondary),
+      '&-alpha': getTransBg(`${unit(colorPickerSliderHeight)}`, token.colorFillSecondary),
       '&-hue': { marginBottom: marginSM },
     },
 

--- a/components/color-picker/style/presets.ts
+++ b/components/color-picker/style/presets.ts
@@ -1,4 +1,5 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import type { GenerateStyle } from '../../theme/internal';
 import type { ColorPickerToken } from './index';
 
@@ -18,6 +19,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
     colorWhite,
     marginXXS,
     paddingXS,
+    fontHeightSM,
   } = token;
 
   return {
@@ -25,7 +27,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
       [`${antCls}-collapse-item > ${antCls}-collapse-header`]: {
         padding: 0,
         [`${antCls}-collapse-expand-icon`]: {
-          height: fontSizeSM * lineHeightSM,
+          height: fontHeightSM,
           color: colorTextQuaternary,
           paddingInlineEnd: paddingXXS,
         },
@@ -36,7 +38,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
         gap: marginXXS,
       },
       [`${antCls}-collapse-item > ${antCls}-collapse-content > ${antCls}-collapse-content-box`]: {
-        padding: `${paddingXS}px 0`,
+        padding: `${unit(paddingXS)} 0`,
       },
       '&-label': {
         fontSize: fontSizeSM,
@@ -46,7 +48,7 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
       '&-items': {
         display: 'flex',
         flexWrap: 'wrap',
-        gap: marginXXS * 1.5,
+        gap: token.calc(marginXXS).mul(1.5).equal(),
         [`${componentCls}-presets-color`]: {
           position: 'relative',
           cursor: 'pointer',
@@ -56,13 +58,16 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
           '&::before': {
             content: '""',
             pointerEvents: 'none',
-            width: colorPickerPresetColorSize + 4 * lineWidth,
-            height: colorPickerPresetColorSize + 4 * lineWidth,
+            width: token.calc(colorPickerPresetColorSize).add(token.calc(lineWidth).mul(4)).equal(),
+            height: token
+              .calc(colorPickerPresetColorSize)
+              .add(token.calc(lineWidth).mul(4))
+              .equal(),
             position: 'absolute',
-            top: -2 * lineWidth,
-            insetInlineStart: -2 * lineWidth,
+            top: token.calc(lineWidth).mul(-2).equal(),
+            insetInlineStart: token.calc(lineWidth).mul(-2).equal(),
             borderRadius,
-            border: `${lineWidth}px solid transparent`,
+            border: `${unit(lineWidth)} solid transparent`,
             transition: `border-color ${token.motionDurationMid} ${token.motionEaseInBack}`,
           },
           '&:hover::before': {
@@ -75,9 +80,9 @@ const genPresetsStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
             top: '50%',
             insetInlineStart: '21.5%',
             display: 'table',
-            width: (colorPickerPresetColorSize / 13) * 5,
-            height: (colorPickerPresetColorSize / 13) * 8,
-            border: `${token.lineWidthBold}px solid ${token.colorWhite}`,
+            width: token.calc(colorPickerPresetColorSize).div(13).mul(5).equal(),
+            height: token.calc(colorPickerPresetColorSize).div(13).mul(8).equal(),
+            border: `${unit(token.lineWidthBold)} solid ${token.colorWhite}`,
             borderTop: 0,
             borderInlineStart: 0,
             transform: 'rotate(45deg) scale(0) translate(-50%,-50%)',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- #45618
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    ColorPicker support cssVar       |
| 🇨🇳 Chinese |   颜色选择器支持 css 变量        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96c7c60</samp>

This pull request refactors the color picker component to use hooks and CSS variables for better compatibility with server-side rendering and design tokens. It also introduces the `@ant-design/cssinjs` package for creating and manipulating CSS objects with units and arithmetic operations. It updates the styles of the component and its subcomponents to improve readability, maintainability, and consistency.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96c7c60</samp>

*  Import and use `unit` function from `@ant-design/cssinjs` to add units to numeric values in CSS objects ( [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL1-R2), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-c24d0ab998b998a6a5cfd4d77148aad78198e1fe93395501020c8bbee7ebfc1cL26-R27), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L1-R2), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L30-R31), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L64-R65), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L191-R192), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L209-R210), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L1-R2), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L39-R40), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L86-R91), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L1-R2), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L40-R41), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L52-R61), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L1-R2), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L28-R30), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L39-R41), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L59-R70), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L78-R85))
* Import and use `token.calc` function and `equal` method to perform arithmetic operations on token values in CSS objects ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L216-R223), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L265-R273), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L55-R58), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L24-R25), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L52-R61), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931R22), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L49-R51), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L59-R70), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L78-R85))
* Import and use `useZIndex` hook from `_util` to control the z-index of the color picker component ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR10))
* Import and use `useCSSVar` hook from `style` to register and apply CSS variables for the color picker component ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL33-R36))
* Replace `wrapSSR` function with `wrapCSSVar` function to wrap the color picker component with a CSS variable provider and a style tag ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL137-R139), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL237-R239))
* Create a new file `cssVar.ts` in the `style` folder, which exports the `genCSSVarRegister` function from the `theme` folder with the `ColorPicker` component name and an empty object as arguments ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-830b273a91f41a04c542529c116795248963c781d95a0e2150e3135b0274b482R1-R3))
* Use `colorPickerPreviewSize` token to calculate the size of the color preview area in the color picker panel ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-1b0771e050d88aebe327dae413b7f31f0797bcee1515f3c6bb2cd890ba0929d0L265-R273))
* Use `fontHeightSM` token to set the height of the font size small in the collapse icon style ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931R22), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L28-R30))
* Use `getTransBg` function to set the background image of the alpha slider ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L52-R61))
* Adjust the spacing and alignment of various elements in the color picker panel, such as the select item, the hex input, the collapse icon, the presets list, and the transparent icon ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L55-R58), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-76a3207c1405e5d3615abf7040b26c6e5366e5d9b863ba2f9a78194d727fe2d7L86-R91), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L28-R30), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L39-R41), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L49-R51), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L59-R70), [link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L78-R85))
* Set the border width and color of the handler element that moves along the color palette or slider ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L40-R41))
* Set the border radius of the slider and gradient elements that show the color spectrum or alpha channel ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L52-R61))
* Set the minimum height of the color palette area in the color picker panel ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-34b89f88ff38f571cda106c0e4980f0487a530c9c21623a0fd1695bb0b132a58L24-R25))
* Create a border effect around the selected preset color item ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L59-R70))
* Create a transparent icon effect on the preset color item that represents the transparent color ([link](https://github.com/ant-design/ant-design/pull/45868/files?diff=unified&w=0#diff-258bf706e0141cb724422da77ea2a1f43ecad3cdaeee2f0b86908eb12f1af931L78-R85))
