### PR TITLE
📖docs: update tabs component docs

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -83,7 +83,8 @@ More option at [rc-tabs tabs](https://github.com/react-component/tabs#tabs)
 | key | TabPane's key | string | - |  |
 | label | TabPane's head display text | ReactNode | - |  |
 | children | TabPane's head display content | ReactNode | - |  |
-| closable | Whether a close (x) button is visible, Only works while type="editable-card" | boolean | true |  |
+| closable | Whether a close (x) button is visible, Only works while `type="editable-card"` | boolean | true |  |
+
 ## Design Token
 
 <ComponentTokenTable component="Tabs"></ComponentTokenTable>

--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -83,7 +83,7 @@ More option at [rc-tabs tabs](https://github.com/react-component/tabs#tabs)
 | key | TabPane's key | string | - |  |
 | label | TabPane's head display text | ReactNode | - |  |
 | children | TabPane's head display content | ReactNode | - |  |
-
+| closable | Whether a close (x) button is visible, Only works while type="editable-card" | boolean | true |  |
 ## Design Token
 
 <ComponentTokenTable component="Tabs"></ComponentTokenTable>

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -85,7 +85,8 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | key | 对应 activeKey | string | - |  |
 | label | 选项卡头显示文字 | ReactNode | - |  |
 | children | 选项卡头显示内容 | ReactNode | - |  |
-| closable | 是否显示选项卡的关闭按钮，在 type="editable-card" 时有效 | boolean | true |  |
+| closable | 是否显示选项卡的关闭按钮，在 `type="editable-card"` 时有效 | boolean | true |  |
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Tabs"></ComponentTokenTable>

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -85,7 +85,7 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | key | 对应 activeKey | string | - |  |
 | label | 选项卡头显示文字 | ReactNode | - |  |
 | children | 选项卡头显示内容 | ReactNode | - |  |
-
+| closable | 是否显示选项卡的关闭按钮，在 type="editable-card" 时有效 | boolean | true |  |
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Tabs"></ComponentTokenTable>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [X] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充
- [X] 代码演示无须提供
- [X] TypeScript 定义无须补充
- [X] Changelog 无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述
新增了Tabs组件props参数说明【closeable】
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90aeeee</samp>

Add a new `closable` prop to the `TabItemType` interface in the `Tabs` component documentation. This prop allows users to control the visibility of the close button on each tab when the `type` prop is `"editable-card"`.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90aeeee</samp>

* Add a new property `closable` to the `TabItemType` interface to indicate whether a tab can be closed by a button ([link](https://github.com/ant-design/ant-design/pull/45875/files?diff=unified&w=0#diff-55d7b2e14d2f70c11368544596a23fa53e1c2d392b85295e52cbf9d21bec7ebcL86-R86), [link](https://github.com/ant-design/ant-design/pull/45875/files?diff=unified&w=0#diff-aae9511c7fe785a991682a0bb026fec2a489547d55493b5fd8264299cd290b15L88-R88))
* Update the English and Chinese documentation files `index.en-US.md` and `index.zh-CN.md` to reflect the new property and its usage ([link](https://github.com/ant-design/ant-design/pull/45875/files?diff=unified&w=0#diff-55d7b2e14d2f70c11368544596a23fa53e1c2d392b85295e52cbf9d21bec7ebcL86-R86), [link](https://github.com/ant-design/ant-design/pull/45875/files?diff=unified&w=0#diff-aae9511c7fe785a991682a0bb026fec2a489547d55493b5fd8264299cd290b15L88-R88))