### PR TITLE
fix: genCSSVarRegister unitless should work

### DIFF
--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -262,8 +262,8 @@ describe('ConfigProvider.Theme', () => {
       const select = container.querySelector('.select-foo')!;
       expect(select).toHaveStyle({
         '--antd-color-primary': '#1890ff',
-        '--antd-option-selected-color': '#000',
-        '--antd-option-selected-font-weight': '600',
+        '--antd-select-option-selected-color': '#000',
+        '--antd-select-option-selected-font-weight': '600',
       });
     });
   });

--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -3,7 +3,7 @@ import kebabCase from 'lodash/kebabCase';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
 
 import ConfigProvider from '..';
-import { InputNumber, Button } from '../..';
+import { InputNumber, Button, Select } from '../..';
 import { render } from '../../../tests/utils';
 import { resetWarned } from '../../_util/warning';
 import theme from '../../theme';
@@ -252,19 +252,18 @@ describe('ConfigProvider.Theme', () => {
           theme={{
             cssVar: { key: 'foo' },
             hashed: true,
-            components: { Button: { colorPrimary: '#1890ff', defaultBg: '#000' } },
+            components: { Select: { colorPrimary: '#1890ff', optionSelectedColor: '#000' } },
           }}
         >
-          <Button className="button-foo" type="primary">
-            Button
-          </Button>
+          <Select className="select-foo" />
         </ConfigProvider>,
       );
 
-      const btn = container.querySelector('.button-foo')!;
-      expect(btn).toHaveStyle({
+      const select = container.querySelector('.select-foo')!;
+      expect(select).toHaveStyle({
         '--antd-color-primary': '#1890ff',
-        '--antd-button-default-bg': '#000',
+        '--antd-option-selected-color': '#000',
+        '--antd-option-selected-font-weight': '600',
       });
     });
   });

--- a/components/select/style/cssVar.ts
+++ b/components/select/style/cssVar.ts
@@ -4,5 +4,6 @@ import { prepareComponentToken } from '.';
 export default genCSSVarRegister('Select', prepareComponentToken, {
   unitless: {
     optionLineHeight: true,
+    optionSelectedFontWeight: true,
   },
 });

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -205,10 +205,7 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
 
         if (cssVar) {
           Object.keys(defaultComponentToken).forEach((key) => {
-            defaultComponentToken[key] = `var(${token2CSSVar(
-              key,
-              getCompVarPrefix(component, cssVar.prefix),
-            )})`;
+            defaultComponentToken[key] = `var(${token2CSSVar(key, cssVar.prefix)})`;
           });
         }
         const mergedToken = mergeToken<
@@ -316,13 +313,7 @@ export const genCSSVarRegister = <C extends OverrideComponent>(
       },
       () => {
         const defaultToken = getDefaultComponentToken(component, realToken, getDefaultToken);
-        const componentToken = getComponentToken(component, realToken, defaultToken);
-        Object.keys(defaultToken).forEach((key) => {
-          componentToken[`${component}${key.slice(0, 1).toUpperCase()}${key.slice(1)}`] =
-            componentToken[key];
-          delete componentToken[key];
-        });
-        return componentToken;
+        return getComponentToken(component, realToken, defaultToken);
       },
     );
     return null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix genCSSVarRegister `unitless` not work.       |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74b36b4</samp>

Added a new theme token for the `Select` component and improved the theme testing and generation logic. The changes allow more customization and better performance of the component styles.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74b36b4</samp>

*  Added `optionSelectedFontWeight` token to control the font weight of the selected option in the `Select` component ([link](https://github.com/ant-design/ant-design/pull/45885/files?diff=unified&w=0#diff-6807efde7996890597453ae80cd4a5d1f126c896134917f6655f14686c0ee6f0R7))
* Simplified the `genComponentStyleHook` function to use the `cssVar.prefix` directly and return the `componentToken` object without modifying it ([link](https://github.com/ant-design/ant-design/pull/45885/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L208-R208), [link](https://github.com/ant-design/ant-design/pull/45885/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L319-R316))
* Modified the test case for the `ConfigProvider` component with custom theme tokens to use the `Select` component and check its style with the expected CSS variables ([link](https://github.com/ant-design/ant-design/pull/45885/files?diff=unified&w=0#diff-778a2283a758d1240e18d499acfb3d06dbbf8139723e404c5c9fd3cf539d8658L255-R266))
* Imported the `Select` component from `../..` in the `components/config-provider/__tests__/theme.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/45885/files?diff=unified&w=0#diff-778a2283a758d1240e18d499acfb3d06dbbf8139723e404c5c9fd3cf539d8658L6-R6))
