### PR TITLE
fix: zIndexPopup should not united

### DIFF
--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -264,6 +264,7 @@ describe('ConfigProvider.Theme', () => {
         '--antd-color-primary': '#1890ff',
         '--antd-select-option-selected-color': '#000',
         '--antd-select-option-selected-font-weight': '600',
+        '--antd-select-z-index-popup': '1050',
       });
     });
   });

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -303,7 +303,9 @@ export const genCSSVarRegister = <C extends OverrideComponent>(
   }
 
   const { unitless: originUnitless = {} } = options ?? {};
-  const compUnitless: any = {};
+  const compUnitless: any = {
+    [prefixToken('zIndexPopup')]: true,
+  };
   Object.keys(originUnitless).forEach((key: keyof ComponentTokenKey<C>) => {
     compUnitless[prefixToken(key)] = originUnitless[key];
   });
@@ -318,7 +320,6 @@ export const genCSSVarRegister = <C extends OverrideComponent>(
         unitless: {
           ...unitless,
           ...compUnitless,
-          zIndexPopup: true,
         },
         ignore,
         token: realToken,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix `zIndexPopup` unit.       |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80d8046</samp>

This pull request refactors the `Select` component to use CSS variables for theming, and adds a new token `zIndexPopup` to control the z-index of the popup menu. It also updates the `theme.test.tsx` file to test the new token and variable.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80d8046</samp>

*  Add `zIndexPopup` token to `Select` component to control the z-index of the popup menu ([link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-778a2283a758d1240e18d499acfb3d06dbbf8139723e404c5c9fd3cf539d8658R267), [link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L306-R308), [link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L321))
  * Update `genCSSVarRegister` function in `genComponentStyleHook.tsx` to generate CSS variable for `zIndexPopup` token ([link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L306-R308), [link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-0a8f81c703cc51a3e3b965dadec5aabff951f566dd51de99f2e457f5a1fe78c8L321))
  * Add test case for `zIndexPopup` token in `theme.test.tsx` ([link](https://github.com/ant-design/ant-design/pull/45889/files?diff=unified&w=0#diff-778a2283a758d1240e18d499acfb3d06dbbf8139723e404c5c9fd3cf539d8658R267))
