### PR TITLE
refactor: Radio support css var

### DIFF
--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -9,6 +9,8 @@ import { RadioGroupContextProvider } from './context';
 import type { RadioChangeEvent, RadioGroupButtonStyle, RadioGroupProps } from './interface';
 import Radio from './radio';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
@@ -49,7 +51,9 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
   const groupPrefixCls = `${prefixCls}-group`;
 
   // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   let childrenToRender = children;
   // 如果存在 options, 优先使用
@@ -99,8 +103,9 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     className,
     rootClassName,
     hashId,
+    rootCls,
   );
-  return wrapSSR(
+  return wrapCSSVar(
     <div
       {...pickAttrs(props, { aria: true, data: true })}
       className={classString}

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -12,6 +12,8 @@ import { FormItemInputContext } from '../form/context';
 import RadioGroupContext, { RadioOptionTypeContext } from './context';
 import type { RadioChangeEvent, RadioProps, RadioRef } from './interface';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (props, ref) => {
   const groupContext = React.useContext(RadioGroupContext);
@@ -47,7 +49,9 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
   const prefixCls = isButtonType ? `${radioPrefixCls}-button` : radioPrefixCls;
 
   // Style
-  const [wrapSSR, hashId] = useStyle(radioPrefixCls);
+  const [, hashId] = useStyle(radioPrefixCls);
+  const rootCls = useCSSVarCls(radioPrefixCls);
+  const wrapCSSVar = useCSSVar(rootCls);
 
   const radioProps: RadioProps = { ...restProps };
 
@@ -74,9 +78,10 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     className,
     rootClassName,
     hashId,
+    rootCls,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <Wave component="Radio" disabled={radioProps.disabled}>
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label

--- a/components/radio/style/cssVar.ts
+++ b/components/radio/style/cssVar.ts
@@ -1,0 +1,9 @@
+import { genCSSVarRegister } from '../../theme/internal';
+import { prepareComponentToken } from '.';
+
+export default genCSSVarRegister('Radio', prepareComponentToken, {
+  unitless: {
+    dotCheckedScale: true,
+    dotCheckedScaleDisabled: true,
+  },
+});

--- a/components/radio/style/cssVar.ts
+++ b/components/radio/style/cssVar.ts
@@ -3,7 +3,7 @@ import { prepareComponentToken } from '.';
 
 export default genCSSVarRegister('Radio', prepareComponentToken, {
   unitless: {
-    dotCheckedScale: true,
-    dotCheckedScaleDisabled: true,
+    radioSize: true,
+    dotSize: true,
   },
 });

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -21,16 +21,6 @@ export interface ComponentToken {
    * @descEN Color of disabled Radio dot
    */
   dotColorDisabled: string;
-  /**
-   * @desc 单选框圆点选中时的缩放比例
-   * @descEN Scale of the Radio dot when checked
-   */
-  dotCheckedScale: number;
-  /**
-   * @desc 单选框圆点选中并禁用时的缩放比例
-   * @descEN Scale of the Radio dot when checked and disabled
-   */
-  dotCheckedScaleDisabled: number;
 
   // Radio buttons
   /**
@@ -141,8 +131,6 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
     colorBgContainer,
     colorBorder,
     lineWidth,
-    dotCheckedScale,
-    dotCheckedScaleDisabled,
     colorBgContainerDisabled,
     colorTextDisabled,
     paddingXS,
@@ -153,6 +141,10 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
     calc,
   } = token;
   const radioInnerPrefixCls = `${componentCls}-inner`;
+
+  const dotPadding = 4;
+  const radioDotDisabledSize = calc(radioSize).sub(calc(dotPadding).mul(2));
+  const radioSizeCalc = calc(1).mul(radioSize).equal();
 
   return {
     [`${componentCls}-wrapper`]: {
@@ -223,14 +215,14 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           insetBlockStart: '50%',
           insetInlineStart: '50%',
           display: 'block',
-          width: radioSize,
-          height: radioSize,
-          marginBlockStart: calc(radioSize).div(-2).equal(),
-          marginInlineStart: calc(radioSize).div(-2).equal(),
+          width: radioSizeCalc,
+          height: radioSizeCalc,
+          marginBlockStart: calc(1).mul(radioSize).div(-2).equal(),
+          marginInlineStart: calc(1).mul(radioSize).div(-2).equal(),
           backgroundColor: radioColor,
           borderBlockStart: 0,
           borderInlineStart: 0,
-          borderRadius: radioSize,
+          borderRadius: radioSizeCalc,
           transform: 'scale(0)',
           opacity: 0,
           transition: `all ${motionDurationSlow} ${motionEaseInOutCirc}`,
@@ -242,8 +234,8 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         insetBlockStart: 0,
         insetInlineStart: 0,
         display: 'block',
-        width: radioSize,
-        height: radioSize,
+        width: radioSizeCalc,
+        height: radioSizeCalc,
         backgroundColor: colorBgContainer,
         borderColor: colorBorder,
         borderStyle: 'solid',
@@ -267,7 +259,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           backgroundColor: radioBgColor,
 
           '&::after': {
-            transform: `scale(${dotCheckedScale})`,
+            transform: `scale(${token.calc(token.dotSize).div(radioSize).equal()})`,
             opacity: 1,
             transition: `all ${motionDurationSlow} ${motionEaseInOutCirc}`,
           },
@@ -299,7 +291,9 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         [`&${componentCls}-checked`]: {
           [radioInnerPrefixCls]: {
             '&::after': {
-              transform: `scale(${dotCheckedScaleDisabled})`,
+              transform: `scale(${calc(radioDotDisabledSize)
+                .div(radioSize)
+                .equal({ unit: false })})`,
             },
           },
         },
@@ -541,11 +535,6 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
   };
 };
 
-const getDotSize = (radioSize: number): number => {
-  const dotPadding = 4; // Fixed Value
-  return radioSize - dotPadding * 2;
-};
-
 // ============================== Export ==============================
 export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
   const {
@@ -567,16 +556,15 @@ export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
 
   const dotPadding = 4; // Fixed value
   const radioSize = fontSizeLG;
-  const radioDotSize = wireframe ? getDotSize(radioSize) : radioSize - (dotPadding + lineWidth) * 2;
-  const radioDotDisabledSize = getDotSize(radioSize);
+  const radioDotSize = wireframe
+    ? radioSize - dotPadding * 2
+    : radioSize - (dotPadding + lineWidth) * 2;
 
   return {
     // Radio
     radioSize,
     dotSize: radioDotSize,
     dotColorDisabled: colorTextDisabled,
-    dotCheckedScale: radioDotSize / radioSize,
-    dotCheckedScaleDisabled: radioDotDisabledSize / radioSize,
 
     // Radio buttons
     buttonSolidCheckedColor: colorTextLightSolid,

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -1,5 +1,6 @@
+import { unit } from '@ant-design/cssinjs';
 import { genFocusOutline, resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 // ============================== Tokens ==============================
@@ -20,6 +21,16 @@ export interface ComponentToken {
    * @descEN Color of disabled Radio dot
    */
   dotColorDisabled: string;
+  /**
+   * @desc 单选框圆点选中时的缩放比例
+   * @descEN Scale of the Radio dot when checked
+   */
+  dotCheckedScale: number;
+  /**
+   * @desc 单选框圆点选中并禁用时的缩放比例
+   * @descEN Scale of the Radio dot when checked and disabled
+   */
+  dotCheckedScaleDisabled: number;
 
   // Radio buttons
   /**
@@ -80,7 +91,6 @@ export interface ComponentToken {
 }
 
 interface RadioToken extends FullToken<'Radio'> {
-  radioDotDisabledSize: number;
   radioFocusShadow: string;
   radioButtonFocusShadow: string;
 }
@@ -126,15 +136,16 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
     colorBgContainer,
     colorBorder,
     lineWidth,
-    dotSize,
+    dotCheckedScale,
+    dotCheckedScaleDisabled,
     colorBgContainerDisabled,
     colorTextDisabled,
     paddingXS,
     dotColorDisabled,
     lineType,
-    radioDotDisabledSize,
     wireframe,
     colorWhite,
+    calc,
   } = token;
   const radioInnerPrefixCls = `${componentCls}-inner`;
 
@@ -171,7 +182,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         insetInlineStart: 0,
         width: '100%',
         height: '100%',
-        border: `${lineWidth}px ${lineType} ${colorPrimary}`,
+        border: `${unit(lineWidth)} ${lineType} ${colorPrimary}`,
         borderRadius: '50%',
         visibility: 'hidden',
         content: '""',
@@ -209,9 +220,9 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           display: 'block',
           width: radioSize,
           height: radioSize,
-          marginBlockStart: radioSize / -2,
-          marginInlineStart: radioSize / -2,
-          backgroundColor: wireframe ? colorPrimary : colorWhite,
+          marginBlockStart: calc(radioSize).div(-2).equal(),
+          marginInlineStart: calc(radioSize).div(-2).equal(),
+          backgroundColor: wireframe ? colorPrimary : colorWhite, // TODO
           borderBlockStart: 0,
           borderInlineStart: 0,
           borderRadius: radioSize,
@@ -248,10 +259,10 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
       [`${componentCls}-checked`]: {
         [radioInnerPrefixCls]: {
           borderColor: colorPrimary,
-          backgroundColor: wireframe ? colorBgContainer : colorPrimary,
+          backgroundColor: wireframe ? colorBgContainer : colorPrimary, // TODO
 
           '&::after': {
-            transform: `scale(${dotSize / radioSize})`,
+            transform: `scale(${dotCheckedScale})`,
             opacity: 1,
             transition: `all ${motionDurationSlow} ${motionEaseInOutCirc}`,
           },
@@ -283,7 +294,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         [`&${componentCls}-checked`]: {
           [radioInnerPrefixCls]: {
             '&::after': {
-              transform: `scale(${radioDotDisabledSize / radioSize})`,
+              transform: `scale(${dotCheckedScaleDisabled})`,
             },
           },
         },
@@ -330,6 +341,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
     buttonSolidCheckedBg,
     buttonSolidCheckedHoverBg,
     buttonSolidCheckedActiveBg,
+    calc,
   } = token;
   return {
     [`${componentCls}-button-wrapper`]: {
@@ -341,12 +353,12 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       paddingBlock: 0,
       color: buttonColor,
       fontSize,
-      lineHeight: `${controlHeight - lineWidth * 2}px`,
+      lineHeight: calc(controlHeight).sub(calc(lineWidth).mul(2)).equal(),
       background: buttonBg,
-      border: `${lineWidth}px ${lineType} ${colorBorder}`,
+      border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
       // strange align fix for chrome but works
       // https://gw.alipayobjects.com/zos/rmsportal/VFTfKXJuogBAXcvfAUWJ.gif
-      borderBlockStartWidth: lineWidth + 0.02,
+      borderBlockStartWidth: calc(lineWidth).add(0.02).equal(),
       borderInlineStartWidth: 0,
       borderInlineEndWidth: lineWidth,
       cursor: 'pointer',
@@ -372,8 +384,8 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       '&:not(:first-child)': {
         '&::before': {
           position: 'absolute',
-          insetBlockStart: -lineWidth,
-          insetInlineStart: -lineWidth,
+          insetBlockStart: calc(lineWidth).mul(-1).equal(),
+          insetInlineStart: calc(lineWidth).mul(-1).equal(),
           display: 'block',
           boxSizing: 'content-box',
           width: 1,
@@ -387,7 +399,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       },
 
       '&:first-child': {
-        borderInlineStart: `${lineWidth}px ${lineType} ${colorBorder}`,
+        borderInlineStart: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
         borderStartStartRadius: borderRadius,
         borderEndStartRadius: borderRadius,
       },
@@ -404,7 +416,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       [`${componentCls}-group-large &`]: {
         height: controlHeightLG,
         fontSize: fontSizeLG,
-        lineHeight: `${controlHeightLG - lineWidth * 2}px`,
+        lineHeight: calc(controlHeightLG).sub(calc(lineWidth).mul(2)).equal(),
 
         '&:first-child': {
           borderStartStartRadius: borderRadiusLG,
@@ -419,9 +431,9 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
 
       [`${componentCls}-group-small &`]: {
         height: controlHeightSM,
-        paddingInline: paddingXS - lineWidth,
+        paddingInline: calc(paddingXS).sub(lineWidth).equal(),
         paddingBlock: 0,
-        lineHeight: `${controlHeightSM - lineWidth * 2}px`,
+        lineHeight: calc(controlHeightSM).sub(calc(lineWidth).mul(2)).equal(),
 
         '&:first-child': {
           borderStartStartRadius: borderRadiusSM,
@@ -530,17 +542,60 @@ const getDotSize = (radioSize: number): number => {
 };
 
 // ============================== Export ==============================
+export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
+  const {
+    wireframe,
+    padding,
+    marginXS,
+    lineWidth,
+    fontSizeLG,
+    colorText,
+    colorBgContainer,
+    colorTextDisabled,
+    controlItemBgActiveDisabled,
+    colorTextLightSolid,
+    colorPrimary,
+    colorPrimaryHover,
+    colorPrimaryActive,
+  } = token;
+
+  const dotPadding = 4; // Fixed value
+  const radioSize = fontSizeLG;
+  const radioDotSize = wireframe ? getDotSize(radioSize) : radioSize - (dotPadding + lineWidth) * 2;
+  const radioDotDisabledSize = getDotSize(radioSize);
+
+  return {
+    // Radio
+    radioSize,
+    dotSize: radioDotSize,
+    dotColorDisabled: colorTextDisabled,
+    dotCheckedScale: radioDotSize / radioSize,
+    dotCheckedScaleDisabled: radioDotDisabledSize / radioSize,
+
+    // Radio buttons
+    buttonSolidCheckedColor: colorTextLightSolid,
+    buttonSolidCheckedBg: colorPrimary,
+    buttonSolidCheckedHoverBg: colorPrimaryHover,
+    buttonSolidCheckedActiveBg: colorPrimaryActive,
+    buttonBg: colorBgContainer,
+    buttonCheckedBg: colorBgContainer,
+    buttonColor: colorText,
+    buttonCheckedBgDisabled: controlItemBgActiveDisabled,
+    buttonCheckedColorDisabled: colorTextDisabled,
+    buttonPaddingInline: padding - lineWidth,
+    wrapperMarginInlineEnd: marginXS,
+  };
+};
+
 export default genComponentStyleHook(
   'Radio',
   (token) => {
-    const { controlOutline, controlOutlineWidth, radioSize } = token;
+    const { controlOutline, controlOutlineWidth } = token;
 
-    const radioFocusShadow = `0 0 0 ${controlOutlineWidth}px ${controlOutline}`;
+    const radioFocusShadow = `0 0 0 ${unit(controlOutlineWidth)} ${controlOutline}`;
     const radioButtonFocusShadow = radioFocusShadow;
-    const radioDotDisabledSize = getDotSize(radioSize);
 
     const radioToken = mergeToken<RadioToken>(token, {
-      radioDotDisabledSize,
       radioFocusShadow,
       radioButtonFocusShadow,
     });
@@ -551,47 +606,5 @@ export default genComponentStyleHook(
       getRadioButtonStyle(radioToken),
     ];
   },
-  (token) => {
-    const {
-      wireframe,
-      padding,
-      marginXS,
-      lineWidth,
-      fontSizeLG,
-      colorText,
-      colorBgContainer,
-      colorTextDisabled,
-      controlItemBgActiveDisabled,
-      colorTextLightSolid,
-      colorPrimary,
-      colorPrimaryHover,
-      colorPrimaryActive,
-    } = token;
-
-    const dotPadding = 4; // Fixed value
-    const radioSize = fontSizeLG;
-    const radioDotSize = wireframe
-      ? getDotSize(radioSize)
-      : radioSize - (dotPadding + lineWidth) * 2;
-
-    return {
-      // Radio
-      radioSize,
-      dotSize: radioDotSize,
-      dotColorDisabled: colorTextDisabled,
-
-      // Radio buttons
-      buttonSolidCheckedColor: colorTextLightSolid,
-      buttonSolidCheckedBg: colorPrimary,
-      buttonSolidCheckedHoverBg: colorPrimaryHover,
-      buttonSolidCheckedActiveBg: colorPrimaryActive,
-      buttonBg: colorBgContainer,
-      buttonCheckedBg: colorBgContainer,
-      buttonColor: colorText,
-      buttonCheckedBgDisabled: controlItemBgActiveDisabled,
-      buttonCheckedColorDisabled: colorTextDisabled,
-      buttonPaddingInline: padding - lineWidth,
-      wrapperMarginInlineEnd: marginXS,
-    };
-  },
+  prepareComponentToken,
 );

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -88,6 +88,11 @@ export interface ComponentToken {
    * @descEN Margin right of Radio button
    */
   wrapperMarginInlineEnd: number;
+
+  /** @internal */
+  radioColor: string;
+  /** @internal */
+  radioBgColor: string;
 }
 
 interface RadioToken extends FullToken<'Radio'> {
@@ -143,8 +148,8 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
     paddingXS,
     dotColorDisabled,
     lineType,
-    wireframe,
-    colorWhite,
+    radioColor,
+    radioBgColor,
     calc,
   } = token;
   const radioInnerPrefixCls = `${componentCls}-inner`;
@@ -222,7 +227,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           height: radioSize,
           marginBlockStart: calc(radioSize).div(-2).equal(),
           marginInlineStart: calc(radioSize).div(-2).equal(),
-          backgroundColor: wireframe ? colorPrimary : colorWhite, // TODO
+          backgroundColor: radioColor,
           borderBlockStart: 0,
           borderInlineStart: 0,
           borderRadius: radioSize,
@@ -259,7 +264,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
       [`${componentCls}-checked`]: {
         [radioInnerPrefixCls]: {
           borderColor: colorPrimary,
-          backgroundColor: wireframe ? colorBgContainer : colorPrimary, // TODO
+          backgroundColor: radioBgColor,
 
           '&::after': {
             transform: `scale(${dotCheckedScale})`,
@@ -557,6 +562,7 @@ export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
     colorPrimary,
     colorPrimaryHover,
     colorPrimaryActive,
+    colorWhite,
   } = token;
 
   const dotPadding = 4; // Fixed value
@@ -584,6 +590,10 @@ export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
     buttonCheckedColorDisabled: colorTextDisabled,
     buttonPaddingInline: padding - lineWidth,
     wrapperMarginInlineEnd: marginXS,
+
+    // internal
+    radioColor: wireframe ? colorPrimary : colorWhite,
+    radioBgColor: wireframe ? colorBgContainer : colorPrimary,
   };
 };
 

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -352,7 +352,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       paddingBlock: 0,
       color: buttonColor,
       fontSize,
-      lineHeight: calc(controlHeight).sub(calc(lineWidth).mul(2)).equal(),
+      lineHeight: unit(calc(controlHeight).sub(calc(lineWidth).mul(2)).equal()),
       background: buttonBg,
       border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
       // strange align fix for chrome but works

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -415,7 +415,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       [`${componentCls}-group-large &`]: {
         height: controlHeightLG,
         fontSize: fontSizeLG,
-        lineHeight: calc(controlHeightLG).sub(calc(lineWidth).mul(2)).equal(),
+        lineHeight: unit(calc(controlHeightLG).sub(calc(lineWidth).mul(2)).equal()),
 
         '&:first-child': {
           borderStartStartRadius: borderRadiusLG,
@@ -432,7 +432,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
         height: controlHeightSM,
         paddingInline: calc(paddingXS).sub(lineWidth).equal(),
         paddingBlock: 0,
-        lineHeight: calc(controlHeightSM).sub(calc(lineWidth).mul(2)).equal(),
+        lineHeight: unit(calc(controlHeightSM).sub(calc(lineWidth).mul(2)).equal()),
 
         '&:first-child': {
           borderStartStartRadius: borderRadiusSM,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Radio support css variables. |
| 🇨🇳 Chinese | Radio 组件支持 css 变量。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fd7c0c</samp>

The pull request refactors the Radio component and its group to use CSS variables for styling, using custom hooks and the `@ant-design/cssinjs` package. It adds a new module, `cssVar.ts`, that exports a function to generate a CSS variable register for the component. It also removes some redundant code for server-side rendering and adds new component token properties.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9fd7c0c</samp>

*  Add support for CSS variables for theming the Radio component and its variants ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749R12-R13), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cR15-R16), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-edec6179fd8063cb1344a9894c050e6ee36ec79aae71605a1690ad5d37d3cd63R1-R9), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL1-R3), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL533-R598), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL554-R609))
*  Call the `useCSSVar` and `useCSSVarCls` hooks to get the CSS variable class name and the wrapper function for the Radio and RadioGroup components ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749L52-R56), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749L102-R108), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL50-R54), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL77-R84))
*  Pass the `rootCls` and `wrapCSSVar` variables to the `useGroupContext`, `useGroupStyle`, `useRadioContext`, and `useRadioStyle` hooks to provide the context and style for the Radio and RadioGroup components and their children ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749L102-R108), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL77-R84))
*  Remove the unused `wrapSSR` variable, which was previously used for server-side rendering, from the Radio and RadioGroup components ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-94794a2156476ac265df2274830a3c700b50b66ef4bf24f7558ab3c2885f7749L52-R56), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-4befd0a047da31184c43bc6fef846467a6e774ecef3cf332ac25310b3d9d4a8cL50-R54))
*  Add two new properties, `dotCheckedScale` and `dotCheckedScaleDisabled`, to the `ComponentToken` interface, which specify the scale of the Radio dot when checked and checked and disabled, respectively ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afR24-R33))
*  Remove the `radioDotDisabledSize` property from the `ComponentToken` interface, which was previously used to specify the size of the Radio dot when disabled, as it is no longer needed ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL83))
*  Replace the `lineWidth` and `radioSize` values with the `unit` and `calc` function calls, respectively, in the `getRadioBasicStyle` function, which generates the basic style for the Radio component, to ensure consistency and compatibility with the CSS variable syntax and to make the style values responsive and dynamic based on the Radio size and line width ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL174-R185), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL212-R225))
*  Replace the `dotSize / radioSize` and `radioDotDisabledSize / radioSize` values with the `dotCheckedScale` and `dotCheckedScaleDisabled` CSS variables, respectively, in the `getRadioBasicStyle` function, to simplify the style values and make them consistent with the component token ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL251-R265), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL286-R297))
*  Add a TODO comment to indicate that the `wireframe` property needs to be handled by the CSS variable logic in the `getRadioBasicStyle` function ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL251-R265))
*  Replace the `lineWidth`, `controlHeight - lineWidth * 2`, `-lineWidth`, and `controlHeightLG - lineWidth * 2` values with the `unit` and `calc` function calls, respectively, in the `getRadioButtonStyle` function, which generates the style for the Radio button component, to ensure consistency and compatibility with the CSS variable syntax and to make the style values responsive and dynamic based on the control height and line width ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL344-R361), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL375-R388), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL390-R402), [link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL407-R419))
*  Replace the `paddingXS - lineWidth` and `controlHeightSM - lineWidth * 2` values with the `calc` function calls in the `getRadioButtonStyle` function, to make the style values responsive and dynamic based on the padding, control height, and line width ([link](https://github.com/ant-design/ant-design/pull/45897/files?diff=unified&w=0#diff-a741439225c8413e967262511dad718192a7a5154ee037fa3c679681b95372afL422-R436))
