### PR TITLE
feat: Breadcrumb support cssVar

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -12,6 +12,7 @@ import type { BreadcrumbItemProps } from './BreadcrumbItem';
 import BreadcrumbItem, { InternalBreadcrumbItem } from './BreadcrumbItem';
 import BreadcrumbSeparator from './BreadcrumbSeparator';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 import useItemRender from './useItemRender';
 import useItems from './useItems';
 
@@ -93,8 +94,10 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
   const { getPrefixCls, direction, breadcrumb } = React.useContext(ConfigContext);
 
   let crumbs: React.ReactNode;
+
   const prefixCls = getPrefixCls('breadcrumb', customizePrefixCls);
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const mergedItems = useItems(items, legacyRoutes);
 
@@ -216,7 +219,7 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
 
   const mergedStyle: React.CSSProperties = { ...breadcrumb?.style, ...style };
 
-  return wrapSSR(
+  return wrapCSSVar(
     <nav className={breadcrumbClassName} style={mergedStyle} {...restProps}>
       <ol>{crumbs}</ol>
     </nav>,

--- a/components/breadcrumb/style/cssVar.ts
+++ b/components/breadcrumb/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Breadcrumb'>('Breadcrumb', prepareComponentToken);

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -70,7 +70,7 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
         transition: `color ${token.motionDurationMid}`,
         padding: `0 ${unit(token.paddingXXS)}`,
         borderRadius: token.borderRadiusSM,
-        height: fontHeight,
+        height: token.fontHeight,
         display: 'inline-block',
         marginInline: calc(token.marginXXS).mul(-1).equal(),
 
@@ -102,7 +102,7 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
 
       [`${componentCls}-overlay-link`]: {
         borderRadius: token.borderRadiusSM,
-        height: fontHeight,
+        height: token.fontHeight,
         display: 'inline-block',
         padding: `0 ${unit(token.paddingXXS)}`,
         marginInline: calc(token.marginXXS).mul(-1).equal(),

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -102,7 +102,7 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
 
       [`${componentCls}-overlay-link`]: {
         borderRadius: token.borderRadiusSM,
-        height: calc(token.lineHeight).mul(token.fontSize).equal(),
+        height: fontHeight,
         display: 'inline-block',
         padding: `0 ${unit(token.paddingXXS)}`,
         marginInline: calc(token.marginXXS).mul(-1).equal(),

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -1,6 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
+
 import { genFocusStyle, resetComponent } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken {
@@ -44,7 +45,7 @@ export interface ComponentToken {
 interface BreadcrumbToken extends FullToken<'Breadcrumb'> {}
 
 const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) => {
-  const { componentCls, iconCls } = token;
+  const { componentCls, iconCls, calc } = token;
 
   return {
     [componentCls]: {
@@ -67,11 +68,11 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
       a: {
         color: token.linkColor,
         transition: `color ${token.motionDurationMid}`,
-        padding: `0 ${token.paddingXXS}px`,
+        padding: `0 ${unit(token.paddingXXS)}`,
         borderRadius: token.borderRadiusSM,
-        height: token.lineHeight * token.fontSize,
+        height: calc(token.lineHeight).mul(token.fontSize).equal(),
         display: 'inline-block',
-        marginInline: -token.marginXXS,
+        marginInline: calc(token.marginXXS).mul(-1).equal(),
 
         '&:hover': {
           color: token.linkHoverColor,
@@ -101,10 +102,10 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
 
       [`${componentCls}-overlay-link`]: {
         borderRadius: token.borderRadiusSM,
-        height: token.lineHeight * token.fontSize,
+        height: calc(token.lineHeight).mul(token.fontSize).equal(),
         display: 'inline-block',
-        padding: `0 ${token.paddingXXS}px`,
-        marginInline: -token.marginXXS,
+        padding: `0 ${unit(token.paddingXXS)}`,
+        marginInline: calc(token.marginXXS).mul(-1).equal(),
 
         [`> ${iconCls}`]: {
           marginInlineStart: token.marginXXS,
@@ -135,20 +136,22 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Breadcrumb'> = (token) => ({
+  itemColor: token.colorTextDescription,
+  lastItemColor: token.colorText,
+  iconFontSize: token.fontSize,
+  linkColor: token.colorTextDescription,
+  linkHoverColor: token.colorText,
+  separatorColor: token.colorTextDescription,
+  separatorMargin: token.marginXS,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Breadcrumb',
   (token) => {
-    const BreadcrumbToken = mergeToken<BreadcrumbToken>(token, {});
-    return [genBreadcrumbStyle(BreadcrumbToken)];
+    const breadcrumbToken = mergeToken<BreadcrumbToken>(token, {});
+    return genBreadcrumbStyle(breadcrumbToken);
   },
-  (token) => ({
-    itemColor: token.colorTextDescription,
-    lastItemColor: token.colorText,
-    iconFontSize: token.fontSize,
-    linkColor: token.colorTextDescription,
-    linkHoverColor: token.colorText,
-    separatorColor: token.colorTextDescription,
-    separatorMargin: token.marginXS,
-  }),
+  prepareComponentToken,
 );

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -70,7 +70,7 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
         transition: `color ${token.motionDurationMid}`,
         padding: `0 ${unit(token.paddingXXS)}`,
         borderRadius: token.borderRadiusSM,
-        height: calc(token.lineHeight).mul(token.fontSize).equal(),
+        height: fontHeight,
         display: 'inline-block',
         marginInline: calc(token.marginXXS).mul(-1).equal(),
 

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -30,7 +30,6 @@ async function checkCSSVar() {
   const ignore = [
     'anchor',
     'badge',
-    'breadcrumb',
     'calendar',
     'cascader',
     'checkbox',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Breadcrumb support cssVar |
| 🇨🇳 Chinese | feat: Breadcrumb 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6f4626</samp>

This pull request adds support for CSS variables to the Breadcrumb component, using a new hook `useCSSVar` and a new component `CSSVarProvider`. It also refactors the component style to use the `@ant-design/cssinjs` package and exports a function to register the default token values.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e6f4626</samp>

* Create and use `useCSSVar` hook to register and apply CSS variables for Breadcrumb component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dR15), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dL96-R100), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-f2426e3ced2642a4e369433c0c19b385fca436f57ad4620b4bd2bfcd7ab9254dL219-R222), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-81e4058082cff62cb75da26a17ca656d4a520923b0d2a1b9972775809d1486c0R1-R4))
* Import and use `unit` and `calc` functions to convert and calculate token values to CSS units in `genBreadcrumbStyle` function ([link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-4fbc88ad11a7132e8158c1091bf3a4f6c0c2c3eab7b56e38cd6fe198fede233dL1-R4), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-4fbc88ad11a7132e8158c1091bf3a4f6c0c2c3eab7b56e38cd6fe198fede233dL47-R48), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-4fbc88ad11a7132e8158c1091bf3a4f6c0c2c3eab7b56e38cd6fe198fede233dL70-R75), [link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-4fbc88ad11a7132e8158c1091bf3a4f6c0c2c3eab7b56e38cd6fe198fede233dL104-R108))
* Export `prepareComponentToken` function to prepare default token values for Breadcrumb component and pass it to `genCSSVarRegister` function in `cssVar.ts` file ([link](https://github.com/ant-design/ant-design/pull/45899/files?diff=unified&w=0#diff-4fbc88ad11a7132e8158c1091bf3a4f6c0c2c3eab7b56e38cd6fe198fede233dL138-R156))
