### PR TITLE
feat: Descriptions support cssVar

### DIFF
--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -15,6 +15,7 @@ import type { DescriptionsItemProps } from './Item';
 import DescriptionsItem from './Item';
 import Row from './Row';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 interface CompoundedComponent {
   Item: typeof DescriptionsItem;
@@ -92,7 +93,8 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
   const mergedSize = useSize(customizeSize);
   const rows = useRow(mergedColumn, mergedItems);
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   // ======================== Render ========================
   const contextValue = React.useMemo(
@@ -100,7 +102,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
     [labelStyle, contentStyle],
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <DescriptionsContext.Provider value={contextValue}>
       <div
         className={classNames(

--- a/components/descriptions/style/cssVar.ts
+++ b/components/descriptions/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Descriptions'>('Descriptions', prepareComponentToken);

--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -1,7 +1,7 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit, type CSSObject } from '@ant-design/cssinjs';
 
 import { resetComponent, textEllipsis } from '../../style';
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 
 /** Component only token. Which will handle additional calculation of alias token */
@@ -56,19 +56,19 @@ const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
   return {
     [`&${componentCls}-bordered`]: {
       [`> ${componentCls}-view`]: {
-        border: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+        border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
         '> table': {
           tableLayout: 'auto',
           borderCollapse: 'collapse',
         },
         [`${componentCls}-row`]: {
-          borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           '&:last-child': {
             borderBottom: 'none',
           },
           [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
-            padding: `${token.padding}px ${token.paddingLG}px`,
-            borderInlineEnd: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+            padding: `${unit(token.padding)} ${unit(token.paddingLG)}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
             '&:last-child': {
               borderInlineEnd: 'none',
             },
@@ -85,14 +85,14 @@ const genBorderedStyle = (token: DescriptionsToken): CSSObject => {
       [`&${componentCls}-middle`]: {
         [`${componentCls}-row`]: {
           [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
-            padding: `${token.paddingSM}px ${token.paddingLG}px`,
+            padding: `${unit(token.paddingSM)} ${unit(token.paddingLG)}`,
           },
         },
       },
       [`&${componentCls}-small`]: {
         [`${componentCls}-row`]: {
           [`> ${componentCls}-item-label, > ${componentCls}-item-content`]: {
-            padding: `${token.paddingXS}px ${token.padding}px`,
+            padding: `${unit(token.paddingXS)} ${unit(token.padding)}`,
           },
         },
       },
@@ -161,7 +161,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
           content: '":"',
           position: 'relative',
           top: -0.5, // magic for position
-          marginInline: `${colonMarginLeft}px ${colonMarginRight}px`,
+          marginInline: `${unit(colonMarginLeft)} ${unit(colonMarginRight)}`,
         },
 
         [`&${componentCls}-item-no-colon::after`]: {
@@ -215,21 +215,24 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
     },
   };
 };
+
+export const prepareComponentToken: GetDefaultToken<'Descriptions'> = (token) => ({
+  labelBg: token.colorFillAlter,
+  titleColor: token.colorText,
+  titleMarginBottom: token.fontSizeSM * token.lineHeightSM,
+  itemPaddingBottom: token.padding,
+  colonMarginRight: token.marginXS,
+  colonMarginLeft: token.marginXXS / 2,
+  contentColor: token.colorText,
+  extraColor: token.colorText,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Descriptions',
   (token) => {
     const descriptionToken = mergeToken<DescriptionsToken>(token, {});
-    return [genDescriptionStyles(descriptionToken)];
+    return genDescriptionStyles(descriptionToken);
   },
-  (token) => ({
-    labelBg: token.colorFillAlter,
-    titleColor: token.colorText,
-    titleMarginBottom: token.fontSizeSM * token.lineHeightSM,
-    itemPaddingBottom: token.padding,
-    colonMarginRight: token.marginXS,
-    colonMarginLeft: token.marginXXS / 2,
-    contentColor: token.colorText,
-    extraColor: token.colorText,
-  }),
+  prepareComponentToken,
 );

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -36,7 +36,6 @@ async function checkCSSVar() {
     'checkbox',
     'collapse',
     'color-picker',
-    'descriptions',
     'drawer',
     'float-button',
     'grid',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Descriptions support cssVar |
| 🇨🇳 Chinese | feat: Descriptions 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91be08a</samp>

This pull request refactors the Descriptions component to use a custom hook for registering and applying CSS variables based on the theme token. It also updates the component style to use the `unit` function from the `@ant-design/cssinjs` package and removes some redundant code.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91be08a</samp>

*  Add `useCSSVar` hook to register and apply CSS variables for Descriptions component based on theme token ([link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-f022e7cd08f9076582db0880df0e19f75075cb8d137a350319d4a1d881808bfbR1-R4), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aR18), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL95-R97), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-fa6188100c10d4e92a00d60fe3e3de4bfa896ad3563c67bba6ecdc141b8c4c9aL103-R105))
*  Use `unit` function from `@ant-design/cssinjs` package to convert numeric values to CSS units in Descriptions component style ([link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L1-R4), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L59-R59), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L65-R71), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L88-R88), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L95-R95), [link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L164-R164))
*  Add `prepareComponentToken` function to return default token for Descriptions component with CSS variable names and values ([link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169R218-R229))
*  Simplify call to `genComponentStyleHook` function by passing `genDescriptionStyles` and `prepareComponentToken` functions directly as arguments ([link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-83d49477d5a3e84b0fcf24f108ae5c1c434b5e3842be98fbecddeb76bc5dd169L223-R237))
*  Remove 'descriptions' string from `checkCSSVar` function in `check-cssinjs.tsx` file as Descriptions component now has `cssVar.ts` file and `useCSSVar` hook ([link](https://github.com/ant-design/ant-design/pull/45900/files?diff=unified&w=0#diff-5b054b9f47063e9b12b347b6e9bd669ad645226477f1d56fbdbc20afa54e109eL39))
