### PR TITLE
feat: Drawer support cssVar

### DIFF
--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -1,6 +1,7 @@
+import * as React from 'react';
 import classNames from 'classnames';
 import type { DrawerProps as RCDrawerProps } from 'rc-drawer';
-import * as React from 'react';
+
 import useClosable from '../_util/hooks/useClosable';
 import { ConfigContext } from '../config-provider';
 

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -8,6 +8,7 @@ import type { CSSMotionProps } from 'rc-motion';
 import { useZIndex } from '../_util/hooks/useZIndex';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
+import zIndexContext from '../_util/zindexContext';
 import { ConfigContext } from '../config-provider';
 import { NoFormStyle } from '../form/context';
 // CSSINJS
@@ -16,7 +17,7 @@ import { usePanelRef } from '../watermark/context';
 import type { DrawerClassNames, DrawerPanelProps, DrawerStyles } from './DrawerPanel';
 import DrawerPanel from './DrawerPanel';
 import useStyle from './style';
-import zIndexContext from '../_util/zindexContext';
+import useCSSVar from './style/cssVar';
 
 const SizeTypes = ['default', 'large'] as const;
 type sizeType = typeof SizeTypes[number];
@@ -70,10 +71,11 @@ const Drawer: React.FC<DrawerProps> & {
   } = props;
 
   const { getPopupContainer, getPrefixCls, direction, drawer } = React.useContext(ConfigContext);
+
   const prefixCls = getPrefixCls('drawer', customizePrefixCls);
 
-  // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const getContainer =
     // 有可能为 false，所以不能直接判断
@@ -149,7 +151,7 @@ const Drawer: React.FC<DrawerProps> & {
   const [zIndex, contextZIndex] = useZIndex('Drawer', rest.zIndex);
 
   // =========================== Render ===========================
-  return wrapSSR(
+  return wrapCSSVar(
     <NoCompactStyle>
       <NoFormStyle status override>
         <zIndexContext.Provider value={contextZIndex}>
@@ -214,8 +216,8 @@ const PurePanel: React.FC<Omit<DrawerPanelProps, 'prefixCls'> & PurePanelInterfa
 
   const prefixCls = getPrefixCls('drawer', customizePrefixCls);
 
-  // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   const cls = classNames(
     prefixCls,
@@ -225,7 +227,7 @@ const PurePanel: React.FC<Omit<DrawerPanelProps, 'prefixCls'> & PurePanelInterfa
     className,
   );
 
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={cls} style={style}>
       <DrawerPanel prefixCls={prefixCls} {...restProps} />
     </div>,

--- a/components/drawer/style/cssVar.ts
+++ b/components/drawer/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Drawer'>('Drawer', prepareComponentToken);

--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -1,4 +1,6 @@
-import type { FullToken, GenerateStyle } from '../../theme/internal';
+import { unit } from '@ant-design/cssinjs';
+
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genComponentStyleHook, mergeToken } from '../../theme/internal';
 import genMotionStyle from './motion';
 
@@ -23,7 +25,7 @@ export interface ComponentToken {
 export interface DrawerToken extends FullToken<'Drawer'> {}
 
 // =============================== Base ===============================
-const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
+const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
   const {
     componentCls,
     zIndexPopup,
@@ -150,10 +152,10 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
         display: 'flex',
         flex: 0,
         alignItems: 'center',
-        padding: `${padding}px ${paddingLG}px`,
+        padding: `${unit(padding)} ${unit(paddingLG)}`,
         fontSize: fontSizeLG,
         lineHeight: lineHeightLG,
-        borderBottom: `${lineWidth}px ${lineType} ${colorSplit}`,
+        borderBottom: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
 
         '&-title': {
           display: 'flex',
@@ -213,8 +215,8 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
       // Footer
       [`${componentCls}-footer`]: {
         flexShrink: 0,
-        padding: `${footerPaddingBlock}px ${footerPaddingInline}px`,
-        borderTop: `${lineWidth}px ${lineType} ${colorSplit}`,
+        padding: `${unit(footerPaddingBlock)} ${unit(footerPaddingInline)}`,
+        borderTop: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
       },
 
       // ====================== RTL =======================
@@ -225,17 +227,18 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
   };
 };
 
+export const prepareComponentToken: GetDefaultToken<'Drawer'> = (token) => ({
+  zIndexPopup: token.zIndexPopupBase,
+  footerPaddingBlock: token.paddingXS,
+  footerPaddingInline: token.padding,
+});
+
 // ============================== Export ==============================
 export default genComponentStyleHook(
   'Drawer',
   (token) => {
     const drawerToken = mergeToken<DrawerToken>(token, {});
-
     return [genDrawerStyle(drawerToken), genMotionStyle(drawerToken)];
   },
-  (token) => ({
-    zIndexPopup: token.zIndexPopupBase,
-    footerPaddingBlock: token.paddingXS,
-    footerPaddingInline: token.padding,
-  }),
+  prepareComponentToken,
 );

--- a/components/drawer/style/motion.ts
+++ b/components/drawer/style/motion.ts
@@ -1,7 +1,7 @@
 import type { DrawerToken } from '.';
 import type { GenerateStyle } from '../../theme/internal';
 
-const genMotionStyle: GenerateStyle<DrawerToken> = (token: DrawerToken) => {
+const genMotionStyle: GenerateStyle<DrawerToken> = (token) => {
   const { componentCls, motionDurationSlow } = token;
 
   const sharedPanelMotion = {

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -37,7 +37,6 @@ async function checkCSSVar() {
     'collapse',
     'color-picker',
     'descriptions',
-    'drawer',
     'float-button',
     'grid',
     'icon',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Drawer support cssVar |
| 🇨🇳 Chinese | feat: Drawer 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 418862c</samp>

The pull request refactors and improves the drawer component by using a context, a hook, and a function for managing z-index, CSS variables, and style. It also cleans up the import order and the type annotation in some files. It removes unnecessary code from the `check-cssinjs.tsx` file.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 418862c</samp>

*  Move CSS variable logic to `DrawerPanel.tsx` and use `useCSSVar` hook to register and apply variables ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-93e3b026986cf56379143412817a4077a256d276a567a550593b2526310d1a69L1-R4), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30R11), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L19-R20), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L73-R78), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L152-R154), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L217-R220), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L228-R230), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-a50fed09e8fb3dbaee6a0cd8fd67fa8f9a31a37ea1556bcabd4ff7d35991a45fR1-R4), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-5b054b9f47063e9b12b347b6e9bd669ad645226477f1d56fbdbc20afa54e109eL40))
* Import `zIndexContext` module in `index.tsx` to provide context for managing z-index of drawer and its children ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30R11))
* Import `unit` function from `@ant-design/cssinjs` package in `index.ts` to convert numeric values to CSS units ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L1-R3))
* Wrap `padding` and `border` values with `unit` function in `genDrawerStyle` function in `index.ts` to apply CSS units ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L153-R158), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L216-R219))
* Extract `prepareComponentToken` function from `useStyle` hook in `index.ts` to a separate export for reusability and readability ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3R230-R235), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L233-R243))
* Remove type annotation of `token` parameter from `genDrawerStyle` and `genMotionStyle` functions as it is inferred from generic type parameter ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-cb2507ee40e1f2f8ba644202d9eb67d9eb5fc3d766b7ba3628703498a44225e3L26-R28), [link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-2d66730347220b9d8b019c7728f378699789f1255d42f9707b1a332fff5fb367L4-R4))
* Rename `wrapSSR` variable to `wrapCSSVar` in `DrawerPanel.tsx` to reflect its new purpose ([link](https://github.com/ant-design/ant-design/pull/45905/files?diff=unified&w=0#diff-10ffbf23ed7075c38649dfd0776998a514a56e42e09a91306f89b25e67e07d30L73-R78))
