### PR TITLE
feat: Badge support cssVar

### DIFF
--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -5,6 +5,7 @@ import type { PresetColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import type { LiteralUnion } from '../_util/type';
 import { ConfigContext } from '../config-provider';
+import useCSSVar from './style/cssVar';
 import useStyle from './style/ribbon';
 
 type RibbonPlacement = 'start' | 'end';
@@ -33,6 +34,10 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
   } = props;
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('ribbon', customizePrefixCls);
+
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
+
   const colorInPreset = isPresetColor(color, false);
   const ribbonCls = classNames(
     prefixCls,
@@ -43,14 +48,14 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
     },
     className,
   );
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+
   const colorStyle: React.CSSProperties = {};
   const cornerColorStyle: React.CSSProperties = {};
   if (color && !colorInPreset) {
     colorStyle.background = color;
     cornerColorStyle.color = color;
   }
-  return wrapSSR(
+  return wrapCSSVar(
     <div className={classNames(`${prefixCls}-wrapper`, rootClassName, hashId)}>
       {children}
       <div className={classNames(ribbonCls, hashId)} style={{ ...colorStyle, ...style }}>

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -1,7 +1,8 @@
-import classnames from 'classnames';
-import CSSMotion from 'rc-motion';
 import * as React from 'react';
 import { useMemo, useRef } from 'react';
+import classnames from 'classnames';
+import CSSMotion from 'rc-motion';
+
 import type { PresetStatusColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import { cloneElement } from '../_util/reactNode';
@@ -11,6 +12,7 @@ import type { PresetColorKey } from '../theme/internal';
 import Ribbon from './Ribbon';
 import ScrollNumber from './ScrollNumber';
 import useStyle from './style';
+import useCSSVar from './style/cssVar';
 
 export type { ScrollNumberProps } from './ScrollNumber';
 
@@ -75,8 +77,8 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   const { getPrefixCls, direction, badge } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('badge', customizePrefixCls);
 
-  // Style
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [, hashId] = useStyle(prefixCls);
+  const wrapCSSVar = useCSSVar(prefixCls);
 
   // ================================ Misc ================================
   const numberedDisplayCount = (
@@ -188,7 +190,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   // <Badge status="success" />
   if (!children && hasStatus) {
     const statusTextColor = mergedStyle.color;
-    return wrapSSR(
+    return wrapCSSVar(
       <span
         {...restProps}
         className={badgeClassName}
@@ -207,7 +209,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
     );
   }
 
-  return wrapSSR(
+  return wrapCSSVar(
     <span
       ref={ref}
       {...restProps}

--- a/components/badge/style/cssVar.ts
+++ b/components/badge/style/cssVar.ts
@@ -1,0 +1,4 @@
+import { prepareComponentToken } from '.';
+import { genCSSVarRegister } from '../../theme/internal';
+
+export default genCSSVarRegister<'Badge'>('Badge', prepareComponentToken);

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -1,11 +1,9 @@
-import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 
 import { resetComponent } from '../../style';
-import type { GlobalToken } from '../../theme';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, genPresetColor, mergeToken } from '../../theme/internal';
-import type { GenStyleFn } from '../../theme/util/genComponentStyleHook';
+import type { GenStyleFn, GetDefaultToken } from '../../theme/util/genComponentStyleHook';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -84,10 +82,12 @@ const antNoWrapperZoomBadgeIn = new Keyframes('antNoWrapperZoomBadgeIn', {
   '0%': { transform: 'scale(0)', opacity: 0 },
   '100%': { transform: 'scale(1)' },
 });
+
 const antNoWrapperZoomBadgeOut = new Keyframes('antNoWrapperZoomBadgeOut', {
   '0%': { transform: 'scale(1)' },
   '100%': { transform: 'scale(0)', opacity: 0 },
 });
+
 const antBadgeLoadingCircle = new Keyframes('antBadgeLoadingCircle', {
   '0%': { transformOrigin: '50%' },
   '100%': {
@@ -96,7 +96,7 @@ const antBadgeLoadingCircle = new Keyframes('antBadgeLoadingCircle', {
   },
 });
 
-const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSObject => {
+const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token) => {
   const {
     componentCls,
     iconCls,
@@ -111,6 +111,7 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
     indicatorHeight,
     indicatorHeightSM,
     marginXS,
+    calc,
   } = token;
   const numberPrefixCls = `${antCls}-scroll-number`;
 
@@ -138,12 +139,12 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
         color: token.badgeTextColor,
         fontWeight: textFontWeight,
         fontSize: textFontSize,
-        lineHeight: `${indicatorHeight}px`,
+        lineHeight: unit(indicatorHeight),
         whiteSpace: 'nowrap',
         textAlign: 'center',
         background: token.badgeColor,
-        borderRadius: indicatorHeight / 2,
-        boxShadow: `0 0 0 ${badgeShadowSize}px ${token.badgeShadowColor}`,
+        borderRadius: calc(indicatorHeight).div(2).equal(),
+        boxShadow: `0 0 0 ${unit(badgeShadowSize)} ${token.badgeShadowColor}`,
         transition: `background ${token.motionDurationMid}`,
 
         a: {
@@ -161,12 +162,12 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
         minWidth: indicatorHeightSM,
         height: indicatorHeightSM,
         fontSize: textFontSizeSM,
-        lineHeight: `${indicatorHeightSM}px`,
-        borderRadius: indicatorHeightSM / 2,
+        lineHeight: unit(indicatorHeightSM),
+        borderRadius: calc(indicatorHeightSM).div(2).equal(),
       },
 
       [`${componentCls}-multiple-words`]: {
-        padding: `0 ${token.paddingXS}px`,
+        padding: `0 ${unit(token.paddingXS)}`,
 
         bdi: {
           unicodeBidi: 'plaintext',
@@ -180,7 +181,7 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
         height: dotSize,
         background: token.badgeColor,
         borderRadius: '100%',
-        boxShadow: `0 0 0 ${badgeShadowSize}px ${token.badgeShadowColor}`,
+        boxShadow: `0 0 0 ${unit(badgeShadowSize)} ${token.badgeShadowColor}`,
       },
       [`${componentCls}-dot${numberPrefixCls}`]: {
         transition: `background ${motionDurationSlow}`,
@@ -308,13 +309,14 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSO
             WebkitBackfaceVisibility: 'hidden',
           },
         },
-        [`${numberPrefixCls}-symbol`]: { verticalAlign: 'top' },
+        [`${numberPrefixCls}-symbol`]: {
+          verticalAlign: 'top',
+        },
       },
 
       // ====================== RTL =======================
       '&-rtl': {
         direction: 'rtl',
-
         [`${componentCls}-count, ${componentCls}-dot, ${numberPrefixCls}-custom-component`]: {
           transform: 'translate(-50%, -50%)',
         },
@@ -351,9 +353,8 @@ export const prepareToken: (token: Parameters<GenStyleFn<'Badge'>>[0]) => BadgeT
   return badgeToken;
 };
 
-export const prepareComponentToken = (token: GlobalToken) => {
+export const prepareComponentToken: GetDefaultToken<'Badge'> = (token) => {
   const { fontSize, lineHeight, fontSizeSM, lineWidth } = token;
-
   return {
     indicatorZIndex: 'auto',
     indicatorHeight: Math.round(fontSize * lineHeight) - 2 * lineWidth,
@@ -370,8 +371,7 @@ export default genComponentStyleHook(
   'Badge',
   (token) => {
     const badgeToken = prepareToken(token);
-
-    return [genSharedBadgeStyle(badgeToken)];
+    return genSharedBadgeStyle(badgeToken);
   },
   prepareComponentToken,
 );

--- a/components/badge/style/ribbon.ts
+++ b/components/badge/style/ribbon.ts
@@ -19,7 +19,9 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
   }));
 
   return {
-    [`${ribbonWrapperPrefixCls}`]: { position: 'relative' },
+    [`${ribbonWrapperPrefixCls}`]: {
+      position: 'relative',
+    },
     [`${ribbonPrefixCls}`]: {
       ...resetComponent(token),
       position: 'absolute',
@@ -30,7 +32,9 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
       whiteSpace: 'nowrap',
       backgroundColor: token.colorPrimary,
       borderRadius: token.borderRadiusSM,
-      [`${ribbonPrefixCls}-text`]: { color: token.colorTextLightSolid },
+      [`${ribbonPrefixCls}-text`]: {
+        color: token.colorTextLightSolid,
+      },
       [`${ribbonPrefixCls}-corner`]: {
         position: 'absolute',
         top: '100%',
@@ -44,7 +48,7 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
       },
       ...statusRibbonPreset,
       [`&${ribbonPrefixCls}-placement-end`]: {
-        insetInlineEnd: -badgeRibbonOffset,
+        insetInlineEnd: -calc(badgeRibbonOffset).mul(-1).equal(),
         borderEndEndRadius: 0,
         [`${ribbonPrefixCls}-corner`]: {
           insetInlineEnd: 0,
@@ -53,7 +57,7 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
         },
       },
       [`&${ribbonPrefixCls}-placement-start`]: {
-        insetInlineStart: -badgeRibbonOffset,
+        insetInlineStart: calc(badgeRibbonOffset).mul(-1).equal(),
         borderEndStartRadius: 0,
         [`${ribbonPrefixCls}-corner`]: {
           insetInlineStart: 0,

--- a/components/badge/style/ribbon.ts
+++ b/components/badge/style/ribbon.ts
@@ -1,4 +1,4 @@
-import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 
 import { prepareComponentToken, prepareToken, type BadgeToken } from '.';
 import { resetComponent } from '../../style';
@@ -6,8 +6,8 @@ import type { GenerateStyle } from '../../theme/internal';
 import { genComponentStyleHook, genPresetColor } from '../../theme/internal';
 
 // ============================== Ribbon ==============================
-const genRibbonStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSObject => {
-  const { antCls, badgeFontHeight, marginXS, badgeRibbonOffset } = token;
+const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
+  const { antCls, badgeFontHeight, marginXS, badgeRibbonOffset, calc } = token;
   const ribbonPrefixCls = `${antCls}-ribbon`;
   const ribbonWrapperPrefixCls = `${antCls}-ribbon-wrapper`;
 
@@ -24,9 +24,9 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSObject
       ...resetComponent(token),
       position: 'absolute',
       top: marginXS,
-      padding: `0 ${token.paddingXS}px`,
+      padding: `0 ${unit(token.paddingXS)}`,
       color: token.colorPrimary,
-      lineHeight: `${badgeFontHeight}px`,
+      lineHeight: unit(badgeFontHeight),
       whiteSpace: 'nowrap',
       backgroundColor: token.colorPrimary,
       borderRadius: token.borderRadiusSM,
@@ -37,7 +37,7 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token: BadgeToken): CSSObject
         width: badgeRibbonOffset,
         height: badgeRibbonOffset,
         color: 'currentcolor',
-        border: `${badgeRibbonOffset / 2}px solid`,
+        border: `${unit(calc(badgeRibbonOffset).div(2).equal())} solid`,
         transform: token.badgeRibbonCornerTransform,
         transformOrigin: 'top',
         filter: token.badgeRibbonCornerFilter,
@@ -75,8 +75,7 @@ export default genComponentStyleHook(
   ['Badge', 'Ribbon'],
   (token) => {
     const badgeToken = prepareToken(token);
-
-    return [genRibbonStyle(badgeToken)];
+    return genRibbonStyle(badgeToken);
   },
   prepareComponentToken,
 );

--- a/components/badge/style/ribbon.ts
+++ b/components/badge/style/ribbon.ts
@@ -48,7 +48,7 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
       },
       ...statusRibbonPreset,
       [`&${ribbonPrefixCls}-placement-end`]: {
-        insetInlineEnd: -calc(badgeRibbonOffset).mul(-1).equal(),
+        insetInlineEnd: calc(badgeRibbonOffset).mul(-1).equal(),
         borderEndEndRadius: 0,
         [`${ribbonPrefixCls}-corner`]: {
           insetInlineEnd: 0,

--- a/scripts/check-cssinjs.tsx
+++ b/scripts/check-cssinjs.tsx
@@ -29,7 +29,6 @@ console.error = (msg: any) => {
 async function checkCSSVar() {
   const ignore = [
     'anchor',
-    'badge',
     'breadcrumb',
     'calendar',
     'cascader',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- #45618

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: Badge support cssVar |
| 🇨🇳 Chinese | feat: Badge 组件支持 cssVar |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c6f9b7c</samp>

The pull request refactors the badge component to use CSS variables for theming, instead of inline styles. It also improves the style module by using the `@ant-design/cssinjs` module and simplifying the code structure. Additionally, it removes the badge component from the `checkCSSVar` function, as it is no longer needed. These changes enhance the code quality, consistency, and flexibility of the badge component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c6f9b7c</samp>

*  Refactor badge component to use `genCSSVarRegister` hook and `unit` and `calc` functions for CSS variables and values ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L1-R5), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391R15), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L78-R81), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L191-R193), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L210-R212), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-78907417f830741564685243413c9c776691d05838e258e834d4972291ceb8feR1-R4), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L1-R6), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L99-R99), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809R114), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L141-R147), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L164-R170), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L183-R184), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L354-R357), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L373-R374), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L1-R1), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L9-R10), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L27-R29), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L40-R40), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L78-R78))
  * Use `useCSSVar` hook from `./style/cssVar` module to register and update CSS variables based on theme token in `components/badge/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391R15), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L78-R81), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L191-R193), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L210-R212))
  * Use `wrapCSSVar` function to wrap badge component with a `style` element that contains the CSS variables in `components/badge/index.tsx` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L78-R81), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L191-R193), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L210-R212))
  * Use `unit` function from `@ant-design/cssinjs` module to convert numeric values to CSS unit strings with default unit of `px` in `components/badge/style/index.ts` and `components/badge/style/ribbon.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L1-R6), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L141-R147), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L164-R170), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L183-R184), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L1-R1), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L27-R29), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L40-R40))
  * Use `calc` function from theme token to perform arithmetic operations on CSS values and return CSS expression strings in `components/badge/style/index.ts` and `components/badge/style/ribbon.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809R114), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L141-R147), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L164-R170), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L183-R184), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L9-R10), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L40-R40))
  * Use `GetDefaultToken` type from `../../theme/util/genComponentStyleHook` module to specify the type of the default token for the badge component in `components/badge/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L354-R357))
  * Simplify the return value of the `genComponentStyleHook` function from an array of CSS objects to a single CSS object in `components/badge/style/index.ts` and `components/badge/style/ribbon.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L373-R374), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L78-R78))
* Remove `badge` component from `checkCSSVar` function in `scripts/check-cssinjs.tsx` as it does not need manual checking for CSS variables ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-5b054b9f47063e9b12b347b6e9bd669ad645226477f1d56fbdbc20afa54e109eL32))
* Reorder import modules to follow convention of React modules, third-party modules, internal modules, and type modules in `components/badge/index.tsx` and `components/badge/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-969bd9a7c5b9c1cd26127d496c4a1e4181d847a2000b9b5f272e4714007b6391L1-R5), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L1-R6))
* Remove unused `CSSObject` type from `components/badge/style/index.ts` and `components/badge/style/ribbon.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L1-R6), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-f9aa8c4ebe6351c36a1004f178a76f580b5fbd0e80e4d41068c3fd06656759b0L1-R1))
* Add or remove empty lines, commas, and type annotations for readability, consistency, and code style in `components/badge/style/index.ts` ([link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L87-R90), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L311-R314), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L317), [link](https://github.com/ant-design/ant-design/pull/45906/files?diff=unified&w=0#diff-b8c8d1867c9fbda6cf6dad3121f976971c2934a5a5ff1b47aa3984aa0c472809L99-R99))
