### PR TITLE
docs: update Nextjs docs

### DIFF
--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -33,8 +33,9 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```tsx
-'use client'; // If used in Pages Router, is no need to add "use client"
+'use client';
 
+// If used in Pages Router, is no need to add "use client"
 import React from 'react';
 import { Button } from 'antd';
 
@@ -56,6 +57,10 @@ We are successfully running antd components now, go build your own application!
 If you are using the App Router in Next.js and using antd as your component library, to make the antd component library work better in your Next.js application and provide a better user experience, you can try using the following method to extract and inject antd's first-screen styles into HTML to avoid page flicker.
 
 1. Install `@ant-design/cssinjs`
+
+> Notes for developers
+>
+> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly.
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 
@@ -158,6 +163,10 @@ For more detailed information, please refer to [with-nextjs-app-router-inline-st
 If you are using the Pages Router in Next.js and using antd as your component library, to make the antd component library work better in your Next.js application and provide a better user experience, you can try using the following method to extract and inject antd's first-screen styles into HTML to avoid page flicker.
 
 1. Install `@ant-design/cssinjs`
+
+> Notes for developers
+>
+> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly.
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -33,8 +33,9 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```tsx
-'use client'; // If used in Pages Router, is no need to add "use client"
+'use client';
 
+// If used in Pages Router, is no need to add "use client"
 import React from 'react';
 import { Button } from 'antd';
 
@@ -59,7 +60,7 @@ If you are using the App Router in Next.js and using antd as your component libr
 
 > Notes for developers
 >
-> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly.
+> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in local `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly. (Tips: you can use `npm ls @ant-design/cssinjs` command to view the local version)
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 
@@ -165,7 +166,7 @@ If you are using the Pages Router in Next.js and using antd as your component li
 
 > Notes for developers
 >
-> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly.
+> Please note that when you install `@ant-design/cssinjs`, you must ensure that the version is consistent with the version of `@ant-design/cssinjs` in local `node_modules` of `antd`, otherwise, multiple React instances will appear, resulting in ctx being unable to be read correctly. (Tips: you can use `npm ls @ant-design/cssinjs` command to view the local version)
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -33,9 +33,8 @@ Now we install `antd` from yarn or npm or pnpm.
 Modify `src/app/page.tsx`, import Button component from `antd`.
 
 ```tsx
-'use client';
+'use client'; // If used in Pages Router, is no need to add "use client"
 
-// If used in Pages Router, is no need to add "use client"
 import React from 'react';
 import { Button } from 'antd';
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -33,8 +33,9 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```tsx
-'use client'; // 如果是在 Pages Router 中使用，则不需要添加 "use client"
+'use client';
 
+// 如果是在 Pages Router 中使用，则不需要添加 "use client"
 import React from 'react';
 import { Button } from 'antd';
 
@@ -59,7 +60,7 @@ export default Home;
 
 > 开发者注意事项：
 >
-> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。
+> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 本地的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。（Tips: 你可以通过 `npm ls @ant-design/cssinjs` 命令查看本地版本）
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 
@@ -165,7 +166,7 @@ export default HomePage;
 
 > 开发者注意事项：
 >
-> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。
+> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 本地的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。（Tips: 你可以通过 `npm ls @ant-design/cssinjs` 命令查看本地版本）
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -33,8 +33,9 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```tsx
-'use client'; // 如果是在 Pages Router 中使用，则不需要添加 "use client"
+'use client';
 
+// 如果是在 Pages Router 中使用，则不需要添加 "use client"
 import React from 'react';
 import { Button } from 'antd';
 
@@ -56,6 +57,10 @@ export default Home;
 如果你在 Next.js 当中使用了 App Router, 并使用 antd 作为页面组件库，为了让 antd 组件库在你的 Next.js 应用中能够更好的工作，提供更好的用户体验，你可以尝试使用下面的方式将 antd 首屏样式按需抽离并植入到 HTML 中，以避免页面闪动的情况。
 
 1. 安装 `@ant-design/cssinjs`
+
+> 开发者注意事项：
+>
+> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 
@@ -158,6 +163,10 @@ export default HomePage;
 如果你在 Next.js 当中使用了 Pages Router, 并使用 antd 作为页面组件库，为了让 antd 组件库在你的 Next.js 应用中能够更好的工作，提供更好的用户体验，你可以尝试使用下面的方式将 antd 首屏样式按需抽离并植入到 HTML 中，以避免页面闪动的情况。
 
 1. 安装 `@ant-design/cssinjs`
+
+> 开发者注意事项：
+>
+> 请注意，安装 `@ant-design/cssinjs` 时必须确保版本号跟 `antd` 的 `node_modules` 中的 `@ant-design/cssinjs` 版本保持一致，否则会出现多个 React 实例，导致无法正确的读取 ctx。
 
 <InstallDependencies npm='$ npm install @ant-design/cssinjs --save' yarn='$ yarn add @ant-design/cssinjs' pnpm='$ pnpm install @ant-design/cssinjs --save'></InstallDependencies>
 

--- a/docs/react/use-with-next.zh-CN.md
+++ b/docs/react/use-with-next.zh-CN.md
@@ -33,9 +33,8 @@ $ npm run dev
 修改 `src/app/page.tsx`，引入 antd 的按钮组件。
 
 ```tsx
-'use client';
+'use client'; // 如果是在 Pages Router 中使用，则不需要添加 "use client"
 
-// 如果是在 Pages Router 中使用，则不需要添加 "use client"
 import React from 'react';
 import { Button } from 'antd';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | docs: update Nextjs docs |
| 🇨🇳 Chinese | docs: update Nextjs docs |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b6c576a</samp>

Improved the documentation for using `antd` with `Next.js` in both English and Chinese. Added tips and notes to help developers resolve style issues and improve performance.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b6c576a</samp>

*  Moved comment to a new line for readability and consistency ([link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4L36-R38), [link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489L36-R38))
*  Added note to warn about potential issue of installing `@ant-design/cssinjs` with a different version than `antd` ([link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4R61-R64), [link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-f40a07db5e50bc714a69751497cc62a602271f477eabf7c895f2fa9950461ae4R167-R170), [link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R61-R64), [link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R167-R170))
*  Translated note into Chinese for `docs/react/use-with-next.zh-CN.md` ([link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R61-R64), [link](https://github.com/ant-design/ant-design/pull/45907/files?diff=unified&w=0#diff-b532268d5c5f44bba9caadf328fe6567e31ba5fc7c36cfe6eec648bcf1b36489R167-R170))