### PR TITLE
refactor: wireframe token for Notification and Tour

### DIFF
--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -19,6 +19,8 @@ export interface ComponentToken {
    * @descEN Width of Notification
    */
   width: number;
+  /** @internal */
+  closeBtnHoverBg: string;
 }
 
 export interface NotificationToken extends FullToken<'Notification'> {
@@ -147,7 +149,7 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
 
       '&:hover': {
         color: token.colorIconHover,
-        backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
+        backgroundColor: token.closeBtnHoverBg,
       },
     },
 
@@ -258,6 +260,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 export const prepareComponentToken = (token: AliasToken) => ({
   zIndexPopup: token.zIndexPopupBase + 50,
   width: 384,
+  closeBtnHoverBg: token.wireframe ? 'transparent' : token.colorFillContent,
 });
 
 export const prepareNotificationToken: (

--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -33,6 +33,8 @@ export interface ComponentToken extends ArrowOffsetToken, ArrowToken {
    * @descEN Hover background color of next button in primary type
    */
   primaryNextBtnHoverBg: string;
+  /** @internal */
+  closeBtnHoverBg: string;
 }
 
 interface TourToken extends FullToken<'Tour'> {
@@ -127,7 +129,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
 
             '&:hover': {
               color: token.colorIconHover,
-              backgroundColor: token.wireframe ? 'transparent' : token.colorFillContent,
+              backgroundColor: token.closeBtnHoverBg,
             },
           },
 
@@ -269,6 +271,7 @@ export const prepareComponentToken: GetDefaultToken<'Tour'> = (token) => ({
   zIndexPopup: token.zIndexPopupBase + 70,
   closeBtnSize: token.fontSize * token.lineHeight,
   primaryPrevBtnBg: new TinyColor(token.colorTextLightSolid).setAlpha(0.15).toRgbString(),
+  closeBtnHoverBg: token.wireframe ? 'transparent' : token.colorFillContent,
   primaryNextBtnHoverBg: new TinyColor(token.colorBgTextHover)
     .onBackground(token.colorWhite)
     .toRgbString(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8c220f3</samp>

This pull request adds a new internal property `closeBtnHoverBg` to the notification and tour component tokens and applies it to the close button hover style. This enhances the visual consistency and customizability of these components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8c220f3</samp>

*  Add `closeBtnHoverBg` property to `ComponentToken` interface in `components/notification/style/index.ts` and `components/tour/style/index.ts` to define the hover background color of the close button in notification and tour components ([link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965R22-R23), [link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20R36-R37))
*  Use `closeBtnHoverBg` property instead of `colorFillContent` property for the hover background color of the close button in `genNoticeStyle` function in `components/notification/style/index.ts` and `genBaseStyle` function in `components/tour/style/index.ts` to make the close button consistent with other buttons ([link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965L150-R152), [link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20L130-R132))
*  Assign a value to `closeBtnHoverBg` property based on `wireframe` and `colorFillContent` properties in `prepareComponentToken` function in `components/notification/style/index.ts` and `components/tour/style/index.ts` to ensure a valid value for the hover background color of the close button ([link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-1b72cd8f976d21d83517b2c963a0b9a9bb6670e5d004ed4a7b0dd2edad3fc965R263), [link](https://github.com/ant-design/ant-design/pull/45915/files?diff=unified&w=0#diff-63a4c996d63007bd6db60b07181ef01d14b1a3e8f8af9a946c2c1aae7500df20R274))
