### PR TITLE
feat: export sider context from layout

### DIFF
--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -11,7 +11,8 @@ type CompoundedComponent = InternalLayoutType & {
   Footer: typeof Footer;
   Content: typeof Content;
   Sider: typeof Sider;
-  SiderContext: typeof SiderContext;
+  /** @private Internal Context. Do not use in your production. */
+  _InternalSiderContext: typeof SiderContext;
 };
 
 const Layout = InternalLayout as CompoundedComponent;
@@ -20,6 +21,6 @@ Layout.Header = Header;
 Layout.Footer = Footer;
 Layout.Content = Content;
 Layout.Sider = Sider;
-Layout.SiderContext = SiderContext;
+Layout._InternalSiderContext = SiderContext;
 
 export default Layout;

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -1,5 +1,5 @@
 import InternalLayout, { Content, Footer, Header } from './layout';
-import Sider from './Sider';
+import Sider, { SiderContext } from './Sider';
 
 export type { BasicProps as LayoutProps } from './layout';
 export type { SiderProps } from './Sider';
@@ -11,6 +11,7 @@ type CompoundedComponent = InternalLayoutType & {
   Footer: typeof Footer;
   Content: typeof Content;
   Sider: typeof Sider;
+  SiderContext: typeof SiderContext;
 };
 
 const Layout = InternalLayout as CompoundedComponent;
@@ -19,5 +20,6 @@ Layout.Header = Header;
 Layout.Footer = Footer;
 Layout.Content = Content;
 Layout.Sider = Sider;
+Layout.SiderContext = SiderContext;
 
 export default Layout;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

None

### 💡 Background and solution

Export `SiderContext` from `Layout`, to avoid multi-instance problem when using `ProLayout` and external `antd` at the same time, ref: https://github.com/ant-design/pro-components/blob/8b451c6e255fecced11e7d7b0be4aad2bfa0a09c/packages/layout/src/components/SiderMenu/SiderMenu.tsx#L5

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Layout export SiderContext |
| 🇨🇳 Chinese | Layout 组件导出 SideContext  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1cc16ab</samp>

Add `SiderContext` to `Layout` component to support responsive `Sider` and its children. This context exposes `Sider`'s collapsed state and width to its descendants.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1cc16ab</samp>

*  Expose `SiderContext` as a static property of `Layout` component to provide `Sider` information to children ([link](https://github.com/ant-design/ant-design/pull/45916/files?diff=unified&w=0#diff-87da5c09eb7577d425c8ee19da79197d0b702d7ba6a47d2204d4170e2c584b81L2-R2), [link](https://github.com/ant-design/ant-design/pull/45916/files?diff=unified&w=0#diff-87da5c09eb7577d425c8ee19da79197d0b702d7ba6a47d2204d4170e2c584b81R14), [link](https://github.com/ant-design/ant-design/pull/45916/files?diff=unified&w=0#diff-87da5c09eb7577d425c8ee19da79197d0b702d7ba6a47d2204d4170e2c584b81R23))
