### PR TITLE
fix(modal): modal静态方法默认展示关闭按钮

### DIFF
--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -1,6 +1,6 @@
-import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import type { ReactNode } from 'react';
 import React from 'react';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
 
 function useInnerClosable(
   closable?: boolean,

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import classNames from 'classnames';
 
+import useClosable from '../_util/hooks/useClosable';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';
@@ -16,6 +18,7 @@ import type { ModalContextProps } from './context';
 import { ModalContextProvider } from './context';
 import type { ModalFuncProps, ModalLocale } from './interface';
 import Dialog from './Modal';
+import { renderCloseIcon } from './shared';
 import ConfirmCmp from './style/confirmCmp';
 
 export interface ConfirmDialogProps extends ModalFuncProps {
@@ -180,7 +183,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     iconPrefixCls,
     theme,
     bodyStyle,
-    closable = false,
+    closable,
     closeIcon,
     modalRender,
     focusTriggerAfterClose,
@@ -213,6 +216,14 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     `${confirmPrefixCls}-${props.type}`,
     { [`${confirmPrefixCls}-rtl`]: direction === 'rtl' },
     props.className,
+  );
+
+  const [mergedClosable, mergedCloseIcon] = useClosable(
+    closable,
+    closeIcon,
+    (icon) => renderCloseIcon(prefixCls, icon),
+    <CloseOutlined className={`${prefixCls}-close-icon`} />,
+    true,
   );
 
   return (
@@ -256,8 +267,8 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         keyboard={keyboard}
         centered={centered}
         getContainer={getContainer}
-        closable={closable}
-        closeIcon={closeIcon}
+        closable={mergedClosable}
+        closeIcon={mergedCloseIcon}
         modalRender={modalRender}
         focusTriggerAfterClose={focusTriggerAfterClose}
       >

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import Dialog from 'rc-dialog';
 
 import useClosable from '../_util/hooks/useClosable';
+import { useZIndex } from '../_util/hooks/useZIndex';
 import { getTransitionName } from '../_util/motion';
 import { canUseDocElement } from '../_util/styleChecker';
 import { devUseWarning } from '../_util/warning';
@@ -15,7 +16,6 @@ import { usePanelRef } from '../watermark/context';
 import type { ModalProps, MousePosition } from './interface';
 import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
-import { useZIndex } from '../_util/hooks/useZIndex';
 
 let mousePosition: MousePosition;
 

--- a/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/confirm.test.tsx.snap
@@ -4,6 +4,40 @@ exports[`Modal.confirm triggers callbacks correctly footer confirm should render
 <div
   class="ant-modal-content"
 >
+  <button
+    aria-label="Close"
+    class="ant-modal-close"
+    type="button"
+  >
+    <span
+      class="ant-modal-close-x"
+    >
+      <span
+        class="ant-modal-close-x"
+      >
+        <span
+          aria-label="close"
+          class="bamboo bamboo-close ant-modal-close-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </span>
+    </span>
+  </button>
   <div
     class="ant-modal-body"
   >


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/45930

### 💡 需求背景和解决方案
![image](https://github.com/ant-design/ant-design/assets/62697454/e1bcd50b-c8e4-4f4e-8c3e-2c02bde5716e)
在版本5.7.0中将closable和closeIcon合并，文档中也删去了closable的描述，且closeIcon默认值为CloseOutlined ，但是只对Modal组件做了该逻辑处理，导致Modal的静态方法仍需要传入closable才能渲染关闭按钮，初次使用时，只传入closeIcon是渲染不了关闭按钮的，文档又没有closable参数的描述，会有些迷惑。

将Modal组件的相同逻辑对Modal的静态方法一样处理即可解决。
![image](https://github.com/ant-design/ant-design/assets/62697454/5e6dbbed-2f5c-45a6-afb7-6b763cc534aa)
参数包含closeIcon，点击按钮，打开弹窗， 展示自定义关闭按钮
参数不包含closeIcon，点击按钮，打开弹窗， 展示默认关闭按钮CloseOutlined

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Fix the issue where the static method of Modal does not display default buttons     |
| 🇨🇳 中文 |   修复Modal的静态方法不展示默认按钮的问题     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 97e4bd8</samp>

Refactored `ConfirmDialog` and `Modal` components to use custom hooks for closable and z-index logic. Improved import order of some files.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 97e4bd8</samp>

*  Import and use `useClosable` hook to handle the logic of closable and closeIcon props for `ConfirmDialog` component ([link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L4-R9), [link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3R21), [link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L183-R186), [link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3R221-R228), [link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L259-R271))
* Swap the import order of `CloseOutlined` and `ReactNode` in `useClosable.tsx` to follow the convention of importing types first ([link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-0c146c2969ebf8d6b49326c6127199fc0831ebf5519583e540a594c011789d11L1-R3))
* Import and use `useZIndex` hook to manage the zIndex of the `Modal` component ([link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-a3edcd43b644d0539a67f65e68ba30d6acb77a12531a6a71d1e26a008a9d752cR7), [link](https://github.com/ant-design/ant-design/pull/45932/files?diff=unified&w=0#diff-a3edcd43b644d0539a67f65e68ba30d6acb77a12531a6a71d1e26a008a9d752cL18))