### PR TITLE
docs: update Modal.method docs

### DIFF
--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -103,7 +103,8 @@ The items listed above are all functions, expecting a settings object as paramet
 | cancelText | Text of the Cancel button with Modal.confirm | string | `Cancel` |  |
 | centered | Centered Modal | boolean | false |  |
 | className | The className of container | string | - |  |
-| closeIcon | Custom close icon. 5.7.0: close button will be hidden when setting to `null` or `false` | boolean \| ReactNode | &lt;CloseOutlined /> |  |
+| closable | Whether a close (x) button is visible on top right of the confirm dialog or not | boolean | false | 4.9.0 |
+| closeIcon | Custom close icon | ReactNode | undefined | 4.9.0 |
 | content | Content | ReactNode | - |  |
 | footer | Footer content, set as `footer: null` when you don't need default buttons | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -104,7 +104,8 @@ demo:
 | cancelText | 设置 Modal.confirm 取消按钮文字 | string | `取消` |  |
 | centered | 垂直居中展示 Modal | boolean | false |  |
 | className | 容器类名 | string | - |  |
-| closeIcon | 自定义关闭图标。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | boolean \| ReactNode | &lt;CloseOutlined /> |  |
+| closable | 是否显示右上角的关闭按钮 | boolean | false | 4.9.0 |
+| closeIcon | 自定义关闭图标 | ReactNode | undefined | 4.9.0 |
 | content | 内容 | ReactNode | - |  |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | (params:[footerRenderParams](/components/modal-cn#footerrenderparams))=> React.ReactNode \| React.ReactNode | - | 5.9.0 |
 | getContainer | 指定 Modal 挂载的 HTML 节点，false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/45930

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/62697454/eecf0fb0-a0a8-413d-91f9-7c7a03ef9b98)
接上一个PR，https://github.com/ant-design/ant-design/pull/45932 ，在上个PR中说道，在使用Ant Design的Modal组件时，我遇到了一些奇怪的问题。我希望在使用Modal的静态方法时能够渲染关闭图标，因为文档只提到了closeIcon属性，没有提到closable属性，以致于我只知道传递closeIcon，但无论如何传递都无法渲染关闭图标。我查看了源码后发现，closable默认false，也就是静态方法默认不展示关闭图标。在5.7.0版本的文档中，移除了closable属性的描述，且closeIcon的默认值是CloseOutlined，按文档描述来说应该是会默认渲染关闭图标的。因此，我认为这可能是一个逻辑上的遗漏实现，并提了一个PR，https://github.com/ant-design/ant-design/pull/45932 来修复，但是成员告诉我，静态方法提供的信息是经过设计的，用户需要自行确认是否启用右上角的关闭图标和点击背景关闭功能。所以提了本PR来修正Modal.method的描述，来确保描述和方法实际的表现一致。
![image](https://github.com/ant-design/ant-design/assets/62697454/0cdb1702-d06d-46dc-b9b1-c15ea3f8cdd6)
### 📝 Changelog
更新了Modal静态方法属性的描述

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      updated the docs of the attributes for the Modal method.     |
| 🇨🇳 Chinese |    更新了Modal静态方法属性的描述     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at db04b4c</samp>

Update the Chinese documentation of `Modal.method()` to include the new `closeIcon` and `closable` props. These props allow users to customize the appearance and behavior of the modal close button.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at db04b4c</samp>

* Add `closeIcon` and `closable` props to `Modal.method()` to customize and control the close button of the modal ([link](https://github.com/ant-design/ant-design/pull/45948/files?diff=unified&w=0#diff-7a204621cc9425007680c097ad01151df377979692bbc09eb2796025b85043f3L107-R108),                           F27L
