### PR TITLE
fix: ColorPicker not support form disabled

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -12,6 +12,7 @@ import { getStatusClassNames } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
+import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext, NoFormStyle } from '../form/context';
@@ -104,7 +105,8 @@ const ColorPicker: CompoundedComponent = (props) => {
   } = props;
 
   const { getPrefixCls, direction, colorPicker } = useContext<ConfigConsumerProps>(ConfigContext);
-
+  const contextDisabled = useContext(DisabledContext);
+  const mergedDisabled = disabled ?? contextDisabled;
   const [, token] = useToken();
 
   const [colorValue, setColorValue] = useColorState(token.colorPrimary, {
@@ -113,7 +115,7 @@ const ColorPicker: CompoundedComponent = (props) => {
   });
   const [popupOpen, setPopupOpen] = useMergedState(false, {
     value: open,
-    postState: (openData) => !disabled && openData,
+    postState: (openData) => !mergedDisabled && openData,
     onChange: onOpenChange,
   });
   const [formatValue, setFormatValue] = useMergedState(format, {
@@ -219,7 +221,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     color: colorValue,
     allowClear,
     colorCleared,
-    disabled,
+    disabled: mergedDisabled,
     disabledAlpha,
     presets,
     panelRender,
@@ -237,7 +239,7 @@ const ColorPicker: CompoundedComponent = (props) => {
       style={styles?.popup}
       overlayInnerStyle={styles?.popupOverlayInner}
       onOpenChange={(visible) => {
-        if (popupAllowCloseRef.current && !disabled) {
+        if (popupAllowCloseRef.current && !mergedDisabled) {
           setPopupOpen(visible);
         }
       }}
@@ -261,7 +263,7 @@ const ColorPicker: CompoundedComponent = (props) => {
           style={mergedStyle}
           color={value ? generateColor(value) : colorValue}
           prefixCls={prefixCls}
-          disabled={disabled}
+          disabled={mergedDisabled}
           colorCleared={colorCleared}
           showText={showText}
           format={formatValue}

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5608,6 +5608,415 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="ColorPicker"
+          >
+            ColorPicker
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-color-picker-trigger ant-color-picker-trigger-disabled"
+              >
+                <div
+                  class="ant-color-picker-color-block"
+                >
+                  <div
+                    class="ant-color-picker-color-block-inner"
+                    style="background: rgb(22, 119, 255);"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+                style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+              >
+                <div
+                  class="ant-popover-arrow"
+                  style="position: absolute;"
+                />
+                <div
+                  class="ant-popover-content"
+                >
+                  <div
+                    class="ant-popover-inner"
+                    role="tooltip"
+                  >
+                    <div
+                      class="ant-popover-inner-content"
+                    >
+                      <div
+                        class="ant-color-picker-inner-content"
+                      >
+                        <div
+                          class="ant-color-picker-panel"
+                        >
+                          <div
+                            class="ant-color-picker-select"
+                          >
+                            <div
+                              class="ant-color-picker-palette"
+                              style="position: relative;"
+                            >
+                              <div
+                                style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                              >
+                                <div
+                                  class="ant-color-picker-handler"
+                                  style="background-color: rgb(22, 119, 255);"
+                                />
+                              </div>
+                              <div
+                                class="ant-color-picker-saturation"
+                                style="background-color: rgb(0, 0, 0);"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="ant-color-picker-slider-container"
+                          >
+                            <div
+                              class="ant-color-picker-slider-group"
+                            >
+                              <div
+                                class="ant-color-picker-slider ant-color-picker-slider-hue"
+                              >
+                                <div
+                                  class="ant-color-picker-palette"
+                                  style="position: relative;"
+                                >
+                                  <div
+                                    style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                                  >
+                                    <div
+                                      class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                      style="background-color: rgb(0, 0, 0);"
+                                    />
+                                  </div>
+                                  <div
+                                    class="ant-color-picker-gradient"
+                                    style="position: absolute; inset: 0;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="ant-color-picker-slider ant-color-picker-slider-alpha"
+                              >
+                                <div
+                                  class="ant-color-picker-palette"
+                                  style="position: relative;"
+                                >
+                                  <div
+                                    style="position: absolute; left: 0px; top: 0px; z-index: 1;"
+                                  >
+                                    <div
+                                      class="ant-color-picker-handler ant-color-picker-handler-sm"
+                                      style="background-color: rgb(22, 119, 255);"
+                                    />
+                                  </div>
+                                  <div
+                                    class="ant-color-picker-gradient"
+                                    style="position: absolute; inset: 0;"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="ant-color-picker-color-block"
+                            >
+                              <div
+                                class="ant-color-picker-color-block-inner"
+                                style="background: rgb(22, 119, 255);"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="ant-color-picker-input-container"
+                        >
+                          <div
+                            class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow ant-select-disabled"
+                          >
+                            <div
+                              class="ant-select-selector"
+                            >
+                              <span
+                                class="ant-select-selection-search"
+                              >
+                                <input
+                                  aria-autocomplete="list"
+                                  aria-controls="rc_select_TEST_OR_SSR_list"
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  aria-owns="rc_select_TEST_OR_SSR_list"
+                                  autocomplete="off"
+                                  class="ant-select-selection-search-input"
+                                  disabled=""
+                                  id="rc_select_TEST_OR_SSR"
+                                  readonly=""
+                                  role="combobox"
+                                  style="opacity: 0;"
+                                  type="search"
+                                  unselectable="on"
+                                  value=""
+                                />
+                              </span>
+                              <span
+                                class="ant-select-selection-item"
+                                title="HEX"
+                              >
+                                HEX
+                              </span>
+                            </div>
+                            <div
+                              class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1150; width: 68px;"
+                            >
+                              <div>
+                                <div
+                                  id="rc_select_TEST_OR_SSR_list"
+                                  role="listbox"
+                                  style="height: 0px; width: 0px; overflow: hidden;"
+                                >
+                                  <div
+                                    aria-label="HEX"
+                                    aria-selected="true"
+                                    id="rc_select_TEST_OR_SSR_list_0"
+                                    role="option"
+                                  >
+                                    hex
+                                  </div>
+                                  <div
+                                    aria-label="HSB"
+                                    aria-selected="false"
+                                    id="rc_select_TEST_OR_SSR_list_1"
+                                    role="option"
+                                  >
+                                    hsb
+                                  </div>
+                                </div>
+                                <div
+                                  class="rc-virtual-list"
+                                  style="position: relative;"
+                                >
+                                  <div
+                                    class="rc-virtual-list-holder"
+                                    style="max-height: 256px; overflow-y: auto;"
+                                  >
+                                    <div>
+                                      <div
+                                        class="rc-virtual-list-holder-inner"
+                                        style="display: flex; flex-direction: column;"
+                                      >
+                                        <div
+                                          aria-selected="true"
+                                          class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                          title="HEX"
+                                        >
+                                          <div
+                                            class="ant-select-item-option-content"
+                                          >
+                                            HEX
+                                          </div>
+                                          <span
+                                            aria-hidden="true"
+                                            class="ant-select-item-option-state"
+                                            style="user-select: none;"
+                                            unselectable="on"
+                                          />
+                                        </div>
+                                        <div
+                                          aria-selected="false"
+                                          class="ant-select-item ant-select-item-option"
+                                          title="HSB"
+                                        >
+                                          <div
+                                            class="ant-select-item-option-content"
+                                          >
+                                            HSB
+                                          </div>
+                                          <span
+                                            aria-hidden="true"
+                                            class="ant-select-item-option-state"
+                                            style="user-select: none;"
+                                            unselectable="on"
+                                          />
+                                        </div>
+                                        <div
+                                          aria-selected="false"
+                                          class="ant-select-item ant-select-item-option"
+                                          title="RGB"
+                                        >
+                                          <div
+                                            class="ant-select-item-option-content"
+                                          >
+                                            RGB
+                                          </div>
+                                          <span
+                                            aria-hidden="true"
+                                            class="ant-select-item-option-state"
+                                            style="user-select: none;"
+                                            unselectable="on"
+                                          />
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="ant-select-arrow"
+                              style="user-select: none;"
+                              unselectable="on"
+                            >
+                              <span
+                                aria-label="down"
+                                class="anticon anticon-down ant-select-suffix"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  data-icon="down"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height="1em"
+                                  viewBox="64 64 896 896"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="ant-color-picker-input"
+                          >
+                            <span
+                              class="ant-input-affix-wrapper ant-input-affix-wrapper-disabled ant-color-picker-hex-input ant-input-affix-wrapper-sm"
+                            >
+                              <span
+                                class="ant-input-prefix"
+                              >
+                                #
+                              </span>
+                              <input
+                                class="ant-input ant-input-disabled ant-input-sm"
+                                disabled=""
+                                type="text"
+                                value="1677ff"
+                              />
+                            </span>
+                          </div>
+                          <div
+                            class="ant-input-number ant-input-number-sm ant-color-picker-steppers ant-color-picker-alpha-input ant-input-number-disabled"
+                          >
+                            <div
+                              class="ant-input-number-handler-wrap"
+                            >
+                              <span
+                                aria-disabled="true"
+                                aria-label="Increase Value"
+                                class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                                role="button"
+                                unselectable="on"
+                              >
+                                <span
+                                  aria-label="up"
+                                  class="anticon anticon-up ant-input-number-handler-up-inner"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="up"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                              <span
+                                aria-disabled="false"
+                                aria-label="Decrease Value"
+                                class="ant-input-number-handler ant-input-number-handler-down"
+                                role="button"
+                                unselectable="on"
+                              >
+                                <span
+                                  aria-label="down"
+                                  class="anticon anticon-down ant-input-number-handler-down-inner"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="down"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </div>
+                            <div
+                              class="ant-input-number-input-wrap"
+                            >
+                              <input
+                                aria-valuemax="100"
+                                aria-valuemin="0"
+                                aria-valuenow="100"
+                                autocomplete="off"
+                                class="ant-input-number-input"
+                                disabled=""
+                                role="spinbutton"
+                                step="1"
+                                value="100%"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3024,6 +3024,48 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="ColorPicker"
+          >
+            ColorPicker
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-color-picker-trigger ant-color-picker-trigger-disabled"
+              >
+                <div
+                  class="ant-color-picker-color-block"
+                >
+                  <div
+                    class="ant-color-picker-color-block-inner"
+                    style="background:rgb(22, 119, 255)"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -1045,6 +1045,48 @@ exports[`Form form should support disabled 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-col-4 ant-form-item-label"
+      >
+        <label
+          class=""
+          title="ColorPicker"
+        >
+          ColorPicker
+        </label>
+      </div>
+      <div
+        class="ant-col ant-col-14 ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-color-picker-trigger ant-color-picker-trigger-disabled"
+            >
+              <div
+                class="ant-color-picker-color-block"
+              >
+                <div
+                  class="ant-color-picker-color-block-inner"
+                  style="background: rgb(22, 119, 255);"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </form>
 `;
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
 import type { ChangeEventHandler } from 'react';
 import React, { version as ReactVersion, useEffect, useRef, useState } from 'react';
+import { AlertFilled } from '@ant-design/icons';
 import type { ColProps } from 'antd/es/grid';
 import classNames from 'classnames';
 import scrollIntoView from 'scroll-into-view-if-needed';
-import { AlertFilled } from '@ant-design/icons';
 
 import type { FormInstance } from '..';
 import Form from '..';
@@ -14,6 +14,7 @@ import { act, fireEvent, pureRender, render, screen, waitFakeTimer } from '../..
 import Button from '../../button';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
+import ColorPicker from '../../color-picker';
 import ConfigProvider from '../../config-provider';
 import DatePicker from '../../date-picker';
 import Drawer from '../../drawer';
@@ -1166,6 +1167,9 @@ describe('Form', () => {
         <Form.Item label="Slider">
           <Slider />
         </Form.Item>
+        <Form.Item label="ColorPicker">
+          <ColorPicker />
+        </Form.Item>
       </Form>
     );
     const { container } = render(<App />);
@@ -1692,6 +1696,7 @@ describe('Form', () => {
           { label: 'female', value: 1 },
         ]}
       />,
+      <ColorPicker key="ColorPicker" disabled={disabled} />,
       <InputNumber key="InputNumber" disabled={disabled} />,
       <Input key="Input" disabled={disabled} />,
       <Select key="Select" disabled={disabled} />,

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -1,9 +1,10 @@
-import { PlusOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
+import { PlusOutlined } from '@ant-design/icons';
 import {
   Button,
   Cascader,
   Checkbox,
+  ColorPicker,
   DatePicker,
   Form,
   Input,
@@ -112,6 +113,9 @@ const FormDisabledDemo: React.FC = () => {
         </Form.Item>
         <Form.Item label="Slider">
           <Slider />
+        </Form.Item>
+        <Form.Item label="ColorPicker">
+          <ColorPicker />
         </Form.Item>
       </Form>
     </>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- close #45976
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ColorPicker not support form disabled     |
| 🇨🇳 Chinese |    修复颜色选择器不支持表单组件的禁用问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6636942</samp>

This pull request improves the `ColorPicker` component to respect the disabled context from the config-provider, and adds it to the form test cases and demo. It also fixes some ESLint issues in the import statements.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6636942</samp>

*  Add support for disabled context to `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR15), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL107-R109), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL116-R118), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL222-R224), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL240-R242), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL264-R266))
  * Import `DisabledContext` from `config-provider` component and use it to get the `contextDisabled` value ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR15), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL107-R109))
  * Merge `contextDisabled` with `disabled` prop using nullish coalescing operator (??) and store the result in `mergedDisabled` variable ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL107-R109))
  * Use `mergedDisabled` instead of `disabled` in `useMergedState` hook, `ColorPickerPanel` component, `ColorPickerInput` component, and `onOpenChange` callback of `Trigger` component ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL116-R118), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL222-R224), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL240-R242), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL264-R266))
  * Prevent opening or closing the popup, triggering the `onOpenChange` callback, or changing the input value when the component is disabled ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL116-R118), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL240-R242), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fL264-R266))
* Update form test cases and demo to include `ColorPicker` component ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL3-R6), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR17), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1170-R1172), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1699), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-a010eb3cd9197697ae038a4c367b0f56ae295f1bd2964da303cc0cc5be0276ddL1-R7), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-a010eb3cd9197697ae038a4c367b0f56ae295f1bd2964da303cc0cc5be0276ddR117-R119))
  * Import `ColorPicker` component from `color-picker` component in test and demo files ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL3-R6), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR17), [link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-a010eb3cd9197697ae038a4c367b0f56ae295f1bd2964da303cc0cc5be0276ddL1-R7))
  * Add `Form.Item` with `ColorPicker` component in test case that checks values and validations of various components ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1170-R1172))
  * Add `ColorPicker` component with `disabled` prop in test case that toggles disabled state of various components ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacR1699))
  * Add `Form.Item` with `ColorPicker` component in demo example of form with disabled components ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-a010eb3cd9197697ae038a4c367b0f56ae295f1bd2964da303cc0cc5be0276ddR117-R119))
* Reorder import statements in form test file according to ESLint rule import/order ([link](https://github.com/ant-design/ant-design/pull/45978/files?diff=unified&w=0#diff-f3bb49bfe69c75aa977732eec74dfe67b8b00e00fc5e008c4f1d3835ae296eacL3-R6))
