### PR TITLE
fix: Fixed image preview in a nested pop-up where z-index Settings did not meet expectations

### DIFF
--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import React, { useEffect } from 'react';
 import { render } from '@testing-library/react';
-import type { MenuProps } from 'antd';
+import type { ImageProps, MenuProps } from 'antd';
 import {
   AutoComplete,
   Cascader,
@@ -9,6 +9,7 @@ import {
   DatePicker,
   Drawer,
   Dropdown,
+  Image,
   Menu,
   Modal,
   Popconfirm,
@@ -178,6 +179,15 @@ const consumerComponent: Record<ZIndexConsumer, React.FC<{ rootClassName: string
     </>
   ),
   Menu: (props) => <Menu {...props} items={items} defaultOpenKeys={['SubMenu']} />,
+  ImagePreview: ({ rootClassName }: ImageProps) => (
+    <Image
+      src="xxx"
+      preview={{
+        visible: true,
+        rootClassName: `${rootClassName} comp-item comp-ImagePreview`,
+      }}
+    />
+  ),
 };
 
 function getConsumerSelector(baseSelector: string, consumer: ZIndexConsumer): string {
@@ -196,6 +206,8 @@ function getConsumerSelector(baseSelector: string, consumer: ZIndexConsumer): st
       .join(',');
   } else if (['Menu'].includes(consumer)) {
     selector = `${baseSelector}.ant-menu-submenu-placement-rightTop`;
+  } else if (consumer === 'ImagePreview') {
+    selector = `${baseSelector}.comp-ImagePreview`;
   }
   return selector;
 }

--- a/components/_util/hooks/useZIndex.tsx
+++ b/components/_util/hooks/useZIndex.tsx
@@ -5,7 +5,7 @@ import zIndexContext from '../zindexContext';
 
 export type ZIndexContainer = 'Modal' | 'Drawer' | 'Popover' | 'Popconfirm' | 'Tooltip' | 'Tour';
 
-export type ZIndexConsumer = 'SelectLike' | 'Dropdown' | 'DatePicker' | 'Menu';
+export type ZIndexConsumer = 'SelectLike' | 'Dropdown' | 'DatePicker' | 'Menu' | 'ImagePreview';
 
 // Z-Index control range
 // Container: 1000 + offset 100 (max base + 10 * offset = 2000)
@@ -30,6 +30,7 @@ export const consumerBaseZIndexOffset: Record<ZIndexConsumer, number> = {
   Dropdown: 50,
   DatePicker: 50,
   Menu: 50,
+  ImagePreview: 1,
 };
 
 function isContainerType(type: ZIndexContainer | ZIndexConsumer): type is ZIndexContainer {

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import RcImage from 'rc-image';
 import type { ImageProps } from 'rc-image';
 
+import { useZIndex } from '../_util/hooks/useZIndex';
 import { getTransitionName } from '../_util/motion';
 import { ConfigContext } from '../config-provider';
 import defaultLocale from '../locale/en_US';
@@ -42,6 +43,11 @@ const Image: CompositionImage<ImageProps> = (props) => {
 
   const mergedClassName = classNames(className, hashId, image?.className);
 
+  const [zIndex] = useZIndex(
+    'ImagePreview',
+    typeof preview === 'object' ? preview.zIndex : undefined,
+  );
+
   const mergedPreview = React.useMemo(() => {
     if (preview === false) {
       return preview;
@@ -60,6 +66,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
       getContainer: getContainer || getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
+      zIndex,
     };
   }, [preview, imageLocale]);
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "rc-drawer": "~6.5.2",
     "rc-dropdown": "~4.1.0",
     "rc-field-form": "~1.40.0",
-    "rc-image": "~7.3.2",
+    "rc-image": "~7.4.0",
     "rc-input": "~1.3.6",
     "rc-input-number": "~8.4.0",
     "rc-mentions": "~2.9.1",


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #45975

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed image preview in a nested pop-up where z-index Settings did not meet expectations |
| 🇨🇳 Chinese | 解决了图像预览在嵌套弹框中中 z-index 设置不符合预期 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d93d306</samp>

Added z-index management for the `Image` component with a preview feature. Used the `useZIndex` hook to assign z-index values to the image preview elements and updated the `rc-image` dependency to support the `zIndex` prop. Added a test case for the `useZIndex` hook with the `Image` component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d93d306</samp>

*  Update `rc-image` dependency to use the latest version that supports the `zIndex` prop for the `PreviewGroup` component ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L136-R136))
*  Import and use `useZIndex` hook in `Image` component to get the z-index value for the preview element based on the `ImagePreview` consumer and the optional `zIndex` prop from the `preview` object ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-6755d2dc445a769167d64d5ff481db516522d39820a68d34bd5476f2b8cc5e05R7), [link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-6755d2dc445a769167d64d5ff481db516522d39820a68d34bd5476f2b8cc5e05R46-R50), [link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-6755d2dc445a769167d64d5ff481db516522d39820a68d34bd5476f2b8cc5e05R69))
*  Pass the z-index value to the `PreviewGroup` component as a prop to set the z-index of the preview element ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-6755d2dc445a769167d64d5ff481db516522d39820a68d34bd5476f2b8cc5e05R69))
*  Update `ZIndexConsumer` type and `consumerBaseZIndexOffset` object to include the `ImagePreview` consumer and assign a base z-index offset value of 1 to it ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-2a902ec0f175b29920c300ea9a4023433a9a9720749632f5ac132e73694b1f71L8-R8), [link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-2a902ec0f175b29920c300ea9a4023433a9a9720749632f5ac132e73694b1f71R33))
*  Add `ImagePreview` component to the `useZIndex` test file and import `Image` component and `ImageProps` type from `antd` to use them in the `ImagePreview` component ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L4-R4), [link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5R12), [link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5R182-R190))
*  Update `getConsumerSelector` function in the `useZIndex` test file to handle the `ImagePreview` consumer case and return the appropriate selector for the preview element based on the root class name ([link](https://github.com/ant-design/ant-design/pull/45979/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5R209-R210))
