### PR TITLE
feat: preserve breakpoint tokens value

### DIFF
--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -106,7 +106,7 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
 const genResponsiveStyle = (token: ListToken): CSSObject => {
   const { componentCls, screenSM, screenMD, marginLG, marginSM, margin } = token;
   return {
-    [`@media screen and (max-width:${screenMD})`]: {
+    [`@media screen and (max-width:${screenMD}px)`]: {
       [`${componentCls}`]: {
         [`${componentCls}-item`]: {
           [`${componentCls}-item-action`]: {
@@ -124,7 +124,7 @@ const genResponsiveStyle = (token: ListToken): CSSObject => {
       },
     },
 
-    [`@media screen and (max-width: ${screenSM})`]: {
+    [`@media screen and (max-width: ${screenSM}px)`]: {
       [`${componentCls}`]: {
         [`${componentCls}-item`]: {
           flexWrap: 'wrap',
@@ -299,10 +299,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
             insetBlockStart: '50%',
             insetInlineEnd: 0,
             width: lineWidth,
-            height: token
-              .calc(token.fontHeight)
-              .sub(token.calc(token.marginXXS).mul(2))
-              .equal(),
+            height: token.calc(token.fontHeight).sub(token.calc(token.marginXXS).mul(2)).equal(),
             transform: 'translateY(-50%)',
             backgroundColor: token.colorSplit,
           },

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -174,7 +174,7 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
           },
         },
 
-        [`@media (max-width: ${token.screenSMMax})`]: {
+        [`@media (max-width: ${token.screenSMMax}px)`]: {
           [componentCls]: {
             maxWidth: 'calc(100vw - 16px)',
             margin: `${unit(token.marginXS)} auto`,

--- a/components/theme/useToken.ts
+++ b/components/theme/useToken.ts
@@ -44,6 +44,28 @@ export const ignore: {
   motionUnit: true,
 };
 
+const preserve: {
+  [key in keyof AliasToken]?: boolean;
+} = {
+  screenXS: true,
+  screenXSMin: true,
+  screenXSMax: true,
+  screenSM: true,
+  screenSMMin: true,
+  screenSMMax: true,
+  screenMD: true,
+  screenMDMin: true,
+  screenMDMax: true,
+  screenLG: true,
+  screenLGMin: true,
+  screenLGMax: true,
+  screenXL: true,
+  screenXLMin: true,
+  screenXLMax: true,
+  screenXXL: true,
+  screenXXLMin: true,
+};
+
 export const getComputedToken = (
   originToken: SeedToken,
   overrideToken: DesignTokenProviderProps['components'] & {
@@ -122,6 +144,7 @@ export default function useToken(): [
         key: cssVar.key,
         unitless,
         ignore,
+        preserve,
       },
     },
   );

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   ],
   "dependencies": {
     "@ant-design/colors": "^7.0.0",
-    "@ant-design/cssinjs": "^1.18.0-alpha.1",
+    "@ant-design/cssinjs": "^1.18.0-alpha.2",
     "@ant-design/icons": "^5.2.6",
     "@ant-design/react-slick": "~1.0.2",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
断点 token 通常用于 media 查询，无法使用 css 变量代替，所以使用 cssinjs 的 preserve 属性来保留原值。
顺便修复一下样式中没有带单位的 media 查询
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07ba093</samp>

This pull request fixes some media query bugs and improves the theming support for the `List` and `Modal` components. It also updates the `@ant-design/cssinjs` dependency to use the new `preserve` option.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07ba093</samp>

*  Fix missing `px` unit in media queries for list and modal components ([link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L109-R109), [link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L127-R127), [link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-a27b99943336f4a3b470158edbccad703a421adf1b1453c0c006e0794c7db486L177-R177))
*  Refactor list item divider style for readability and consistency ([link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-8ed8eddb13b4537df4b99afb831a6d4be1bef5a7d3b3cc4ddac6b3d1307e87a4L302-R302))
*  Add `preserve` option to `useToken` hook and `createTheme` function to prevent CSS variable conversion for media query tokens ([link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-c71eb91865998661d8139ee89317ebd253b704a1fae92b80254b164c05c67e8cR47-R68), [link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-c71eb91865998661d8139ee89317ebd253b704a1fae92b80254b164c05c67e8cR147))
*  Update `@ant-design/cssinjs` dependency to support `preserve` option ([link](https://github.com/ant-design/ant-design/pull/45981/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L116-R116))
