### PR TITLE
feat: cssVar could be disabled by set to false

### DIFF
--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -68,6 +68,7 @@ const useThemeAnimation = () => {
     if (!(event && typeof document.startViewTransition === 'function')) {
       return;
     }
+    const time = Date.now();
     const x = event.clientX;
     const y = event.clientY;
     const endRadius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y));
@@ -98,6 +99,7 @@ const useThemeAnimation = () => {
         root.classList.add(isDark ? 'light' : 'dark');
       })
       .ready.then(() => {
+        console.log(`Theme transition finished in ${Date.now() - time}ms`);
         const clipPath = [
           `circle(0px at ${x}px ${y}px)`,
           `circle(${endRadius}px at ${x}px ${y}px)`,

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -177,6 +177,7 @@ const GlobalLayout: React.FC = () => {
               token: {
                 motion: !theme.includes('motion-off'),
               },
+              cssVar: true,
             }}
           >
             <HappyProvider disabled={!theme.includes('happy-work')}>{content}</HappyProvider>

--- a/components/button/style/cssVar.ts
+++ b/components/button/style/cssVar.ts
@@ -1,4 +1,8 @@
 import { genCSSVarRegister } from '../../theme/internal';
 import { prepareComponentToken } from '.';
 
-export default genCSSVarRegister('Button', prepareComponentToken);
+export default genCSSVarRegister('Button', prepareComponentToken, {
+  unitless: {
+    fontWeight: true,
+  },
+});

--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -210,9 +210,9 @@ describe('ConfigProvider.Theme', () => {
 
       expect(button).toHaveClass('foo');
       expect(button).toHaveStyle({
-        '--antd-color-text': 'rgba(0, 0, 0, 0.88)',
-        boxShadow: 'var(--antd-button-default-shadow)',
-        'line-height': 'var(--antd-line-height)',
+        '--ant-color-text': 'rgba(0, 0, 0, 0.88)',
+        boxShadow: 'var(--ant-button-default-shadow)',
+        'line-height': 'var(--ant-line-height)',
       });
     });
 
@@ -233,9 +233,9 @@ describe('ConfigProvider.Theme', () => {
 
       expect(fooBtn).toHaveClass('foo');
       expect(fooBtn).toHaveStyle({
-        '--antd-color-text': 'rgba(0, 0, 0, 0.88)',
-        boxShadow: 'var(--antd-button-default-shadow)',
-        'line-height': 'var(--antd-line-height)',
+        '--ant-color-text': 'rgba(0, 0, 0, 0.88)',
+        boxShadow: 'var(--ant-button-default-shadow)',
+        'line-height': 'var(--ant-line-height)',
       });
 
       expect(barBtn).toHaveClass('bar');
@@ -261,10 +261,10 @@ describe('ConfigProvider.Theme', () => {
 
       const select = container.querySelector('.select-foo')!;
       expect(select).toHaveStyle({
-        '--antd-color-primary': '#1890ff',
-        '--antd-select-option-selected-color': '#000',
-        '--antd-select-option-selected-font-weight': '600',
-        '--antd-select-z-index-popup': '1050',
+        '--ant-color-primary': '#1890ff',
+        '--ant-select-option-selected-color': '#000',
+        '--ant-select-option-selected-font-weight': '600',
+        '--ant-select-z-index-popup': '1050',
       });
     });
   });

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -50,8 +50,8 @@ export default function useTheme(
       });
 
       const cssVarKey = `css-var-${themeKey.replace(/:/g, '')}`;
-      const mergedCssVar = (themeConfig.cssVar || parentThemeConfig.cssVar) && {
-        prefix: 'antd', // Default to antd
+      const mergedCssVar = (themeConfig.cssVar ?? parentThemeConfig.cssVar) && {
+        prefix: 'ant', // Default to ant
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
         key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key) || cssVarKey,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1f6b552</samp>

This pull request implements a CSS variable-based theme animation feature for the `ant-design` library. It adds a `cssVar` prop to the `GlobalLayout` component, modifies the `useTheme` and `useThemeAnimation` hooks, and updates the `Button` component's CSS variable registration.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1f6b552</samp>

* Enable CSS variable-based theme animation for `GlobalLayout` component by adding `cssVar` prop ([link](https://github.com/ant-design/ant-design/pull/45987/files?diff=unified&w=0#diff-5d7076c9ed6d07433cbe0e9ec9d4940ec94b53422e0475998ac2ce2e9caa3b46R180))
* Add `time` variable to measure theme transition duration in `useThemeAnimation` hook ([link](https://github.com/ant-design/ant-design/pull/45987/files?diff=unified&w=0#diff-941fcbacf1a38746130e95a5c46349e59999f00997963e17e027e79e2840a2c0R71))
* Log theme transition duration in console after animation ends ([link](https://github.com/ant-design/ant-design/pull/45987/files?diff=unified&w=0#diff-941fcbacf1a38746130e95a5c46349e59999f00997963e17e027e79e2840a2c0R102))
* Modify `mergedCssVar` object in `useTheme` hook to use `ant` prefix and nullish coalescing operator ([link](https://github.com/ant-design/ant-design/pull/45987/files?diff=unified&w=0#diff-85ff925f8aa07cbb863b96b5bffc960720ad00516700939d2aa40cde582d41f3L53-R54))
* Specify unitless CSS properties for `Button` component in `genCSSVarRegister` function call ([link](https://github.com/ant-design/ant-design/pull/45987/files?diff=unified&w=0#diff-da465e13e5a6616903efcbebef2ee41cf92990ed7325110b8fde64d7367a7836L4-R8))
