### PR TITLE
docs: changelog for 4.24.15

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,13 @@ timeline: true
 
 ---
 
+## 4.24.15
+
+`2023-11-21`
+
+- 🐞 Fix Radio has wrong `disabled` state problem that affected by Form. [#44837](https://github.com/ant-design/ant-design/pull/44837) [@Yuiai01](https://github.com/Yuiai01)
+- 💄 Fix DatePicker disabled styles when hovered in Form. [#44779](https://github.com/ant-design/ant-design/pull/44779) [@crazyair](https://github.com/crazyair)
+
 ## 4.24.14
 
 `2023-09-06`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,13 @@ timeline: true
 
 ---
 
+## 4.24.15
+
+`2023-11-21`
+
+- 🐞 修复 Radio 的 `disabled` 状态被 Form 的 `disabled` 覆盖的问题。[#44837](https://github.com/ant-design/ant-design/pull/44837) [@Yuiai01](https://github.com/Yuiai01)
+- 💄 修复 DatePicker 的 `disabled` 样式在 Form hover 场景下被覆盖的问题。[#44779](https://github.com/ant-design/ant-design/pull/44779) [@crazyair](https://github.com/crazyair)
+
 ## 4.24.14
 
 `2023-09-06`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "4.24.14",
+  "version": "4.24.15",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 📝 Changelog

- 🐞 Fix Radio has wrong `disabled` state problem that affected by Form. [#44837](https://github.com/ant-design/ant-design/pull/44837) [@Yuiai01](https://github.com/Yuiai01)
- 💄 Fix DatePicker disabled styles when hovered in Form. [#44779](https://github.com/ant-design/ant-design/pull/44779) [@crazyair](https://github.com/crazyair)

---

- 🐞 修复 Radio 的 `disabled` 状态被 Form 的 `disabled` 覆盖的问题。[#44837](https://github.com/ant-design/ant-design/pull/44837) [@Yuiai01](https://github.com/Yuiai01)
- 💄 修复 DatePicker 的 `disabled` 样式在 Form hover 场景下被覆盖的问题。[#44779](https://github.com/ant-design/ant-design/pull/44779) [@crazyair](https://github.com/crazyair)

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8bd327</samp>

This pull request prepares the release of antd version 4.24.15. It updates the `package.json` file and the `CHANGELOG.en-US.md` and `CHANGELOG.zh-CN.md` files with the latest bug fixes.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a8bd327</samp>

* Bump antd version to 4.24.15 and add release notes ([link](https://github.com/ant-design/ant-design/pull/45997/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3), [link](https://github.com/ant-design/ant-design/pull/45997/files?diff=unified&w=0#diff-e961ad288c43a2feb2d56b696e10c0b670d652dbb17c76c9aa0452d45157977cR18-R24), [link](https://github.com/ant-design/ant-design/pull/45997/files?diff=unified&w=0#diff-1224d5ca5233fdeba67ba2e2dc6fa3e615905253f35dc132c4b4b86f51f9eab4R18-R24))
