### PR TITLE
chore: umd version will try to reuse global `@ant-design/cssinjs` first

### DIFF
--- a/alias/cssinjs.js
+++ b/alias/cssinjs.js
@@ -12,6 +12,7 @@ if (typeof window !== 'undefined' && window.antdCssinjs) {
   cssinjs = global.antdCssinjs;
 } else {
   // Use local version.
+  // Use relative path since webpack will also replace module here.
   cssinjs = require('../node_modules/@ant-design/cssinjs');
 }
 

--- a/alias/cssinjs.js
+++ b/alias/cssinjs.js
@@ -1,0 +1,18 @@
+/* eslint-disable global-require, import/no-unresolved */
+
+// This is a alias proxy, which will use global `@ant-design/cssinjs` first.
+// Use local if global not found.
+let cssinjs;
+
+if (typeof window !== 'undefined' && window.antdCssinjs) {
+  // Use window UMD version
+  cssinjs = window.antdCssinjs;
+} else if (typeof global !== 'undefined' && global.antdCssinjs) {
+  // Use global UMD version
+  cssinjs = global.antdCssinjs;
+} else {
+  // Use local version.
+  cssinjs = require('../node_modules/@ant-design/cssinjs');
+}
+
+module.exports = cssinjs;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { EsbuildPlugin } = require('esbuild-loader');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+const path = require('path');
 
 function addLocales(webpackConfig) {
   let packageName = 'antd-with-locales';
@@ -24,6 +25,13 @@ function externalDayjs(config) {
   };
 }
 
+function externalCssinjs(config) {
+  config.resolve = config.resolve || {};
+  config.resolve.alias = config.resolve.alias || {};
+
+  config.resolve.alias['@ant-design/cssinjs'] = path.resolve(__dirname, 'alias/cssinjs');
+}
+
 let webpackConfig = getWebpackConfig(false);
 
 // Used for `size-limit` ci which only need to check min files
@@ -37,6 +45,8 @@ if (process.env.RUN_ENV === 'PRODUCTION') {
   webpackConfig.forEach((config) => {
     addLocales(config);
     externalDayjs(config);
+    externalCssinjs(config);
+
     // Reduce non-minified dist files size
     config.optimization.usedExports = true;
     // use esbuild


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   UMD `antd.js` will try to reuse global `@ant-design/cssinjs` first now.        |
| 🇨🇳 Chinese |    UMD 版本 `antd.js` 现在会优先使用全局的 `@ant-design/cssinjs` 依赖。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bcefa6f</samp>

This pull request adds support for using `@ant-design/cssinjs` as an external dependency in webpack projects. It introduces a new alias module `alias/cssinjs.js` that handles the global or local loading of the library.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bcefa6f</samp>

*  Add a proxy module for `@ant-design/cssinjs` to avoid duplicate bundling ([link](https://github.com/ant-design/ant-design/pull/46009/files?diff=unified&w=0#diff-c183351e6258736b0535bb494db91948bd0991868bae0b9590187e08c4c7d86dR1-R18))
*  Import `path` module to resolve alias path in webpack config ([link](https://github.com/ant-design/ant-design/pull/46009/files?diff=unified&w=0#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR8))
*  Define `externalCssinjs` function to modify webpack config with alias proxy ([link](https://github.com/ant-design/ant-design/pull/46009/files?diff=unified&w=0#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR28-R34))
*  Invoke `externalCssinjs` in `webpackConfig` function to apply alias proxy ([link](https://github.com/ant-design/ant-design/pull/46009/files?diff=unified&w=0#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR48-R49))
