### PR TITLE
fix: Static method provides wrong zIndex context

### DIFF
--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -349,13 +349,17 @@ describe('Test useZIndex hooks', () => {
 
     const instance = Modal.confirm({
       title: 'bamboo',
-      content: 'little',
+      content: <Select open />,
     });
 
     await waitFakeTimer();
 
     expect(document.querySelector('.ant-modal-wrap')).toHaveStyle({
       zIndex: '2000',
+    });
+
+    expect(document.querySelector('.ant-select-dropdown')).toHaveStyle({
+      zIndex: '2050',
     });
 
     instance.destroy();

--- a/components/_util/hooks/useZIndex.tsx
+++ b/components/_util/hooks/useZIndex.tsx
@@ -44,7 +44,7 @@ export function useZIndex(
   const [, token] = useToken();
   const parentZIndex = React.useContext(zIndexContext);
   const isContainer = isContainerType(componentType);
-  let zIndex = parentZIndex ?? customZIndex ?? 0;
+  let zIndex = customZIndex ?? parentZIndex ?? 0;
   if (isContainer) {
     zIndex +=
       // Use preset token zIndex by default but not stack when has parent container

--- a/components/_util/hooks/useZIndex.tsx
+++ b/components/_util/hooks/useZIndex.tsx
@@ -44,7 +44,13 @@ export function useZIndex(
   const [, token] = useToken();
   const parentZIndex = React.useContext(zIndexContext);
   const isContainer = isContainerType(componentType);
-  let zIndex = customZIndex ?? parentZIndex ?? 0;
+
+  if (customZIndex !== undefined) {
+    return [customZIndex, customZIndex];
+  }
+
+  let zIndex = parentZIndex ?? 0;
+
   if (isContainer) {
     zIndex +=
       // Use preset token zIndex by default but not stack when has parent container

--- a/components/_util/hooks/useZIndex.tsx
+++ b/components/_util/hooks/useZIndex.tsx
@@ -44,7 +44,7 @@ export function useZIndex(
   const [, token] = useToken();
   const parentZIndex = React.useContext(zIndexContext);
   const isContainer = isContainerType(componentType);
-  let zIndex = parentZIndex ?? 0;
+  let zIndex = parentZIndex ?? customZIndex ?? 0;
   if (isContainer) {
     zIndex +=
       // Use preset token zIndex by default but not stack when has parent container

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -17,7 +17,7 @@ import OkBtn from './components/ConfirmOkBtn';
 import type { ModalContextProps } from './context';
 import { ModalContextProvider } from './context';
 import type { ModalFuncProps, ModalLocale } from './interface';
-import Dialog from './Modal';
+import Modal from './Modal';
 import ConfirmCmp from './style/confirmCmp';
 
 export interface ConfirmDialogProps extends ModalFuncProps {
@@ -233,7 +233,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
 
   // ========================= Render =========================
   return (
-    <Dialog
+    <Modal
       prefixCls={prefixCls}
       className={classString}
       wrapClassName={classNames(
@@ -269,7 +269,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
       focusTriggerAfterClose={focusTriggerAfterClose}
     >
       <ConfirmContent {...props} confirmPrefixCls={confirmPrefixCls} />
-    </Dialog>
+    </Modal>
   );
 };
 

--- a/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -670,31 +670,60 @@ exports[`renders components/modal/demo/modal-render.tsx extend context correctly
 exports[`renders components/modal/demo/modal-render.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/modal/demo/nested.tsx extend context correctly 1`] = `
-<button
-  aria-checked="false"
-  class="ant-switch"
-  role="switch"
-  style="position: relative; z-index: 0;"
-  type="button"
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
 >
   <div
-    class="ant-switch-handle"
-  />
-  <span
-    class="ant-switch-inner"
+    class="ant-space-item"
   >
-    <span
-      class="ant-switch-inner-checked"
+    <button
+      aria-checked="false"
+      class="ant-switch"
+      role="switch"
+      style="position: relative; z-index: 0;"
+      type="button"
     >
-      Open
-    </span>
-    <span
-      class="ant-switch-inner-unchecked"
+      <div
+        class="ant-switch-handle"
+      />
+      <span
+        class="ant-switch-inner"
+      >
+        <span
+          class="ant-switch-inner-checked"
+        >
+          Open
+        </span>
+        <span
+          class="ant-switch-inner-unchecked"
+        >
+          Close
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
     >
-      Close
-    </span>
-  </span>
-</button>
+      <span>
+        Static
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  />
+</div>
 `;
 
 exports[`renders components/modal/demo/nested.tsx extend context correctly 2`] = `[]`;

--- a/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
@@ -640,31 +640,60 @@ exports[`renders components/modal/demo/modal-render.tsx correctly 1`] = `
 `;
 
 exports[`renders components/modal/demo/nested.tsx correctly 1`] = `
-<button
-  aria-checked="false"
-  class="ant-switch"
-  role="switch"
-  style="position:relative;z-index:0"
-  type="button"
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
 >
   <div
-    class="ant-switch-handle"
-  />
-  <span
-    class="ant-switch-inner"
+    class="ant-space-item"
   >
-    <span
-      class="ant-switch-inner-checked"
+    <button
+      aria-checked="false"
+      class="ant-switch"
+      role="switch"
+      style="position:relative;z-index:0"
+      type="button"
     >
-      Open
-    </span>
-    <span
-      class="ant-switch-inner-unchecked"
+      <div
+        class="ant-switch-handle"
+      />
+      <span
+        class="ant-switch-inner"
+      >
+        <span
+          class="ant-switch-inner-checked"
+        >
+          Open
+        </span>
+        <span
+          class="ant-switch-inner-unchecked"
+        >
+          Close
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-default"
+      type="button"
     >
-      Close
-    </span>
-  </span>
-</button>
+      <span>
+        Static
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  />
+</div>
 `;
 
 exports[`renders components/modal/demo/position.tsx correctly 1`] = `

--- a/components/modal/demo/nested.tsx
+++ b/components/modal/demo/nested.tsx
@@ -25,7 +25,7 @@ const Demo: React.FC = () => {
   };
 
   return (
-    <>
+    <Space>
       <Switch
         style={{ position: 'relative', zIndex: isModalOpen ? 4000 : 0 }}
         checkedChildren="Open"
@@ -130,7 +130,7 @@ const Demo: React.FC = () => {
 
       {messageHolder}
       {notificationHolder}
-    </>
+    </Space>
   );
 };
 

--- a/components/modal/demo/nested.tsx
+++ b/components/modal/demo/nested.tsx
@@ -18,6 +18,12 @@ const Demo: React.FC = () => {
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
+  const onShowStatic = () => {
+    Modal.confirm({
+      content: <Select open value="1" options={options} />,
+    });
+  };
+
   return (
     <>
       <Switch
@@ -26,6 +32,7 @@ const Demo: React.FC = () => {
         unCheckedChildren="Close"
         onChange={(open) => setIsModalOpen(open)}
       />
+      <Button onClick={onShowStatic}>Static</Button>
       <Modal
         title="Basic Modal"
         open={isModalOpen}

--- a/scripts/post-script.ts
+++ b/scripts/post-script.ts
@@ -50,6 +50,7 @@ const DEPRECIATED_VERSION = {
   '5.10.0': ['https://github.com/ant-design/ant-design/issues/45289'],
   '5.11.0': ['https://github.com/ant-design/ant-design/issues/45742'],
   '5.11.1': ['https://github.com/ant-design/ant-design/issues/45883'],
+  '5.11.2': ['https://github.com/ant-design/ant-design/issues/46005'],
 } as const;
 
 function matchDeprecated(v: string) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #46005

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal static method create `zIndex` too high will cover other popup content      |
| 🇨🇳 Chinese |   修复 Modal 静态方法创建 `zIndex` 过高会覆盖其他弹出内容的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce78457</samp>

Added a customZIndex prop to the `useZIndex` hook and a test case for the z-index of select components inside modal confirm dialogs. Renamed Dialog to Modal in `ConfirmDialog.tsx` to avoid naming conflict. Updated the nested modal demo to show a static modal confirm with a select component.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce78457</samp>

*  Add customZIndex prop to useZIndex hook to allow overriding parent z-index ([link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-2a902ec0f175b29920c300ea9a4023433a9a9720749632f5ac132e73694b1f71L47-R47))
*  Rename Dialog import to Modal in ConfirmDialog component to avoid confusion ([link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L20-R20), [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L236-R236), [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-d3734257bd9f28b52a331a7cc2fb5a3efd91c2fc71be29356d2fb171768ba9a3L272-R272))
*  Add a new nested modal demo with a select component inside a modal confirm dialog (`components/modal/demo/nested.tsx`, [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-740d231aa0062e7ab64fb1c11b1a82f487d219f392ddcbf2be01b45a8538e1e6L21-R28), [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-740d231aa0062e7ab64fb1c11b1a82f487d219f392ddcbf2be01b45a8538e1e6R35), [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-740d231aa0062e7ab64fb1c11b1a82f487d219f392ddcbf2be01b45a8538e1e6L126-R133))
*  Add a test case for the z-index behavior of the select component inside a modal confirm dialog (`components/_util/__tests__/useZIndex.test.tsx`, [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L352-R352), [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5R361-R364))
*  Add a new entry to the DEPRECIATED_VERSION object in the post-script file to link the issue for version 5.11.2 (`scripts/post-script.ts`, [link](https://github.com/ant-design/ant-design/pull/46012/files?diff=unified&w=0#diff-f90e598624ba13764610410ae49732147dec4738e55891b356f6162482dc8923R53))
