### PR TITLE
fix: Fix image group preview z index in nested modal

### DIFF
--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -302,11 +302,15 @@ describe('Test useZIndex hooks', () => {
               const consumerOffset = isColorPicker
                 ? containerBaseZIndexOffset.Popover
                 : consumerBaseZIndexOffset[key as ZIndexConsumer];
+              const operOffset = comp.classList.contains('ant-image-preview-operations-wrapper')
+                ? 1
+                : 0;
               expect((comp as HTMLDivElement).style.zIndex).toBe(
                 String(
                   1000 +
                     containerBaseZIndexOffset[containerKey as ZIndexContainer] +
-                    consumerOffset,
+                    consumerOffset +
+                    operOffset,
                 ),
               );
             });
@@ -317,11 +321,15 @@ describe('Test useZIndex hooks', () => {
               const consumerOffset = isColorPicker
                 ? containerBaseZIndexOffset.Popover
                 : consumerBaseZIndexOffset[key as ZIndexConsumer];
+              const operOffset = comp.classList.contains('ant-image-preview-operations-wrapper')
+                ? 1
+                : 0;
               expect((comp as HTMLDivElement).style.zIndex).toBe(
                 String(
                   1000 +
                     containerBaseZIndexOffset[containerKey as ZIndexContainer] * 2 +
-                    consumerOffset,
+                    consumerOffset +
+                    operOffset,
                 ),
               );
             });

--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -180,13 +180,23 @@ const consumerComponent: Record<ZIndexConsumer, React.FC<{ rootClassName: string
   ),
   Menu: (props) => <Menu {...props} items={items} defaultOpenKeys={['SubMenu']} />,
   ImagePreview: ({ rootClassName }: ImageProps) => (
-    <Image
-      src="xxx"
-      preview={{
-        visible: true,
-        rootClassName: `${rootClassName} comp-item comp-ImagePreview`,
-      }}
-    />
+    <>
+      <Image
+        src="xxx"
+        preview={{
+          visible: true,
+          rootClassName: `${rootClassName} comp-item comp-ImagePreview`,
+        }}
+      />
+      <Image.PreviewGroup
+        preview={{
+          visible: true,
+          rootClassName: `${rootClassName} comp-item comp-ImagePreview`,
+        }}
+      >
+        <Image src="xxx" />
+      </Image.PreviewGroup>
+    </>
   ),
 };
 

--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -191,7 +191,7 @@ const consumerComponent: Record<ZIndexConsumer, React.FC<{ rootClassName: string
       <Image.PreviewGroup
         preview={{
           visible: true,
-          rootClassName: `${rootClassName} comp-item comp-ImagePreview`,
+          rootClassName: `${rootClassName} comp-item comp-ImagePreviewGroup`,
         }}
       >
         <Image src="xxx" />
@@ -217,7 +217,12 @@ function getConsumerSelector(baseSelector: string, consumer: ZIndexConsumer): st
   } else if (['Menu'].includes(consumer)) {
     selector = `${baseSelector}.ant-menu-submenu-placement-rightTop`;
   } else if (consumer === 'ImagePreview') {
-    selector = `${baseSelector}.comp-ImagePreview`;
+    selector = ['ImagePreview', 'ImagePreviewGroup']
+      .map(
+        (item) =>
+          `${baseSelector}.comp-${item} .ant-image-preview-wrap, ${baseSelector}.comp-${item}.ant-image-preview-operations-wrapper`,
+      )
+      .join(',');
   }
   return selector;
 }
@@ -286,7 +291,7 @@ describe('Test useZIndex hooks', () => {
           const selector2 = getConsumerSelector('.consumer2', key as ZIndexConsumer);
           const selector3 = getConsumerSelector('.consumer3', key as ZIndexConsumer);
 
-          if (['SelectLike', 'DatePicker'].includes(key)) {
+          if (['SelectLike', 'DatePicker', 'ImagePreview'].includes(key)) {
             let comps = document.querySelectorAll(selector1);
             comps.forEach((comp) => {
               expect((comp as HTMLDivElement).style.zIndex).toBeFalsy();

--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -15,6 +15,7 @@ import { getTransitionName } from '../_util/motion';
 
 // CSSINJS
 import useStyle from './style';
+import { useZIndex } from '../_util/hooks/useZIndex';
 
 export const icons = {
   rotateLeft: <RotateLeftOutlined />,
@@ -40,6 +41,11 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
 
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
+  const [zIndex] = useZIndex(
+    'ImagePreview',
+    typeof preview === 'object' ? preview.zIndex : undefined,
+  );
+
   const mergedPreview = React.useMemo(() => {
     if (preview === false) {
       return preview;
@@ -52,6 +58,7 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
       rootClassName: mergedRootClassName,
+      zIndex,
     };
   }, [preview]);
 

--- a/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -349,6 +349,19 @@ exports[`renders components/image/demo/imageRender.tsx extend context correctly 
 
 exports[`renders components/image/demo/imageRender.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/image/demo/nested.tsx extend context correctly 1`] = `
+<button
+  class="ant-btn ant-btn-default"
+  type="button"
+>
+  <span>
+    showModal
+  </span>
+</button>
+`;
+
+exports[`renders components/image/demo/nested.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/image/demo/placeholder.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/image/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo.test.ts.snap
@@ -340,6 +340,17 @@ exports[`renders components/image/demo/imageRender.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/image/demo/nested.tsx correctly 1`] = `
+<button
+  class="ant-btn ant-btn-default"
+  type="button"
+>
+  <span>
+    showModal
+  </span>
+</button>
+`;
+
 exports[`renders components/image/demo/placeholder.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"

--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Button, Modal } from 'antd';
+
 import Image from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -115,5 +117,71 @@ describe('Image', () => {
     fireEvent.click(container.querySelector('.ant-image')!);
 
     expect(baseElement.querySelector('.test-root-class')).toBeTruthy();
+  });
+  it('Image.PreviewGroup preview in a nested modal where z-index Settings should be correct', () => {
+    const App = () => (
+      <Modal open>
+        <Modal open>
+          <Modal open>
+            <Image
+              width={200}
+              src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+              preview={{
+                rootClassName: 'test-image-preview-class',
+              }}
+            />
+            <Image.PreviewGroup
+              preview={{
+                rootClassName: 'test-image-preview-group-class',
+              }}
+            >
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+              />
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+              />
+            </Image.PreviewGroup>
+          </Modal>
+        </Modal>
+      </Modal>
+    );
+    const { baseElement } = render(<App />);
+
+    fireEvent.click(baseElement.querySelector('.ant-image')!);
+
+    expect(
+      (
+        baseElement.querySelector(
+          '.test-image-preview-class .ant-image-preview-wrap',
+        ) as HTMLElement
+      ).style.zIndex,
+    ).toBe('1301');
+    expect(
+      (
+        baseElement.querySelector(
+          '.test-image-preview-class.ant-image-preview-operations-wrapper',
+        ) as HTMLElement
+      ).style.zIndex,
+    ).toBe('1301');
+
+    fireEvent.click(baseElement.querySelectorAll('.ant-image')[1]!);
+
+    expect(
+      (
+        baseElement.querySelector(
+          '.test-image-preview-group-class .ant-image-preview-wrap',
+        ) as HTMLElement
+      ).style.zIndex,
+    ).toBe('1301');
+    expect(
+      (
+        baseElement.querySelector(
+          '.test-image-preview-group-class.ant-image-preview-operations-wrapper',
+        ) as HTMLElement
+      ).style.zIndex,
+    ).toBe('1301');
   });
 });

--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -165,7 +165,7 @@ describe('Image', () => {
           '.test-image-preview-class.ant-image-preview-operations-wrapper',
         ) as HTMLElement
       ).style.zIndex,
-    ).toBe('1301');
+    ).toBe('1302');
 
     fireEvent.click(baseElement.querySelectorAll('.ant-image')[1]!);
 
@@ -182,6 +182,6 @@ describe('Image', () => {
           '.test-image-preview-group-class.ant-image-preview-operations-wrapper',
         ) as HTMLElement
       ).style.zIndex,
-    ).toBe('1301');
+    ).toBe('1302');
   });
 });

--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Modal } from 'antd';
+import { Modal } from 'antd';
 
 import Image from '..';
 import mountTest from '../../../tests/shared/mountTest';

--- a/components/image/demo/nested.md
+++ b/components/image/demo/nested.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+嵌套在弹框当中使用
+
+## en-US
+
+Nested in the modal

--- a/components/image/demo/nested.tsx
+++ b/components/image/demo/nested.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { Button, Divider, Image, Modal } from 'antd';
+
+const App: React.FC = () => {
+  const [show1, setShow1] = useState(false);
+  const [show2, setShow2] = useState(false);
+  const [show3, setShow3] = useState(false);
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setShow1(true);
+        }}
+      >
+        showModal
+      </Button>
+      <Modal
+        open={show1}
+        afterOpenChange={(open) => {
+          setShow1(open);
+        }}
+        onCancel={() => {
+          setShow1(false);
+        }}
+      >
+        <Button
+          onClick={() => {
+            setShow2(true);
+          }}
+        >
+          test2
+        </Button>
+        <Modal
+          open={show2}
+          afterOpenChange={(open) => {
+            setShow2(open);
+          }}
+          onCancel={() => {
+            setShow2(false);
+          }}
+        >
+          <Button
+            onClick={() => {
+              setShow3(true);
+            }}
+          >
+            test3
+          </Button>
+          <Modal
+            open={show3}
+            afterOpenChange={(open) => {
+              setShow3(open);
+            }}
+            onCancel={() => {
+              setShow3(false);
+            }}
+          >
+            <Image
+              width={200}
+              src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+            />
+            <Divider />
+            <Image.PreviewGroup
+              preview={{
+                onChange: (current, prev) =>
+                  console.log(`current index: ${current}, prev index: ${prev}`),
+              }}
+            >
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+              />
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+              />
+            </Image.PreviewGroup>
+          </Modal>
+        </Modal>
+      </Modal>
+    </>
+  );
+};
+
+export default App;

--- a/components/image/demo/nested.tsx
+++ b/components/image/demo/nested.tsx
@@ -1,85 +1,31 @@
-import React, { useState } from 'react';
-import { Button, Divider, Image, Modal } from 'antd';
+import React from 'react';
+import { Divider, Image, Modal } from 'antd';
 
-const App: React.FC = () => {
-  const [show1, setShow1] = useState(false);
-  const [show2, setShow2] = useState(false);
-  const [show3, setShow3] = useState(false);
-  return (
-    <>
-      <Button
-        onClick={() => {
-          setShow1(true);
-        }}
-      >
-        showModal
-      </Button>
-      <Modal
-        open={show1}
-        afterOpenChange={(open) => {
-          setShow1(open);
-        }}
-        onCancel={() => {
-          setShow1(false);
-        }}
-      >
-        <Button
-          onClick={() => {
-            setShow2(true);
+const App: React.FC = () => (
+  <Modal open>
+    <Modal open>
+      <Modal open>
+        <Image
+          width={200}
+          src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+          preview={{
+            visible: true,
+          }}
+        />
+        <Divider />
+        <Image.PreviewGroup
+          preview={{
+            visible: true,
           }}
         >
-          test2
-        </Button>
-        <Modal
-          open={show2}
-          afterOpenChange={(open) => {
-            setShow2(open);
-          }}
-          onCancel={() => {
-            setShow2(false);
-          }}
-        >
-          <Button
-            onClick={() => {
-              setShow3(true);
-            }}
-          >
-            test3
-          </Button>
-          <Modal
-            open={show3}
-            afterOpenChange={(open) => {
-              setShow3(open);
-            }}
-            onCancel={() => {
-              setShow3(false);
-            }}
-          >
-            <Image
-              width={200}
-              src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-            />
-            <Divider />
-            <Image.PreviewGroup
-              preview={{
-                onChange: (current, prev) =>
-                  console.log(`current index: ${current}, prev index: ${prev}`),
-              }}
-            >
-              <Image
-                width={200}
-                src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-              />
-              <Image
-                width={200}
-                src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
-              />
-            </Image.PreviewGroup>
-          </Modal>
-        </Modal>
+          <Image
+            width={200}
+            src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+          />
+        </Image.PreviewGroup>
       </Modal>
-    </>
-  );
-};
+    </Modal>
+  </Modal>
+);
 
 export default App;

--- a/components/image/demo/nested.tsx
+++ b/components/image/demo/nested.tsx
@@ -1,31 +1,85 @@
-import React from 'react';
-import { Divider, Image, Modal } from 'antd';
+import React, { useState } from 'react';
+import { Button, Divider, Image, Modal } from 'antd';
 
-const App: React.FC = () => (
-  <Modal open>
-    <Modal open>
-      <Modal open>
-        <Image
-          width={200}
-          src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
-          preview={{
-            visible: true,
-          }}
-        />
-        <Divider />
-        <Image.PreviewGroup
-          preview={{
-            visible: true,
+const App: React.FC = () => {
+  const [show1, setShow1] = useState(false);
+  const [show2, setShow2] = useState(false);
+  const [show3, setShow3] = useState(false);
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setShow1(true);
+        }}
+      >
+        showModal
+      </Button>
+      <Modal
+        open={show1}
+        afterOpenChange={(open) => {
+          setShow1(open);
+        }}
+        onCancel={() => {
+          setShow1(false);
+        }}
+      >
+        <Button
+          onClick={() => {
+            setShow2(true);
           }}
         >
-          <Image
-            width={200}
-            src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
-          />
-        </Image.PreviewGroup>
+          test2
+        </Button>
+        <Modal
+          open={show2}
+          afterOpenChange={(open) => {
+            setShow2(open);
+          }}
+          onCancel={() => {
+            setShow2(false);
+          }}
+        >
+          <Button
+            onClick={() => {
+              setShow3(true);
+            }}
+          >
+            test3
+          </Button>
+          <Modal
+            open={show3}
+            afterOpenChange={(open) => {
+              setShow3(open);
+            }}
+            onCancel={() => {
+              setShow3(false);
+            }}
+          >
+            <Image
+              width={200}
+              src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+            />
+            <Divider />
+            <Image.PreviewGroup
+              preview={{
+                onChange: (current, prev) =>
+                  console.log(`current index: ${current}, prev index: ${prev}`),
+              }}
+            >
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
+              />
+              <Image
+                width={200}
+                src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
+              />
+            </Image.PreviewGroup>
+          </Modal>
+        </Modal>
       </Modal>
-    </Modal>
-  </Modal>
-);
+    </>
+  );
+};
 
 export default App;

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -27,6 +27,7 @@ Previewable image.
 <code src="./demo/toolbarRender.tsx">Custom toolbar render</code>
 <code src="./demo/imageRender.tsx">Custom preview render</code>
 <code src="./demo/preview-mask.tsx" debug>Custom preview mask</code>
+<code src="./demo/nested.tsx" debug>nested</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>Top progress customization when previewing multiple images</code>
 <code src="./demo/component-token.tsx" debug>Custom component token</code>
 

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -27,7 +27,7 @@ Previewable image.
 <code src="./demo/toolbarRender.tsx">Custom toolbar render</code>
 <code src="./demo/imageRender.tsx">Custom preview render</code>
 <code src="./demo/preview-mask.tsx" debug>Custom preview mask</code>
-<code src="./demo/nested.tsx" debug>nested</code>
+<code src="./demo/nested.tsx" debug iframe="800">nested</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>Top progress customization when previewing multiple images</code>
 <code src="./demo/component-token.tsx" debug>Custom component token</code>
 

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -27,7 +27,7 @@ Previewable image.
 <code src="./demo/toolbarRender.tsx">Custom toolbar render</code>
 <code src="./demo/imageRender.tsx">Custom preview render</code>
 <code src="./demo/preview-mask.tsx" debug>Custom preview mask</code>
-<code src="./demo/nested.tsx" debug iframe="800">nested</code>
+<code src="./demo/nested.tsx">nested</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>Top progress customization when previewing multiple images</code>
 <code src="./demo/component-token.tsx" debug>Custom component token</code>
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -28,6 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 <code src="./demo/toolbarRender.tsx">自定义工具栏</code>
 <code src="./demo/imageRender.tsx">自定义预览内容</code>
 <code src="./demo/preview-mask.tsx" debug>自定义预览文本</code>
+<code src="./demo/nested.tsx" debug>嵌套</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>多图预览时顶部进度自定义</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 Token</code>
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -28,7 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 <code src="./demo/toolbarRender.tsx">自定义工具栏</code>
 <code src="./demo/imageRender.tsx">自定义预览内容</code>
 <code src="./demo/preview-mask.tsx" debug>自定义预览文本</code>
-<code src="./demo/nested.tsx" debug>嵌套</code>
+<code src="./demo/nested.tsx" debug iframe="800">嵌套</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>多图预览时顶部进度自定义</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 Token</code>
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -28,7 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 <code src="./demo/toolbarRender.tsx">自定义工具栏</code>
 <code src="./demo/imageRender.tsx">自定义预览内容</code>
 <code src="./demo/preview-mask.tsx" debug>自定义预览文本</code>
-<code src="./demo/nested.tsx" debug iframe="800">嵌套</code>
+<code src="./demo/nested.tsx">嵌套</code>
 <code src="./demo/preview-group-top-progress.tsx" debug>多图预览时顶部进度自定义</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 Token</code>
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "rc-drawer": "~6.5.2",
     "rc-dropdown": "~4.1.0",
     "rc-field-form": "~1.40.0",
-    "rc-image": "~7.5.0",
+    "rc-image": "~7.5.1",
     "rc-input": "~1.3.6",
     "rc-input-number": "~8.4.0",
     "rc-mentions": "~2.9.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #46034 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: Fix image group preview z-index in nested modal |
| 🇨🇳 Chinese | 解决图片组 z-index 在嵌套弹框中设置异常问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0b7ff02</samp>

This pull request adds a new feature to the `Image.PreviewGroup` component that allows users to customize the z-index of the modal that shows the image preview group. It also adds a new demo example of using the `Image.PreviewGroup` component nested in a modal, and updates the documentation and tests accordingly.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0b7ff02</samp>

*  Add `Image.PreviewGroup` component to support previewing multiple images in a group with a modal ([link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R18), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R44-R48), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R61), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L183-R199), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L210-R225), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L279-R294))
*  Use `useZIndex` hook to get the z-index value for the `Image.PreviewGroup` component and pass it to the `Modal` component ([link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R18), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R44-R48), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-229cf95fe3dde541084c824a9a86e2ed7f5c88be0d6ad5fdaae9f538cb7c6138R61))
*  Test the `useZIndex` hook with the `Image.PreviewGroup` component in the `useZIndex.test.tsx` file ([link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L183-R199), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L210-R225), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-7e29bdf7b3d15903dfc9bea72d699ed4bef2146dc1a0689897752772a15c3de5L279-R294))
*  Add a new demo example of using the `Image.PreviewGroup` component nested in a modal in the `image/demo` folder and the documentation files ([link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-d124313e2c4dac92be547d13fb9b890fc064084289036e3d6e42d3c537ee4799R1-R7), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-ed8fb3d5b42c707d1b397ccc037d829b140863b1b3be52352f46049b8cabb7b4R1-R85), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-6a52026f5728b46e5b93ce0149ddfd4b94f79896c72f98ad4cbfa9ed2843a8b2R30), [link](https://github.com/ant-design/ant-design/pull/46035/files?diff=unified&w=0#diff-f5b985fbb4265b0e83d262d5f201a0b268c58dcadfde017e1126a4c1e6c15281R31))
