### PR TITLE
feat(Tree): disable Tree when Form is disabled

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -6,6 +6,7 @@ import type { CSSMotionProps } from 'rc-motion';
 import type { BasicDataNode, TreeProps as RcTreeProps } from 'rc-tree';
 import RcTree from 'rc-tree';
 import type { DataNode, Key } from 'rc-tree/lib/interface';
+import DisabledContext from '../config-provider/DisabledContext';
 
 import initCollapseMotion from '../_util/motion';
 import { ConfigContext } from '../config-provider';
@@ -172,10 +173,15 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     draggable,
     motion: customMotion,
     style,
+    disabled: customDisabled,
   } = props;
 
   const prefixCls = getPrefixCls('tree', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
+
+  // ===================== Disabled =====================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? disabled;
 
   const motion: CSSMotionProps = customMotion ?? {
     ...initCollapseMotion(rootPrefixCls),
@@ -191,6 +197,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     blockNode,
     showLine: Boolean(showLine),
     dropIndicatorRender,
+    disabled: mergedDisabled,
   };
 
   const [wrapSSR, hashId] = useStyle(prefixCls);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->
https://github.com/ant-design/ant-design/issues/46037

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 在 Form 中使用 Tree，Form 设置 disabled 时，Tree 应被禁用

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    当 Form 组件被禁用时禁用表单内的 Tree 组件      |
| 🇨🇳 中文 |    Disabling the Tree within a form when the Form is disabled      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

<!--
以下为 copilot 自动生成的 CR 结果，请勿修改
-->

### 🚀 概述

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 881b056</samp>

Added a `disabled` prop to the `Tree` component to enable or disable the tree or its nodes. Used the existing `DisabledContext` component to handle different levels of disabling.

### 🔍 实现细节

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 881b056</samp>

*  Add `disabled` prop to `Tree` component to allow disabling the whole tree or some nodes ([link](https://github.com/ant-design/ant-design/pull/46040/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R176))
*  Import `DisabledContext` component from `../config-provider/DisabledContext` to access the global disabled state ([link](https://github.com/ant-design/ant-design/pull/46040/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R9))
*  Use `useContext` hook to get the `disabled` value from `DisabledContext` and compute the `mergedDisabled` value based on the `customDisabled` prop ([link](https://github.com/ant-design/ant-design/pull/46040/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R182-R185))
*  Pass the `mergedDisabled` value to the `disabled` prop of the `rc-tree` component to render the tree nodes accordingly ([link](https://github.com/ant-design/ant-design/pull/46040/files?diff=unified&w=0#diff-cfa7dd13daab065170858e4020c67f79d11b4f6f1aab2c5d6ef13a40f60c72d6R200))