### PR TITLE
feat(pagination): Add showSearch prop into showSizeChanger

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import DoubleLeftOutlined from '@ant-design/icons/DoubleLeftOutlined';
 import DoubleRightOutlined from '@ant-design/icons/DoubleRightOutlined';
 import LeftOutlined from '@ant-design/icons/LeftOutlined';
@@ -6,17 +7,19 @@ import classNames from 'classnames';
 import type { PaginationLocale, PaginationProps as RcPaginationProps } from 'rc-pagination';
 import RcPagination from 'rc-pagination';
 import enUS from 'rc-pagination/lib/locale/en_US';
-import * as React from 'react';
+
 import { ConfigContext } from '../config-provider';
 import useSize from '../config-provider/hooks/useSize';
 import useBreakpoint from '../grid/hooks/useBreakpoint';
 import { useLocale } from '../locale';
-import { MiddleSelect, MiniSelect } from './Select';
+import { CustomSelect, SelectContext } from './Select';
+import type { SelectContextProps } from './Select';
 import useStyle from './style';
 
 export interface PaginationProps extends RcPaginationProps {
   showQuickJumper?: boolean | { goButton?: React.ReactNode };
   size?: 'default' | 'small';
+  showSearch?: boolean;
   responsive?: boolean;
   role?: string;
   totalBoundaryShowSizeChanger?: number;
@@ -46,6 +49,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     selectComponentClass,
     responsive,
     showSizeChanger,
+    showSearch = true,
     ...restProps
   } = props;
   const { xs } = useBreakpoint(responsive);
@@ -120,18 +124,28 @@ const Pagination: React.FC<PaginationProps> = (props) => {
 
   const mergedStyle: React.CSSProperties = { ...pagination?.style, ...style };
 
+  const memoizedContextValue = React.useMemo<SelectContextProps>(
+    () => ({
+      size: isSmall ? 'small' : 'middle',
+      showSearch,
+    }),
+    [showSearch, isSmall],
+  );
+
   return wrapSSR(
-    <RcPagination
-      {...iconsProps}
-      {...restProps}
-      style={mergedStyle}
-      prefixCls={prefixCls}
-      selectPrefixCls={selectPrefixCls}
-      className={extendedClassName}
-      selectComponentClass={selectComponentClass || (isSmall ? MiniSelect : MiddleSelect)}
-      locale={locale}
-      showSizeChanger={mergedShowSizeChanger}
-    />,
+    <SelectContext.Provider value={memoizedContextValue}>
+      <RcPagination
+        {...iconsProps}
+        {...restProps}
+        style={mergedStyle}
+        prefixCls={prefixCls}
+        selectPrefixCls={selectPrefixCls}
+        className={extendedClassName}
+        selectComponentClass={selectComponentClass ?? CustomSelect}
+        locale={locale}
+        showSizeChanger={mergedShowSizeChanger}
+      />
+    </SelectContext.Provider>,
   );
 };
 

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -16,10 +16,10 @@ import { CustomSelect, SelectContext } from './Select';
 import type { SelectContextProps } from './Select';
 import useStyle from './style';
 
-export interface PaginationProps extends RcPaginationProps {
+export interface PaginationProps extends Omit<RcPaginationProps, 'showSizeChanger'> {
   showQuickJumper?: boolean | { goButton?: React.ReactNode };
   size?: 'default' | 'small';
-  showSearch?: boolean;
+  showSizeChanger: boolean | { showSearch?: boolean };
   responsive?: boolean;
   role?: string;
   totalBoundaryShowSizeChanger?: number;
@@ -49,7 +49,6 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     selectComponentClass,
     responsive,
     showSizeChanger,
-    showSearch = true,
     ...restProps
   } = props;
   const { xs } = useBreakpoint(responsive);
@@ -60,7 +59,8 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   // Style
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
-  const mergedShowSizeChanger = showSizeChanger ?? pagination.showSizeChanger;
+  const mergedShowSizeChanger =
+    typeof showSizeChanger === 'boolean' ? showSizeChanger : pagination.showSizeChanger;
 
   const iconsProps = React.useMemo<Record<PropertyKey, React.ReactNode>>(() => {
     const ellipsis = <span className={`${prefixCls}-item-ellipsis`}>•••</span>;
@@ -127,9 +127,9 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const memoizedContextValue = React.useMemo<SelectContextProps>(
     () => ({
       size: isSmall ? 'small' : 'middle',
-      showSearch,
+      showSearch: typeof showSizeChanger === 'boolean' ? true : showSizeChanger?.showSearch ?? true,
     }),
-    [showSearch, isSmall],
+    [showSizeChanger, isSmall],
   );
 
   return wrapSSR(

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -19,7 +19,7 @@ import useStyle from './style';
 export interface PaginationProps extends Omit<RcPaginationProps, 'showSizeChanger'> {
   showQuickJumper?: boolean | { goButton?: React.ReactNode };
   size?: 'default' | 'small';
-  showSizeChanger: boolean | { showSearch?: boolean };
+  showSizeChanger?: boolean | { showSearch?: boolean };
   responsive?: boolean;
   role?: string;
   totalBoundaryShowSizeChanger?: number;

--- a/components/pagination/Select.tsx
+++ b/components/pagination/Select.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import type { SelectProps } from '../select';
 import Select from '../select';
 
@@ -6,10 +7,18 @@ type CompoundedComponent = React.FC<SelectProps> & {
   Option: typeof Select.Option;
 };
 
-const MiniSelect: CompoundedComponent = (props) => <Select {...props} showSearch size="small" />;
-const MiddleSelect: CompoundedComponent = (props) => <Select {...props} showSearch size="middle" />;
+export interface SelectContextProps {
+  size?: SelectProps['size'];
+  showSearch?: SelectProps['showSearch'];
+}
 
-MiniSelect.Option = Select.Option;
-MiddleSelect.Option = Select.Option;
+const SelectContext = React.createContext<SelectContextProps>({});
 
-export { MiniSelect, MiddleSelect };
+const CustomSelect: CompoundedComponent = (props) => {
+  const selectProps = React.useContext(SelectContext);
+  return <Select {...props} {...selectProps} />;
+};
+
+CustomSelect.Option = Select.Option;
+
+export { CustomSelect, SelectContext };

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -50,12 +50,11 @@ Common props ref：[Common props](/docs/react/common-props)
 | responsive | If `size` is not specified, `Pagination` would resize according to the width of the window | boolean | - |  |
 | showLessItems | Show less page items | boolean | false |  |
 | showQuickJumper | Determine whether you can jump to pages directly | boolean \| { goButton: ReactNode } | false |  |
-| showSizeChanger | Determine whether to show `pageSize` select, it will be true when `total > 50` | boolean | - |  |
+| showSizeChanger | Determine whether to show `pageSize` select, it will be true when `total > 50` | boolean \| { showSearch: boolean } | - |  |
 | showTitle | Show page item's title | boolean | true |  |
 | showTotal | To display the total number and range | function(total, range) | - |  |
 | simple | Whether to use simple mode | boolean | - |  |
 | size | Specify the size of `Pagination`, can be set to `small` | `default` \| `small` | `default` |  |
-| showSearch | Configuration of page number selector is searchable | boolean | true |  |
 | total | Total number of data items | number | 0 |  |
 | onChange | Called when the page number or `pageSize` is changed, and it takes the resulting page number and pageSize as its arguments | function(page, pageSize) | - |  |
 | onShowSizeChange | Called when `pageSize` is changed | function(current, size) | - |  |

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -55,6 +55,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | showTotal | To display the total number and range | function(total, range) | - |  |
 | simple | Whether to use simple mode | boolean | - |  |
 | size | Specify the size of `Pagination`, can be set to `small` | `default` \| `small` | `default` |  |
+| showSearch | Configuration of page number selector is searchable | boolean | true |  |
 | total | Total number of data items | number | 0 |  |
 | onChange | Called when the page number or `pageSize` is changed, and it takes the resulting page number and pageSize as its arguments | function(page, pageSize) | - |  |
 | onShowSizeChange | Called when `pageSize` is changed | function(current, size) | - |  |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -56,6 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | showTotal | 用于显示数据总量和当前数据顺序 | function(total, range) | - |  |
 | simple | 当添加该属性时，显示为简单分页 | boolean | - |  |
 | size | 当为 `small` 时，是小尺寸分页 | `default` \| `small` | `default` |  |
+| showSearch | 页码选择器配置是否可搜索 | boolean | true |  |
 | total | 数据总数 | number | 0 |  |
 | onChange | 页码或 `pageSize` 改变的回调，参数是改变后的页码及每页条数 | function(page, pageSize) | - |  |
 | onShowSizeChange | pageSize 变化的回调 | function(current, size) | - |  |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -51,7 +51,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | responsive | 当 size 未指定时，根据屏幕宽度自动调整尺寸 | boolean | - |  |
 | showLessItems | 是否显示较少页面内容 | boolean | false |  |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean \| { goButton: ReactNode } | false |  |
-| showSizeChanger | 是否展示 `pageSize` 切换器，当 `total` 大于 50 时默认为 true | boolean | - |  |
+| showSizeChanger | 是否展示 `pageSize` 切换器，当 `total` 大于 50 时默认为 true | boolean \| { showSearch: boolean } | - |  |
 | showTitle | 是否显示原生 tooltip 页码提示 | boolean | true |  |
 | showTotal | 用于显示数据总量和当前数据顺序 | function(total, range) | - |  |
 | simple | 当添加该属性时，显示为简单分页 | boolean | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #30324 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Pagination added a showSearch prop to control the Select |
| 🇨🇳 Chinese |  Pagination 新增 showSearch prop 控制分頁的輸入框  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 879bad3</samp>

Added search feature to `Pagination` component and removed unused `Select` component. Simplified code by using existing React and Select components.

### 🔍 Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 879bad3</samp>

*  Add `showSearch` prop to `PaginationProps` interface to enable search functionality in pagination select component ([link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352R56))
*  Define `CustomSelect` component that wraps imported `Select` component and passes `showSearch` and `size` props to it ([link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352R131-R139))
*  Replace `MiddleSelect` and `MiniSelect` components with `CustomSelect` component in `selectComponentClass` prop ([link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352L131-R148), [link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352L9-R26), [link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-a34e1dd1a02f6ee6067986a1242ba2b093bb074eafa1739c050af8d2dd1edc52))
*  Import React as a namespace and Select component and props type from parent directory ([link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352R1), [link](https://github.com/ant-design/ant-design/pull/46070/files?diff=unified&w=0#diff-6ded05884b813a9ee306b10152a2e379ac9c8c724ade740984c1aed485d14352L9-R26))
