### PR TITLE
fix: Form label tooltip icon trigger Switch

### DIFF
--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -102,7 +102,16 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
     const { icon = <QuestionCircleOutlined />, ...restTooltipProps } = tooltipProps;
     const tooltipNode: React.ReactNode = (
       <Tooltip {...restTooltipProps}>
-        {React.cloneElement(icon, { className: `${prefixCls}-item-tooltip`, title: '' })}
+        {React.cloneElement(icon, {
+          className: `${prefixCls}-item-tooltip`,
+          title: '',
+          onClick: (e: React.MouseEvent) => {
+            // Prevent label behavior in tooltip icon
+            // https://github.com/ant-design/ant-design/issues/46154
+            e.preventDefault();
+          },
+          tabIndex: null,
+        })}
       </Tooltip>
     );
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1284,6 +1284,7 @@ describe('Form', () => {
       );
 
       fireEvent.mouseEnter(container.querySelector('.anticon-question-circle')!);
+      fireEvent.click(container.querySelector('.anticon-question-circle')!);
       await waitFakeTimer();
 
       expect(container.querySelector('.ant-tooltip-inner')).toHaveTextContent('Bamboo');


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/46154

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix that clicking Form `tooltip` icon should not trigger Switch.          |
| 🇨🇳 Chinese |  修复点击 Form `tooltip` 图标会触发 Switch 切换的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
