### PR TITLE
fix: Form label tooltip icon trigger Switch

### DIFF
--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -103,7 +103,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
                   // https://github.com/ant-design/ant-design/issues/46154
                   e.preventDefault();
                 },
-                tabindex: null,
+                tabIndex: null,
               })}
             </Tooltip>
           );

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -93,9 +93,18 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
         const tooltipProps = toTooltipProps(tooltip);
         if (tooltipProps) {
           const { icon = <QuestionCircleOutlined />, ...restTooltipProps } = tooltipProps;
-          const tooltipNode = (
+          const tooltipNode: React.ReactNode = (
             <Tooltip {...restTooltipProps}>
-              {React.cloneElement(icon, { className: `${prefixCls}-item-tooltip`, title: '' })}
+              {React.cloneElement(icon, {
+                className: `${prefixCls}-item-tooltip`,
+                title: '',
+                onClick: (e: React.MouseEvent) => {
+                  // Prevent label behavior in tooltip icon
+                  // https://github.com/ant-design/ant-design/issues/46154
+                  e.preventDefault();
+                },
+                tabindex: undefined,
+              })}
             </Tooltip>
           );
 

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -103,7 +103,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
                   // https://github.com/ant-design/ant-design/issues/46154
                   e.preventDefault();
                 },
-                tabindex: undefined,
+                tabindex: null,
               })}
             </Tooltip>
           );

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -225,7 +225,7 @@ describe('Form', () => {
       </Form>,
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      "Warning: [antd: Form.Item] A `Form.Item` with a render function cannot be a field, and thus cannot have a `name` prop.",
+      'Warning: [antd: Form.Item] A `Form.Item` with a render function cannot be a field, and thus cannot have a `name` prop.',
     );
   });
 
@@ -1252,6 +1252,21 @@ describe('Form', () => {
 
       expect(container.querySelector('.ant-tooltip-inner')).toHaveTextContent('Bamboo');
     });
+
+    // https://github.com/ant-design/ant-design/issues/46154
+    it('should not trigger form change when click icon', async () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <Form>
+          <Form.Item label="light" name="foo" tooltip={{ title: 'Bar' }}>
+            <Switch onChange={onChange} />
+          </Form.Item>
+        </Form>,
+      );
+      fireEvent.click(container.querySelector('.anticon-question-circle')!);
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   it('warningOnly validate', async () => {
@@ -1494,7 +1509,7 @@ describe('Form', () => {
   it('item customize margin', async () => {
     const computeSpy = jest
       .spyOn(window, 'getComputedStyle')
-      .mockImplementation(() => ({ marginBottom: 24 } as unknown as CSSStyleDeclaration));
+      .mockImplementation(() => ({ marginBottom: 24 }) as unknown as CSSStyleDeclaration);
 
     const { container } = render(
       <Form>

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -225,7 +225,7 @@ describe('Form', () => {
       </Form>,
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Form.Item] A `Form.Item` with a render function cannot be a field, and thus cannot have a `name` prop.',
+      "Warning: [antd: Form.Item] A `Form.Item` with a render function cannot be a field, and thus cannot have a `name` prop.",
     );
   });
 
@@ -1509,7 +1509,7 @@ describe('Form', () => {
   it('item customize margin', async () => {
     const computeSpy = jest
       .spyOn(window, 'getComputedStyle')
-      .mockImplementation(() => ({ marginBottom: 24 }) as unknown as CSSStyleDeclaration);
+      .mockImplementation(() => ({ marginBottom: 24 } as unknown as CSSStyleDeclaration));
 
     const { container } = render(
       <Form>


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/46154

(cherry picked from commit 64fb0ddabed3324fd8ef4a8afb386d38b0e13932)

# Conflicts:
#	components/form/FormItemLabel.tsx

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref: #46155 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

不要忘记 4.x 用户，这个 bug 修复方案 pick 一份

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix that clicking Form `tooltip` icon should not trigger Switch.          |
| 🇨🇳 Chinese |  修复点击 Form `tooltip` 图标会触发 Switch 切换的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
