### PR TITLE
feat: deprecate onAfterChange for onChangeComplete

### DIFF
--- a/components/slider/__tests__/type.test.tsx
+++ b/components/slider/__tests__/type.test.tsx
@@ -6,7 +6,7 @@ describe('Slider.typescript', () => {
     const value = 0;
     const onChange = (v: number) => v;
     const result = (
-      <Slider defaultValue={value} value={value} onChange={onChange} onAfterChange={onChange} />
+      <Slider defaultValue={value} value={value} onChange={onChange} onChangeComplete={onChange} />
     );
     expect(result).toBeTruthy();
   });
@@ -20,7 +20,7 @@ describe('Slider.typescript', () => {
         defaultValue={value}
         value={value}
         onChange={onChange}
-        onAfterChange={onChange}
+        onChangeComplete={onChange}
       />
     );
     expect(result).toBeTruthy();
@@ -34,7 +34,7 @@ describe('Slider.typescript', () => {
         defaultValue={value}
         value={value}
         onChange={onChange}
-        onAfterChange={onChange}
+        onChangeComplete={onChange}
         step={null}
       />
     );

--- a/components/slider/demo/event.md
+++ b/components/slider/demo/event.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-当 Slider 的值发生改变时，会触发 `onChange` 事件，并把改变后的值作为参数传入。在 `onmouseup` 时，会触发 `onAfterChange` 事件，并把当前值作为参数传入。
+当 Slider 的值发生改变时，会触发 `onChange` 事件，并把改变后的值作为参数传入。在 `mouseup` 或者 `keyup` 时，会触发 `onChangeComplete` 事件，并把当前值作为参数传入。
 
 ## en-US
 
-The `onChange` callback function will fire when the user changes the slider's value. The `onAfterChange` callback function will fire when `onmouseup` fired.
+The `onChange` callback function will fire when the user changes the slider's value. The `onChangeComplete` callback function will fire when `mouseup` or `keyup` fired.

--- a/components/slider/demo/event.tsx
+++ b/components/slider/demo/event.tsx
@@ -5,19 +5,19 @@ const onChange = (value: number | number[]) => {
   console.log('onChange: ', value);
 };
 
-const onAfterChange = (value: number | number[]) => {
-  console.log('onAfterChange: ', value);
+const onChangeComplete = (value: number | number[]) => {
+  console.log('onChangeComplete: ', value);
 };
 
 const App: React.FC = () => (
   <>
-    <Slider defaultValue={30} onChange={onChange} onAfterChange={onAfterChange} />
+    <Slider defaultValue={30} onChange={onChange} onChangeComplete={onChangeComplete} />
     <Slider
       range
       step={10}
       defaultValue={[20, 50]}
       onChange={onChange}
-      onAfterChange={onAfterChange}
+      onChangeComplete={onChangeComplete}
     />
   </>
 );

--- a/components/slider/index.en-US.md
+++ b/components/slider/index.en-US.md
@@ -52,7 +52,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | tooltip | The tooltip relate props | [tooltip](#tooltip) | - | 4.23.0 |
 | value | The value of slider. When `range` is false, use number, otherwise, use \[number, number] | number \| \[number, number] | - |  |
 | vertical | If true, the slider will be vertical | boolean | false |  |
-| onAfterChange | Fire when onmouseup is fired | (value) => void | - |  |
+| onChangeComplete | Fire when `mouseup` or `keyup` is fired | (value) => void | - |  |
 | onChange | Callback function that is fired when the user changes the slider's value | (value) => void | - |  |
 
 ### `styles` 和 `classNames` 属性

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -81,7 +81,9 @@ export interface SliderSingleProps extends SliderBaseProps {
   value?: number;
   defaultValue?: number;
   onChange?: (value: number) => void;
+  /** @deprecated Please use `onChangeComplete` instead */
   onAfterChange?: (value: number) => void;
+  onChangeComplete?: (value: number) => void;
   /** @deprecated Please use `styles.handle` instead */
   handleStyle?: React.CSSProperties;
   /** @deprecated Please use `styles.track` instead */
@@ -95,7 +97,9 @@ export interface SliderRangeProps extends SliderBaseProps {
   value?: number[];
   defaultValue?: number[];
   onChange?: (value: number[]) => void;
+  /** @deprecated Please use `onChangeComplete` instead */
   onAfterChange?: (value: number[]) => void;
+  onChangeComplete?: (value: number[]) => void;
   /** @deprecated Please use `styles.handle` instead */
   handleStyle?: React.CSSProperties[];
   /** @deprecated Please use `styles.track` instead */

--- a/components/slider/index.zh-CN.md
+++ b/components/slider/index.zh-CN.md
@@ -54,7 +54,7 @@ demo:
 | tooltip | 设置 Tooltip 相关属性 | [tooltip](#tooltip) | - | 4.23.0 |
 | value | 设置当前取值。当 `range` 为 false 时，使用 number，否则用 \[number, number] | number \| \[number, number] | - |  |
 | vertical | 值为 true 时，Slider 为垂直方向 | boolean | false |  |
-| onAfterChange | 与 `onmouseup` 触发时机一致，把当前值作为参数传入 | (value) => void | - |  |
+| onChangeComplete | 与 `mouseup` 和 `keyup` 触发时机一致，把当前值作为参数传入 | (value) => void | - |  |
 | onChange | 当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入 | (value) => void | - |  |
 
 ### `styles` 和 `classNames` 属性

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "rc-resize-observer": "^1.4.0",
     "rc-segmented": "~2.2.2",
     "rc-select": "~14.10.0",
-    "rc-slider": "~10.4.0",
+    "rc-slider": "~10.5.0",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.36.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Slider support `onChangeComplete` and deprecate `onAfterChange`.       |
| 🇨🇳 Chinese |    Slider 组件支持 `onChangeComplete` 事件，并废弃 `onAfterChange`.       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
