### PR TITLE
fix: Notification title overlaps with the close icon when it is too long

### DIFF
--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -97,7 +97,7 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       color: colorText,
     },
 
-    [`&${noticeCls}-closable ${noticeCls}-message`]: {
+    [`${noticeCls}-closable ${noticeCls}-message`]: {
       paddingInlineEnd: token.paddingLG,
     },
 


### PR DESCRIPTION
Fix the issue where the notification title overlaps with the close icon when it is too long.
close #46179. 

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #46179

### 💡 Background and solution

 When the notification title is too long, it will overlap with the close icon.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where the `notification` title overlaps with the `close` icon when it is too long     |
| 🇨🇳 Chinese |      修复 `notification` 标题太长时会与 `close` 图标重叠的问题    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
