### PR TITLE
fix: nested trigger arrow position

### DIFF
--- a/components/style/placementArrow.ts
+++ b/components/style/placementArrow.ts
@@ -77,15 +77,15 @@ export default function getArrowStyle<
       // >>>>> Top
       ...isInject(!!arrowPlacement.top, {
         [[
-          `&-placement-top ${componentCls}-arrow`,
-          `&-placement-topLeft ${componentCls}-arrow`,
-          `&-placement-topRight ${componentCls}-arrow`,
+          `&-placement-top > ${componentCls}-arrow`,
+          `&-placement-topLeft > ${componentCls}-arrow`,
+          `&-placement-topRight > ${componentCls}-arrow`,
         ].join(',')]: {
           bottom: arrowDistance,
           transform: 'translateY(100%) rotate(180deg)',
         },
 
-        [`&-placement-top ${componentCls}-arrow`]: {
+        [`&-placement-top > ${componentCls}-arrow`]: {
           left: {
             _skip_check_: true,
             value: '50%',
@@ -93,14 +93,14 @@ export default function getArrowStyle<
           transform: 'translateX(-50%) translateY(100%) rotate(180deg)',
         },
 
-        [`&-placement-topLeft ${componentCls}-arrow`]: {
+        [`&-placement-topLeft > ${componentCls}-arrow`]: {
           left: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
           },
         },
 
-        [`&-placement-topRight ${componentCls}-arrow`]: {
+        [`&-placement-topRight > ${componentCls}-arrow`]: {
           right: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -111,15 +111,15 @@ export default function getArrowStyle<
       // >>>>> Bottom
       ...isInject(!!arrowPlacement.bottom, {
         [[
-          `&-placement-bottom ${componentCls}-arrow`,
-          `&-placement-bottomLeft ${componentCls}-arrow`,
-          `&-placement-bottomRight ${componentCls}-arrow`,
+          `&-placement-bottom > ${componentCls}-arrow`,
+          `&-placement-bottomLeft > ${componentCls}-arrow`,
+          `&-placement-bottomRight > ${componentCls}-arrow`,
         ].join(',')]: {
           top: arrowDistance,
           transform: `translateY(-100%)`,
         },
 
-        [`&-placement-bottom ${componentCls}-arrow`]: {
+        [`&-placement-bottom > ${componentCls}-arrow`]: {
           left: {
             _skip_check_: true,
             value: '50%',
@@ -127,14 +127,14 @@ export default function getArrowStyle<
           transform: `translateX(-50%) translateY(-100%)`,
         },
 
-        [`&-placement-bottomLeft ${componentCls}-arrow`]: {
+        [`&-placement-bottomLeft > ${componentCls}-arrow`]: {
           left: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
           },
         },
 
-        [`&-placement-bottomRight ${componentCls}-arrow`]: {
+        [`&-placement-bottomRight > ${componentCls}-arrow`]: {
           right: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -145,9 +145,9 @@ export default function getArrowStyle<
       // >>>>> Left
       ...isInject(!!arrowPlacement.left, {
         [[
-          `&-placement-left ${componentCls}-arrow`,
-          `&-placement-leftTop ${componentCls}-arrow`,
-          `&-placement-leftBottom ${componentCls}-arrow`,
+          `&-placement-left > ${componentCls}-arrow`,
+          `&-placement-leftTop > ${componentCls}-arrow`,
+          `&-placement-leftBottom > ${componentCls}-arrow`,
         ].join(',')]: {
           right: {
             _skip_check_: true,
@@ -156,7 +156,7 @@ export default function getArrowStyle<
           transform: 'translateX(100%) rotate(90deg)',
         },
 
-        [`&-placement-left ${componentCls}-arrow`]: {
+        [`&-placement-left > ${componentCls}-arrow`]: {
           top: {
             _skip_check_: true,
             value: '50%',
@@ -164,11 +164,11 @@ export default function getArrowStyle<
           transform: 'translateY(-50%) translateX(100%) rotate(90deg)',
         },
 
-        [`&-placement-leftTop ${componentCls}-arrow`]: {
+        [`&-placement-leftTop > ${componentCls}-arrow`]: {
           top: arrowOffsetVertical,
         },
 
-        [`&-placement-leftBottom ${componentCls}-arrow`]: {
+        [`&-placement-leftBottom > ${componentCls}-arrow`]: {
           bottom: arrowOffsetVertical,
         },
       }),
@@ -176,9 +176,9 @@ export default function getArrowStyle<
       // >>>>> Right
       ...isInject(!!arrowPlacement.right, {
         [[
-          `&-placement-right ${componentCls}-arrow`,
-          `&-placement-rightTop ${componentCls}-arrow`,
-          `&-placement-rightBottom ${componentCls}-arrow`,
+          `&-placement-right > ${componentCls}-arrow`,
+          `&-placement-rightTop > ${componentCls}-arrow`,
+          `&-placement-rightBottom > ${componentCls}-arrow`,
         ].join(',')]: {
           left: {
             _skip_check_: true,
@@ -187,7 +187,7 @@ export default function getArrowStyle<
           transform: 'translateX(-100%) rotate(-90deg)',
         },
 
-        [`&-placement-right ${componentCls}-arrow`]: {
+        [`&-placement-right > ${componentCls}-arrow`]: {
           top: {
             _skip_check_: true,
             value: '50%',
@@ -195,11 +195,11 @@ export default function getArrowStyle<
           transform: 'translateY(-50%) translateX(-100%) rotate(-90deg)',
         },
 
-        [`&-placement-rightTop ${componentCls}-arrow`]: {
+        [`&-placement-rightTop > ${componentCls}-arrow`]: {
           top: arrowOffsetVertical,
         },
 
-        [`&-placement-rightBottom ${componentCls}-arrow`]: {
+        [`&-placement-rightBottom > ${componentCls}-arrow`]: {
           bottom: arrowOffsetVertical,
         },
       }),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

公司里有一个代码，因为历史遗留原因，必须要使用嵌套popover，且内部的popover的挂载节点不是body上，而是外部的popover下面的一个div，我尝试着抽离出了一个demo：
```ts
import React from "react";
import { Popover, Button } from "antd";

const App: React.FC = () => {
  const domRef = React.useRef<any>();
  return (
    <Popover
      content={
        <>
          <div ref={domRef}></div>
          <Popover
            getPopupContainer={() => domRef.current}
            title="prompt text"
            placement="top"
            trigger="click"
            content={<span>Tooltip will show on mouse enter.</span>}
          >
            <span>Tooltip</span>
          </Popover>
        </>
      }
      title="Title"
      trigger="click"
      placement="bottomLeft"
    >
      <Button>Click me</Button>
    </Popover>
  );
};

export default App;
```
其中，外部的placement时bottomLeft的，内部的是top的。
此时就会发生内部的arrow指向有问题：
<img width="415" alt="image" src="https://github.com/ant-design/ant-design/assets/51100990/fb583d33-470c-4fa6-be34-cf3ffd48be99">
我认为这是不合理的，top的arrow却出现了bottom的arrow样式，每一个trigger只应该影响他当前的trigger arrow样式就够了。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fixed arrow pointing issue when nesting triggers.        |
| 🇨🇳 Chinese |  修复嵌套trigger时的arrow指向问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
