### PR TITLE
feat: Tabs support indicatorAlign prop

### DIFF
--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1998,18 +1998,18 @@ Array [
     style="margin-bottom: 12px;"
   >
     <label
-      class="ant-radio-button-wrapper"
+      class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio-button"
+        class="ant-radio ant-wave-target"
       >
         <input
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="start"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>
@@ -2017,19 +2017,19 @@ Array [
       </span>
     </label>
     <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+      class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio-button ant-radio-button-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="center"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>
@@ -2037,18 +2037,18 @@ Array [
       </span>
     </label>
     <label
-      class="ant-radio-button-wrapper"
+      class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio-button"
+        class="ant-radio ant-wave-target"
       >
         <input
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="end"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1992,142 +1992,207 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context corr
 exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/tabs/demo/custom-indicator.tsx extend context correctly 1`] = `
-<div
-  class="ant-tabs ant-tabs-top"
->
+Array [
   <div
-    class="ant-tabs-nav"
-    role="tablist"
+    class="ant-radio-group ant-radio-group-outline"
+    style="margin-bottom: 12px;"
   >
-    <div
-      class="ant-tabs-nav-wrap"
+    <label
+      class="ant-radio-button-wrapper"
     >
-      <div
-        class="ant-tabs-nav-list"
-        style="transform: translate(0px, 0px);"
+      <span
+        class="ant-radio-button"
       >
-        <div
-          class="ant-tabs-tab ant-tabs-tab-active"
-          data-node-key="1"
-        >
-          <div
-            aria-controls="rc-tabs-test-panel-1"
-            aria-selected="true"
-            class="ant-tabs-tab-btn"
-            id="rc-tabs-test-tab-1"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 1
-          </div>
-        </div>
-        <div
-          class="ant-tabs-tab"
-          data-node-key="2"
-        >
-          <div
-            aria-controls="rc-tabs-test-panel-2"
-            aria-selected="false"
-            class="ant-tabs-tab-btn"
-            id="rc-tabs-test-tab-2"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 2
-          </div>
-        </div>
-        <div
-          class="ant-tabs-tab"
-          data-node-key="3"
-        >
-          <div
-            aria-controls="rc-tabs-test-panel-3"
-            aria-selected="false"
-            class="ant-tabs-tab-btn"
-            id="rc-tabs-test-tab-3"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 3
-          </div>
-        </div>
-        <div
-          class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+          value="start"
         />
-      </div>
-    </div>
-    <div
-      class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-    >
-      <button
-        aria-controls="rc-tabs-test-more-popup"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-hidden="true"
-        class="ant-tabs-nav-more"
-        id="rc-tabs-test-more"
-        style="visibility: hidden; order: 1;"
-        tabindex="-1"
-        type="button"
-      >
         <span
-          aria-label="ellipsis"
-          class="anticon anticon-ellipsis"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="ellipsis"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-            />
-          </svg>
-        </span>
-      </button>
-      <div
-        class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span>
+        start
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
       >
-        <ul
-          aria-label="expanded dropdown"
-          class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-          data-menu-list="true"
-          id="rc-tabs-test-more-popup"
-          role="listbox"
-          tabindex="-1"
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+          value="center"
         />
-        <div
-          aria-hidden="true"
-          style="display: none;"
+        <span
+          class="ant-radio-button-inner"
         />
-      </div>
-    </div>
-  </div>
+      </span>
+      <span>
+        center
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper"
+    >
+      <span
+        class="ant-radio-button"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+          value="end"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span>
+        end
+      </span>
+    </label>
+  </div>,
   <div
-    class="ant-tabs-content-holder"
+    class="ant-tabs ant-tabs-top"
   >
     <div
-      class="ant-tabs-content ant-tabs-content-top"
+      class="ant-tabs-nav"
+      role="tablist"
     >
       <div
-        aria-hidden="false"
-        aria-labelledby="rc-tabs-test-tab-1"
-        class="ant-tabs-tabpane ant-tabs-tabpane-active"
-        id="rc-tabs-test-panel-1"
-        role="tabpanel"
-        tabindex="0"
+        class="ant-tabs-nav-wrap"
       >
-        Content of Tab Pane 1
+        <div
+          class="ant-tabs-nav-list"
+          style="transform: translate(0px, 0px);"
+        >
+          <div
+            class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-1"
+              aria-selected="true"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-1"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 1
+            </div>
+          </div>
+          <div
+            class="ant-tabs-tab"
+            data-node-key="2"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-2"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-2"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 2
+            </div>
+          </div>
+          <div
+            class="ant-tabs-tab"
+            data-node-key="3"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-3"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-3"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 3
+            </div>
+          </div>
+          <div
+            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+      >
+        <button
+          aria-controls="rc-tabs-test-more-popup"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-hidden="true"
+          class="ant-tabs-nav-more"
+          id="rc-tabs-test-more"
+          style="visibility: hidden; order: 1;"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </button>
+        <div
+          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            aria-label="expanded dropdown"
+            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+            data-menu-list="true"
+            id="rc-tabs-test-more-popup"
+            role="listbox"
+            tabindex="-1"
+          />
+          <div
+            aria-hidden="true"
+            style="display: none;"
+          />
+        </div>
       </div>
     </div>
-  </div>
-</div>
+    <div
+      class="ant-tabs-content-holder"
+    >
+      <div
+        class="ant-tabs-content ant-tabs-content-top"
+      >
+        <div
+          aria-hidden="false"
+          aria-labelledby="rc-tabs-test-tab-1"
+          class="ant-tabs-tabpane ant-tabs-tabpane-active"
+          id="rc-tabs-test-panel-1"
+          role="tabpanel"
+          tabindex="0"
+        >
+          Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/tabs/demo/custom-indicator.tsx extend context correctly 2`] = `[]`;

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1994,67 +1994,56 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context corr
 exports[`renders components/tabs/demo/custom-indicator.tsx extend context correctly 1`] = `
 Array [
   <div
-    class="ant-radio-group ant-radio-group-outline"
-    style="margin-bottom: 12px;"
+    class="ant-segmented"
+    style="margin-bottom: 8px;"
   >
-    <label
-      class="ant-radio-wrapper"
+    <div
+      class="ant-segmented-group"
     >
-      <span
-        class="ant-radio ant-wave-target"
+      <label
+        class="ant-segmented-item"
       >
         <input
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="start"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        start
-      </span>
-    </label>
-    <label
-      class="ant-radio-wrapper ant-radio-wrapper-checked"
-    >
-      <span
-        class="ant-radio ant-wave-target ant-radio-checked"
+        <div
+          class="ant-segmented-item-label"
+          title="start"
+        >
+          start
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item ant-segmented-item-selected"
       >
         <input
           checked=""
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="center"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        center
-      </span>
-    </label>
-    <label
-      class="ant-radio-wrapper"
-    >
-      <span
-        class="ant-radio ant-wave-target"
+        <div
+          class="ant-segmented-item-label"
+          title="center"
+        >
+          center
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item"
       >
         <input
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="end"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        end
-      </span>
-    </label>
+        <div
+          class="ant-segmented-item-label"
+          title="end"
+        >
+          end
+        </div>
+      </label>
+    </div>
   </div>,
   <div
     class="ant-tabs ant-tabs-top"

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -1663,67 +1663,56 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
 exports[`renders components/tabs/demo/custom-indicator.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-radio-group ant-radio-group-outline"
-    style="margin-bottom:12px"
+    class="ant-segmented"
+    style="margin-bottom:8px"
   >
-    <label
-      class="ant-radio-wrapper"
+    <div
+      class="ant-segmented-group"
     >
-      <span
-        class="ant-radio ant-wave-target"
+      <label
+        class="ant-segmented-item"
       >
         <input
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="start"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        start
-      </span>
-    </label>
-    <label
-      class="ant-radio-wrapper ant-radio-wrapper-checked"
-    >
-      <span
-        class="ant-radio ant-wave-target ant-radio-checked"
+        <div
+          class="ant-segmented-item-label"
+          title="start"
+        >
+          start
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item ant-segmented-item-selected"
       >
         <input
           checked=""
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="center"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        center
-      </span>
-    </label>
-    <label
-      class="ant-radio-wrapper"
-    >
-      <span
-        class="ant-radio ant-wave-target"
+        <div
+          class="ant-segmented-item-label"
+          title="center"
+        >
+          center
+        </div>
+      </label>
+      <label
+        class="ant-segmented-item"
       >
         <input
-          class="ant-radio-input"
+          class="ant-segmented-item-input"
           type="radio"
-          value="end"
         />
-        <span
-          class="ant-radio-inner"
-        />
-      </span>
-      <span>
-        end
-      </span>
-    </label>
+        <div
+          class="ant-segmented-item-label"
+          title="end"
+        >
+          end
+        </div>
+      </label>
+    </div>
   </div>,
   <div
     class="ant-tabs ant-tabs-top"

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -1667,18 +1667,18 @@ Array [
     style="margin-bottom:12px"
   >
     <label
-      class="ant-radio-button-wrapper"
+      class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio-button"
+        class="ant-radio ant-wave-target"
       >
         <input
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="start"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>
@@ -1686,19 +1686,19 @@ Array [
       </span>
     </label>
     <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+      class="ant-radio-wrapper ant-radio-wrapper-checked"
     >
       <span
-        class="ant-radio-button ant-radio-button-checked"
+        class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
           checked=""
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="center"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>
@@ -1706,18 +1706,18 @@ Array [
       </span>
     </label>
     <label
-      class="ant-radio-button-wrapper"
+      class="ant-radio-wrapper"
     >
       <span
-        class="ant-radio-button"
+        class="ant-radio ant-wave-target"
       >
         <input
-          class="ant-radio-button-input"
+          class="ant-radio-input"
           type="radio"
           value="end"
         />
         <span
-          class="ant-radio-button-inner"
+          class="ant-radio-inner"
         />
       </span>
       <span>

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -1661,117 +1661,182 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
 `;
 
 exports[`renders components/tabs/demo/custom-indicator.tsx correctly 1`] = `
-<div
-  class="ant-tabs ant-tabs-top"
->
+Array [
   <div
-    class="ant-tabs-nav"
-    role="tablist"
+    class="ant-radio-group ant-radio-group-outline"
+    style="margin-bottom:12px"
   >
-    <div
-      class="ant-tabs-nav-wrap"
+    <label
+      class="ant-radio-button-wrapper"
     >
-      <div
-        class="ant-tabs-nav-list"
-        style="transform:translate(0px, 0px)"
+      <span
+        class="ant-radio-button"
       >
-        <div
-          class="ant-tabs-tab ant-tabs-tab-active"
-          data-node-key="1"
-        >
-          <div
-            aria-selected="true"
-            class="ant-tabs-tab-btn"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 1
-          </div>
-        </div>
-        <div
-          class="ant-tabs-tab"
-          data-node-key="2"
-        >
-          <div
-            aria-selected="false"
-            class="ant-tabs-tab-btn"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 2
-          </div>
-        </div>
-        <div
-          class="ant-tabs-tab"
-          data-node-key="3"
-        >
-          <div
-            aria-selected="false"
-            class="ant-tabs-tab-btn"
-            role="tab"
-            tabindex="0"
-          >
-            Tab 3
-          </div>
-        </div>
-        <div
-          class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+          value="start"
         />
-      </div>
-    </div>
-    <div
-      class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-    >
-      <button
-        aria-controls="null-more-popup"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-hidden="true"
-        class="ant-tabs-nav-more"
-        id="null-more"
-        style="visibility:hidden;order:1"
-        tabindex="-1"
-        type="button"
-      >
         <span
-          aria-label="ellipsis"
-          class="anticon anticon-ellipsis"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="ellipsis"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span>
+        start
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked"
+    >
+      <span
+        class="ant-radio-button ant-radio-button-checked"
+      >
+        <input
+          checked=""
+          class="ant-radio-button-input"
+          type="radio"
+          value="center"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span>
+        center
+      </span>
+    </label>
+    <label
+      class="ant-radio-button-wrapper"
+    >
+      <span
+        class="ant-radio-button"
+      >
+        <input
+          class="ant-radio-button-input"
+          type="radio"
+          value="end"
+        />
+        <span
+          class="ant-radio-button-inner"
+        />
+      </span>
+      <span>
+        end
+      </span>
+    </label>
+  </div>,
   <div
-    class="ant-tabs-content-holder"
+    class="ant-tabs ant-tabs-top"
   >
     <div
-      class="ant-tabs-content ant-tabs-content-top"
+      class="ant-tabs-nav"
+      role="tablist"
     >
       <div
-        aria-hidden="false"
-        class="ant-tabs-tabpane ant-tabs-tabpane-active"
-        role="tabpanel"
-        tabindex="0"
+        class="ant-tabs-nav-wrap"
       >
-        Content of Tab Pane 1
+        <div
+          class="ant-tabs-nav-list"
+          style="transform:translate(0px, 0px)"
+        >
+          <div
+            class="ant-tabs-tab ant-tabs-tab-active"
+            data-node-key="1"
+          >
+            <div
+              aria-selected="true"
+              class="ant-tabs-tab-btn"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 1
+            </div>
+          </div>
+          <div
+            class="ant-tabs-tab"
+            data-node-key="2"
+          >
+            <div
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 2
+            </div>
+          </div>
+          <div
+            class="ant-tabs-tab"
+            data-node-key="3"
+          >
+            <div
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 3
+            </div>
+          </div>
+          <div
+            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+      >
+        <button
+          aria-controls="null-more-popup"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-hidden="true"
+          class="ant-tabs-nav-more"
+          id="null-more"
+          style="visibility:hidden;order:1"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </button>
       </div>
     </div>
-  </div>
-</div>
+    <div
+      class="ant-tabs-content-holder"
+    >
+      <div
+        class="ant-tabs-content ant-tabs-content-top"
+      >
+        <div
+          aria-hidden="false"
+          class="ant-tabs-tabpane ant-tabs-tabpane-active"
+          role="tabpanel"
+          tabindex="0"
+        >
+          Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/tabs/demo/custom-tab-bar.tsx correctly 1`] = `

--- a/components/tabs/demo/custom-indicator.md
+++ b/components/tabs/demo/custom-indicator.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-自定义指示器宽度
+自定义指示器宽度和对齐方式。
 
 ## en-US
 
-Custom indicator size
+Custom indicator size and align.

--- a/components/tabs/demo/custom-indicator.tsx
+++ b/components/tabs/demo/custom-indicator.tsx
@@ -30,15 +30,14 @@ const App: React.FC = () => {
     <>
       <Radio.Group
         defaultValue="center"
-        onChange={(e) => setAlign(e.target.value)}
         style={{ marginBottom: 12 }}
-      >
-        {['start', 'center', 'end'].map((item) => (
-          <Radio.Button key={item} value={item}>
-            {item}
-          </Radio.Button>
-        ))}
-      </Radio.Group>
+        onChange={(e) => setAlign(e.target.value)}
+        options={[
+          { label: 'start', value: 'start' },
+          { label: 'center', value: 'center' },
+          { label: 'end', value: 'end' },
+        ]}
+      />
       <Tabs
         defaultActiveKey="1"
         items={items}

--- a/components/tabs/demo/custom-indicator.tsx
+++ b/components/tabs/demo/custom-indicator.tsx
@@ -32,11 +32,7 @@ const App: React.FC = () => {
         defaultValue="center"
         style={{ marginBottom: 12 }}
         onChange={(e) => setAlign(e.target.value)}
-        options={[
-          { label: 'start', value: 'start' },
-          { label: 'center', value: 'center' },
-          { label: 'end', value: 'end' },
-        ]}
+        options={['start', 'center', 'end']}
       />
       <Tabs
         defaultActiveKey="1"

--- a/components/tabs/demo/custom-indicator.tsx
+++ b/components/tabs/demo/custom-indicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tabs } from 'antd';
+import { Radio, Tabs } from 'antd';
 import type { TabsProps } from 'antd';
 
 const onChange = (key: string) => {
@@ -24,13 +24,30 @@ const items: TabsProps['items'] = [
   },
 ];
 
-const App: React.FC = () => (
-  <Tabs
-    defaultActiveKey="1"
-    items={items}
-    onChange={onChange}
-    indicatorSize={(origin) => origin - 16}
-  />
-);
+const App: React.FC = () => {
+  const [align, setAlign] = React.useState<TabsProps['indicatorAlign']>('center');
+  return (
+    <>
+      <Radio.Group
+        defaultValue="center"
+        onChange={(e) => setAlign(e.target.value)}
+        style={{ marginBottom: 12 }}
+      >
+        {['start', 'center', 'end'].map((item) => (
+          <Radio.Button key={item} value={item}>
+            {item}
+          </Radio.Button>
+        ))}
+      </Radio.Group>
+      <Tabs
+        defaultActiveKey="1"
+        items={items}
+        onChange={onChange}
+        indicatorSize={(origin) => origin - 20}
+        indicatorAlign={align}
+      />
+    </>
+  );
+};
 
 export default App;

--- a/components/tabs/demo/custom-indicator.tsx
+++ b/components/tabs/demo/custom-indicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Radio, Tabs } from 'antd';
+import { Segmented, Tabs } from 'antd';
 import type { TabsProps } from 'antd';
 
 const onChange = (key: string) => {
@@ -28,10 +28,10 @@ const App: React.FC = () => {
   const [align, setAlign] = React.useState<TabsProps['indicatorAlign']>('center');
   return (
     <>
-      <Radio.Group
+      <Segmented
         defaultValue="center"
-        style={{ marginBottom: 12 }}
-        onChange={(e) => setAlign(e.target.value)}
+        style={{ marginBottom: 8 }}
+        onChange={(value) => setAlign(value as TabsProps['indicatorAlign'])}
         options={['start', 'center', 'end']}
       />
       <Tabs

--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -53,6 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | centered | Centers tabs | boolean | false | 4.4.0 |
 | defaultActiveKey | Initial active TabPane's key, if `activeKey` is not set | string | - |  |
 | hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | false |  |
+| indicatorAlign | Customize align of indicator | `start` \| `center` \| `end` | `center` | 5.13.0 |
 | indicatorSize | Customize length of indicator, which is the same as tab by default | number \| (origin: number) => number | - | 5.9.0 |
 | items | Configure tab content | [TabItemType](#tabitemtype) | [] | 4.23.0 |
 | moreIcon | The custom icon of ellipsis | ReactNode | &lt;EllipsisOutlined /> | 4.14.0 |

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -55,6 +55,7 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | centered | 标签居中展示 | boolean | false | 4.4.0 |
 | defaultActiveKey | 初始化选中面板的 key，如果没有设置 activeKey | string | `第一个面板` |  |
 | hideAdd | 是否隐藏加号图标，在 `type="editable-card"` 时有效 | boolean | false |  |
+| indicatorAlign | 自定义指示条对齐方式 | `start` \| `center` \| `end` | `center` | 5.13.0 |
 | indicatorSize | 自定义指示条长度，默认与 tab 等宽 | number \| (origin: number) => number | - | 5.9.0 |
 | items | 配置选项卡内容 | [TabItemType](#tabitemtype) | [] | 4.23.0 |
 | moreIcon | 自定义折叠 icon | ReactNode | &lt;EllipsisOutlined /> | 4.14.0 |

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.36.0",
-    "rc-tabs": "~12.14.1",
+    "rc-tabs": "~12.15.0",
     "rc-textarea": "~1.5.3",
     "rc-tooltip": "~6.1.2",
     "rc-tree": "~5.8.2",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- close #46191

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

https://github.com/ant-design/ant-design/assets/49217418/c4e4f10b-ec10-42bf-ab02-7feca4389eb3

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tabs support `indicatorAlign` prop to align indicator with tabs. |
| 🇨🇳 Chinese | Tabs 组件新增 `indicatorAlign` 属性，用于自定义指示条对齐方式。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed