### PR TITLE
fix PopoverProps type error and update unit test

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -89,4 +89,24 @@ describe('Popover', () => {
     );
     expect(Array.from(wrapper.container.children)).toMatchSnapshot();
   });
+
+  it('forceRender works', () => {
+    const content = (
+      <div className='forceRender'>
+        rendered
+      </div>
+    );
+    const { baseElement, rerender } = render(
+      <Popover content={content} title="Title" >
+       should not be rendered
+      </Popover>
+    );
+    expect(baseElement.querySelectorAll('div.forceRender').length).toBe(0);
+    rerender(
+      <Popover content={content} title="Title" forceRender>
+       should be rendered
+      </Popover>
+    );
+    expect(baseElement.querySelectorAll('div.forceRender').length).toBe(1);
+  });
 });

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -91,21 +91,17 @@ describe('Popover', () => {
   });
 
   it('forceRender works', () => {
-    const content = (
-      <div className='forceRender'>
-        rendered
-      </div>
-    );
+    const content = <div className="forceRender">rendered</div>;
     const { baseElement, rerender } = render(
-      <Popover content={content} title="Title" >
-       should not be rendered
-      </Popover>
+      <Popover content={content} title="Title">
+        should not be rendered
+      </Popover>,
     );
     expect(baseElement.querySelectorAll('div.forceRender').length).toBe(0);
     rerender(
       <Popover content={content} title="Title" forceRender>
-       should be rendered
-      </Popover>
+        should be rendered
+      </Popover>,
     );
     expect(baseElement.querySelectorAll('div.forceRender').length).toBe(1);
   });

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -14,6 +14,8 @@ import useStyle from './style';
 export interface PopoverProps extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;
   content?: React.ReactNode | RenderFunction;
+  /** Force render Popover content*/
+  forceRender?: boolean;
 }
 
 interface OverlayProps {

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -14,7 +14,7 @@ import useStyle from './style';
 export interface PopoverProps extends AbstractTooltipProps {
   title?: React.ReactNode | RenderFunction;
   content?: React.ReactNode | RenderFunction;
-  /** Force render Popover content*/
+  /** Force render Popover content */
   forceRender?: boolean;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close [46364](https://github.com/ant-design/ant-design/issues/46364)
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix the issue of unsupported "forceRender" in the ts type of PopoverProps and add corresponding unit tests.  |
| 🇨🇳 Chinese |   修复PopoverProps的ts类型中不支持forceRender的问题，并添加对应单元测试    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
