### PR TITLE
ci: compare css-var and css-in-js to the same css-in-js png in master

### DIFF
--- a/scripts/visual-regression/build.ts
+++ b/scripts/visual-regression/build.ts
@@ -197,11 +197,12 @@ ${commonHeader}
 }
 
 async function boot() {
-  console.log(chalk.green('Preparing image snapshots from latest `master` branch\n'));
-  const baseImgSourceDir = path.resolve(__dirname, '../../imageSnapshots-master');
+  const targetBranch = 'master';
+
+  console.log(chalk.green('Preparing image snapshots from latest `%s` branch\n', targetBranch));
+  const baseImgSourceDir = path.resolve(__dirname, `../../imageSnapshots-${targetBranch}`);
   await fse.ensureDir(baseImgSourceDir);
 
-  const targetBranch = 'master';
   const targetRef = await getBranchLatestRef(targetBranch);
   assert(targetRef, `Missing ref from ${targetBranch}`);
 
@@ -227,7 +228,11 @@ async function boot() {
 
   const deletedImgs = _.difference(baseImgFileList, currentImgFileList);
   if (deletedImgs.length) {
-    console.log(chalk.red('⛔️ Missing images compare to master:\n'), prettyList(deletedImgs));
+    console.log(
+      chalk.red('⛔️ Missing images compare to %s:\n%s'),
+      targetBranch,
+      prettyList(deletedImgs),
+    );
     console.log('\n');
   }
   // ignore new images

--- a/scripts/visual-regression/build.ts
+++ b/scripts/visual-regression/build.ts
@@ -239,7 +239,11 @@ async function boot() {
 
   const badCases: IBadCase[] = [];
 
-  for (const file of baseImgFileList) {
+  // compare cssinjs and css-var png from pr
+  // to the same cssinjs png in `master` branch
+  const cssinjsImgs = baseImgFileList.filter((i) => !i.endsWith('.css-var.png'));
+
+  for (const file of cssinjsImgs) {
     const baseImgPath = path.join(baseImgSourceDir, file);
     const currentImgPath = path.join(currentImgSourceDir, file);
     const diffImgPath = path.join(diffImgReportDir, file);

--- a/scripts/visual-regression/report-template.html
+++ b/scripts/visual-regression/report-template.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Ant Design Visual Diff Report</title>
     <link href="https://unpkg.com/antd@latest/dist/reset.css" rel="stylesheet" />
     <style>
       body {

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -107,7 +107,6 @@ export default function imageTest(
         `[CSS Var] component image screenshot should correct ${key}`,
         `-${key}.css-var`,
         <div style={{ background: key === 'dark' ? '#000' : '', padding: `24px 12px` }} key={key}>
-          <div>CSS Var</div>
           <ConfigProvider theme={{ algorithm, cssVar: true }}>{component}</ConfigProvider>
         </div>,
       );
@@ -128,7 +127,6 @@ export default function imageTest(
       `[CSS Var] component image screenshot should correct`,
       '.css-var',
       <>
-        <div>CSS Var</div>
         {Object.entries(themes).map(([key, algorithm]) => (
           <div style={{ background: key === 'dark' ? '#000' : '', padding: `24px 12px` }} key={key}>
             <ConfigProvider theme={{ algorithm, cssVar: true }}>{component}</ConfigProvider>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

对比 pr 中 css-var 和 cssinjs 的 demo 截屏时，都使用同一份 master 上的 cssinjs 的 demo 截屏做对比

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   -----        |
| 🇨🇳 Chinese |  -----         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
