### PR TITLE
refactor: separate cssVarCls from hashId

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -243,9 +243,9 @@ const Affix = React.forwardRef<AffixRef, AffixProps>((props, ref) => {
     updatePosition();
   }, [target, offsetTop, offsetBottom]);
 
-  const [wrapCSSVar, hashId] = useStyle(affixPrefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(affixPrefixCls);
 
-  const rootCls = classNames(rootClassName, hashId, affixPrefixCls);
+  const rootCls = classNames(rootClassName, hashId, affixPrefixCls, cssVarCls);
 
   const mergedCls = classNames({ [rootCls]: affixStyle });
 

--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -127,7 +127,7 @@ const Alert: React.FC<AlertProps> = (props) => {
   const { getPrefixCls, direction, alert } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('alert', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
     setClosed(true);
@@ -169,6 +169,7 @@ const Alert: React.FC<AlertProps> = (props) => {
     alert?.className,
     className,
     rootClassName,
+    cssVarCls,
     hashId,
   );
 

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -153,7 +153,7 @@ const Anchor: React.FC<AnchorProps> = (props) => {
   const prefixCls = getPrefixCls('anchor', customPrefixCls);
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const getCurrentContainer = getContainer ?? getTargetContainer ?? getDefaultContainer;
 
@@ -273,7 +273,7 @@ const Anchor: React.FC<AnchorProps> = (props) => {
 
   const wrapperClass = classNames(
     hashId,
-    rootCls,
+    cssVarCls,
     rootClassName,
     `${prefixCls}-wrapper`,
     {

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -274,6 +274,7 @@ const Anchor: React.FC<AnchorProps> = (props) => {
   const wrapperClass = classNames(
     hashId,
     cssVarCls,
+    rootCls,
     rootClassName,
     `${prefixCls}-wrapper`,
     {

--- a/components/app/index.tsx
+++ b/components/app/index.tsx
@@ -36,8 +36,8 @@ const App: React.FC<AppProps> & { useApp: () => useAppProps } = (props) => {
   } = props;
   const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('app', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
-  const customClassName = classNames(hashId, prefixCls, className, rootClassName);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
+  const customClassName = classNames(hashId, prefixCls, className, rootClassName, cssVarCls);
 
   const appConfig = useContext<AppConfig>(AppConfigContext);
 

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -145,8 +145,8 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
   }
 
   const prefixCls = getPrefixCls('avatar', customizePrefixCls);
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const sizeCls = classNames({
     [`${prefixCls}-lg`]: size === 'large',

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -167,6 +167,7 @@ const InternalAvatar: React.ForwardRefRenderFunction<HTMLSpanElement, AvatarProp
       [`${prefixCls}-icon`]: !!icon,
     },
     cssVarCls,
+    rootCls,
     className,
     rootClassName,
     hashId,

--- a/components/avatar/group.tsx
+++ b/components/avatar/group.tsx
@@ -70,6 +70,7 @@ const Group: React.FC<GroupProps> = (props) => {
       [`${groupPrefixCls}-rtl`]: direction === 'rtl',
     },
     cssVarCls,
+    rootCls,
     className,
     rootClassName,
     hashId,

--- a/components/avatar/group.tsx
+++ b/components/avatar/group.tsx
@@ -61,8 +61,8 @@ const Group: React.FC<GroupProps> = (props) => {
 
   const prefixCls = getPrefixCls('avatar', customizePrefixCls);
   const groupPrefixCls = `${prefixCls}-group`;
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const cls = classNames(
     groupPrefixCls,

--- a/components/back-top/index.tsx
+++ b/components/back-top/index.tsx
@@ -77,10 +77,11 @@ const BackTop: React.FC<BackTopProps> = (props) => {
 
   const rootPrefixCls = getPrefixCls();
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const classString = classNames(
     hashId,
+    cssVarCls,
     prefixCls,
     {
       [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -34,7 +34,8 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('ribbon', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const wrapperCls = `${prefixCls}-wrapper`;
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, wrapperCls);
 
   const colorInPreset = isPresetColor(color, false);
   const ribbonCls = classNames(
@@ -54,7 +55,7 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
     cornerColorStyle.color = color;
   }
   return wrapCSSVar(
-    <div className={classNames(`${prefixCls}-wrapper`, rootClassName, hashId)}>
+    <div className={classNames(wrapperCls, rootClassName, hashId, cssVarCls)}>
       {children}
       <div className={classNames(ribbonCls, hashId)} style={{ ...colorStyle, ...style }}>
         <span className={`${prefixCls}-text`}>{text}</span>

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -76,7 +76,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
   const { getPrefixCls, direction, badge } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('badge', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   // ================================ Misc ================================
   const numberedDisplayCount = (
@@ -183,6 +183,7 @@ const InternalBadge: React.ForwardRefRenderFunction<HTMLSpanElement, BadgeProps>
     badge?.classNames?.root,
     classNames?.root,
     hashId,
+    cssVarCls,
   );
 
   // <Badge status="success" />

--- a/components/badge/style/ribbon.ts
+++ b/components/badge/style/ribbon.ts
@@ -1,9 +1,9 @@
 import { unit } from '@ant-design/cssinjs';
 
-import { prepareComponentToken, prepareToken, type BadgeToken } from '.';
+import { type BadgeToken, prepareComponentToken, prepareToken } from '.';
 import { resetComponent } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
-import { genComponentStyleHook, genPresetColor } from '../../theme/internal';
+import { genPresetColor, genStyleHooks } from '../../theme/internal';
 
 // ============================== Ribbon ==============================
 const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
@@ -75,7 +75,7 @@ const genRibbonStyle: GenerateStyle<BadgeToken> = (token) => {
 };
 
 // ============================== Export ==============================
-export default genComponentStyleHook(
+export default genStyleHooks(
   ['Badge', 'Ribbon'],
   (token) => {
     const badgeToken = prepareToken(token);

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -95,7 +95,7 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
   let crumbs: React.ReactNode;
 
   const prefixCls = getPrefixCls('breadcrumb', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const mergedItems = useItems(items, legacyRoutes);
 
@@ -213,6 +213,7 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...breadcrumb?.style, ...style };

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -118,7 +118,7 @@ const InternalButton: React.ForwardRefRenderFunction<
   const { getPrefixCls, autoInsertSpaceInButton, direction, button } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('btn', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const disabled = useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
@@ -215,6 +215,7 @@ const InternalButton: React.ForwardRefRenderFunction<
   const classes = classNames(
     prefixCls,
     hashId,
+    cssVarCls,
     {
       [`${prefixCls}-${shape}`]: shape !== 'default' && shape,
       [`${prefixCls}-${type}`]: type,

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -119,7 +119,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
     const calendarPrefixCls = `${prefixCls}-calendar`;
 
-    const [wrapCSSVar, hashId] = useStyle(prefixCls, calendarPrefixCls);
+    const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, calendarPrefixCls);
 
     const today = generateConfig.getNow();
 
@@ -294,6 +294,7 @@ function generateCalendar<DateType>(generateConfig: GenerateConfig<DateType>) {
           className,
           rootClassName,
           hashId,
+          cssVarCls,
         )}
         style={{ ...calendar?.style, ...style }}
       >

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -109,7 +109,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   }, [children]);
 
   const prefixCls = getPrefixCls('card', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const loadingBlock = (
     <Skeleton loading active paragraph={{ rows: 4 }} title={false}>
@@ -177,6 +177,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...card?.style, ...style };

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -94,7 +94,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     typeof dots === 'boolean' ? false : dots?.className,
   );
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const className = classNames(
     prefixCls,
@@ -103,6 +103,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
       [`${prefixCls}-vertical`]: newProps.vertical,
     },
     hashId,
+    cssVarCls,
     rootClassName,
   );
 

--- a/components/cascader/Panel.tsx
+++ b/components/cascader/Panel.tsx
@@ -33,7 +33,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
   );
 
   const rootCls = useCSSVarCls(cascaderPrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(cascaderPrefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(cascaderPrefixCls, rootCls);
   usePanelStyle(cascaderPrefixCls);
 
   const isRtl = mergedDirection === 'rtl';
@@ -56,7 +56,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
       {...props}
       checkable={checkable}
       prefixCls={cascaderPrefixCls}
-      className={classNames(className, hashId, rootClassName, rootCls)}
+      className={classNames(className, hashId, rootClassName, cssVarCls)}
       notFoundContent={mergedNotFoundContent}
       direction={mergedDirection}
       expandIcon={mergedExpandIcon}

--- a/components/cascader/Panel.tsx
+++ b/components/cascader/Panel.tsx
@@ -56,7 +56,7 @@ export default function CascaderPanel(props: CascaderPanelProps) {
       {...props}
       checkable={checkable}
       prefixCls={cascaderPrefixCls}
-      className={classNames(className, hashId, rootClassName, cssVarCls)}
+      className={classNames(className, hashId, rootClassName, cssVarCls, rootCls)}
       notFoundContent={mergedNotFoundContent}
       direction={mergedDirection}
       expandIcon={mergedExpandIcon}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -213,7 +213,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
   const rootPrefixCls = getPrefixCls();
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapSelectCSSVar, hashId] = useSelectStyle(prefixCls, rootCls);
+  const [wrapSelectCSSVar, hashId, cssVarCls] = useSelectStyle(prefixCls, rootCls);
   const cascaderRootCls = useCSSVarCls(cascaderPrefixCls);
   const [wrapCascaderCSSVar] = useStyle(cascaderPrefixCls, cascaderRootCls);
 
@@ -232,9 +232,9 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       [`${cascaderPrefixCls}-dropdown-rtl`]: mergedDirection === 'rtl',
     },
     rootClassName,
-    rootCls,
     cascaderRootCls,
     hashId,
+    cssVarCls,
   );
 
   // ==================== Search =====================
@@ -315,9 +315,9 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
         cascader?.className,
         className,
         rootClassName,
-        rootCls,
         cascaderRootCls,
         hashId,
+        cssVarCls,
       )}
       disabled={mergedDisabled}
       style={{ ...cascader?.style, ...style }}

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -316,6 +316,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
         cascader?.className,
         className,
         rootClassName,
+        rootCls,
         cascaderRootCls,
         hashId,
         cssVarCls,

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -232,6 +232,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       [`${cascaderPrefixCls}-dropdown-rtl`]: mergedDirection === 'rtl',
     },
     rootClassName,
+    rootCls,
     cascaderRootCls,
     hashId,
     cssVarCls,

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -107,7 +107,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
 
   const prefixCls = getPrefixCls('checkbox', customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const checkboxProps: CheckboxProps = { ...restProps };
   if (checkboxGroup && !skipGroup) {
@@ -133,7 +133,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     checkbox?.className,
     className,
     rootClassName,
-    rootCls,
+    cssVarCls,
     hashId,
   );
   const checkboxClass = classNames(

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -134,6 +134,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     className,
     rootClassName,
     cssVarCls,
+    rootCls,
     hashId,
   );
   const checkboxClass = classNames(

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -112,7 +112,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
   const groupPrefixCls = `${prefixCls}-group`;
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const domProps = omit(restProps, ['value', 'disabled']);
 
@@ -153,7 +153,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
     },
     className,
     rootClassName,
-    rootCls,
+    cssVarCls,
     hashId,
   );
   return wrapCSSVar(

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -154,6 +154,7 @@ const InternalGroup: React.ForwardRefRenderFunction<HTMLDivElement, CheckboxGrou
     className,
     rootClassName,
     cssVarCls,
+    rootCls,
     hashId,
   );
   return wrapCSSVar(

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -76,7 +76,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
   const mergedSize = useSize((ctx) => customizeSize ?? ctx ?? 'middle');
   const prefixCls = getPrefixCls('collapse', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Collapse');
@@ -126,6 +126,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
   const openMotion: CSSMotionProps = {
     ...initCollapseMotion(rootPrefixCls),

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -137,9 +137,9 @@ const ColorPicker: CompoundedComponent = (props) => {
   // ===================== Style =====================
   const mergedSize = useSize(customizeSize);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
-  const mergeRootCls = classNames(rootClassName, rootCls, rtlCls);
+  const mergeRootCls = classNames(rootClassName, cssVarCls, rtlCls);
   const mergeCls = classNames(
     getStatusClassNames(prefixCls, contextStatus),
     {

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -139,7 +139,7 @@ const ColorPicker: CompoundedComponent = (props) => {
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
-  const mergeRootCls = classNames(rootClassName, cssVarCls, rtlCls);
+  const mergeRootCls = classNames(rootClassName, cssVarCls, rootCls, rtlCls);
   const mergeCls = classNames(
     getStatusClassNames(prefixCls, contextStatus),
     {

--- a/components/config-provider/hooks/useCSSVarCls.ts
+++ b/components/config-provider/hooks/useCSSVarCls.ts
@@ -1,5 +1,10 @@
 import { useToken } from '../../theme/internal';
 
+/**
+ * This hook is only for cssVar to add root className for components.
+ * If root ClassName is needed, this hook could be refactored with `-root`
+ * @param prefixCls
+ */
 const useCSSVarCls = (prefixCls: string) => {
   const [, , , , cssVar] = useToken();
 

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -147,6 +147,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
           className,
           rangePicker?.className,
           cssVarCls,
+          rootCls,
           rootClassName,
         )}
         style={{ ...rangePicker?.style, ...style }}
@@ -160,6 +161,7 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
           hashId,
           popupClassName || dropdownClassName,
           cssVarCls,
+          rootCls,
           rootClassName,
         )}
         popupStyle={{

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -72,8 +72,8 @@ export default function generateRangePicker<DateType>(generateConfig: GenerateCo
     const { format, showTime, picker } = props as any;
     const rootPrefixCls = getPrefixCls();
 
-    const cssVarCls = useCSSVarCls(prefixCls);
-    const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+    const rootCls = useCSSVarCls(prefixCls);
+    const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
     const additionalOverrideProps: any = {
       ...(showTime ? getTimeProps({ format, picker, ...showTime }) : {}),

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -174,6 +174,7 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
               consumerStyle?.className,
               className,
               cssVarCls,
+              rootCls,
               rootClassName,
             )}
             style={{ ...consumerStyle?.style, ...style }}

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -80,8 +80,8 @@ export default function generatePicker<DateType>(generateConfig: GenerateConfig<
         const innerRef = React.useRef<RCPicker<DateType>>(null);
         const { format, showTime } = props as any;
 
-        const cssVarCls = useCSSVarCls(prefixCls);
-        const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+        const rootCls = useCSSVarCls(prefixCls);
+        const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
         useImperativeHandle(ref, () => ({
           focus: () => innerRef.current?.focus(),

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -93,7 +93,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
   const mergedSize = useSize(customizeSize);
   const rows = useRow(mergedColumn, mergedItems);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   // ======================== Render ========================
   const contextValue = React.useMemo(
@@ -115,6 +115,7 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
           className,
           rootClassName,
           hashId,
+          cssVarCls,
         )}
         style={{ ...descriptions?.style, ...style }}
         {...restProps}

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -36,7 +36,7 @@ const Divider: React.FC<DividerProps> = (props) => {
   } = props;
   const prefixCls = getPrefixCls('divider', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const orientationPrefix = orientation.length > 0 ? `-${orientation}` : orientation;
   const hasChildren = !!children;
@@ -46,6 +46,7 @@ const Divider: React.FC<DividerProps> = (props) => {
     prefixCls,
     divider?.className,
     hashId,
+    cssVarCls,
     `${prefixCls}-${type}`,
     {
       [`${prefixCls}-with-text`]: hasChildren,

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -72,7 +72,7 @@ const Drawer: React.FC<DrawerProps> & {
 
   const prefixCls = getPrefixCls('drawer', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const getContainer =
     // 有可能为 false，所以不能直接判断
@@ -87,6 +87,7 @@ const Drawer: React.FC<DrawerProps> & {
     },
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   // ========================== Warning ===========================

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -214,13 +214,14 @@ const PurePanel: React.FC<Omit<DrawerPanelProps, 'prefixCls'> & PurePanelInterfa
 
   const prefixCls = getPrefixCls('drawer', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const cls = classNames(
     prefixCls,
     `${prefixCls}-pure`,
     `${prefixCls}-${placement}`,
     hashId,
+    cssVarCls,
     className,
   );
 

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -211,6 +211,7 @@ const Dropdown: CompoundedComponent = (props) => {
     rootClassName,
     hashId,
     cssVarCls,
+    rootCls,
     dropdown?.className,
     { [`${prefixCls}-rtl`]: direction === 'rtl' },
   );

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -171,7 +171,7 @@ const Dropdown: CompoundedComponent = (props) => {
 
   const prefixCls = getPrefixCls('dropdown', customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const [, token] = useToken();
 
@@ -210,7 +210,7 @@ const Dropdown: CompoundedComponent = (props) => {
     overlayClassName,
     rootClassName,
     hashId,
-    rootCls,
+    cssVarCls,
     dropdown?.className,
     { [`${prefixCls}-rtl`]: direction === 'rtl' },
   );
@@ -253,7 +253,7 @@ const Dropdown: CompoundedComponent = (props) => {
     return (
       <OverrideProvider
         prefixCls={`${prefixCls}-menu`}
-        rootClassName={rootCls}
+        rootClassName={cssVarCls}
         expandIcon={
           <span className={`${prefixCls}-menu-submenu-arrow`}>
             <RightOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -45,7 +45,7 @@ const Empty: CompoundedComponent = ({
   const { getPrefixCls, direction, empty } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('empty', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const [locale] = useLocale('Empty');
 
@@ -64,6 +64,7 @@ const Empty: CompoundedComponent = ({
     <div
       className={classNames(
         hashId,
+        cssVarCls,
         prefixCls,
         empty?.className,
         {

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -31,7 +31,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('flex', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const mergedVertical = vertical ?? ctxFlex?.vertical;
 
@@ -41,6 +41,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     ctxFlex?.className,
     prefixCls,
     hashId,
+    cssVarCls,
     createFlexClassNames(prefixCls, props),
     {
       [`${prefixCls}-rtl`]: ctxDirection === 'rtl',

--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -46,6 +46,7 @@ const FloatButton = React.forwardRef<FloatButtonElement, FloatButtonProps>((prop
   const classString = classNames(
     hashId,
     cssVarCls,
+    rootCls,
     prefixCls,
     className,
     rootClassName,

--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -39,13 +39,13 @@ const FloatButton = React.forwardRef<FloatButtonElement, FloatButtonProps>((prop
   const groupShape = useContext<FloatButtonShape | undefined>(FloatButtonGroupContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const mergeShape = groupShape || shape;
 
   const classString = classNames(
     hashId,
-    rootCls,
+    cssVarCls,
     prefixCls,
     className,
     rootClassName,

--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -34,10 +34,10 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
   const { direction, getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   const groupPrefixCls = `${prefixCls}-group`;
 
-  const groupCls = classNames(groupPrefixCls, hashId, rootCls, className, {
+  const groupCls = classNames(groupPrefixCls, hashId, cssVarCls, className, {
     [`${groupPrefixCls}-rtl`]: direction === 'rtl',
     [`${groupPrefixCls}-${shape}`]: shape,
     [`${groupPrefixCls}-${shape}-shadow`]: !trigger,

--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -37,7 +37,7 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   const groupPrefixCls = `${prefixCls}-group`;
 
-  const groupCls = classNames(groupPrefixCls, hashId, cssVarCls, className, {
+  const groupCls = classNames(groupPrefixCls, hashId, cssVarCls, rootCls, className, {
     [`${groupPrefixCls}-rtl`]: direction === 'rtl',
     [`${groupPrefixCls}-${shape}`]: shape,
     [`${groupPrefixCls}-${shape}-shadow`]: !trigger,

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -55,8 +55,8 @@ const ErrorList: React.FC<ErrorListProps> = ({
 
   const baseClassName = `${prefixCls}-item-explain`;
 
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const collapseMotion: CSSMotionProps = useMemo(() => initCollapseMotion(prefixCls), [prefixCls]);
 

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -97,7 +97,14 @@ const ErrorList: React.FC<ErrorListProps> = ({
         return (
           <div
             {...helpProps}
-            className={classNames(baseClassName, holderClassName, cssVarCls, rootClassName, hashId)}
+            className={classNames(
+              baseClassName,
+              holderClassName,
+              cssVarCls,
+              rootCls,
+              rootClassName,
+              hashId,
+            )}
             style={holderStyle}
             role="alert"
           >

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -104,8 +104,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
   const prefixCls = getPrefixCls('form', customizePrefixCls);
 
   // Style
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const formClassName = classNames(
     prefixCls,

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -116,6 +116,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (p
       [`${prefixCls}-${mergedSize}`]: mergedSize,
     },
     cssVarCls,
+    rootCls,
     hashId,
     contextForm?.className,
     className,

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -127,8 +127,8 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
   const prefixCls = getPrefixCls('form', customizePrefixCls);
 
   // Style
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   // ========================= Warn =========================
   const warning = devUseWarning('Form.Item');

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -242,7 +242,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
       <ItemHolder
         key="row"
         {...props}
-        className={classNames(className, cssVarCls, hashId)}
+        className={classNames(className, cssVarCls, rootCls, hashId)}
         prefixCls={prefixCls}
         fieldId={fieldId}
         isRequired={isRequired}

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -68,7 +68,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('col', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useColStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useColStyle(prefixCls);
 
   let sizeClassObj = {};
   sizes.forEach((size) => {
@@ -107,6 +107,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
     className,
     sizeClassObj,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = {};

--- a/components/grid/row.tsx
+++ b/components/grid/row.tsx
@@ -147,7 +147,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('row', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useRowStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useRowStyle(prefixCls);
 
   const gutters = getGutter();
   const classes = classNames(
@@ -160,6 +160,7 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>((props, ref) => {
     },
     className,
     hashId,
+    cssVarCls,
   );
 
   // Add gutter related style

--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -40,7 +40,7 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
   const rootPrefixCls = getPrefixCls();
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const [zIndex] = useZIndex(
     'ImagePreview',
@@ -52,7 +52,7 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
       return preview;
     }
     const _preview = typeof preview === 'object' ? preview : {};
-    const mergedRootClassName = classNames(hashId, rootCls, _preview.rootClassName ?? '');
+    const mergedRootClassName = classNames(hashId, cssVarCls, _preview.rootClassName ?? '');
 
     return {
       ..._preview,

--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -52,7 +52,12 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
       return preview;
     }
     const _preview = typeof preview === 'object' ? preview : {};
-    const mergedRootClassName = classNames(hashId, cssVarCls, _preview.rootClassName ?? '');
+    const mergedRootClassName = classNames(
+      hashId,
+      cssVarCls,
+      rootCls,
+      _preview.rootClassName ?? '',
+    );
 
     return {
       ..._preview,

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -38,9 +38,9 @@ const Image: CompositionImage<ImageProps> = (props) => {
   const imageLocale = contextLocale.Image || defaultLocale.Image;
   // Style
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
-  const mergedRootClassName = classNames(rootClassName, hashId, rootCls);
+  const mergedRootClassName = classNames(rootClassName, hashId, cssVarCls);
 
   const mergedClassName = classNames(className, hashId, image?.className);
 

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -40,7 +40,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
-  const mergedRootClassName = classNames(rootClassName, hashId, cssVarCls);
+  const mergedRootClassName = classNames(rootClassName, hashId, cssVarCls, rootCls);
 
   const mergedClassName = classNames(className, hashId, image?.className);
 

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -55,8 +55,8 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
   const prefixCls = getPrefixCls('input-number', customizePrefixCls);
 
   // Style
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
   let upIcon = <UpOutlined className={`${prefixCls}-handler-up-inner`} />;

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -112,7 +112,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     <RcInputNumber
       ref={inputRef}
       disabled={mergedDisabled}
-      className={classNames(cssVarCls, className, rootClassName, compactItemClassnames)}
+      className={classNames(cssVarCls, rootCls, className, rootClassName, compactItemClassnames)}
       upHandler={upIcon}
       downHandler={downIcon}
       prefixCls={prefixCls}

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -95,8 +95,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const inputRef = useRef<InputRef>(null);
 
   // Style
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   // ===================== Compact Item =====================
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -183,6 +183,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         className,
         rootClassName,
         cssVarCls,
+        rootCls,
         hashId,
         compactItemClassnames,
         input?.className,

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -84,8 +84,8 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   }
 
   // ===================== Style =====================
-  const cssVarCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, cssVarCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   return wrapCSSVar(
     <RcTextArea

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -92,7 +92,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
       {...rest}
       disabled={mergedDisabled}
       allowClear={mergedAllowClear}
-      className={classNames(cssVarCls, className, rootClassName)}
+      className={classNames(cssVarCls, rootCls, className, rootClassName)}
       classes={{
         affixWrapper: classNames(
           `${prefixCls}-textarea-affix-wrapper`,

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -47,13 +47,18 @@ const Basic = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((props, re
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('layout', customizePrefixCls);
 
-  const [wrapSSR, hashId] = useStyle(prefixCls);
+  const [wrapSSR, hashId, cssVarCls] = useStyle(prefixCls);
 
   const prefixWithSuffixCls = suffixCls ? `${prefixCls}-${suffixCls}` : prefixCls;
 
   return wrapSSR(
     <TagName
-      className={classNames(customizePrefixCls || prefixWithSuffixCls, className, hashId)}
+      className={classNames(
+        customizePrefixCls || prefixWithSuffixCls,
+        className,
+        hashId,
+        cssVarCls,
+      )}
       ref={ref}
       {...others}
     />,
@@ -83,7 +88,7 @@ const BasicLayout = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((pro
 
   const mergedHasSider = useHasSider(siders, children, hasSider);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   const classString = classNames(
     prefixCls,
     {
@@ -94,6 +99,7 @@ const BasicLayout = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((pro
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const contextValue = React.useMemo(

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -141,7 +141,7 @@ function List<T>({
   const prefixCls = getPrefixCls('list', customizePrefixCls);
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   let loadingProp = loading;
   if (typeof loadingProp === 'boolean') {
@@ -183,6 +183,7 @@ function List<T>({
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const paginationProps = extendsObject<PaginationConfig>(

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -156,7 +156,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
 
   // Style
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const mergedClassName = classNames(
     {
@@ -169,7 +169,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
     !hasFeedback && className,
     rootClassName,
     hashId,
-    rootCls,
+    cssVarCls,
   );
 
   const mentions = (
@@ -184,11 +184,11 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
       filterOption={mentionsfilterOption}
       onFocus={onFocus}
       onBlur={onBlur}
-      dropdownClassName={classNames(popupClassName, rootClassName, hashId, rootCls)}
+      dropdownClassName={classNames(popupClassName, rootClassName, hashId, cssVarCls)}
       ref={mergedRef}
       options={mergedOptions}
       suffix={hasFeedback && feedbackIcon}
-      classes={{ affixWrapper: classNames(rootCls, hashId, className) }}
+      classes={{ affixWrapper: classNames(hashId, className) }}
     >
       {mentionOptions}
     </RcMentions>

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -170,6 +170,7 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
     rootClassName,
     hashId,
     cssVarCls,
+    rootCls,
   );
 
   const mentions = (
@@ -184,11 +185,11 @@ const InternalMentions: React.ForwardRefRenderFunction<MentionsRef, MentionProps
       filterOption={mentionsfilterOption}
       onFocus={onFocus}
       onBlur={onBlur}
-      dropdownClassName={classNames(popupClassName, rootClassName, hashId, cssVarCls)}
+      dropdownClassName={classNames(popupClassName, rootClassName, hashId, cssVarCls, rootCls)}
       ref={mergedRef}
       options={mergedOptions}
       suffix={hasFeedback && feedbackIcon}
-      classes={{ affixWrapper: classNames(hashId, className) }}
+      classes={{ affixWrapper: classNames(hashId, className, cssVarCls, rootCls) }}
     >
       {mentionOptions}
     </RcMentions>

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -122,7 +122,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('menu', customizePrefixCls || overrideObj.prefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls, !override);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls, !override);
   const menuClassName = classNames(`${prefixCls}-${theme}`, menu?.className, className);
 
   // ====================== Expand Icon ========================
@@ -181,7 +181,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           defaultMotions={defaultMotions}
           expandIcon={mergedExpandIcon}
           ref={ref}
-          rootClassName={classNames(rootClassName, hashId, overrideObj.rootClassName, rootCls)}
+          rootClassName={classNames(rootClassName, hashId, overrideObj.rootClassName, cssVarCls)}
         >
           {mergedChildren}
         </RcMenu>

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -181,7 +181,13 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           defaultMotions={defaultMotions}
           expandIcon={mergedExpandIcon}
           ref={ref}
-          rootClassName={classNames(rootClassName, hashId, overrideObj.rootClassName, cssVarCls)}
+          rootClassName={classNames(
+            rootClassName,
+            hashId,
+            overrideObj.rootClassName,
+            cssVarCls,
+            rootCls,
+          )}
         >
           {mergedChildren}
         </RcMenu>

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -54,7 +54,13 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
     <Notice
       {...restProps}
       prefixCls={prefixCls}
-      className={classNames(className, hashId, `${prefixCls}-notice-pure-panel`, cssVarCls)}
+      className={classNames(
+        className,
+        hashId,
+        `${prefixCls}-notice-pure-panel`,
+        cssVarCls,
+        rootCls,
+      )}
       eventKey="pure"
       duration={null}
       content={

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -48,13 +48,13 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   return wrapCSSVar(
     <Notice
       {...restProps}
       prefixCls={prefixCls}
-      className={classNames(className, hashId, `${prefixCls}-notice-pure-panel`, rootCls)}
+      className={classNames(className, hashId, `${prefixCls}-notice-pure-panel`, cssVarCls)}
       eventKey="pure"
       duration={null}
       content={

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -40,7 +40,7 @@ const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefi
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   return wrapCSSVar(
-    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls) }}>
+    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls, rootCls) }}>
       {children}
     </NotificationProvider>,
   );

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -19,6 +19,7 @@ import type {
 import { PureContent } from './PurePanel';
 import useStyle from './style';
 import { getMotion, wrapPromiseFn } from './util';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 const DEFAULT_OFFSET = 8;
 const DEFAULT_DURATION = 3;
@@ -36,9 +37,12 @@ interface HolderRef extends NotificationAPI {
 }
 
 const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   return wrapCSSVar(
-    <NotificationProvider classNames={{ list: hashId }}>{children}</NotificationProvider>,
+    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls) }}>
+      {children}
+    </NotificationProvider>,
   );
 };
 

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -95,7 +95,7 @@ const Modal: React.FC<ModalProps> = (props) => {
   const rootPrefixCls = getPrefixCls();
   // Style
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const wrapClassNameExtended = classNames(wrapClassName, {
     [`${prefixCls}-centered`]: !!centered,
@@ -131,7 +131,7 @@ const Modal: React.FC<ModalProps> = (props) => {
             zIndex={zIndex}
             getContainer={getContainer === undefined ? getContextPopupContainer : getContainer}
             prefixCls={prefixCls}
-            rootClassName={classNames(hashId, rootClassName, rootCls)}
+            rootClassName={classNames(hashId, rootClassName, cssVarCls, rootCls)}
             footer={dialogFooter}
             visible={open ?? visible}
             mousePosition={restProps.mousePosition ?? mousePosition}

--- a/components/modal/PurePanel.tsx
+++ b/components/modal/PurePanel.tsx
@@ -37,7 +37,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const rootPrefixCls = getPrefixCls();
   const prefixCls = customizePrefixCls || getPrefixCls('modal');
   const rootCls = useCSSVarCls(rootPrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const confirmPrefixCls = `${prefixCls}-confirm`;
 
@@ -76,6 +76,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
         type && confirmPrefixCls,
         type && `${confirmPrefixCls}-${type}`,
         className,
+        cssVarCls,
         rootCls,
       )}
       {...restProps}

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -103,7 +103,9 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   return wrapCSSVar(
-    <div className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className, cssVarCls)}>
+    <div
+      className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className, cssVarCls, rootCls)}
+    >
       <PurePanelStyle prefixCls={prefixCls} />
       <Notice
         {...restProps}

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -100,10 +100,10 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const noticePrefixCls = `${prefixCls}-notice`;
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   return wrapCSSVar(
-    <div className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className, rootCls)}>
+    <div className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className, cssVarCls)}>
       <PurePanelStyle prefixCls={prefixCls} />
       <Notice
         {...restProps}

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -17,6 +17,7 @@ import { getCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
 import { getMotion, getPlacementStyle } from './util';
 import { useToken } from '../theme/internal';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -35,9 +36,12 @@ interface HolderRef extends NotificationAPI {
 }
 
 const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const rootCls = useCSSVarCls(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   return wrapCSSVar(
-    <NotificationProvider classNames={{ list: hashId }}>{children}</NotificationProvider>,
+    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls) }}>
+      {children}
+    </NotificationProvider>,
   );
 };
 

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -39,7 +39,7 @@ const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefi
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   return wrapCSSVar(
-    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls) }}>
+    <NotificationProvider classNames={{ list: classNames(hashId, cssVarCls, rootCls) }}>
       {children}
     </NotificationProvider>,
   );

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -57,7 +57,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const prefixCls = getPrefixCls('pagination', customizePrefixCls);
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const mergedShowSizeChanger = showSizeChanger ?? pagination.showSizeChanger;
 
@@ -120,6 +120,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...pagination?.style, ...style };

--- a/components/popover/PurePanel.tsx
+++ b/components/popover/PurePanel.tsx
@@ -61,13 +61,20 @@ export const RawPurePanel: React.FC<RawPurePanelProps> = (props) => {
 };
 
 const PurePanel: React.FC<PurePanelProps> = (props) => {
-  const { prefixCls: customizePrefixCls, ...restProps } = props;
+  const { prefixCls: customizePrefixCls, className, ...restProps } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('popover', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
-  return wrapCSSVar(<RawPurePanel {...restProps} prefixCls={prefixCls} hashId={hashId} />);
+  return wrapCSSVar(
+    <RawPurePanel
+      {...restProps}
+      prefixCls={prefixCls}
+      hashId={hashId}
+      className={classNames(className, cssVarCls)}
+    />,
+  );
 };
 
 export default PurePanel;

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -45,10 +45,10 @@ const Popover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('popover', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   const rootPrefixCls = getPrefixCls();
 
-  const overlayCls = classNames(overlayClassName, hashId);
+  const overlayCls = classNames(overlayClassName, hashId, cssVarCls);
 
   return wrapCSSVar(
     <Tooltip

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -97,7 +97,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     progress: progressStyle,
   } = React.useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('progress', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const progressInfo = React.useMemo<React.ReactNode>(() => {
     if (!showInfo) {
@@ -188,6 +188,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -35,7 +35,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('qrcode', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const imageSettings: QRProps['imageSettings'] = {
     src: icon,
@@ -74,7 +74,7 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     return null;
   }
 
-  const mergedCls = classNames(prefixCls, className, rootClassName, hashId, {
+  const mergedCls = classNames(prefixCls, className, rootClassName, hashId, cssVarCls, {
     [`${prefixCls}-borderless`]: !bordered,
   });
 

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -51,7 +51,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
 
   // Style
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   let childrenToRender = children;
   // 如果存在 options, 优先使用
@@ -102,7 +102,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     className,
     rootClassName,
     hashId,
-    rootCls,
+    cssVarCls,
   );
   return wrapCSSVar(
     <div

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -103,6 +103,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     rootClassName,
     hashId,
     cssVarCls,
+    rootCls,
   );
   return wrapCSSVar(
     <div

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -49,7 +49,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
 
   // Style
   const rootCls = useCSSVarCls(radioPrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(radioPrefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(radioPrefixCls, rootCls);
 
   const radioProps: RadioProps = { ...restProps };
 
@@ -76,7 +76,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     className,
     rootClassName,
     hashId,
-    rootCls,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -77,6 +77,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     rootClassName,
     hashId,
     cssVarCls,
+    rootCls,
   );
 
   return wrapCSSVar(

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -38,7 +38,7 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
   const ratePrefixCls = getPrefixCls('rate', prefixCls);
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(ratePrefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(ratePrefixCls);
 
   const mergedStyle: React.CSSProperties = { ...rate?.style, ...style };
 
@@ -48,7 +48,7 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
       character={character}
       characterRender={characterRender}
       {...rest}
-      className={classNames(className, rootClassName, hashId, rate?.className)}
+      className={classNames(className, rootClassName, hashId, cssVarCls, rate?.className)}
       style={mergedStyle}
       prefixCls={ratePrefixCls}
       direction={direction}

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -125,7 +125,7 @@ const Result: ResultType = ({
   const prefixCls = getPrefixCls('result', customizePrefixCls);
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const className = classNames(
     prefixCls,
@@ -135,6 +135,7 @@ const Result: ResultType = ({
     rootClassName,
     { [`${prefixCls}-rtl`]: direction === 'rtl' },
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...result?.style, ...style };

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -57,7 +57,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) 
   const { getPrefixCls, direction, segmented } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('segmented', customizePrefixCls);
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   // ===================== Size =====================
   const mergedSize = useSize(customSize);
@@ -93,6 +93,7 @@ const Segmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) 
       [`${prefixCls}-lg`]: mergedSize === 'large',
     },
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...segmented?.style, ...style };

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -190,6 +190,7 @@ const InternalSelect = <
     },
     rootClassName,
     cssVarCls,
+    rootCls,
     hashId,
   );
 
@@ -213,6 +214,7 @@ const InternalSelect = <
     className,
     rootClassName,
     cssVarCls,
+    rootCls,
     hashId,
   );
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -123,7 +123,7 @@ const InternalSelect = <
   const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
 
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const mode = React.useMemo(() => {
     const { mode: m } = props as InternalSelectProps<OptionType>;
@@ -189,7 +189,7 @@ const InternalSelect = <
       [`${prefixCls}-dropdown-${direction}`]: direction === 'rtl',
     },
     rootClassName,
-    rootCls,
+    cssVarCls,
     hashId,
   );
 
@@ -212,7 +212,7 @@ const InternalSelect = <
     select?.className,
     className,
     rootClassName,
-    rootCls,
+    cssVarCls,
     hashId,
   );
 

--- a/components/skeleton/Avatar.tsx
+++ b/components/skeleton/Avatar.tsx
@@ -21,7 +21,7 @@ const SkeletonAvatar: React.FC<AvatarProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const otherProps = omit(props, ['prefixCls', 'className']);
   const cls = classNames(
@@ -33,6 +33,7 @@ const SkeletonAvatar: React.FC<AvatarProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/skeleton/Button.tsx
+++ b/components/skeleton/Button.tsx
@@ -23,7 +23,7 @@ const SkeletonButton: React.FC<SkeletonButtonProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const otherProps = omit(props, ['prefixCls']);
   const cls = classNames(
@@ -36,6 +36,7 @@ const SkeletonButton: React.FC<SkeletonButtonProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/skeleton/Image.tsx
+++ b/components/skeleton/Image.tsx
@@ -13,7 +13,7 @@ const SkeletonImage: React.FC<SkeletonImageProps> = (props) => {
   const { prefixCls: customizePrefixCls, className, rootClassName, style, active } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   const cls = classNames(
     prefixCls,
     `${prefixCls}-element`,
@@ -23,6 +23,7 @@ const SkeletonImage: React.FC<SkeletonImageProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/skeleton/Input.tsx
+++ b/components/skeleton/Input.tsx
@@ -23,7 +23,7 @@ const SkeletonInput: React.FC<SkeletonInputProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const otherProps = omit(props, ['prefixCls']);
   const cls = classNames(
@@ -36,6 +36,7 @@ const SkeletonInput: React.FC<SkeletonInputProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/skeleton/Node.tsx
+++ b/components/skeleton/Node.tsx
@@ -21,7 +21,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
   } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const cls = classNames(
     prefixCls,
@@ -32,6 +32,7 @@ const SkeletonNode: React.FC<SkeletonNodeProps> = (props) => {
     hashId,
     className,
     rootClassName,
+    cssVarCls,
   );
 
   const content = children ?? <DotChartOutlined />;

--- a/components/skeleton/Skeleton.tsx
+++ b/components/skeleton/Skeleton.tsx
@@ -103,7 +103,7 @@ const Skeleton: React.FC<SkeletonProps> & CompoundedComponent = (props) => {
 
   const { getPrefixCls, direction, skeleton } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('skeleton', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   if (loading || !('loading' in props)) {
     const hasAvatar = !!avatar;
@@ -172,6 +172,7 @@ const Skeleton: React.FC<SkeletonProps> & CompoundedComponent = (props) => {
       className,
       rootClassName,
       hashId,
+      cssVarCls,
     );
 
     return wrapCSSVar(

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -162,7 +162,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
 
   const prefixCls = getPrefixCls('slider', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const cls = classNames(
     className,
@@ -172,6 +172,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
     hashId,
+    cssVarCls,
   );
 
   // make reverse default on rtl direction

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -63,7 +63,7 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
 
   const mergedAlign = align === undefined && direction === 'horizontal' ? 'center' : align;
   const prefixCls = getPrefixCls('space', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const cls = classNames(
     prefixCls,
@@ -78,6 +78,7 @@ const Space = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) => {
     },
     className,
     rootClassName,
+    cssVarCls,
   );
 
   const itemClassName = classNames(

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -47,7 +47,7 @@ const Statistic: React.FC<StatisticProps> = (props) => {
 
   const prefixCls = getPrefixCls('statistic', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const valueNode: React.ReactNode = (
     <StatisticNumber
@@ -68,6 +68,7 @@ const Statistic: React.FC<StatisticProps> = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -79,7 +79,7 @@ const Steps: CompoundedComponent = (props) => {
 
   const prefixCls = getPrefixCls('steps', props.prefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const isInline = props.type === 'inline';
   const iconPrefix = getPrefixCls('', props.iconPrefix);
@@ -97,6 +97,7 @@ const Steps: CompoundedComponent = (props) => {
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
   const icons = {
     finish: <CheckOutlined className={`${prefixCls}-finish-icon`} />,

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -91,7 +91,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => 
   );
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const mergedSize = useSize(customizeSize);
 
@@ -105,6 +105,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, ref) => 
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...SWITCH?.style, ...style };

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -545,6 +545,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
 
   const wrapperClassNames = classNames(
     cssVarCls,
+    rootCls,
     `${prefixCls}-wrapper`,
     table?.className,
     {
@@ -607,6 +608,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
               [`${prefixCls}-empty`]: rawData.length === 0,
             },
             cssVarCls,
+            rootCls,
             hashId,
           )}
           data={pageData}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -204,7 +204,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
 
   const [, token] = useToken();
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const mergedExpandable: ExpandableConfig<RecordType> = {
     childrenColumnName: legacyChildrenColumnName,
@@ -544,7 +544,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   }
 
   const wrapperClassNames = classNames(
-    rootCls,
+    cssVarCls,
     `${prefixCls}-wrapper`,
     table?.className,
     {
@@ -606,7 +606,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
               [`${prefixCls}-bordered`]: bordered,
               [`${prefixCls}-empty`]: rawData.length === 0,
             },
-            rootCls,
+            cssVarCls,
             hashId,
           )}
           data={pageData}

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -107,8 +107,9 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
         rootClassName,
         hashId,
         cssVarCls,
+        rootCls,
       )}
-      popupClassName={classNames(popupClassName, hashId, cssVarCls)}
+      popupClassName={classNames(popupClassName, hashId, cssVarCls, rootCls)}
       style={mergedStyle}
       editable={editable}
       moreIcon={moreIcon}

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -55,7 +55,7 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
   const { direction, tabs, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   let editable: EditableConfig | undefined;
   if (type === 'editable-card') {
@@ -106,9 +106,9 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
         className,
         rootClassName,
         hashId,
-        rootCls,
+        cssVarCls,
       )}
-      popupClassName={classNames(popupClassName, hashId, rootCls)}
+      popupClassName={classNames(popupClassName, hashId, cssVarCls)}
       style={mergedStyle}
       editable={editable}
       moreIcon={moreIcon}

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -38,7 +38,7 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
 
   const prefixCls = getPrefixCls('tag', customizePrefixCls);
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const cls = classNames(
     prefixCls,
@@ -49,6 +49,7 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
     tag?.className,
     className,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -79,7 +79,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
   };
 
   const prefixCls = getPrefixCls('tag', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   // Style
 
   const tagClassName = classNames(
@@ -95,6 +95,7 @@ const InternalTag: React.ForwardRefRenderFunction<HTMLSpanElement, TagProps> = (
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const handleCloseClick = (e: React.MouseEvent<HTMLElement>) => {

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -419,9 +419,15 @@ export const genStyleHooks = <C extends OverrideComponent>(
 
   const useCSSVar = genCSSVarRegister(component, getDefaultToken, options);
 
-  return (prefixCls: string, rootCls: string = prefixCls) => {
+  return (
+    prefixCls: string,
+    rootCls: string = prefixCls,
+    styleOptions: { extraRootCls?: boolean } = { extraRootCls: true },
+  ) => {
     const [, hashId] = useStyle(prefixCls);
-    const [wrapCSSVar, cssVarCls] = useCSSVar(rootCls, { extraRootCls: rootCls !== prefixCls });
+    const [wrapCSSVar, cssVarCls] = useCSSVar(rootCls, {
+      extraRootCls: styleOptions.extraRootCls && rootCls !== prefixCls,
+    });
 
     return [wrapCSSVar, hashId, cssVarCls] as const;
   };

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -19,7 +19,6 @@ import type AbstractCalculator from './calc/calculator';
 import genMaxMin from './maxmin';
 import statisticToken, { merge as mergeToken } from './statistic';
 import useResetIconStyle from './useResetIconStyle';
-import classNames from 'classnames';
 
 export type OverrideTokenWithoutDerivative = ComponentTokenMap;
 export type OverrideComponent = keyof OverrideTokenWithoutDerivative;
@@ -361,7 +360,7 @@ const genCSSVarRegister = <C extends OverrideComponent>(
     return null;
   };
 
-  const useCSSVar = (rootCls: string, cssVarOptions?: { extraRootCls?: boolean }) => {
+  const useCSSVar = (rootCls: string) => {
     const [, , , , cssVar] = useToken();
 
     return [
@@ -374,7 +373,7 @@ const genCSSVarRegister = <C extends OverrideComponent>(
         ) : (
           node
         ),
-      cssVar && classNames({ [rootCls]: cssVarOptions?.extraRootCls }, cssVar.key),
+      cssVar?.key,
     ] as const;
   };
 
@@ -419,15 +418,9 @@ export const genStyleHooks = <C extends OverrideComponent>(
 
   const useCSSVar = genCSSVarRegister(component, getDefaultToken, options);
 
-  return (
-    prefixCls: string,
-    rootCls: string = prefixCls,
-    styleOptions: { extraRootCls?: boolean } = { extraRootCls: true },
-  ) => {
+  return (prefixCls: string, rootCls: string = prefixCls) => {
     const [, hashId] = useStyle(prefixCls);
-    const [wrapCSSVar, cssVarCls] = useCSSVar(rootCls, {
-      extraRootCls: styleOptions.extraRootCls && rootCls !== prefixCls,
-    });
+    const [wrapCSSVar, cssVarCls] = useCSSVar(rootCls);
 
     return [wrapCSSVar, hashId, cssVarCls] as const;
   };

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -381,7 +381,7 @@ const genCSSVarRegister = <C extends OverrideComponent>(
 };
 
 export const genStyleHooks = <C extends OverrideComponent>(
-  component: C,
+  component: C | [C, string],
   styleFn: GenStyleFn<C>,
   getDefaultToken?: GetDefaultToken<C>,
   options?: {
@@ -416,7 +416,11 @@ export const genStyleHooks = <C extends OverrideComponent>(
 ) => {
   const useStyle = genComponentStyleHook(component, styleFn, getDefaultToken, options);
 
-  const useCSSVar = genCSSVarRegister(component, getDefaultToken, options);
+  const useCSSVar = genCSSVarRegister(
+    Array.isArray(component) ? component[0] : component,
+    getDefaultToken,
+    options,
+  );
 
   return (prefixCls: string, rootCls: string = prefixCls) => {
     const [, hashId] = useStyle(prefixCls);

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -50,7 +50,7 @@ const Timeline: CompoundedComponent = (props) => {
   return wrapCSSVar(
     <TimelineItemList
       {...restProps}
-      className={classNames(timeline?.className, className, cssVarCls)}
+      className={classNames(timeline?.className, className, cssVarCls, rootCls)}
       style={{ ...timeline?.style, ...style }}
       prefixCls={prefixCls}
       direction={direction}

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -43,14 +43,14 @@ const Timeline: CompoundedComponent = (props) => {
 
   // Style
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const mergedItems: TimelineItemProps[] = useItems(items, children);
 
   return wrapCSSVar(
     <TimelineItemList
       {...restProps}
-      className={classNames(timeline?.className, className, rootCls)}
+      className={classNames(timeline?.className, className, cssVarCls)}
       style={{ ...timeline?.style, ...style }}
       prefixCls={prefixCls}
       direction={direction}

--- a/components/tooltip/PurePanel.tsx
+++ b/components/tooltip/PurePanel.tsx
@@ -21,7 +21,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   // Color
   const colorInfo = parseColor(prefixCls, color);
@@ -35,6 +35,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   const cls = classNames(
     hashId,
+    cssVarCls,
     prefixCls,
     `${prefixCls}-pure`,
     `${prefixCls}-placement-${placement}`,

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -274,7 +274,7 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
       : childProps.className;
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, !injectFromPopover);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, !injectFromPopover);
 
   // Color
   const colorInfo = parseColor(prefixCls, color);
@@ -292,6 +292,7 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
     colorInfo.className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   // ============================ zIndex ============================

--- a/components/tour/PurePanel.tsx
+++ b/components/tour/PurePanel.tsx
@@ -23,13 +23,18 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('tour', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   return wrapCSSVar(
     <PopoverRawPurePanel
       prefixCls={prefixCls}
       hashId={hashId}
-      className={classNames(className, `${prefixCls}-pure`, type && `${prefixCls}-${type}`)}
+      className={classNames(
+        className,
+        `${prefixCls}-pure`,
+        type && `${prefixCls}-${type}`,
+        cssVarCls,
+      )}
       style={style}
     >
       <TourPanel stepProps={{ ...restProps, prefixCls, total }} current={current} type={type} />

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -26,7 +26,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
   } = props;
   const { getPrefixCls, direction } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('tour', customizePrefixCls);
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   const [, token] = useToken();
 
   const mergedSteps = useMemo(
@@ -53,6 +53,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
       [`${prefixCls}-rtl`]: direction === 'rtl',
     },
     hashId,
+    cssVarCls,
     rootClassName,
   );
 

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -151,7 +151,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('transfer', customizePrefixCls);
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   // Fill record with `key`
   const [mergedDataSource, leftDataSource, rightDataSource] = useData(
@@ -411,6 +411,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const [contextLocale] = useLocale('Transfer', defaultLocale.Transfer);

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -154,7 +154,7 @@ const InternalTreeSelect = <
 
   const rootCls = useCSSVarCls(prefixCls);
   const treeSelectRootCls = useCSSVarCls(treeSelectPrefixCls);
-  const [wrapCSSVar, hashId] = useSelectStyle(prefixCls, rootCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useSelectStyle(prefixCls, rootCls);
   const [treeSelectWrapCSSVar] = useStyle(treeSelectPrefixCls, treePrefixCls, treeSelectRootCls);
 
   const mergedDropdownClassName = classNames(
@@ -164,7 +164,7 @@ const InternalTreeSelect = <
       [`${treeSelectPrefixCls}-dropdown-rtl`]: direction === 'rtl',
     },
     rootClassName,
-    rootCls,
+    cssVarCls,
     treeSelectRootCls,
     hashId,
   );
@@ -243,7 +243,7 @@ const InternalTreeSelect = <
     compactItemClassnames,
     className,
     rootClassName,
-    rootCls,
+    cssVarCls,
     treeSelectRootCls,
     hashId,
   );

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -245,6 +245,7 @@ const InternalTreeSelect = <
     className,
     rootClassName,
     cssVarCls,
+    rootCls,
     treeSelectRootCls,
     hashId,
   );

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -165,6 +165,7 @@ const InternalTreeSelect = <
     },
     rootClassName,
     cssVarCls,
+    rootCls,
     treeSelectRootCls,
     hashId,
   );

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -193,7 +193,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     dropIndicatorRender,
   };
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const draggableConfig = React.useMemo(() => {
     if (!draggable) {
@@ -248,6 +248,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
         tree?.className,
         className,
         hashId,
+        cssVarCls,
       )}
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -115,7 +115,7 @@ const Editable: React.FC<EditableProps> = (props) => {
 
   const textClassName = component ? `${prefixCls}-${component}` : '';
 
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const textAreaClassName = classNames(
     prefixCls,
@@ -126,6 +126,7 @@ const Editable: React.FC<EditableProps> = (props) => {
     className,
     textClassName,
     hashId,
+    cssVarCls,
   );
 
   return wrapCSSVar(

--- a/components/typography/Typography.tsx
+++ b/components/typography/Typography.tsx
@@ -64,7 +64,7 @@ const Typography = React.forwardRef<
   const prefixCls = getPrefixCls('typography', customizePrefixCls);
 
   // Style
-  const [wrapCSSVar, hashId] = useStyle(prefixCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
   const componentClassName = classNames(
     prefixCls,
@@ -75,6 +75,7 @@ const Typography = React.forwardRef<
     className,
     rootClassName,
     hashId,
+    cssVarCls,
   );
 
   const mergedStyle: React.CSSProperties = { ...typography?.style, ...style };

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -364,7 +364,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   }
 
   const wrapperCls = `${prefixCls}-wrapper`;
-  const [wrapCSSVar, hashId] = useStyle(prefixCls, wrapperCls);
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, wrapperCls, { extraRootCls: false });
 
   const [contextLocale] = useLocale('Upload', defaultLocale.Upload);
 
@@ -412,11 +412,19 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     );
   };
 
-  const mergedCls = classNames(wrapperCls, className, rootClassName, hashId, ctxUpload?.className, {
-    [`${prefixCls}-rtl`]: direction === 'rtl',
-    [`${prefixCls}-picture-card-wrapper`]: listType === 'picture-card',
-    [`${prefixCls}-picture-circle-wrapper`]: listType === 'picture-circle',
-  });
+  const mergedCls = classNames(
+    wrapperCls,
+    className,
+    rootClassName,
+    hashId,
+    cssVarCls,
+    ctxUpload?.className,
+    {
+      [`${prefixCls}-rtl`]: direction === 'rtl',
+      [`${prefixCls}-picture-card-wrapper`]: listType === 'picture-card',
+      [`${prefixCls}-picture-circle-wrapper`]: listType === 'picture-circle',
+    },
+  );
 
   const mergedStyle: React.CSSProperties = { ...ctxUpload?.style, ...style };
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -364,7 +364,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   }
 
   const wrapperCls = `${prefixCls}-wrapper`;
-  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, wrapperCls, { extraRootCls: false });
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, wrapperCls);
 
   const [contextLocale] = useLocale('Upload', defaultLocale.Upload);
 


### PR DESCRIPTION
- refactor: cssVarCls
- refactor: update

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [x] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
之前 `cssVar` 的 `key` 作为 className 时是合并在 hashId 里面的，但是 hashId 存在滥用情况，并不局限于组件的 rootClassName，所以会产生 https://github.com/ant-design/ant-design/issues/46411 这样的问题。
这个 PR 把 `cssVar` 的 `key` 单独拆出来并和组件自己的 rootCls 合并，保证这两个 className 联动正常。

以 Input 为例：
before：
![image](https://github.com/ant-design/ant-design/assets/27722486/dfaffae8-f402-4e28-b2c2-2ecc20db05a0)

after:
![image](https://github.com/ant-design/ant-design/assets/27722486/ceec1e66-05fb-4adb-99b0-a908855a9089)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |    -       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
