### PR TITLE
Fix: Input-password icon can't disabled

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -67,7 +67,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
   };
 
   const getIcon = (prefixCls: string) => {
-    const { action = 'click', iconRender = defaultIconRender } = props;
+    const { action = 'click', iconRender = defaultIconRender, disabled } = props;
     const iconTrigger = ActionMap[action] || '';
     const icon = iconRender(visible);
     const iconProps = {
@@ -84,8 +84,9 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
         // https://github.com/ant-design/ant-design/issues/23524
         e.preventDefault();
       },
+      disabled,
     };
-    return React.cloneElement(React.isValidElement(icon) ? icon : <span>{icon}</span>, iconProps);
+    return React.cloneElement(<span>{icon}</span>, iconProps);
   };
 
   const {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix #46470
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
问题：当input-password  disabled 后 eye switch icon 依旧可以点击
解决办法：给icon 添加disable 属性，
由于icon 没有disable属性，必须在外层包一层span
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add disabled attribute to password and force wrap  span to the icon|
| 🇨🇳 Chinese |  给password组件添加 disabled 属性 并 强制 包裹一层span      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed