### PR TITLE
Fix:Input-Password onVisibleChange

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -43,6 +43,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
   React.useEffect(() => {
     if (visibilityControlled) {
       setVisible(visibilityToggle.visible!);
+      visibilityToggle.onVisibleChange?.(visibilityToggle.visible!);
     }
   }, [visibilityControlled, visibilityToggle]);
 
@@ -59,14 +60,12 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     }
     setVisible((prevState) => {
       const newState = !prevState;
+      if (typeof visibilityToggle === 'object') {
+        visibilityToggle.onVisibleChange?.(newState);
+      }
       return newState;
     });
   };
-  React.useEffect(() => {
-    if (typeof visibilityToggle === 'object') {
-      visibilityToggle.onVisibleChange?.(visible);
-    }
-  }, [visible]);
 
   const getIcon = (prefixCls: string) => {
     const { action = 'click', iconRender = defaultIconRender } = props;

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -59,12 +59,14 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     }
     setVisible((prevState) => {
       const newState = !prevState;
-      if (typeof visibilityToggle === 'object') {
-        visibilityToggle.onVisibleChange?.(newState);
-      }
       return newState;
     });
   };
+  React.useEffect(() => {
+    if (typeof visibilityToggle === 'object') {
+      visibilityToggle.onVisibleChange?.(visible);
+    }
+  }, [visible]);
 
   const getIcon = (prefixCls: string) => {
     const { action = 'click', iconRender = defaultIconRender } = props;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
问题：input.password 在 由 icon 控制时 onVisibleChange 回调会被触发，而由外部控件控制visible 时，不会触发回调。
[复现链接](https://codesandbox.io/p/sandbox/antd-reproduction-template-forked-rn9s9l?file=%2Findex.js)

解决办法：
使用useEffect 在当 visbleChange 后 回调函数，符合语义



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
我的理解onVisibleChange 回调 本来就不应该在“onVisibleChange” 点击事件处理函数里调用，
源码里的“onVisibleChange” 函数是 icon 的点击处理
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed onVisibleChange callback for issues that cannot be motivated by visible switch controls other than icon   |
| 🇨🇳 Chinese | 修正onVisibleChange回调，无法被除icon 以外的visible switch 控件 激发的问题          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
