### PR TITLE
fix: ColorPicker not support `prefixCls`

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -12,8 +12,8 @@ import { getStatusClassNames } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
 import type { ConfigConsumerProps } from '../config-provider/context';
 import { ConfigContext } from '../config-provider/context';
-import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import DisabledContext from '../config-provider/DisabledContext';
+import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext, NoFormStyle } from '../form/context';
@@ -33,7 +33,7 @@ import type {
   TriggerType,
 } from './interface';
 import useStyle from './style';
-import { customizePrefixCls, genAlphaColor, generateColor, getAlphaColor } from './util';
+import { genAlphaColor, generateColor, getAlphaColor } from './util';
 
 export type ColorPickerProps = Omit<
   RcColorPickerProps,
@@ -92,6 +92,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     className,
     size: customizeSize,
     rootClassName,
+    prefixCls: customizePrefixCls,
     styles,
     disabledAlpha = false,
     onFormatChange,

--- a/components/color-picker/util.ts
+++ b/components/color-picker/util.ts
@@ -2,8 +2,6 @@ import type { ColorGenInput } from '@rc-component/color-picker';
 import type { Color } from './color';
 import { ColorFactory } from './color';
 
-export const customizePrefixCls = 'ant-color-picker';
-
 export const generateColor = (color: ColorGenInput<Color>): Color => {
   if (color instanceof ColorFactory) {
     return color;

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -12543,6 +12543,111 @@ exports[`ConfigProvider components Collapse prefixCls 1`] = `
 </div>
 `;
 
+exports[`ConfigProvider components ColorPicker configProvider 1`] = `
+<div
+  class="config-color-picker-trigger"
+>
+  <div
+    class="config-color-picker-color-block"
+  >
+    <div
+      class="config-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker configProvider componentDisabled 1`] = `
+<div
+  class="config-color-picker-trigger config-color-picker-trigger-disabled"
+>
+  <div
+    class="config-color-picker-color-block"
+  >
+    <div
+      class="config-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker configProvider componentSize large 1`] = `
+<div
+  class="config-color-picker-trigger config-color-picker-lg"
+>
+  <div
+    class="config-color-picker-color-block"
+  >
+    <div
+      class="config-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker configProvider componentSize middle 1`] = `
+<div
+  class="config-color-picker-trigger"
+>
+  <div
+    class="config-color-picker-color-block"
+  >
+    <div
+      class="config-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker configProvider componentSize small 1`] = `
+<div
+  class="config-color-picker-trigger config-color-picker-sm"
+>
+  <div
+    class="config-color-picker-color-block"
+  >
+    <div
+      class="config-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker normal 1`] = `
+<div
+  class="ant-color-picker-trigger"
+>
+  <div
+    class="ant-color-picker-color-block"
+  >
+    <div
+      class="ant-color-picker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
+exports[`ConfigProvider components ColorPicker prefixCls 1`] = `
+<div
+  class="prefix-ColorPicker-trigger"
+>
+  <div
+    class="prefix-ColorPicker-color-block"
+  >
+    <div
+      class="prefix-ColorPicker-color-block-inner"
+      style="background: rgb(22, 119, 255);"
+    />
+  </div>
+</div>
+`;
+
 exports[`ConfigProvider components DatePicker DatePicker configProvider 1`] = `
 <div>
   <div

--- a/components/config-provider/__tests__/components.test.tsx
+++ b/components/config-provider/__tests__/components.test.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import React from 'react';
+
 import ConfigProvider from '..';
+import { render } from '../../../tests/utils';
 import Alert from '../../alert';
 import Anchor from '../../anchor';
 import AutoComplete from '../../auto-complete';
@@ -16,6 +18,7 @@ import Carousel from '../../carousel';
 import Cascader from '../../cascader';
 import Checkbox from '../../checkbox';
 import Collapse from '../../collapse';
+import ColorPicker from '../../color-picker';
 import DatePicker from '../../date-picker';
 import Divider from '../../divider';
 import Drawer from '../../drawer';
@@ -39,7 +42,6 @@ import Select from '../../select';
 import Skeleton from '../../skeleton';
 import type { SliderTooltipProps } from '../../slider';
 import Slider from '../../slider';
-import { render } from '../../../tests/utils';
 import Spin from '../../spin';
 import Statistic from '../../statistic';
 import Steps from '../../steps';
@@ -232,6 +234,9 @@ describe('ConfigProvider', () => {
         </Collapse.Panel>
       </Collapse>
     ));
+
+    // ColorPicker
+    testPair('ColorPicker', (props) => <ColorPicker {...props} />);
 
     // DatePicker
     describe('DatePicker', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #46559

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ColorPicker not support `prefixCls`.      |
| 🇨🇳 Chinese |   修复 ColorPicker 配置 `prefixCls` 不生效的问题。        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
