### PR TITLE
docs: fix theme change

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -146,12 +146,19 @@ const GlobalLayout: React.FC = () => {
       plain: true,
       types: ['cssVar', 'token'],
     });
-    return <style data-type="antd-css-var" dangerouslySetInnerHTML={{ __html: styleText }} />;
+    return (
+      <style
+        data-type="antd-css-var"
+        data-rc-order="prepend"
+        data-rc-priority="-9999"
+        dangerouslySetInnerHTML={{ __html: styleText }}
+      />
+    );
   });
 
-  useEffect(() => {
-    document.head.querySelectorAll('[data-type="antd-css-var"]')?.forEach((node) => node.remove());
-  }, []);
+  // useEffect(() => {
+  //   document.head.querySelectorAll('[data-type="antd-css-var"]')?.forEach((node) => node.remove());
+  // }, []);
 
   useServerInsertedHTML(() => (
     <style

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -134,9 +134,24 @@ const GlobalLayout: React.FC = () => {
   const [styleCache] = React.useState(() => createCache());
 
   useServerInsertedHTML(() => {
-    const styleText = extractStyle(styleCache, true);
+    const styleText = extractStyle(styleCache, {
+      plain: true,
+      types: 'style',
+    });
     return <style data-type="antd-cssinjs" dangerouslySetInnerHTML={{ __html: styleText }} />;
   });
+
+  useServerInsertedHTML(() => {
+    const styleText = extractStyle(styleCache, {
+      plain: true,
+      types: ['cssVar', 'token'],
+    });
+    return <style data-type="antd-css-var" dangerouslySetInnerHTML={{ __html: styleText }} />;
+  });
+
+  useEffect(() => {
+    document.head.querySelectorAll('[data-type="antd-css-var"]')?.forEach((node) => node.remove());
+  }, []);
 
   useServerInsertedHTML(() => (
     <style

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -156,10 +156,6 @@ const GlobalLayout: React.FC = () => {
     );
   });
 
-  // useEffect(() => {
-  //   document.head.querySelectorAll('[data-type="antd-css-var"]')?.forEach((node) => node.remove());
-  // }, []);
-
   useServerInsertedHTML(() => (
     <style
       data-sandpack="true"

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -180,12 +180,12 @@ const RoutesPlugin = (api: IApi) => {
         file.content = addLinkStyle(file.content, cssFile, true);
 
         // Insert antd cssVar to head
-        const cssVarMatchRegex = /<style data-type="antd-css-var">[\S\s]+?<\/style>/;
+        const cssVarMatchRegex = /<style data-type="antd-css-var"[\S\s]+?<\/style>/;
         const cssVarMatchList = file.content.match(cssVarMatchRegex) || [];
 
         cssVarMatchList.forEach((text) => {
           file.content = file.content.replace(text, '');
-          file.content = file.content.replace('</head>', `${text}</head>`);
+          file.content = file.content.replace('<head>', `<head>${text}`);
         });
 
         return file;

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -179,6 +179,15 @@ const RoutesPlugin = (api: IApi) => {
         const cssFile = writeCSSFile('antd', antdStyle, antdStyle);
         file.content = addLinkStyle(file.content, cssFile, true);
 
+        // Insert antd cssVar to head
+        const cssVarMatchRegex = /<style data-type="antd-css-var">[\S\s]+?<\/style>/;
+        const cssVarMatchList = file.content.match(cssVarMatchRegex) || [];
+
+        cssVarMatchList.forEach((text) => {
+          file.content = file.content.replace(text, '');
+          file.content = file.content.replace('</head>', `${text}</head>`);
+        });
+
         return file;
       }),
   );
@@ -190,20 +199,6 @@ const RoutesPlugin = (api: IApi) => {
 
     return memo;
   });
-
-  // zombieJ: Unique CSS file is large, we move to build css for each page.
-  // See the `modifyExportHTMLFiles` above.
-
-  // generate ssr css file
-  // api.onBuildHtmlComplete(() => {
-  //   const styleCache = (global as any)?.styleCache;
-  //   const styleText = styleCache ? extractStyle(styleCache) : '';
-  //   const styleTextWithoutStyleTag = styleText
-  //     .replace(/<style\s[^>]*>/g, '')
-  //     .replace(/<\/style>/g, '');
-
-  //   fs.writeFileSync(`./_site/${ssrCssFileName}`, styleTextWithoutStyleTag, 'utf8');
-  // });
 };
 
 export default RoutesPlugin;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix: https://github.com/ant-design/ant-design/issues/46517
wait https://github.com/umijs/umi/pull/12002
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

这个 PR 将 antd SSR 生成的 cssVar 单独拆分并在 client 去除，目的是让动态的 cssVar 不会被静态覆盖。
剩下的 useId 问题等待 umi 合并 https://github.com/umijs/umi/pull/12002 并发布

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |     -      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
