### PR TITLE
fix: the shadow of the table overflows

### DIFF
--- a/components/table/style/fixed.ts
+++ b/components/table/style/fixed.ts
@@ -70,6 +70,8 @@ const genFixedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-container`]: {
+        position: 'relative',
+
         '&::before, &::after': {
           position: 'absolute',
           top: 0,
@@ -91,12 +93,8 @@ const genFixedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-ping-left`]: {
-        [`&:not(${componentCls}-has-fix-left) ${componentCls}-container`]: {
-          position: 'relative',
-
-          '&::before': {
-            boxShadow: `inset 10px 0 8px -8px ${shadowColor}`,
-          },
+        [`&:not(${componentCls}-has-fix-left) ${componentCls}-container::before`]: {
+          boxShadow: `inset 10px 0 8px -8px ${shadowColor}`,
         },
 
         [`
@@ -112,12 +110,8 @@ const genFixedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-ping-right`]: {
-        [`&:not(${componentCls}-has-fix-right) ${componentCls}-container`]: {
-          position: 'relative',
-
-          '&::after': {
-            boxShadow: `inset -10px 0 8px -8px ${shadowColor}`,
-          },
+        [`&:not(${componentCls}-has-fix-right) ${componentCls}-container::after`]: {
+          boxShadow: `inset -10px 0 8px -8px ${shadowColor}`,
         },
 
         [`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
fix #46634

### 💡 Background and solution

fix the shadow overflow in the table 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the issue of table component edge shadow overflows      |
| 🇨🇳 Chinese |      修复 Table 边缘阴影会超出 Table 高度     |

### ☑️ Self-Check before Merge


⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
