### PR TITLE
fix: Fix itemHeight of Tree

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -231,7 +231,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
 
   return wrapCSSVar(
     <RcTree
-      itemHeight={20}
+      itemHeight={28}
       ref={ref}
       virtual={virtual}
       {...newProps}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -12,6 +12,7 @@ import { ConfigContext } from '../config-provider';
 import useStyle from './style';
 import dropIndicatorRender from './utils/dropIndicator';
 import SwitcherIconCom from './utils/iconUtil';
+import { useToken } from '../theme/internal';
 
 export type SwitcherIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
 export type TreeLeafIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
@@ -194,6 +195,9 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
   };
 
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
+  const [, token] = useToken();
+
+  const itemHeight = (token.paddingXS / 2) + (token.Tree?.titleHeight || token.controlHeightSM);
 
   const draggableConfig = React.useMemo(() => {
     if (!draggable) {
@@ -231,7 +235,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
 
   return wrapCSSVar(
     <RcTree
-      itemHeight={28}
+      itemHeight={itemHeight}
       ref={ref}
       virtual={virtual}
       {...newProps}


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/46612

实际的 `itemHeight` 应为 `28`。现在的 `itemHeight` 小于实际值，导致虚拟列表没有显示滚动条。

![image](https://github.com/ant-design/ant-design/assets/47586954/564b7266-6973-453f-838b-bb6182458977)

