### PR TITLE
docs: update workarounds for sub-components with Next.js App router

### DIFF
--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -268,13 +268,48 @@ The above problem occurs if `strictNullChecks` is set to `true`, If you can dete
 
 ## The antd component reported an error when using the App Router of Next.js
 
-If you are using the App Router of Next.js, when you use the sub-components provided by some antd components, such as `Select.Option `, `Form.Item`, etc., you may get the following error:
+If you are using the App Router of Next.js, when you use the sub-components provided by some antd components, such as `Select.Option `, `Form.Item`, `Typography.Title`, etc., you may get the following error:
 
 ```bash
 Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
 ```
 
-At present, this problem is waiting for Next.js to give an official solution, before this, if you use sub-components in your page, you can try to add the following client tag at the top of the page to solve this problem:
+Currently, this problem is [waiting for Next.js to give an official solution](https://github.com/vercel/next.js/issues/51593). There are two workarounds as of now if you need to use sub-components in your page with the App Router:
+
+
+- Create a wrapper component that extracts the sub-components that you need, and re-exports them. Take the `Typography` component as an example. A wrapper component would look something like this:
+
+```tsx
+"use client";
+import { Typography as _Typography } from "antd";
+import { forwardRef, ForwardRefExoticComponent, RefAttributes } from "react";
+import { TitleProps } from "antd/lib/typography/Title";
+import { ParagraphProps } from "antd/lib/typography/Paragraph";
+import { LinkProps } from "antd/lib/typography/Link";
+import { TextProps } from "antd/lib/typography/Text";
+
+const Title: ForwardRefExoticComponent<
+  TitleProps & RefAttributes<HTMLElement>
+> = forwardRef((props, ref) => <_Typography.Title ref={ref} {...props} />);
+Title.displayName = "ClientTitle";
+
+const Paragraph: ForwardRefExoticComponent<
+  ParagraphProps & RefAttributes<HTMLElement>
+> = forwardRef((props, ref) => <_Typography.Paragraph ref={ref} {...props} />);
+Paragraph.displayName = "ClientParagraph";
+
+const Link: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLElement>> =
+  forwardRef((props, ref) => <_Typography.Link ref={ref} {...props} />);
+Link.displayName = "ClientLink";
+
+const Text: ForwardRefExoticComponent<TextProps & RefAttributes<HTMLElement>> =
+  forwardRef((props, ref) => <_Typography.Text ref={ref} {...props} />);
+Text.displayName = "ClientText";
+
+export { Title, Link, Text, Paragraph };
+```
+
+- You can also make the page fully client-rendered by adding `use client` tag at the beginning of your page's source:
 
 ```tsx
 'use client';
@@ -292,3 +327,5 @@ export default () => {
   );
 };
 ```
+
+

--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -280,31 +280,30 @@ Currently, this problem is [waiting for Next.js to give an official solution](ht
 - Create a wrapper component that extracts the sub-components that you need, and re-exports them. Take the `Typography` component as an example. A wrapper component would look something like this:
 
 ```tsx
-"use client";
-import { Typography as _Typography } from "antd";
-import { forwardRef, ForwardRefExoticComponent, RefAttributes } from "react";
-import { TitleProps } from "antd/lib/typography/Title";
-import { ParagraphProps } from "antd/lib/typography/Paragraph";
-import { LinkProps } from "antd/lib/typography/Link";
-import { TextProps } from "antd/lib/typography/Text";
+'use client';
 
-const Title: ForwardRefExoticComponent<
-  TitleProps & RefAttributes<HTMLElement>
-> = forwardRef((props, ref) => <_Typography.Title ref={ref} {...props} />);
-Title.displayName = "ClientTitle";
+import React from 'react';
+import { Typography as OriginTypography } from 'antd';
+import type { LinkProps } from 'antd/es/typography/Link';
+import type { ParagraphProps } from 'antd/es/typography/Paragraph';
+import type { TextProps } from 'antd/es/typography/Text';
+import type { TitleProps } from 'antd/es/typography/Title';
 
-const Paragraph: ForwardRefExoticComponent<
-  ParagraphProps & RefAttributes<HTMLElement>
-> = forwardRef((props, ref) => <_Typography.Paragraph ref={ref} {...props} />);
-Paragraph.displayName = "ClientParagraph";
+const Title = React.forwardRef<HTMLElement, TitleProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Title ref={ref} {...props} />,
+);
 
-const Link: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLElement>> =
-  forwardRef((props, ref) => <_Typography.Link ref={ref} {...props} />);
-Link.displayName = "ClientLink";
+const Paragraph = React.forwardRef<HTMLElement, ParagraphProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Paragraph ref={ref} {...props} />,
+);
 
-const Text: ForwardRefExoticComponent<TextProps & RefAttributes<HTMLElement>> =
-  forwardRef((props, ref) => <_Typography.Text ref={ref} {...props} />);
-Text.displayName = "ClientText";
+const Link = React.forwardRef<HTMLElement, LinkProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Link ref={ref} {...props} />,
+);
+
+const Text = React.forwardRef<HTMLElement, TextProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Text ref={ref} {...props} />,
+);
 
 export { Title, Link, Text, Paragraph };
 ```

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -303,7 +303,7 @@ export default () => {
 Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
 ```
 
-目前这个问题[等待 Next.js 给出官方的解决方案](https://github.com/vercel/next.js/issues/51593). 如果您需要在使用应用程序路由器的页面中使用子组件，目前有两种变通方法：
+目前这个问题需要[等待 Next.js 官方给出解决方案](https://github.com/vercel/next.js/issues/51593)，如果你需要在使用 App router 的页面中使用子组件，目前有两种变通方法：
 
 - 创建一个包装组件，提取所需的子组件并重新导出。以 `Typography` 组件为例。包装组件的代码大概像这样
 

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -297,18 +297,52 @@ export default () => {
 
 ## 使用 Next.js 的 App Router 时 antd 组件报错
 
-如果你在使用 Next.js 的 App Router，当你使用 antd 中某些组件提供的子组件，如：`Select.Option`、`Form.Item` 等，可能会出现如下报错：
+如果你在使用 Next.js 的 App Router，当你使用 antd 中某些组件提供的子组件，如：`Select.Option`、`Form.Item`、`Typography.Title` 等，可能会出现如下报错：
 
 ```bash
 Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
 ```
 
-目前这个问题等待 Next.js 给出官方的解决方案，在此之前，如果在你的页面中有使用子组件的话，可以尝试在页面顶部增加如下客户端标签解决这个问题：
+[目前这个问题等待 Next.js 给出官方的解决方案](https://github.com/vercel/next.js/issues/51593). 如果您需要在使用应用程序路由器的页面中使用子组件，目前有两种变通方法：
+
+- 创建一个封装组件，提取所需的子组件并重新导出。以排版组件为例。包装组件的外观是这样的
+
+```tsx
+"use client";
+import { Typography as _Typography } from "antd";
+import { forwardRef, ForwardRefExoticComponent, RefAttributes } from "react";
+import { TitleProps } from "antd/lib/typography/Title";
+import { ParagraphProps } from "antd/lib/typography/Paragraph";
+import { LinkProps } from "antd/lib/typography/Link";
+import { TextProps } from "antd/lib/typography/Text";
+
+const Title: ForwardRefExoticComponent<
+  TitleProps & RefAttributes<HTMLElement>
+> = forwardRef((props, ref) => <_Typography.Title ref={ref} {...props} />);
+Title.displayName = "ClientTitle";
+
+const Paragraph: ForwardRefExoticComponent<
+  ParagraphProps & RefAttributes<HTMLElement>
+> = forwardRef((props, ref) => <_Typography.Paragraph ref={ref} {...props} />);
+Paragraph.displayName = "ClientParagraph";
+
+const Link: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLElement>> =
+  forwardRef((props, ref) => <_Typography.Link ref={ref} {...props} />);
+Link.displayName = "ClientLink";
+
+const Text: ForwardRefExoticComponent<TextProps & RefAttributes<HTMLElement>> =
+  forwardRef((props, ref) => <_Typography.Text ref={ref} {...props} />);
+Text.displayName = "ClientText";
+
+export { Title, Link, Text, Paragraph };
+```
+
+- 您也可以在页面源代码的开头添加 "use client "标签，使页面完全由客户端渲染：
 
 ```tsx
 'use client';
 
-// This is not real world code, just for explain
+// 非真实代码，仅供解释
 export default () => (
   <div className="App">
     <Form>

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -308,31 +308,30 @@ Error: Cannot access .Option on the server. You cannot dot into a client module 
 - 创建一个包裹组件，提取所需的子组件并重新导出。以 `Typography` 组件为例，代码大概像这样：
 
 ```tsx
-"use client";
-import { Typography as _Typography } from "antd";
-import { forwardRef, ForwardRefExoticComponent, RefAttributes } from "react";
-import { TitleProps } from "antd/lib/typography/Title";
-import { ParagraphProps } from "antd/lib/typography/Paragraph";
-import { LinkProps } from "antd/lib/typography/Link";
-import { TextProps } from "antd/lib/typography/Text";
+'use client';
 
-const Title: ForwardRefExoticComponent<
-  TitleProps & RefAttributes<HTMLElement>
-> = forwardRef((props, ref) => <_Typography.Title ref={ref} {...props} />);
-Title.displayName = "ClientTitle";
+import React from 'react';
+import { Typography as OriginTypography } from 'antd';
+import type { LinkProps } from 'antd/es/typography/Link';
+import type { ParagraphProps } from 'antd/es/typography/Paragraph';
+import type { TextProps } from 'antd/es/typography/Text';
+import type { TitleProps } from 'antd/es/typography/Title';
 
-const Paragraph: ForwardRefExoticComponent<
-  ParagraphProps & RefAttributes<HTMLElement>
-> = forwardRef((props, ref) => <_Typography.Paragraph ref={ref} {...props} />);
-Paragraph.displayName = "ClientParagraph";
+const Title = React.forwardRef<HTMLElement, TitleProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Title ref={ref} {...props} />,
+);
 
-const Link: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLElement>> =
-  forwardRef((props, ref) => <_Typography.Link ref={ref} {...props} />);
-Link.displayName = "ClientLink";
+const Paragraph = React.forwardRef<HTMLElement, ParagraphProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Paragraph ref={ref} {...props} />,
+);
 
-const Text: ForwardRefExoticComponent<TextProps & RefAttributes<HTMLElement>> =
-  forwardRef((props, ref) => <_Typography.Text ref={ref} {...props} />);
-Text.displayName = "ClientText";
+const Link = React.forwardRef<HTMLElement, LinkProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Link ref={ref} {...props} />,
+);
+
+const Text = React.forwardRef<HTMLElement, TextProps & React.RefAttributes<HTMLElement>>(
+  (props, ref) => <OriginTypography.Text ref={ref} {...props} />,
+);
 
 export { Title, Link, Text, Paragraph };
 ```

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -305,7 +305,7 @@ Error: Cannot access .Option on the server. You cannot dot into a client module 
 
 目前这个问题需要[等待 Next.js 官方给出解决方案](https://github.com/vercel/next.js/issues/51593)，如果你需要在使用 App router 的页面中使用子组件，目前有两种变通方法：
 
-- 创建一个包装组件，提取所需的子组件并重新导出。以 `Typography` 组件为例。包装组件的代码大概像这样
+- 创建一个包裹组件，提取所需的子组件并重新导出。以 `Typography` 组件为例，代码大概像这样：
 
 ```tsx
 "use client";

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -303,7 +303,7 @@ export default () => {
 Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
 ```
 
-[目前这个问题等待 Next.js 给出官方的解决方案](https://github.com/vercel/next.js/issues/51593). 如果您需要在使用应用程序路由器的页面中使用子组件，目前有两种变通方法：
+目前这个问题[等待 Next.js 给出官方的解决方案](https://github.com/vercel/next.js/issues/51593). 如果您需要在使用应用程序路由器的页面中使用子组件，目前有两种变通方法：
 
 - 创建一个包装组件，提取所需的子组件并重新导出。以 `Typography` 组件为例。包装组件的代码大概像这样
 

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -342,7 +342,7 @@ export { Title, Link, Text, Paragraph };
 ```tsx
 'use client';
 
-// 非真实代码，仅供解释
+// 非真实代码，仅做逻辑说明
 export default () => (
   <div className="App">
     <Form>

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -337,7 +337,7 @@ Text.displayName = "ClientText";
 export { Title, Link, Text, Paragraph };
 ```
 
-- 您也可以在页面源代码的开头添加 "use client "标签，使页面完全由客户端渲染：
+- 你也可以在组件的开头添加 "use client" 指令，使页面完全由客户端渲染：
 
 ```tsx
 'use client';

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -305,7 +305,7 @@ Error: Cannot access .Option on the server. You cannot dot into a client module 
 
 [目前这个问题等待 Next.js 给出官方的解决方案](https://github.com/vercel/next.js/issues/51593). 如果您需要在使用应用程序路由器的页面中使用子组件，目前有两种变通方法：
 
-- 创建一个封装组件，提取所需的子组件并重新导出。以排版组件为例。包装组件的外观是这样的
+- 创建一个包装组件，提取所需的子组件并重新导出。以 `Typography` 组件为例。包装组件的代码大概像这样
 
 ```tsx
 "use client";

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -303,7 +303,7 @@ export default () => {
 Error: Cannot access .Option on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
 ```
 
-目前这个问题需要[等待 Next.js 官方给出解决方案](https://github.com/vercel/next.js/issues/51593)，如果你需要在使用 App router 的页面中使用子组件，目前有两种变通方法：
+目前这个问题需要[等待 Next.js 官方给出解决方案](https://github.com/vercel/next.js/issues/51593)，在此之前，如果你需要在使用 App router 的页面中使用子组件，目前有两种变通方法：
 
 - 创建一个包裹组件，提取所需的子组件并重新导出。以 `Typography` 组件为例，代码大概像这样：
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
workaround for https://github.com/vercel/next.js/issues/51593


### 💡 Background and solution

Using subcomponents of components (like `Typography` in Next.js app router causes an error that tells that client components are not dottable on the server.
The current proposed fix is just to make the page fully client-rendered which works well as a workaround but is less than optimal since by making the component fully client-rendered developers can't use SSR patterns if they want to.

The new workaround that I'm proposing here is to extract the needed subcomponents into client components which allows for usage is SSR pages.  

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
