### PR TITLE
docs: tweak change-log drawer width in small screen

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable global-require */
 import React, { useMemo } from 'react';
 import { HistoryOutlined } from '@ant-design/icons';
-import { Button, Drawer, Timeline, Typography } from 'antd';
+import { Button, Drawer, Timeline, Typography, Grid } from 'antd';
 import { createStyles } from 'antd-style';
 
 import useFetch from '../../../hooks/useFetch';
@@ -158,6 +158,9 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
     });
   }, [list]);
 
+  const screens = Grid.useBreakpoint();
+  const width = screens.md ? '48vw' : '90vw';
+
   if (!list || !list.length) {
     return null;
   }
@@ -181,7 +184,7 @@ export default function ComponentChangelog(props: ComponentChangelogProps) {
           </Link>
         }
         open={show}
-        width="40vw"
+        width={width}
         onClose={() => {
           setShow(false);
         }}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
<img width="615" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/0bf71673-af88-42b8-b62f-1d2872f6ad3c">
在移动端等小屏幕下阅读体验不好。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
