### PR TITLE
fix: Upload.Dragger not align center

### DIFF
--- a/components/upload/style/dragger.ts
+++ b/components/upload/style/dragger.ts
@@ -23,12 +23,13 @@ const genDraggerStyle: GenerateStyle<UploadToken> = (token) => {
         },
 
         [`${componentCls}-btn`]: {
-          display: 'flex',
-          placeContent: 'center',
+          display: 'table',
+          width: '100%',
+          height: '100%',
           outline: 'none',
           borderRadius: token.borderRadiusLG,
 
-          '&:focus': {
+          '&:focus-visible': {
             outline: `${unit(token.lineWidthFocus)} solid ${token.colorPrimaryBorder}`,
           },
         },


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #46795

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
https://github.com/ant-design/ant-design/pull/46432 里改成 `display: flex;` 是为了让 focus 的 outline 样式有圆角，这个后面再想办法。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Upload.Dragger not align center and focus ring style.  |
| 🇨🇳 Chinese |  修复 Upload.Dragger 内容不居中和多余的 focus 样式的问题。   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
