### PR TITLE
fix: document homepage style optimization

### DIFF
--- a/.dumi/pages/index/components/Theme/ThemePicker.tsx
+++ b/.dumi/pages/index/components/Theme/ThemePicker.tsx
@@ -88,7 +88,7 @@ export default function ThemePicker(props: ThemePickerProps) {
   const [locale] = useLocale(locales);
 
   return (
-    <Space size={token.paddingLG}>
+    <Space size={token.paddingLG} style={{ flexWrap: 'wrap' }}>
       {Object.keys(THEMES).map((theme, index) => {
         const url = THEMES[theme as THEME];
 

--- a/.dumi/pages/index/components/Theme/ThemePicker.tsx
+++ b/.dumi/pages/index/components/Theme/ThemePicker.tsx
@@ -88,7 +88,7 @@ export default function ThemePicker(props: ThemePickerProps) {
   const [locale] = useLocale(locales);
 
   return (
-    <Space size={token.paddingLG} style={{ flexWrap: 'wrap' }}>
+    <Space size={token.paddingLG} wrap>
       {Object.keys(THEMES).map((theme, index) => {
         const url = THEMES[theme as THEME];
 

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -189,7 +189,7 @@ const useStyle = createStyles(({ token, cx }) => {
     `,
 
     form: css`
-      width: 800px;
+      width: 100%;
       margin: 0 auto;
     `,
     carousel,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     document homepage style optimization      |
| 🇨🇳 Chinese |     文档首页样式优化     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed



before:
![55801704439534_ pic](https://github.com/ant-design/ant-design/assets/47295879/6cce75f1-8a8a-4f07-a470-3b220baddc8a)

after:
![55931704440688_ pic](https://github.com/ant-design/ant-design/assets/47295879/57be722c-bd27-49a8-9722-ca308b0f8123)

