### PR TITLE
✨ feat:  add select option type

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import type { BaseSelectRef, SelectProps as RcSelectProps } from 'rc-select';
 import RcSelect, { OptGroup, Option } from 'rc-select';
 import type { OptionProps } from 'rc-select/lib/Option';
-import type { BaseOptionType, DefaultOptionType } from 'rc-select/lib/Select';
+import type { BaseOptionType, DefaultOptionType as _DefaultOptionType } from 'rc-select/lib/Select';
 import omit from 'rc-util/lib/omit';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
@@ -29,6 +29,11 @@ import useShowArrow from './useShowArrow';
 import { useToken } from '../theme/internal';
 
 type RawValue = string | number;
+
+interface DefaultOptionType extends _DefaultOptionType {
+  title?: string;
+  className?: string;
+}
 
 export type { BaseOptionType, DefaultOptionType, OptionProps, BaseSelectRef as RefSelectProps };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] TypeScript 定义更新 

### 🔗 相关 Issue
 

### 💡 需求背景和解决方案

补全 Select Options 类型
https://ant-design.antgroup.com/components/select-cn#option-props

Select 引用自 rc-select 这个库, 没有 `className` 和 `title` 这两个类型

相关链接 : https://github.com/react-component/select/blob/master/src/Select.tsx

### 📝 更新日志
 
| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     add Select.Options ts type     |
| 🇨🇳 中文 |  增加 Select.Option ts 类型         |

### ☑️ 请求合并前的自查清单 
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供