### PR TITLE
style: fix Tree cursor style

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -251,7 +251,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           cursor: 'unset',
         },
 
-        '&:not(&-noop):hover': {
+        [`&:not(${treeCls}-switcher-noop):hover`]: {
           backgroundColor: token.colorBgTextHover,
         },
 

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -191,6 +191,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         },
 
         '&-draggable': {
+          cursor: 'grab',
+
           [`${treeCls}-draggable-icon`]: {
             // https://github.com/ant-design/ant-design/issues/41915
             flexShrink: 0,
@@ -242,9 +244,15 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         textAlign: 'center',
         cursor: 'pointer',
         userSelect: 'none',
+        transition: `all ${token.motionDurationSlow}`,
+        borderRadius: token.borderRadius,
 
         '&-noop': {
-          cursor: 'default',
+          cursor: 'unset',
+        },
+
+        '&:not(&-noop):hover': {
+          backgroundColor: token.colorBgTextHover,
         },
 
         '&_close': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
<img width="307" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/741307e1-77c6-4800-98b0-88b097d6fe4a">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Optimize Tree draggable node cursor style and collaspe icon hover style.       |
| 🇨🇳 Chinese |  优化 Tree 拖拽节点和展开收起按钮的鼠标 hover 样式。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
