### PR TITLE
fix: Modal static func

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -266,6 +266,12 @@ const setGlobalConfig = (props: GlobalConfigProps) => {
 };
 
 export const globalConfig = () => ({
+  getPrefixCls: (suffixCls?: string, customizePrefixCls?: string) => {
+    if (customizePrefixCls) {
+      return customizePrefixCls;
+    }
+    return suffixCls ? `${getGlobalPrefixCls()}-${suffixCls}` : getGlobalPrefixCls();
+  },
   getIconPrefixCls: getGlobalIconPrefixCls,
   getRootPrefixCls: () => {
     // If Global prefixCls provided, use this

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -276,8 +276,6 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
 const ConfirmDialogWrapper: React.FC<ConfirmDialogProps> = (props) => {
   const { rootPrefixCls, iconPrefixCls, direction, theme } = props;
 
-  console.log('Inner:', props.prefixCls);
-
   return (
     <ConfigProvider
       prefixCls={rootPrefixCls}

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -276,6 +276,8 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
 const ConfirmDialogWrapper: React.FC<ConfirmDialogProps> = (props) => {
   const { rootPrefixCls, iconPrefixCls, direction, theme } = props;
 
+  console.log('Inner:', props.prefixCls);
+
   return (
     <ConfigProvider
       prefixCls={rootPrefixCls}

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -468,7 +468,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     expect($$('.custom-modal-wrap')).toHaveLength(1);
     expect($$('.custom-modal-confirm')).toHaveLength(1);
     expect($$('.custom-modal-confirm-body-wrapper')).toHaveLength(1);
-    expect($$('.custom-modal-btn')).toHaveLength(2);
+    expect($$('.ant-btn')).toHaveLength(2);
   });
 
   it('should be Modal.confirm without mask', async () => {
@@ -878,7 +878,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     expect(document.querySelector('.custom-footer-ele')).toBeTruthy();
   });
-  it('should be able to config holderRender', async () => {
+  it('work with holderRender', async () => {
     ConfigProvider.config({
       holderRender: (children) => (
         <ConfigProvider prefixCls="test" iconPrefixCls="icon">
@@ -888,6 +888,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     });
     Modal.confirm({ content: 'hai' });
     await waitFakeTimer();
+    console.log(document.body.innerHTML);
     expect(document.querySelectorAll('.ant-modal-root')).toHaveLength(0);
     expect(document.querySelectorAll('.anticon-exclamation-circle')).toHaveLength(0);
     expect(document.querySelectorAll('.test-modal-root')).toHaveLength(1);

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -878,7 +878,7 @@ describe('Modal.confirm triggers callbacks correctly', () => {
 
     expect(document.querySelector('.custom-footer-ele')).toBeTruthy();
   });
-  it('work with holderRender', async () => {
+  it('should be able to config holderRender', async () => {
     ConfigProvider.config({
       holderRender: (children) => (
         <ConfigProvider prefixCls="test" iconPrefixCls="icon">
@@ -888,7 +888,6 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     });
     Modal.confirm({ content: 'hai' });
     await waitFakeTimer();
-    console.log(document.body.innerHTML);
     expect(document.querySelectorAll('.ant-modal-root')).toHaveLength(0);
     expect(document.querySelectorAll('.anticon-exclamation-circle')).toHaveLength(0);
     expect(document.querySelectorAll('.test-modal-root')).toHaveLength(1);

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -29,7 +29,7 @@ const ConfirmDialogWrapper: React.FC<ConfirmDialogProps> = (props) => {
   const runtimeLocale = getConfirmLocale();
 
   const config = useContext(ConfigContext);
-  const rootPrefixCls = customizePrefixCls || getRootPrefixCls() || config.getPrefixCls();
+  const rootPrefixCls = getRootPrefixCls() || config.getPrefixCls();
   // because Modal.config set rootPrefixCls, which is different from other components
   const prefixCls = customizePrefixCls || `${rootPrefixCls}-modal`;
 
@@ -98,7 +98,7 @@ export default function confirm(config: ModalFuncProps) {
      * Sync render blocks React event. Let's make this async.
      */
     timeoutId = setTimeout(() => {
-      const rootPrefixCls = global.getRootPrefixCls();
+      const rootPrefixCls = global.getPrefixCls(undefined, getRootPrefixCls());
       const iconPrefixCls = global.getIconPrefixCls();
       const theme = global.getTheme();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #47007

### 💡 Background and solution

`Modal.confirm` 的 `prefixCls`不应该作为 `rootPrefixCls` 生效，导致 CSSINJS Cache 命中策略失效 以及 子元素 `prefixCls` break change。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal static function with `prefixCls` breaks children other component `prefixCls` and thus bring the motion miss.      |
| 🇨🇳 Chinese |  修复 Modal 静态方法配置 `prefixCls`  时，会改变所有子元素的 `prefixCls` 并导致动画丢失的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
