### PR TITLE
fix: Image 组件 preview.getContainer=false 内联渲染不生效

### DIFF
--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -55,11 +55,18 @@ describe('Image', () => {
     const { container, baseElement } = render(
       <Image
         src={src}
-        preview={{ visible: true, transitionName: 'abc', maskTransitionName: 'def' }}
+        preview={{
+          visible: true,
+          transitionName: 'abc',
+          maskTransitionName: 'def',
+          getContainer: false,
+        }}
       />,
     );
 
     fireEvent.click(container.querySelector('.ant-image')!);
+
+    expect(container.querySelector('.ant-image-preview-root')).not.toBe(null);
 
     expect(baseElement.querySelector('.ant-image-preview')).toHaveClass('abc');
     expect(baseElement.querySelector('.ant-image-preview-mask')).toHaveClass('def');

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -64,7 +64,8 @@ const Image: CompositionImage<ImageProps> = (props) => {
       ),
       icons,
       ...restPreviewProps,
-      getContainer: getContainer || getContextPopupContainer,
+      getContainer:
+        getContainer || getContainer === false ? getContainer : getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
       zIndex,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无相关issue

### 💡 需求背景和解决方案
-  需求背景
- 
1. 
2. 修复后的用法没有变化，详见原官方使用文档 https://ant-design.antgroup.com/components/image-cn#previewtype
3. 无UI/交互变动
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供