### PR TITLE
fix: Image inline rendering not work when getContainer is false

### DIFF
--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -55,11 +55,18 @@ describe('Image', () => {
     const { container, baseElement } = render(
       <Image
         src={src}
-        preview={{ visible: true, transitionName: 'abc', maskTransitionName: 'def' }}
+        preview={{
+          visible: true,
+          transitionName: 'abc',
+          maskTransitionName: 'def',
+          getContainer: false,
+        }}
       />,
     );
 
     fireEvent.click(container.querySelector('.ant-image')!);
+
+    expect(container.querySelector('.ant-image-preview-root')).not.toBe(null);
 
     expect(baseElement.querySelector('.ant-image-preview')).toHaveClass('abc');
     expect(baseElement.querySelector('.ant-image-preview-mask')).toHaveClass('def');

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -64,7 +64,8 @@ const Image: CompositionImage<ImageProps> = (props) => {
       ),
       icons,
       ...restPreviewProps,
-      getContainer: getContainer || getContextPopupContainer,
+      getContainer:
+        getContainer || getContainer === false ? getContainer : getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
       zIndex,

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -49,7 +49,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
     typeof preview === 'object' ? preview.zIndex : undefined,
   );
 
-  const mergedPreview = React.useMemo(() => {
+  const mergedPreview = React.useMemo<ImageProps['preview']>(() => {
     if (preview === false) {
       return preview;
     }
@@ -64,8 +64,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
       ),
       icons,
       ...restPreviewProps,
-      getContainer:
-        getContainer || getContainer === false ? getContainer : getContextPopupContainer,
+      getContainer: getContainer ?? getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),
       zIndex,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无相关issue

### 💡 需求背景和解决方案

- 需求背景 
`Image` 组件 `preview.getContainer=false` 依据使用文档，表示图像预览框在组件DOM容器内渲染，但实际并不生效，依旧是挂载在了 document.body 下的全局位置。
- 解决方案
产生此问题的原因是 `preview.getContainer`属性在透传给 rc-image 组件时，使用 || 做空值兼容，但忽略了其值可能会为 false 的情况。所以解决方案：1. 显式的忽略 false 的判空兼容 `getContainer:
        getContainer || getContainer === false ? getContainer : getContextPopupContainer,` 2. 使用 `??` 代替 `||` 做空值合并。 这里使用了方案1，是为了更明确的表示其值会为 `false` 的特殊处理。


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Fixed an issue where the inline rendering does not take effect when the preview.getContainer value of the Image component is set to false      |
| 🇨🇳 中文 |    修复 Image 组件 preview.getContainer 值为 false时，内联渲染不生效的问题      |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供