### PR TITLE
feat: Button add tokens

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -179,14 +179,14 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
   ...genHoverActiveButtonStyle(
     token.componentCls,
     {
-      color: token.defaultColorHover,
-      borderColor: token.defaultColorHover,
-      background: token.defaultBgHover,
+      color: token.defaultHoverColor,
+      borderColor: token.defaultHoverBorderColor,
+      background: token.defaultHoverBg,
     },
     {
-      color: token.defaultColorActive,
-      borderColor: token.defaultBorderColorActive,
-      background: token.defaultBgActive,
+      color: token.defaultActiveColor,
+      borderColor: token.defaultActiveBorderColor,
+      background: token.defaultActiveBg,
     },
   ),
 

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -179,12 +179,14 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
   ...genHoverActiveButtonStyle(
     token.componentCls,
     {
-      color: token.colorPrimaryHover,
-      borderColor: token.colorPrimaryHover,
+      color: token.defaultColorHover,
+      borderColor: token.defaultColorHover,
+      background: token.defaultBgHover,
     },
     {
-      color: token.colorPrimaryActive,
-      borderColor: token.colorPrimaryActive,
+      color: token.defaultColorActive,
+      borderColor: token.defaultBorderColorActive,
+      background: token.defaultBgActive,
     },
   ),
 

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -54,32 +54,32 @@ export interface ComponentToken {
    * @desc 默认按钮悬浮态背景色
    * @descEN Background color of default button when hover
    */
-  defaultBgHover: string;
+  defaultHoverBg: string;
   /**
    * @desc 默认按钮悬浮态文本颜色
    * @descEN Text color of default button when hover
    */
-  defaultColorHover: string;
+  defaultHoverColor: string;
   /**
    * @desc 默认按钮悬浮态边框颜色
    * @descEN Border color of default button
    */
-  defaultBorderColorHover: string;
+  defaultHoverBorderColor: string;
   /**
    * @desc 默认按钮激活态背景色
    * @descEN Background color of default button when active
    */
-  defaultBgActive: string;
+  defaultActiveBg: string;
   /**
-   * @desc 默认按钮激活态边框颜色
+   * @desc 默认按钮激活态文字颜色
    * @descEN Text color of default button when active
    */
-  defaultColorActive: string;
+  defaultActiveColor: string;
   /**
    * @desc 默认按钮激活态边框颜色
    * @descEN Border color of default button when active
    */
-  defaultBorderColorActive: string;
+  defaultActiveBorderColor: string;
   /**
    * @desc 禁用状态边框颜色
    * @descEN Border color of disabled button
@@ -219,12 +219,6 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
   const contentLineHeight = token.contentLineHeight ?? getLineHeight(contentFontSize);
   const contentLineHeightSM = token.contentLineHeightSM ?? getLineHeight(contentFontSizeSM);
   const contentLineHeightLG = token.contentLineHeightLG ?? getLineHeight(contentFontSizeLG);
-  const defaultBgHover = token.defaultBgHover ?? token.colorBgContainer;
-  const defaultColorHover = token.defaultColorHover ?? token.colorPrimaryHover;
-  const defaultBorderColorHover = token.defaultBorderColorHover ?? defaultColorHover;
-  const defaultBgActive = token.defaultBgActive ?? token.colorBgContainer;
-  const defaultColorActive = token.defaultColorActive ?? token.colorPrimaryActive;
-  const defaultBorderColorActive = token.defaultBorderColorActive ?? token.colorPrimaryActive;
 
   return {
     fontWeight: 400,
@@ -250,12 +244,12 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     defaultBg: token.colorBgContainer,
     defaultBorderColor: token.colorBorder,
     defaultBorderColorDisabled: token.colorBorder,
-    defaultBgHover,
-    defaultColorHover,
-    defaultBorderColorHover,
-    defaultBgActive,
-    defaultColorActive,
-    defaultBorderColorActive,
+    defaultHoverBg: token.colorBgContainer,
+    defaultHoverColor: token.colorPrimaryHover,
+    defaultHoverBorderColor: token.colorPrimaryHover,
+    defaultActiveBg: token.colorBgContainer,
+    defaultActiveColor: token.colorPrimaryActive,
+    defaultActiveBorderColor: token.colorPrimaryActive,
     contentFontSize,
     contentFontSizeSM,
     contentFontSizeLG,

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -51,6 +51,36 @@ export interface ComponentToken {
    */
   dangerColor: string;
   /**
+   * @desc 默认按钮悬浮态背景色
+   * @descEN Background color of default button when hover
+   */
+  defaultBgHover: string;
+  /**
+   * @desc 默认按钮悬浮态文本颜色
+   * @descEN Text color of default button when hover
+   */
+  defaultColorHover: string;
+  /**
+   * @desc 默认按钮悬浮态边框颜色
+   * @descEN Border color of default button
+   */
+  defaultBorderColorHover: string;
+  /**
+   * @desc 默认按钮激活态背景色
+   * @descEN Background color of default button when active
+   */
+  defaultBgActive: string;
+  /**
+   * @desc 默认按钮激活态边框颜色
+   * @descEN Text color of default button when active
+   */
+  defaultColorActive: string;
+  /**
+   * @desc 默认按钮激活态边框颜色
+   * @descEN Border color of default button when active
+   */
+  defaultBorderColorActive: string;
+  /**
    * @desc 禁用状态边框颜色
    * @descEN Border color of disabled button
    */
@@ -189,6 +219,12 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
   const contentLineHeight = token.contentLineHeight ?? getLineHeight(contentFontSize);
   const contentLineHeightSM = token.contentLineHeightSM ?? getLineHeight(contentFontSizeSM);
   const contentLineHeightLG = token.contentLineHeightLG ?? getLineHeight(contentFontSizeLG);
+  const defaultBgHover = token.defaultBgHover ?? token.colorBgContainer;
+  const defaultColorHover = token.defaultColorHover ?? token.colorPrimaryHover;
+  const defaultBorderColorHover = token.defaultBorderColorHover ?? defaultColorHover;
+  const defaultBgActive = token.defaultBgActive ?? token.colorBgContainer;
+  const defaultColorActive = token.defaultColorActive ?? token.colorPrimaryActive;
+  const defaultBorderColorActive = token.defaultBorderColorActive ?? token.colorPrimaryActive;
 
   return {
     fontWeight: 400,
@@ -214,6 +250,12 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     defaultBg: token.colorBgContainer,
     defaultBorderColor: token.colorBorder,
     defaultBorderColorDisabled: token.colorBorder,
+    defaultBgHover,
+    defaultColorHover,
+    defaultBorderColorHover,
+    defaultBgActive,
+    defaultColorActive,
+    defaultBorderColorActive,
     contentFontSize,
     contentFontSizeSM,
     contentFontSizeLG,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close: #46249 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Button add `defaultHoverBg`,  `defaultHoverColor`, ` defaultHoverBorderColor`, `defaultActiveBg`, `defaultActiveColor` and `defaultActiveBorderColor` tokens.        |
| 🇨🇳 Chinese |    Button 添加 `defaultHoverBg`、`defaultHoverColor`、`defaultHoverBorderColor`、 `defaultActiveBg`、`defaultActiveColor` 和 `defaultActiveBorderColor` 六个 token。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
