### PR TITLE
fix: Modal conflicting props classNames.wrapper and centered

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -146,7 +146,7 @@ const Modal: React.FC<ModalProps> = (props) => {
             classNames={{
               ...modal?.classNames,
               ...modalClassNames,
-              wrapper: `${wrapClassNameExtended} ${modalClassNames?.wrapper}`,
+              wrapper: `${wrapClassNameExtended} ${modalClassNames?.wrapper || ''}`,
             }}
             styles={{
               ...modal?.styles,

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -144,9 +144,9 @@ const Modal: React.FC<ModalProps> = (props) => {
             className={classNames(hashId, className, modal?.className)}
             style={{ ...modal?.style, ...style }}
             classNames={{
-              wrapper: wrapClassNameExtended,
               ...modal?.classNames,
               ...modalClassNames,
+              wrapper: `${wrapClassNameExtended} ${modalClassNames?.wrapper}`,
             }}
             styles={{
               ...modal?.styles,

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -146,7 +146,7 @@ const Modal: React.FC<ModalProps> = (props) => {
             classNames={{
               ...modal?.classNames,
               ...modalClassNames,
-              wrapper: `${wrapClassNameExtended} ${modalClassNames?.wrapper || ''}`,
+              wrapper: classNames(wrapClassNameExtended, modalClassNames?.wrapper),
             }}
             styles={{
               ...modal?.styles,

--- a/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Modal render correctly 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap  "
+        class="ant-modal-wrap"
         tabindex="-1"
       >
         <div
@@ -151,7 +151,7 @@ exports[`Modal render without footer 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap  "
+        class="ant-modal-wrap"
         tabindex="-1"
       >
         <div
@@ -226,7 +226,7 @@ exports[`Modal support closeIcon 1`] = `
     class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
   />
   <div
-    class="ant-modal-wrap  "
+    class="ant-modal-wrap"
     tabindex="-1"
   >
     <div

--- a/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Modal render correctly 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap"
+        class="ant-modal-wrap  undefined"
         tabindex="-1"
       >
         <div
@@ -151,7 +151,7 @@ exports[`Modal render without footer 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap"
+        class="ant-modal-wrap  undefined"
         tabindex="-1"
       >
         <div
@@ -226,7 +226,7 @@ exports[`Modal support closeIcon 1`] = `
     class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
   />
   <div
-    class="ant-modal-wrap"
+    class="ant-modal-wrap  undefined"
     tabindex="-1"
   >
     <div

--- a/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Modal render correctly 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap  undefined"
+        class="ant-modal-wrap  "
         tabindex="-1"
       >
         <div
@@ -151,7 +151,7 @@ exports[`Modal render without footer 1`] = `
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
       />
       <div
-        class="ant-modal-wrap  undefined"
+        class="ant-modal-wrap  "
         tabindex="-1"
       >
         <div
@@ -226,7 +226,7 @@ exports[`Modal support closeIcon 1`] = `
     class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
   />
   <div
-    class="ant-modal-wrap  undefined"
+    class="ant-modal-wrap  "
     tabindex="-1"
   >
     <div

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -52,7 +52,7 @@ export interface ModalProps extends ModalCommonProps {
   transitionName?: string;
   className?: string;
   rootClassName?: string;
-  classNames?: Omit<NonNullable<DialogProps['classNames']>, 'wrapper'>;
+  classNames?: NonNullable<DialogProps['classNames']>;
   getContainer?: string | HTMLElement | getContainerFunc | false;
   zIndex?: number;
   /** @deprecated Please use `styles.body` instead */


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
close https://github.com/ant-design/ant-design/issues/47041

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal conflicting props bettween `classNames.wrapper` and `centered`.     |
| 🇨🇳 Chinese |   修复 Modal 自定义 `classNames.wrapper` 时 `centered` 属性不生效的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
