### PR TITLE
feat: input-number support wheel setting(default false)

### DIFF
--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -62,6 +62,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | stringMode | Set value as string to support high precision decimals. Will return string value by `onChange` | boolean | false | 4.13.0 |
 | value | The current value | number | - | - |
 | variant | Variants of Input | `outlined` \| `borderless` \| `filled` | `outlined` | 5.13.0 |
+| wheel | Allows changing value with mouse wheel | boolean | false | - |
 | onChange | The callback triggered when the value is changed | function(value: number \| string \| null) | - | - |
 | onPressEnter | The callback function that is triggered when Enter key is pressed | function(e) | - | - |
 | onStep | The callback function that is triggered when click up or down buttons | (value: number, info: { offset: number, type: 'up' \| 'down' }) => void | - | 4.7.0 |

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -37,6 +37,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
    * @default "outlined"
    */
   variant?: Variant;
+  wheel?: boolean;
 }
 
 const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props, ref) => {
@@ -65,6 +66,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
     status: customStatus,
     controls,
     variant: customVariant,
+    wheel = false,
     ...others
   } = props;
 
@@ -136,6 +138,7 @@ const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props,
       controls={controlsTemp}
       prefix={prefix}
       suffix={suffixNode}
+      wheel={wheel}
       addonAfter={
         addonAfter && (
           <NoCompactStyle>

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -63,6 +63,7 @@ demo:
 | stringMode | 字符值模式，开启后支持高精度小数。同时 `onChange` 将返回 string 类型 | boolean | false | 4.13.0 |
 | value | 当前值 | number | - | - |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` | `outlined` | 5.13.0 |
+| wheel | 是否允许滚轮滑动更改数值 | boolean | false | - |
 | onChange | 变化回调 | function(value: number \| string \| null) | - | - |
 | onPressEnter | 按下回车的回调 | function(e) | - | - |
 | onStep | 点击上下箭头的回调 | (value: number, info: { offset: number, type: 'up' \| 'down' }) => void | - | 4.7.0 |


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ✔️] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->](https://github.com/ant-design/ant-design/issues/47115)

### 💡 需求背景和解决方案

<!--
1. 禁止掉最新版本的 input-number 组件默认滑轮滚动改变数值的行为，用户需要可以手动开启。
2. 增加了 wheel 属性，默认为 false。
-->

### 📝 更新日志

<!--
input-number 组件默认不再开启鼠标滑轮滚动调整数值的功能。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   The input-number component no longer enables the mouse wheel scrolling function to adjust the value by default.   |
| 🇨🇳 中文 |   input-number 组件默认不再开启鼠标滑轮滚动调整数值的功能。   |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✔️] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供