### PR TITLE
fix(Site): Fix the issue of font color not synchronizing with theme c…

### DIFF
--- a/.dumi/theme/common/styles/Highlight.tsx
+++ b/.dumi/theme/common/styles/Highlight.tsx
@@ -1,5 +1,5 @@
-import { css, Global } from '@emotion/react';
 import React from 'react';
+import { css, Global } from '@emotion/react';
 import { useTheme } from 'antd-style';
 
 export default () => {
@@ -29,7 +29,7 @@ export default () => {
 
         code[class*='language-'],
         pre[class*='language-'] {
-          color: black;
+          color: ${token.colorText};
           font-family: 'Lucida Console', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
           line-height: 1.5;
           direction: ltr;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

nothing
<!--
	1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
	-->

### 💡 Background and solution

![image](https://github.com/ant-design/ant-design/assets/23185852/c1f34338-1fce-4bb5-a55d-4d86d8f596de)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
	Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Part of the font colors in the code preview of the document site in dark mode did not change due to theme switching       |
| 🇨🇳 Chinese |      文档站点暗黑模式下代码预览中部分字体颜色没有按照主题切换而变化     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
