### PR TITLE
fix: Descriptions lost border style when children is falsy

### DIFF
--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -17,6 +17,7 @@ export interface CellProps {
   label?: React.ReactNode;
   content?: React.ReactNode;
   colon?: boolean;
+  type?: 'label' | 'content' | 'item';
 }
 
 const Cell: React.FC<CellProps> = (props) => {
@@ -32,6 +33,7 @@ const Cell: React.FC<CellProps> = (props) => {
     label,
     content,
     colon,
+    type,
   } = props;
 
   const Component = component as keyof JSX.IntrinsicElements;
@@ -41,8 +43,8 @@ const Cell: React.FC<CellProps> = (props) => {
       <Component
         className={classNames(
           {
-            [`${itemPrefixCls}-item-label`]: notEmpty(label),
-            [`${itemPrefixCls}-item-content`]: notEmpty(content),
+            [`${itemPrefixCls}-item-label`]: type === 'label',
+            [`${itemPrefixCls}-item-content`]: type === 'content',
           },
           className,
         )}

--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -7,7 +7,7 @@ import DescriptionsContext from './DescriptionsContext';
 
 interface CellConfig {
   component: string | [string, string];
-  type: string;
+  type: 'label' | 'content' | 'item';
   showLabel?: boolean;
   showContent?: boolean;
 }
@@ -54,6 +54,7 @@ function renderCells(
             bordered={bordered}
             label={showLabel ? label : null}
             content={showContent ? children : null}
+            type={type}
           />
         );
       }
@@ -69,6 +70,7 @@ function renderCells(
           itemPrefixCls={itemPrefixCls}
           bordered={bordered}
           label={label}
+          type="label"
         />,
         <Cell
           key={`content-${key || index}`}
@@ -79,6 +81,7 @@ function renderCells(
           itemPrefixCls={itemPrefixCls}
           bordered={bordered}
           content={children}
+          type="content"
         />,
       ];
     },

--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -377,4 +377,22 @@ describe('Descriptions', () => {
       expect.anything(),
     );
   });
+
+  // https://github.com/ant-design/ant-design/issues/47151
+  it('should has .ant-descriptions-item-content className when children is falsy', () => {
+    const wrapper = render(
+      <Descriptions
+        bordered
+        items={[
+          {
+            key: '1',
+            label: null,
+            children: null,
+          },
+        ]}
+      />,
+    );
+    expect(wrapper.container.querySelectorAll('.ant-descriptions-item-label')).toHaveLength(1);
+    expect(wrapper.container.querySelectorAll('.ant-descriptions-item-content')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/47151

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Descriptions lost border style when item's children is falsy.        |
| 🇨🇳 Chinese |   修复 Descriptions 当 `item` 的 `children` 为 `null` 时丢失单元格右边框样式的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
