### PR TITLE
fix: Menu submenu hover style

### DIFF
--- a/.dumi/theme/builtins/DemoWrapper/index.tsx
+++ b/.dumi/theme/builtins/DemoWrapper/index.tsx
@@ -110,7 +110,7 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
           )}
         </Tooltip>
       </span>
-      <ConfigProvider theme={{ cssVar: enableCssVar }}>
+      <ConfigProvider theme={{ cssVar: enableCssVar, hashed: !enableCssVar }}>
         <DumiDemoGrid items={demos} />
       </ConfigProvider>
     </div>

--- a/.dumi/theme/builtins/DemoWrapper/index.tsx
+++ b/.dumi/theme/builtins/DemoWrapper/index.tsx
@@ -110,7 +110,7 @@ const DemoWrapper: typeof DumiDemoGrid = ({ items }) => {
           )}
         </Tooltip>
       </span>
-      <ConfigProvider theme={{ cssVar: enableCssVar, hashed: !enableCssVar }}>
+      <ConfigProvider theme={{ cssVar: enableCssVar }}>
         <DumiDemoGrid items={demos} />
       </ConfigProvider>
     </div>

--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -373,7 +373,6 @@ export interface MenuToken extends FullToken<'Menu'> {
   menuHorizontalHeight: number | string;
   menuArrowSize: number | string;
   menuArrowOffset: number | string;
-  menuPanelMaskInset: number;
   menuSubMenuBg: string;
   darkPopupBg: string;
 }
@@ -528,7 +527,6 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
     menuArrowSize,
     menuArrowOffset,
     lineType,
-    menuPanelMaskInset,
     groupTitleLineHeight,
     groupTitleFontSize,
   } = token;
@@ -680,7 +678,7 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
             // https://github.com/ant-design/ant-design/issues/13955
             '&::before': {
               position: 'absolute',
-              inset: `${unit(menuPanelMaskInset)} 0 0`,
+              inset: 0,
               zIndex: -1,
               width: '100%',
               height: '100%',
@@ -702,12 +700,6 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
                 transition: `transform ${motionDurationSlow} ${motionEaseInOut}`,
               },
             },
-          },
-
-          // https://github.com/ant-design/ant-design/issues/13955
-          '&-placement-rightTop::before': {
-            top: 0,
-            insetInlineStart: menuPanelMaskInset,
           },
 
           [`
@@ -977,7 +969,6 @@ export default (prefixCls: string, rootCls: string = prefixCls, injectStyle: boo
         menuArrowSize,
         menuHorizontalHeight: token.calc(controlHeightLG).mul(1.15).equal(),
         menuArrowOffset: token.calc(menuArrowSize).mul(0.25).equal(),
-        menuPanelMaskInset: -7, // Still a hardcode here since it's offset by rc-align
         menuSubMenuBg: colorBgElevated,
         calc: token.calc,
         popupBg,


### PR DESCRIPTION
- fix: Menu submenu hover style
- chore: code clean

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
resolve https://github.com/ant-design/ant-design/issues/47143

close https://github.com/ant-design/ant-design/pull/47221
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

在 https://github.com/ant-design/ant-design/pull/42648 中 Menu 的子菜单不再通过 align 对齐，所以一些 hardcode 可以删除了。

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Menu that submenu hover style disappear when hover on the edge.      |
| 🇨🇳 Chinese |        修复 Menu 组件子菜单 hover 样式在边缘消失的问题。   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
