### PR TITLE
feat: add `rowSelection.cellRender` for `Table` and mark `rowSelection.renderCell` as `deprecated`

### DIFF
--- a/components/table/demo/row-selection-custom-debug.tsx
+++ b/components/table/demo/row-selection-custom-debug.tsx
@@ -26,7 +26,7 @@ for (let i = 0; i < 46; i++) {
 
 const App: React.FC = () => {
   const rowSelection: TableRowSelection<DataType> = {
-    renderCell: (checked, _record, index, node) => ({
+    cellRender: (checked, _record, index, node) => ({
       props: { rowSpan: index % 2 === 0 ? 2 : 0 },
       children: (
         <>

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -91,7 +91,8 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
     type: selectionType,
     selections,
     fixed,
-    renderCell: customizeRenderCell,
+    renderCell: deprecatedCustomizeRenderCell,
+    cellRender: customizeCellRender,
     hideSelectAll,
     checkStrictly = true,
   } = rowSelection || {};
@@ -602,6 +603,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
         };
       }
 
+      const customizeRenderCell = customizeCellRender ?? deprecatedCustomizeRenderCell;
       const renderSelectionCell = (_: any, record: RecordType, index: number) => {
         const { node, checked } = renderCell(_, record, index);
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -267,7 +267,8 @@ Properties for row selection.
 | getCheckboxProps | Get Checkbox or Radio props | function(record) | - |  |
 | hideSelectAll | Hide the selectAll checkbox and custom selection | boolean | false | 4.3.0 |
 | preserveSelectedRowKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4.0 |
-| renderCell | Renderer of the table cell. Same as `render` in column | function(checked, record, index, originNode) {} | - | 4.1.0 |
+| renderCell | deprecated, use `cellRender` instead | - | 4.1.0 |
+| cellRender | Renderer of the table cell. Same as `render` in column | function(checked, record, index, originNode) {} | - | x.y.z |
 | selectedRowKeys | Controlled selected row keys | string\[] \| number\[] | \[] |  |
 | selections | Custom selection [config](#selection), only displays default selections when set to `true` | object\[] \| boolean | - |  |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |
@@ -384,4 +385,4 @@ Fixed column use `z-index` to make it over other columns. You will find sometime
 
 ### How to custom render Table Checkbox（For example, adding Tooltip）?
 
-Since `4.1.0`, You can use [`rowSelection.renderCell`](https://ant.design/components/table/#rowselection) to custom render Table Checkbox. If you want to add Tooltip, please refer to this [demo](https://codesandbox.io/s/table-row-tooltip-v79j2v).
+Since `x.y.z`, You can use [`rowSelection.cellRender`](or `rowSelection.renderCell` if (`x.y.z` ＞ `your version` ≥ `4.1.0`))(https://ant.design/components/table/#rowselection) to custom render Table Checkbox. If you want to add Tooltip, please refer to this [demo](https://codesandbox.io/s/table-row-tooltip-v79j2v).

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -268,7 +268,8 @@ const columns = [
 | getCheckboxProps | 选择框的默认属性配置 | function(record) | - |  |
 | hideSelectAll | 隐藏全选勾选框与自定义选择项 | boolean | false | 4.3.0 |
 | preserveSelectedRowKeys | 当数据被删除时仍然保留选项的 `key` | boolean | - | 4.4.0 |
-| renderCell | 渲染勾选框，用法与 Column 的 `render` 相同 | function(checked, record, index, originNode) {} | - | 4.1.0 |
+| renderCell | 已废弃，请使用`cellRender` | - | 4.1.0 |
+| cellRender | 渲染勾选框，用法与 Column 的 `render` 相同 | function(checked, record, index, originNode) {} | - | x.y.z |
 | selectedRowKeys | 指定选中项的 key 数组，需要和 onChange 进行配合 | string\[] \| number\[] | \[] |  |
 | defaultSelectedRowKeys | 默认选中项的 key 数组 | string\[] \| number\[] | \[] |  |
 | selections | 自定义选择项 [配置项](#selection), 设为 `true` 时使用默认选择项 | object\[] \| boolean | true |  |
@@ -384,4 +385,4 @@ return <Table rowKey={(record) => record.uid} />;
 
 ### 如何自定义渲染可选列的勾选框（比如增加 Tooltip）？
 
-自 `4.1.0` 起，可以通过 [rowSelection](https://ant.design/components/table-cn/#rowselection) 的 `renderCell` 属性控制，可以参考此处 [Demo](https://codesandbox.io/s/table-row-tooltip-v79j2v) 实现展示 Tooltip 需求或其他自定义的需求。
+自 `x.y.z` 起，可以通过 [rowSelection](https://ant.design/components/table-cn/#rowselection) 的 `cellRender` 属性（如果`x.y.z` ＞ `你的版本` ≥ `4.1.0`，使用`renderCell`）控制，可以参考此处 [Demo](https://codesandbox.io/s/table-row-tooltip-v79j2v) 实现展示 Tooltip 需求或其他自定义的需求。

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -174,6 +174,13 @@ export type SelectionSelectFn<T> = (
 
 export type RowSelectMethod = 'all' | 'none' | 'invert' | 'single' | 'multiple';
 
+type TableRowSelectionCellRender<T> = (
+  value: boolean,
+  record: T,
+  index: number,
+  originNode: React.ReactNode,
+) => React.ReactNode | RcRenderedCell<T>;
+
 export interface TableRowSelection<T> {
   /** Keep the selection keys in list even the key not exist in `dataSource` anymore */
   preserveSelectedRowKeys?: boolean;
@@ -197,12 +204,9 @@ export interface TableRowSelection<T> {
   columnWidth?: string | number;
   columnTitle?: React.ReactNode | ((checkboxNode: React.ReactNode) => React.ReactNode);
   checkStrictly?: boolean;
-  renderCell?: (
-    value: boolean,
-    record: T,
-    index: number,
-    originNode: React.ReactNode,
-  ) => React.ReactNode | RcRenderedCell<T>;
+  /** @deprecated Please use `cellRender` instead */
+  renderCell?: TableRowSelectionCellRender<T>;
+  cellRender?: TableRowSelectionCellRender<T>;
   onCell?: GetComponentProps<T>;
 }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/46970

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

`rowSelection.renderCell` of `Table` is irregular 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add `rowSelection.cellRender` to `Table` and mark `rowSelection.renderCell` as `deprecated` |
| 🇨🇳 Chinese | `Table`支持`rowSelection.cellRender`,原`rowSelection.renderCell`标记为`已废弃` |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

文档更新中，暂时用x.y.z作为本pr可能被合并的版本
