### PR TITLE
style: Use description color instead of disabled in Empty

### DIFF
--- a/components/empty/style/index.ts
+++ b/components/empty/style/index.ts
@@ -51,10 +51,10 @@ const genSharedEmptyStyle: GenerateStyle<EmptyToken> = (token): CSSObject => {
 
       '&-normal': {
         marginBlock: marginXL,
-        color: token.colorTextDisabled,
+        color: token.colorTextDescription,
 
         [`${componentCls}-description`]: {
-          color: token.colorTextDisabled,
+          color: token.colorTextDescription,
         },
 
         [`${componentCls}-image`]: {
@@ -64,7 +64,7 @@ const genSharedEmptyStyle: GenerateStyle<EmptyToken> = (token): CSSObject => {
 
       '&-small': {
         marginBlock: marginXS,
-        color: token.colorTextDisabled,
+        color: token.colorTextDescription,
 
         [`${componentCls}-image`]: {
           height: token.emptyImgHeightSM,


### PR DESCRIPTION
### 🤔 This is a ...

Component style update

### 💡 Background and solution

Imo, using the _disabled_ color for _description_ makes the text to be way too light: as a user I think it's not readable enough. And it does not comply with a11y guidelines.

### 📝 Changelog

The description text for empty states has become slightly darker

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | The description text for empty states has become slightly darker |
| 🇨🇳 Chinese | 空状态的描述文本变得稍微暗一些 |

