### PR TITLE
feat: 新增Form.List.usePrefixName

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -5,6 +5,7 @@ import type { StoreValue, ValidatorRule } from 'rc-field-form/lib/interface';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { FormItemPrefixContext } from './context';
+import useFormListPrefixName from './hooks/useFormListPrefixName';
 
 export interface FormListFieldData {
   name: number;
@@ -31,11 +32,7 @@ export interface FormListProps {
   ) => React.ReactNode;
 }
 
-const FormList: React.FC<FormListProps> = ({
-  prefixCls: customizePrefixCls,
-  children,
-  ...props
-}) => {
+const InternalFormList = ({ prefixCls: customizePrefixCls, children, ...props }: FormListProps) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Form.List');
 
@@ -74,5 +71,14 @@ const FormList: React.FC<FormListProps> = ({
     </List>
   );
 };
+
+type InternalFormListType = typeof InternalFormList;
+
+type CompoundedComponent = InternalFormListType & {
+  usePrefixName: typeof useFormListPrefixName;
+};
+
+const FormList = InternalFormList as CompoundedComponent;
+FormList.usePrefixName = useFormListPrefixName;
 
 export default FormList;

--- a/components/form/__tests__/list.test.tsx
+++ b/components/form/__tests__/list.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { renderHook } from '@testing-library/react';
 import type { FormListFieldData, FormListOperation } from '..';
 import Form from '..';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
@@ -327,5 +328,55 @@ describe('Form.List', () => {
     expect(errorSpy).toHaveBeenCalled();
 
     errorSpy.mockRestore();
+  });
+
+  it('Form.List.usePrefixName', () => {
+    const { result } = renderHook(() => Form.List.usePrefixName(), {
+      wrapper({ children }) {
+        return (
+          <Form
+            layout="vertical"
+            initialValues={{
+              parent1: [
+                {
+                  name: 'parent1',
+                  parent2: [
+                    {
+                      name: 'parent2',
+                    },
+                  ],
+                },
+              ],
+            }}
+          >
+            <Form.List name="parent1">
+              {(fields) =>
+                fields.map((field) => (
+                  <div key={field.key}>
+                    <Form.Item label="parent1" name={[field.name, 'name']}>
+                      <Input />
+                    </Form.Item>
+                    <Form.List name={[field.name, 'parent2']}>
+                      {(fields2) =>
+                        fields2.map((field2) => (
+                          <div key={field2.key}>
+                            <Form.Item label="parent2" name={[field2.name, 'name']}>
+                              <Input />
+                            </Form.Item>
+                            {children}
+                          </div>
+                        ))
+                      }
+                    </Form.List>
+                  </div>
+                ))
+              }
+            </Form.List>
+          </Form>
+        );
+      },
+    });
+
+    expect(result.current).toEqual(['parent1', 0, 'parent2']);
   });
 });

--- a/components/form/demo/use-form-list-prefix-name.tsx
+++ b/components/form/demo/use-form-list-prefix-name.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const prefixName = Form.List.usePrefixName();
+  const watchedValue = Form.useWatch([...prefixName!, 'watched']);
+
+  return (
+    <>
+      <Form.Item label="watched" name="watched">
+        <Input />
+      </Form.Item>
+      <Form.Item>watched value: {watchedValue}</Form.Item>
+      <Form.Item label="prefixName">{JSON.stringify(prefixName)}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) =>
+                fields2.map((field2) => (
+                  <div key={field2.key}>
+                    <Form.Item label="parent2" name={[field2.name, 'name']}>
+                      <Input />
+                    </Form.Item>
+                    <ChildrenContent />
+                  </div>
+                ))
+              }
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);

--- a/components/form/hooks/useFormListPrefixName.ts
+++ b/components/form/hooks/useFormListPrefixName.ts
@@ -1,0 +1,7 @@
+import { FieldContext } from 'rc-field-form';
+import * as React from 'react';
+
+export default () => {
+  const { prefixName } = React.useContext(FieldContext);
+  return prefixName;
+};

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -55,6 +55,7 @@ High performance Form component with data scope management. Including data colle
 <code src="./demo/ref-item.tsx" debug>Ref item</code>
 <code src="./demo/custom-feedback-icons.tsx" debug>Custom feedback icons</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
+<code src="./demo/use-form-list-prefix-name.tsx" debug>Form.List.usePrefixName</code>
 
 ## API
 
@@ -434,6 +435,74 @@ const Demo = () => {
     </div>
   );
 };
+```
+
+### Form.List.usePrefixName
+
+`type Form.List.usePrefixName = (): (string | number)[] | undefined`
+
+Used to get the `NamePath` collection of all parent `Form.List`. If there are multiple `Form.List`, all `NamePath` will be merged. If there is no `Form.List` in the upper layer, `usePrefixName` will return` undefined`
+
+```tsx
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const prefixName = Form.List.usePrefixName();
+  const watchedValue = Form.useWatch([...prefixName!, 'watched']);
+  console.log(prefixName); // output ['parent1', 0, 'parent2']
+
+  return (
+    <>
+      <Form.Item label="watched" name="watched">
+        <Input />
+      </Form.Item>
+      <Form.Item>watched value: {watchedValue}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) =>
+                fields2.map((field2) => (
+                  <div key={field2.key}>
+                    <Form.Item label="parent2" name={[field2.name, 'name']}>
+                      <Input />
+                    </Form.Item>
+                    <ChildrenContent />
+                  </div>
+                ))
+              }
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);
 ```
 
 ### Form.Item.useStatus

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -56,6 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ylFATY6w-ygAAA
 <code src="./demo/ref-item.tsx" debug>引用字段</code>
 <code src="./demo/custom-feedback-icons.tsx" debug>Custom feedback icons</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
+<code src="./demo/use-form-list-prefix-name.tsx" debug>Form.List.usePrefixName</code>
 
 ## API
 
@@ -433,6 +434,74 @@ const Demo = () => {
     </div>
   );
 };
+```
+
+### Form.List.usePrefixName
+
+`type Form.List.usePrefixName = (): (string | number)[] | undefined`
+
+用于获取所有父级`Form.List`的`NamePath`集合，如果有多个`Form.List`，则将合并所有`NamePath`，如果上层没有`Form.List`，`usePrefixName`将返回`undefined`
+
+```tsx
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const prefixName = Form.List.usePrefixName();
+  const watchedValue = Form.useWatch([...prefixName!, 'watched']);
+  console.log(prefixName); // output ['parent1', 0, 'parent2']
+
+  return (
+    <>
+      <Form.Item label="watched" name="watched">
+        <Input />
+      </Form.Item>
+      <Form.Item>watched value: {watchedValue}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) =>
+                fields2.map((field2) => (
+                  <div key={field2.key}>
+                    <Form.Item label="parent2" name={[field2.name, 'name']}>
+                      <Input />
+                    </Form.Item>
+                    <ChildrenContent />
+                  </div>
+                ))
+              }
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);
 ```
 
 ### Form.Item.useStatus


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [x] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

场景：在某些复杂的大表单场景中，表单代码通常要拆分成好几个组件，在有多个Form.List嵌套的后代组件中，想要拿到完整的namePath并不容易，需要层层传递props；

目的：希望可以在所有的后代元素中，使用hook就可以拿到prefixName；

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add new hook:  `Form.List.usePrefixName`    |
| 🇨🇳 Chinese |     新增hook：`Form.List.usePrefixName`     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
