### PR TITLE
feat: 新增FormScope功能

### DIFF
--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -4,7 +4,7 @@ import type { StoreValue, ValidatorRule } from 'rc-field-form/lib/interface';
 
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
-import { FormItemPrefixContext } from './context';
+import { FormItemPrefixContext, BaseScopeProvider } from './context';
 
 export interface FormListFieldData {
   name: number;
@@ -61,14 +61,16 @@ const FormList: React.FC<FormListProps> = ({
     <List {...props}>
       {(fields, operation, meta) => (
         <FormItemPrefixContext.Provider value={contextValue}>
-          {children(
-            fields.map((field) => ({ ...field, fieldKey: field.key })),
-            operation,
-            {
-              errors: meta.errors,
-              warnings: meta.warnings,
-            },
-          )}
+          <BaseScopeProvider name={props.name}>
+            {children(
+              fields.map((field) => ({ ...field, fieldKey: field.key })),
+              operation,
+              {
+                errors: meta.errors,
+                warnings: meta.warnings,
+              },
+            )}
+          </BaseScopeProvider>
         </FormItemPrefixContext.Provider>
       )}
     </List>

--- a/components/form/__tests__/scope.test.tsx
+++ b/components/form/__tests__/scope.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import Form from '..';
+import Input from '../../input';
+import { FieldContext } from 'rc-field-form';
+
+describe('Form.Scope', () => {
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <Form
+      layout="vertical"
+      initialValues={{
+        parent1: [
+          {
+            name: 'parent1',
+            parent2: [
+              {
+                name: 'parent2',
+              },
+            ],
+          },
+        ],
+      }}
+    >
+      <Form.List name="parent1">
+        {(fields) =>
+          fields.map((field) => (
+            <div key={field.key}>
+              <Form.Item label="parent1" name={[field.name, 'name']}>
+                <Input />
+              </Form.Item>
+              <Form.List name={[field.name, 'parent2']}>
+                {(fields2) =>
+                  fields2.map((field2) => (
+                    <div key={field2.key}>
+                      <Form.Item label="parent2" name={[field2.name, 'name']}>
+                        <Input />
+                      </Form.Item>
+                      <Form.Scope name={field2.name}>{children}</Form.Scope>
+                    </div>
+                  ))
+                }
+              </Form.List>
+            </div>
+          ))
+        }
+      </Form.List>
+    </Form>
+  );
+
+  it('Form.useScope', () => {
+    const { result } = renderHook(() => Form.useScope(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.prefixName).toEqual(['parent1', 0, 'parent2', 0]);
+    expect(result.current.name).toBe(0);
+  });
+
+  it('FieldContext', () => {
+    const { result } = renderHook(() => React.useContext(FieldContext), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.prefixName).toEqual(['parent1', 0, 'parent2', 0]);
+  });
+});

--- a/components/form/demo/use-form-scope.tsx
+++ b/components/form/demo/use-form-scope.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const { prefixName } = Form.useScope();
+  const child = Form.useWatch([...prefixName!, 'child']);
+
+  return (
+    <>
+      {/* 这里的name只写'child'即可，不需要写[field.name, 'child']，因为Form.Scope已经做了这件事 */}
+      <Form.Item label="Children Content" name="child">
+        <Input />
+      </Form.Item>
+      <Form.Item>child value: {child}</Form.Item>
+      <Form.Item label="prefixName">{JSON.stringify(prefixName)}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) => (
+                <>
+                  {fields2.map((field2) => (
+                    <div key={field2.key}>
+                      <Form.Item label="parent2" name={[field2.name, 'name']}>
+                        <Input />
+                      </Form.Item>
+                      <Form.Scope name={field2.name}>
+                        <ChildrenContent />
+                      </Form.Scope>
+                    </div>
+                  ))}
+                </>
+              )}
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);

--- a/components/form/hooks/useFormScope.ts
+++ b/components/form/hooks/useFormScope.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { ScopeContext } from '../context';
+
+export default () => React.useContext(ScopeContext);

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -55,6 +55,7 @@ High performance Form component with data scope management. Including data colle
 <code src="./demo/ref-item.tsx" debug>Ref item</code>
 <code src="./demo/custom-feedback-icons.tsx" debug>Custom feedback icons</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
+<code src="./demo/use-form-scope.tsx" debug>Form.useScope</code>
 
 ## API
 
@@ -291,6 +292,10 @@ Provide linkage between forms. If a sub form with `name` prop update, it will au
 </Form.Provider>
 ```
 
+## Form.Scope
+
+Create a `Scope` used to pass `NamePath`, which is used to pass `namePath` in complex form scenarios. Use it with [Form.useScope](#formusescope)
+
 ### FormInstance
 
 | Name | Description | Type | Version |
@@ -436,6 +441,78 @@ const Demo = () => {
 };
 ```
 
+### Form.useScope
+
+`type Form.useScope = (): FormScope`
+
+Used to get the `NamePath` collection of all parent `Form.List` and `Form.Scope`
+
+```tsx
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const { prefixName } = Form.useScope();
+  const child = Form.useWatch([...prefixName!, 'child']);
+  console.log(prefixName); // output ["parent1",0,"parent2",0]
+
+  return (
+    <>
+      <Form.Item label="Children Content" name="child">
+        <Input />
+      </Form.Item>
+      <Form.Item>child value: {child}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) => (
+                <>
+                  {fields2.map((field2) => (
+                    <div key={field2.key}>
+                      <Form.Item label="parent2" name={[field2.name, 'name']}>
+                        <Input />
+                      </Form.Item>
+                      <Form.Scope name={field2.name}>
+                        <ChildrenContent />
+                      </Form.Scope>
+                    </div>
+                  ))}
+                </>
+              )}
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);
+```
+
 ### Form.Item.useStatus
 
 `type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[], warnings: ReactNode[] }`
@@ -552,6 +629,15 @@ type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
 | --- | --- | --- | --- | --- |
 | form | Form instance | FormInstance | Current form in context | 5.4.0 |
 | preserve | Whether to watch the field which has no matched `Form.Item` | boolean | false | 5.4.0 |
+
+#### FormScope
+
+```ts
+interface FormScope {
+  prefixName?: (string | number)[];
+  name?: NamePath;
+}
+```
 
 ## Design Token
 

--- a/components/form/index.ts
+++ b/components/form/index.ts
@@ -8,8 +8,10 @@ import List, {
   type FormListOperation,
   type FormListProps,
 } from './FormList';
-import { FormProvider } from './context';
+import type { FormScope, FormScopeProps } from './context';
+import { FormProvider, ScopeProvider } from './context';
 import useFormInstance from './hooks/useFormInstance';
+import useFormScope from './hooks/useFormScope';
 
 type InternalFormType = typeof InternalForm;
 
@@ -17,10 +19,12 @@ type CompoundedComponent = InternalFormType & {
   useForm: typeof useForm;
   useFormInstance: typeof useFormInstance;
   useWatch: typeof useWatch;
+  useScope: typeof useFormScope;
   Item: typeof Item;
   List: typeof List;
   ErrorList: typeof ErrorList;
   Provider: typeof FormProvider;
+  Scope: typeof ScopeProvider;
 
   /** @deprecated Only for warning usage. Do not use. */
   create: () => void;
@@ -35,6 +39,8 @@ Form.useForm = useForm;
 Form.useFormInstance = useFormInstance;
 Form.useWatch = useWatch;
 Form.Provider = FormProvider;
+Form.Scope = ScopeProvider;
+Form.useScope = useFormScope;
 Form.create = () => {
   warning(
     false,
@@ -54,6 +60,8 @@ export type {
   Rule,
   RuleObject,
   RuleRender,
+  FormScope,
+  FormScopeProps,
 };
 
 export default Form;

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -56,6 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ylFATY6w-ygAAA
 <code src="./demo/ref-item.tsx" debug>引用字段</code>
 <code src="./demo/custom-feedback-icons.tsx" debug>Custom feedback icons</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
+<code src="./demo/use-form-scope.tsx" debug>Form.useScope</code>
 
 ## API
 
@@ -290,6 +291,10 @@ Form.List 渲染表单相关操作函数。
 </Form.Provider>
 ```
 
+## Form.Scope
+
+创建一个用来传递`NamePath`的`Scope`，用于复杂表单场景下的`namePath`传递，配合[Form.useScope](#formusescope)使用
+
 ### FormInstance
 
 | 名称 | 说明 | 类型 | 版本 |
@@ -435,6 +440,78 @@ const Demo = () => {
 };
 ```
 
+### Form.useScope
+
+`type Form.useScope = (): FormScope`
+
+用于获取所有父级`Form.List`和`Form.Scope`的`NamePath`集合
+
+```tsx
+import * as React from 'react';
+import { Form, Input } from 'antd';
+
+const ChildrenContent = () => {
+  const { prefixName } = Form.useScope();
+  const child = Form.useWatch([...prefixName!, 'child']);
+  console.log(prefixName); // output ["parent1",0,"parent2",0]
+
+  return (
+    <>
+      <Form.Item label="Children Content" name="child">
+        <Input />
+      </Form.Item>
+      <Form.Item>child value: {child}</Form.Item>
+    </>
+  );
+};
+
+export default () => (
+  <Form
+    layout="vertical"
+    initialValues={{
+      parent1: [
+        {
+          name: 'parent1',
+          parent2: [
+            {
+              name: 'parent2',
+            },
+          ],
+        },
+      ],
+    }}
+  >
+    <Form.List name="parent1">
+      {(fields) =>
+        fields.map((field) => (
+          <div key={field.key}>
+            <Form.Item label="parent1" name={[field.name, 'name']}>
+              <Input />
+            </Form.Item>
+            <Form.List name={[field.name, 'parent2']}>
+              {(fields2) => (
+                <>
+                  {fields2.map((field2) => (
+                    <div key={field2.key}>
+                      <Form.Item label="parent2" name={[field2.name, 'name']}>
+                        <Input />
+                      </Form.Item>
+                      <Form.Scope name={field2.name}>
+                        <ChildrenContent />
+                      </Form.Scope>
+                    </div>
+                  ))}
+                </>
+              )}
+            </Form.List>
+          </div>
+        ))
+      }
+    </Form.List>
+  </Form>
+);
+```
+
 ### Form.Item.useStatus
 
 `type Form.Item.useStatus = (): { status: ValidateStatus | undefined, errors: ReactNode[], warnings: ReactNode[] }`
@@ -551,6 +628,15 @@ type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
 | -------- | ------------------------------------- | ------------ | ---------------------- | ----- |
 | form     | 指定 Form 实例                        | FormInstance | 当前 context 中的 Form | 5.4.0 |
 | preserve | 是否监视没有对应的 `Form.Item` 的字段 | boolean      | false                  | 5.4.0 |
+
+#### FormScope
+
+```ts
+interface FormScope {
+  prefixName?: (string | number)[];
+  name?: NamePath;
+}
+```
 
 ## 主题变量（Design Token）
 


### PR DESCRIPTION
- 新增组件Form.Scope
- 新增hook: Form.useScope

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/discussions/47328

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
问题：  
- 在某些复杂的大表单场景中，表单代码通常要拆分成好几个组件，在有多层嵌套的后代组件中，想要拿到完整的NamePath并不容易，需要层层传递props；
- 只有`Form.List`可以向下传递`NamePath`，`Form.List`下的Item只能写成`name={[field.name, 'name']}`，写法很繁琐；

目的：
- 希望可以在Form的所有后代元素中，使用hook就可以拿到prefixName；
- 希望可以引入一个Scope的概念，即便不是Form.List也可以获得层级效果；

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | New feature: FormScope |
| 🇨🇳 Chinese | 新增FormScope功能 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
