### PR TITLE
fix: inherit should not affect hashed and cssVar

### DIFF
--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -198,6 +198,29 @@ describe('ConfigProvider.Theme', () => {
     expect(tokenRef?.colorPrimaryText).toBe('#1677ff');
   });
 
+  it('theme inherit should not affect hashed and cssVar', () => {
+    let hashId = 'hashId';
+    let cssVar;
+
+    const Demo = () => {
+      const [, , hash, , cssVarConfig] = useToken();
+      hashId = hash;
+      cssVar = cssVarConfig;
+      return null;
+    };
+
+    render(
+      <ConfigProvider theme={{ hashed: true, cssVar: true }}>
+        <ConfigProvider theme={{ inherit: false }}>
+          <Demo />
+        </ConfigProvider>
+      </ConfigProvider>,
+    );
+
+    expect(hashId).toBeTruthy();
+    expect(cssVar).toBeTruthy();
+  });
+
   describe('cssVar', () => {
     it('should work', () => {
       const { container } = render(

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -15,7 +15,11 @@ export default function useTheme(
   const themeConfig = theme || {};
   const parentThemeConfig: ThemeConfig =
     themeConfig.inherit === false || !parentTheme
-      ? { ...defaultConfig, hashed: parentTheme?.hashed, cssVar: parentTheme?.cssVar }
+      ? {
+          ...defaultConfig,
+          hashed: parentTheme?.hashed ?? defaultConfig.hashed,
+          cssVar: parentTheme?.cssVar,
+        }
       : parentTheme;
 
   const themeKey = useThemeKey();

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -14,7 +14,9 @@ export default function useTheme(
 
   const themeConfig = theme || {};
   const parentThemeConfig: ThemeConfig =
-    themeConfig.inherit === false || !parentTheme ? defaultConfig : parentTheme;
+    themeConfig.inherit === false || !parentTheme
+      ? { ...defaultConfig, hashed: parentTheme?.hashed, cssVar: parentTheme?.cssVar }
+      : parentTheme;
 
   const themeKey = useThemeKey();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/27722486/64f4f327-2a37-496c-84c2-7628b3e09d49)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix that `theme.inherit` should not affect `hashded` and `cssVar`.      |
| 🇨🇳 Chinese |     修复主题 `inherit` 配置会隔断 `hashed` 和 `cssVar` 配置的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
