### PR TITLE
fix: RangePicker time column sometime not scroll

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -571,7 +571,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
 
           '&::after': {
             display: 'block',
-            height: token.calc(timeColumnHeight).sub(timeCellHeight).equal(),
+            height: token.calc('100%').sub(timeCellHeight).equal(),
             content: '""',
           },
 
@@ -628,14 +628,6 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
             },
           },
         },
-      },
-      // https://github.com/ant-design/ant-design/issues/39227
-      [`&-datetime-panel ${componentCls}-time-panel-column:after`]: {
-        height: token
-          .calc(timeColumnHeight)
-          .sub(timeCellHeight)
-          .add(token.calc(paddingXXS).mul(2))
-          .equal(),
       },
     },
   };

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rc-motion": "^2.9.0",
     "rc-notification": "~5.3.0",
     "rc-pagination": "~4.0.4",
-    "rc-picker": "~4.1.3",
+    "rc-picker": "~4.1.4",
     "rc-progress": "~3.5.1",
     "rc-rate": "~2.12.0",
     "rc-resize-observer": "^1.4.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #47526

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix DatePicker.RangePicker time column sometime not scroll to the target time value.       |
| 🇨🇳 Chinese |    修复 DatePicker.RangePicker 的时间列有时不会滚动到正确位置的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
