### PR TITLE
demo: a better Form usage inside Modal

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7290,16 +7290,14 @@ exports[`renders components/form/demo/form-context.tsx extend context correctly 
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx extend context correctly 1`] = `
-<div>
-  <button
-    class="ant-btn ant-btn-primary"
-    type="button"
-  >
-    <span>
-      New Collection
-    </span>
-  </button>
-</div>
+<button
+  class="ant-btn ant-btn-primary"
+  type="button"
+>
+  <span>
+    New Collection
+  </span>
+</button>
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx extend context correctly 2`] = `[]`;

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7290,14 +7290,17 @@ exports[`renders components/form/demo/form-context.tsx extend context correctly 
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx extend context correctly 1`] = `
-<button
-  class="ant-btn ant-btn-primary"
-  type="button"
->
-  <span>
-    New Collection
-  </span>
-</button>
+Array [
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      New Collection
+    </span>
+  </button>,
+  <pre />,
+]
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx extend context correctly 2`] = `[]`;

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4217,16 +4217,14 @@ exports[`renders components/form/demo/form-context.tsx correctly 1`] = `
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx correctly 1`] = `
-<div>
-  <button
-    class="ant-btn ant-btn-primary"
-    type="button"
-  >
-    <span>
-      New Collection
-    </span>
-  </button>
-</div>
+<button
+  class="ant-btn ant-btn-primary"
+  type="button"
+>
+  <span>
+    New Collection
+  </span>
+</button>
 `;
 
 exports[`renders components/form/demo/form-item-path.tsx correctly 1`] = `

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4217,14 +4217,17 @@ exports[`renders components/form/demo/form-context.tsx correctly 1`] = `
 `;
 
 exports[`renders components/form/demo/form-in-modal.tsx correctly 1`] = `
-<button
-  class="ant-btn ant-btn-primary"
-  type="button"
->
-  <span>
-    New Collection
-  </span>
-</button>
+Array [
+  <button
+    class="ant-btn ant-btn-primary"
+    type="button"
+  >
+    <span>
+      New Collection
+    </span>
+  </button>,
+  <pre />,
+]
 `;
 
 exports[`renders components/form/demo/form-item-path.tsx correctly 1`] = `

--- a/components/form/demo/form-in-modal.md
+++ b/components/form/demo/form-in-modal.md
@@ -7,9 +7,3 @@
 ## en-US
 
 When user visit a page with a list of items, and want to create a new item. The page can popup a form in Modal, then let user fill in the form to create an item.
-
-```css
-.collection-create-form_last-form-item {
-  margin-bottom: 0;
-}
-```

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -1,24 +1,55 @@
-import React, { useState } from 'react';
-import { Button, Form, Input, Modal, Radio } from 'antd';
+import React, { useState, useRef } from 'react';
+import { Button, Form, Input, Modal, Radio, type FormInstance } from 'antd';
 
 interface Values {
-  title: string;
-  description: string;
-  modifier: string;
+  title?: string;
+  description?: string;
+  modifier?: string;
 }
 
-interface CollectionCreateFormProps {
+const CollectionCreateForm = React.forwardRef<FormInstance, { initialValues: Values }>(
+  ({ initialValues }, ref) => (
+    <Form
+      ref={ref}
+      layout="vertical"
+      name="form_in_modal"
+      preserve={false}
+      initialValues={initialValues}
+    >
+      <Form.Item
+        name="title"
+        label="Title"
+        rules={[{ required: true, message: 'Please input the title of collection!' }]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item name="description" label="Description">
+        <Input type="textarea" />
+      </Form.Item>
+      <Form.Item name="modifier" className="collection-create-form_last-form-item">
+        <Radio.Group>
+          <Radio value="public">Public</Radio>
+          <Radio value="private">Private</Radio>
+        </Radio.Group>
+      </Form.Item>
+    </Form>
+  ),
+);
+
+interface CollectionCreateFormModalProps {
   open: boolean;
   onCreate: (values: Values) => void;
   onCancel: () => void;
+  initialValues: Values;
 }
 
-const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
+const CollectionCreateFormModal: React.FC<CollectionCreateFormModalProps> = ({
   open,
   onCreate,
   onCancel,
+  initialValues,
 }) => {
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
   return (
     <Modal
       open={open}
@@ -26,41 +57,18 @@ const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
       okText="Create"
       cancelText="Cancel"
       onCancel={onCancel}
-      onOk={() => {
-        form
-          .validateFields()
-          .then((values) => {
-            form.resetFields();
-            onCreate(values);
-          })
-          .catch((info) => {
-            console.log('Validate Failed:', info);
-          });
+      destroyOnClose
+      onOk={async () => {
+        try {
+          const values = await formRef.current?.validateFields();
+          formRef.current?.resetFields();
+          onCreate(values);
+        } catch (error) {
+          console.log('Failed:', error);
+        }
       }}
     >
-      <Form
-        form={form}
-        layout="vertical"
-        name="form_in_modal"
-        initialValues={{ modifier: 'public' }}
-      >
-        <Form.Item
-          name="title"
-          label="Title"
-          rules={[{ required: true, message: 'Please input the title of collection!' }]}
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item name="description" label="Description">
-          <Input type="textarea" />
-        </Form.Item>
-        <Form.Item name="modifier" className="collection-create-form_last-form-item">
-          <Radio.Group>
-            <Radio value="public">Public</Radio>
-            <Radio value="private">Private</Radio>
-          </Radio.Group>
-        </Form.Item>
-      </Form>
+      <CollectionCreateForm initialValues={initialValues} ref={formRef} />
     </Modal>
   );
 };
@@ -74,23 +82,17 @@ const App: React.FC = () => {
   };
 
   return (
-    <div>
-      <Button
-        type="primary"
-        onClick={() => {
-          setOpen(true);
-        }}
-      >
+    <>
+      <Button type="primary" onClick={() => setOpen(true)}>
         New Collection
       </Button>
-      <CollectionCreateForm
+      <CollectionCreateFormModal
         open={open}
         onCreate={onCreate}
-        onCancel={() => {
-          setOpen(false);
-        }}
+        onCancel={() => setOpen(false)}
+        initialValues={{ modifier: 'public' }}
       />
-    </div>
+    </>
   );
 };
 

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -68,6 +68,7 @@ const CollectionCreateFormModal: React.FC<CollectionCreateFormModalProps> = ({
       title="Create a new collection"
       okText="Create"
       cancelText="Cancel"
+      okButtonProps={{ autoFocus: true }}
       onCancel={onCancel}
       destroyOnClose
       onOk={async () => {

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -21,7 +21,13 @@ const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
     onFormInstanceReady(form);
   }, []);
   return (
-    <Form layout="vertical" name="form_in_modal" preserve={false} initialValues={initialValues}>
+    <Form
+      layout="vertical"
+      form={form}
+      name="form_in_modal"
+      preserve={false}
+      initialValues={initialValues}
+    >
       <Form.Item
         name="title"
         label="Title"

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -91,10 +91,12 @@ const CollectionCreateFormModal: React.FC<CollectionCreateFormModalProps> = ({
 };
 
 const App: React.FC = () => {
+  const [formValues, setFormValues] = useState<Values>();
   const [open, setOpen] = useState(false);
 
-  const onCreate = (values: any) => {
+  const onCreate = (values: Values) => {
     console.log('Received values of form: ', values);
+    setFormValues(values);
     setOpen(false);
   };
 
@@ -103,6 +105,7 @@ const App: React.FC = () => {
       <Button type="primary" onClick={() => setOpen(true)}>
         New Collection
       </Button>
+      <pre>{JSON.stringify(formValues, null, 2)}</pre>
       <CollectionCreateFormModal
         open={open}
         onCreate={onCreate}

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -21,13 +21,7 @@ const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
     onFormInstanceReady(form);
   }, []);
   return (
-    <Form
-      layout="vertical"
-      form={form}
-      name="form_in_modal"
-      preserve={false}
-      initialValues={initialValues}
-    >
+    <Form layout="vertical" form={form} name="form_in_modal" initialValues={initialValues}>
       <Form.Item
         name="title"
         label="Title"

--- a/components/form/demo/form-in-modal.tsx
+++ b/components/form/demo/form-in-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button, Form, Input, Modal, Radio, type FormInstance } from 'antd';
 
 interface Values {
@@ -7,15 +7,21 @@ interface Values {
   modifier?: string;
 }
 
-const CollectionCreateForm = React.forwardRef<FormInstance, { initialValues: Values }>(
-  ({ initialValues }, ref) => (
-    <Form
-      ref={ref}
-      layout="vertical"
-      name="form_in_modal"
-      preserve={false}
-      initialValues={initialValues}
-    >
+interface CollectionCreateFormProps {
+  initialValues: Values;
+  onFormInstanceReady: (instance: FormInstance<Values>) => void;
+}
+
+const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
+  initialValues,
+  onFormInstanceReady,
+}) => {
+  const [form] = Form.useForm();
+  useEffect(() => {
+    onFormInstanceReady(form);
+  }, []);
+  return (
+    <Form layout="vertical" name="form_in_modal" preserve={false} initialValues={initialValues}>
       <Form.Item
         name="title"
         label="Title"
@@ -33,8 +39,8 @@ const CollectionCreateForm = React.forwardRef<FormInstance, { initialValues: Val
         </Radio.Group>
       </Form.Item>
     </Form>
-  ),
-);
+  );
+};
 
 interface CollectionCreateFormModalProps {
   open: boolean;
@@ -49,7 +55,7 @@ const CollectionCreateFormModal: React.FC<CollectionCreateFormModalProps> = ({
   onCancel,
   initialValues,
 }) => {
-  const formRef = useRef<FormInstance>(null);
+  const [formInstance, setFormInstance] = useState<FormInstance>();
   return (
     <Modal
       open={open}
@@ -60,15 +66,20 @@ const CollectionCreateFormModal: React.FC<CollectionCreateFormModalProps> = ({
       destroyOnClose
       onOk={async () => {
         try {
-          const values = await formRef.current?.validateFields();
-          formRef.current?.resetFields();
+          const values = await formInstance?.validateFields();
+          formInstance?.resetFields();
           onCreate(values);
         } catch (error) {
           console.log('Failed:', error);
         }
       }}
     >
-      <CollectionCreateForm initialValues={initialValues} ref={formRef} />
+      <CollectionCreateForm
+        initialValues={initialValues}
+        onFormInstanceReady={(instance) => {
+          setFormInstance(instance);
+        }}
+      />
     </Modal>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/issues/47573


### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->



一个 Modal 和 Form 结合使用的例子。

- [x] 简化代码。
- [x] 核心解决 `<Form />` 元素 unmount 但 useForm 的状态不会被清除的问题。

类比 useState。

```jsx
const App = () => {
  const [value, setValue] = useState();
  return (
    <Modal destoryOnClose>
      <input value={value} onChange={e => setValue(e.target.value)} /> // modal 关闭时，input dom 会被销毁，value 状态不会被销毁
    </Modal>
  );
};
```

Modal 关闭的时候，value 不可能被销毁，因此下次打开还会带着上次的填的内容。

更合理的方式是把 state 也丢进去。

```jsx
const Content = () => {
  const [value, setValue] = useState();
  return <input value={value} onChange={e => setValue(e.target.value)} />;
};

const App = () => {
  return (
    <Modal destoryOnClose>
       <Content /> // 这样 modal 关闭时状态就会被销毁了
    </Modal>
  );
}
```


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     --      |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
