### PR TITLE
feat: Remove unless necessary warning in alert

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -42,10 +42,6 @@ export interface AlertProps {
   rootClassName?: string;
   banner?: boolean;
   icon?: React.ReactNode;
-  /**
-   * Custom closeIcon
-   * @deprecated please use `closable.closeIcon` instead.
-   */
   closeIcon?: React.ReactNode;
   action?: React.ReactNode;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
@@ -131,7 +127,6 @@ const Alert: React.FC<AlertProps> = (props) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Alert');
     warning.deprecated(!closeText, 'closeText', 'closable.closeIcon');
-    warning.deprecated(!closeIcon, 'closeIcon', 'closable.closeIcon');
   }
 
   const ref = React.useRef<HTMLDivElement>(null);

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -193,18 +193,4 @@ describe('Alert', () => {
 
     warnSpy.mockRestore();
   });
-  it('should warning when using closeIcon', () => {
-    resetWarned();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    const { container } = render(<Alert closeIcon="close" />);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      `Warning: [antd: Alert] \`closeIcon\` is deprecated. Please use \`closable.closeIcon\` instead.`,
-    );
-
-    expect(container.querySelector('.ant-alert-close-icon')?.textContent).toBe('close');
-
-    warnSpy.mockRestore();
-  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- feat: Remove unless necessary warning in alert
#https://github.com/ant-design/ant-design/pull/47474
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove unless necessary warning in Alert |
| 🇨🇳 Chinese | 删除 Alert 中的非必要警告          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
