### PR TITLE
📃 docs(Select): add optGroups props

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -154,10 +154,14 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### OptGroup props
 
-| Property | Description | Type                    | Default | Version |
-| -------- | ----------- | ----------------------- | ------- | ------- |
-| key      | Group key   | string                  | -       |         |
-| label    | Group label | string \| React.Element | -       |         |
+| Property | Description                           | Type                    | Default | Version |
+| -------- | ------------------------------------- | ----------------------- | ------- | ------- |
+| key      | Group key                             | string                  | -       |         |
+| label    | Group label                           | string \| React.Element | -       |         |
+| className | The additional class to option       | string                  | -       |         |
+| title     | `title` attribute of Select Option   | string                  | -       |         |
+
+
 
 ## Design Token
 

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -155,10 +155,13 @@ return (
 
 ### OptGroup props
 
-| 参数  | 说明 | 类型                    | 默认值 | 版本 |
-| ----- | ---- | ----------------------- | ------ | ---- |
-| key   | Key  | string                  | -      |      |
-| label | 组名 | string \| React.Element | -      |      |
+| 参数       | 说明                    | 类型                     | 默认值   | 版本 |
+| --------- | ----------------------- | ------------------------ | ------- | ---- |
+| key       | Key                     | string                   | -       |      |
+| label     | 组名                    | string \| React.Element  | -        |      |
+| className | Option 器类名           | string                   | -        |      |
+| title     | 选项上的原生 title 提示  | string                   | -        |      |
+
 
 ## 主题变量（Design Token）
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 站点、文档改进 

### 🔗 相关 Issue

https://github.com/react-component/select/pull/1020
rc-select v14.12.0 已经更新

这个是之前的 pr
https://github.com/ant-design/ant-design/pull/46931

### 💡 需求背景和解决方案

select options groups 需要 `className` 和 `title` 的支持, 
已经在 rc-select 中 pr 功能, 并在 14.12.0 合并.  现在 rc-select 14.12.0 已经合并到 ant-design, 添加 ant-design 站点说明

### 📝 更新日志

添加 select options groups 的 `className`  和 `title` 支持.

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    已更新       |
| 🇨🇳 中文 |      已更新    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供