### PR TITLE
fix: padding vertical menu if expandIcon is null

### DIFF
--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -126,7 +126,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
 
   const prefixCls = getPrefixCls('menu', customizePrefixCls || overrideObj.prefixCls);
   const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls, !override);
+  // const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls, !override);
   const menuClassName = classNames(`${prefixCls}-${theme}`, menu?.className, className);
 
   // ====================== ExpandIcon ========================
@@ -148,6 +148,13 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
       ),
     });
   }, [expandIcon, overrideObj?.expandIcon, menu?.expandIcon, prefixCls]);
+
+  const [wrapCSSVar, hashId, cssVarCls] = useStyle(
+    prefixCls,
+    rootCls,
+    !override,
+    mergedExpandIcon != null,
+  );
 
   // ======================== Context ==========================
   const contextValue = React.useMemo<MenuContextProps>(

--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -934,7 +934,12 @@ export const prepareComponentToken: GetDefaultToken<'Menu'> = (token) => {
 };
 
 // ============================== Export ==============================
-export default (prefixCls: string, rootCls: string = prefixCls, injectStyle: boolean = true) => {
+export default (
+  prefixCls: string,
+  rootCls: string = prefixCls,
+  injectStyle: boolean = true,
+  hasExpandIcon = true,
+) => {
   const useStyle = genStyleHooks(
     'Menu',
     (token) => {
@@ -960,7 +965,7 @@ export default (prefixCls: string, rootCls: string = prefixCls, injectStyle: boo
         darkPopupBg,
       } = token;
 
-      const menuArrowSize = token.calc(fontSize).div(7).mul(5).equal();
+      const menuArrowSize = hasExpandIcon ? token.calc(fontSize).div(7).mul(5).equal() : 0;
 
       // Menu Token
       const menuToken = mergeToken<MenuToken & CssUtil>(token, {

--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -15,7 +15,9 @@ const getVerticalInlineStyle: GenerateStyle<MenuToken, CSSObject> = (token) => {
     itemWidth,
   } = token;
 
-  const paddingWithArrow = token.calc(menuArrowSize).add(padding).add(marginXS).equal();
+  const paddingWithArrow = menuArrowSize
+    ? token.calc(menuArrowSize).add(padding).add(marginXS).equal()
+    : padding;
 
   return {
     [`${componentCls}-item`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Fix padding vertical menu if expandIcon is null
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix padding vertical menu if expandIcon is null|
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

