### PR TITLE
fix: ColorPicker clear display value

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, FC } from 'react';
-import React, { useContext, useMemo, useRef, useState } from 'react';
+import React, { useContext, useMemo, useRef } from 'react';
 import type {
   HsbaColorType,
   ColorPickerProps as RcColorPickerProps,
@@ -32,7 +32,7 @@ import type {
   TriggerType,
 } from './interface';
 import useStyle from './style';
-import { genAlphaColor, generateColor, getAlphaColor } from './util';
+import { genAlphaColor, generateColor, getAlphaColor, isColorCleared } from './util';
 
 export type ColorPickerProps = Omit<
   RcColorPickerProps,
@@ -124,11 +124,11 @@ const ColorPicker: CompoundedComponent = (props) => {
     onChange: onFormatChange,
   });
 
-  const [colorCleared, setColorCleared] = useState(!value && !defaultValue);
-
+  const colorCleared = isColorCleared(colorValue);
   const prefixCls = getPrefixCls('color-picker', customizePrefixCls);
 
-  const isAlphaColor = useMemo(() => getAlphaColor(colorValue) < 100, [colorValue]);
+  const alpha = getAlphaColor(colorValue);
+  const isAlphaColor = useMemo(() => alpha < 100, [colorValue]);
 
   // ===================== Form Status =====================
   const { status: contextStatus } = React.useContext(FormItemInputContext);
@@ -169,9 +169,8 @@ const ColorPicker: CompoundedComponent = (props) => {
     let color: Color = generateColor(data);
     const isNull = value === null || (!value && defaultValue === null);
     if (colorCleared || isNull) {
-      setColorCleared(false);
       // ignore alpha slider
-      if (getAlphaColor(colorValue) === 0 && type !== 'alpha') {
+      if (alpha === 0 && type !== 'alpha') {
         color = genAlphaColor(color);
       }
     }
@@ -192,7 +191,6 @@ const ColorPicker: CompoundedComponent = (props) => {
   };
 
   const handleClear = () => {
-    setColorCleared(true);
     onClear?.();
   };
 

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13,6 +13,11 @@ Array [
         style="background: rgb(22, 119, 255);"
       />
     </div>
+    <div
+      class="ant-color-picker-trigger-text"
+    >
+      #1677FF
+    </div>
   </div>,
   <div
     class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"

--- a/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.ts.snap
@@ -12,6 +12,11 @@ exports[`renders components/color-picker/demo/allowClear.tsx correctly 1`] = `
       style="background:rgb(22, 119, 255)"
     />
   </div>
+  <div
+    class="ant-color-picker-trigger-text"
+  >
+    #1677FF
+  </div>
 </div>
 `;
 

--- a/components/color-picker/color.ts
+++ b/components/color-picker/color.ts
@@ -10,7 +10,7 @@ export const getHex = (value?: string, alpha?: boolean) => (value ? toHexFormat(
 export interface Color
   extends Pick<
     RcColor,
-    'toHsb' | 'toHsbString' | 'toHex' | 'toHexString' | 'toRgb' | 'toRgbString'
+    'toHsb' | 'toHsbString' | 'toHex' | 'toHexString' | 'toRgb' | 'toRgbString' | 'equals'
   > {}
 
 export class ColorFactory {
@@ -48,5 +48,9 @@ export class ColorFactory {
 
   toRgbString() {
     return this.metaColor.toRgbString();
+  }
+
+  equals(color: RcColor) {
+    return this.metaColor.equals(color);
   }
 }

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -2,20 +2,24 @@ import type { FC } from 'react';
 import React from 'react';
 import type { Color } from '../color';
 import type { ColorPickerBaseProps } from '../interface';
-import { generateColor } from '../util';
+import { generateColor, isColorCleared } from '../util';
 
-interface ColorClearProps extends Pick<ColorPickerBaseProps, 'prefixCls' | 'colorCleared'> {
+interface ColorClearProps extends Pick<ColorPickerBaseProps, 'prefixCls'> {
   value?: Color;
   onChange?: (value: Color) => void;
 }
 
-const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, colorCleared, onChange }) => {
+const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange }) => {
   const handleClick = () => {
-    if (value && !colorCleared) {
-      const hsba = value.toHsb();
-      hsba.a = 0;
-      const genColor = generateColor(hsba);
-      onChange?.(genColor);
+    if (value && !isColorCleared(value)) {
+      onChange?.(
+        generateColor({
+          r: 0,
+          g: 0,
+          b: 0,
+          a: 0,
+        }),
+      );
     }
   };
   return <div className={`${prefixCls}-clear`} onClick={handleClick} />;

--- a/components/color-picker/components/PanelPicker.tsx
+++ b/components/color-picker/components/PanelPicker.tsx
@@ -21,7 +21,6 @@ export interface PanelPickerProps
 const PanelPicker: FC = () => {
   const {
     prefixCls,
-    colorCleared,
     allowClear,
     value,
     disabledAlpha,
@@ -36,7 +35,6 @@ const PanelPicker: FC = () => {
         <ColorClear
           prefixCls={prefixCls}
           value={value}
-          colorCleared={colorCleared}
           onChange={(clearColor) => {
             onChange?.(clearColor);
             onClear?.();

--- a/components/color-picker/demo/allowClear.tsx
+++ b/components/color-picker/demo/allowClear.tsx
@@ -1,4 +1,4 @@
 import React from 'react';
 import { ColorPicker } from 'antd';
 
-export default () => <ColorPicker defaultValue="#1677ff" allowClear />;
+export default () => <ColorPicker defaultValue="#1677ff" allowClear showText />;

--- a/components/color-picker/util.ts
+++ b/components/color-picker/util.ts
@@ -18,3 +18,5 @@ export const genAlphaColor = (color: Color, alpha?: number) => {
   hsba.a = alpha || 1;
   return generateColor(hsba);
 };
+
+export const isColorCleared = (color: Color) => color.equals('#00000000');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
- fix https://github.com/ant-design/ant-design/issues/47539
- close https://github.com/ant-design/ant-design/pull/47586

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
主要修复两个问题。

- [x] https://github.com/ant-design/ant-design/issues/47539 中色彩块始终显示清空状态的问题。
- [x] showText 情况下清空颜色后还会显示原始颜色值的问题：https://stackblitz.com/edit/react-nsl1cy?file=demo.tsx

![图片](https://github.com/ant-design/ant-design/assets/507615/471b77f8-cc0d-4378-868a-f284569467f2)

#### 解法和改动点

- 去掉不必要的 `colorCleared` 状态，直接从色彩推导出来，这能更彻底地解决受控后无法更新的问题。
- 原先清除只是将色彩的透明度设为 0，现在改成设为 `#00000000`。
- 是否清除的判断逻辑也从 `透明度是否是 0` 改成色彩是否等于 `#00000000`。虽然依旧不完美，但比原来好很多，解决了大多数场景的显示问题。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix ColorPicker unexpected color and text after clear it.    |
| 🇨🇳 Chinese |  修复 ColorPicker 清除操作后色块和文本不符合预期的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
