### PR TITLE
chore: code optimization

### DIFF
--- a/components/skeleton/Paragraph.tsx
+++ b/components/skeleton/Paragraph.tsx
@@ -27,7 +27,7 @@ const Paragraph: React.FC<SkeletonParagraphProps> = (props) => {
   const { prefixCls, className, style, rows } = props;
   const rowList = [...Array(rows)].map((_, index) => (
     // eslint-disable-next-line react/no-array-index-key
-    <li key={index} style={{ width: getWidth(index) }} />
+    <li key={index} style={{ width: getWidth(index, props) }} />
   ));
   return (
     <ul className={classNames(prefixCls, className)} style={style}>

--- a/components/skeleton/Paragraph.tsx
+++ b/components/skeleton/Paragraph.tsx
@@ -11,18 +11,19 @@ export interface SkeletonParagraphProps {
   rows?: number;
 }
 
+const getWidth = (index: number, props: SkeletonParagraphProps) => {
+  const { width, rows = 2 } = props;
+  if (Array.isArray(width)) {
+    return width[index];
+  }
+  // last paragraph
+  if (rows - 1 === index) {
+    return width;
+  }
+  return undefined;
+};
+
 const Paragraph: React.FC<SkeletonParagraphProps> = (props) => {
-  const getWidth = (index: number) => {
-    const { width, rows = 2 } = props;
-    if (Array.isArray(width)) {
-      return width[index];
-    }
-    // last paragraph
-    if (rows - 1 === index) {
-      return width;
-    }
-    return undefined;
-  };
   const { prefixCls, className, style, rows } = props;
   const rowList = [...Array(rows)].map((_, index) => (
     // eslint-disable-next-line react/no-array-index-key

--- a/components/skeleton/Skeleton.tsx
+++ b/components/skeleton/Skeleton.tsx
@@ -182,7 +182,7 @@ const Skeleton: React.FC<SkeletonProps> & CompoundedComponent = (props) => {
       </div>,
     );
   }
-  return typeof children !== 'undefined' ? (children as React.ReactElement) : null;
+  return children ?? null;
 };
 
 Skeleton.Button = SkeletonButton;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Skeleton component children null value merge operation  extract the getWidth method inside the Paragraph component  |
| 🇨🇳 Chinese |   Skeleton 组件 children null 判断  Paragraph组件内部getWidth方法抽离  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
