### PR TITLE
fix: Typography symbol height exceed line should also support ellipsis

### DIFF
--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1919,7 +1919,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-multiple-line"
+    class="ant-typography ant-typography-ellipsis"
     style="width: 300px;"
   >
     In the process of internal desktop applications development,

--- a/components/typography/demo/ellipsis-debug.tsx
+++ b/components/typography/demo/ellipsis-debug.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Slider, Switch, Typography } from 'antd';
+import { Button, Slider, Switch, Typography } from 'antd';
 
 const { Text, Paragraph } = Typography;
 
@@ -78,7 +78,14 @@ const App: React.FC = () => {
         </Text>
       </div>
 
-      <Typography.Paragraph style={{ width: 300 }} ellipsis={{ rows: 3 }}>
+      <Typography.Paragraph
+        style={{ width: 300 }}
+        ellipsis={{
+          rows: 3,
+          expandable: true,
+          symbol: <Button>Open</Button>,
+        }}
+      >
         {templateStr.slice(0, 60)}
         <span style={{ fontSize: '5em' }}>ANTD</span>
         {templateStr.slice(60)}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #41861

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Typography config the `ellipsis.symbol` exceed the single line height will make ellipsis rows not correct issue.     |
| 🇨🇳 Chinese |   修复 Typography 配置的 `ellipsis.symbol` 超出单行高度时，省略行数不正确的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
