### PR TITLE
fix: button padding

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -18,7 +18,9 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
     [componentCls]: {
       outline: 'none',
       position: 'relative',
-      display: 'inline-block',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
       fontWeight,
       whiteSpace: 'nowrap',
       textAlign: 'center',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
1. The problem: The issue with button padding was caused by the CSS property `display: 'inline-block'`. 

![button](https://github.com/ant-design/ant-design/assets/109994179/e23a88dd-8d41-4aa3-bc74-b53cb4d33371)

2. The solution: To fix this, I updated the CSS properties of button to:

```css
display: 'flex',
justifyContent: 'center',
alignItems: 'center'
```

3. Result:

![new-button](https://github.com/ant-design/ant-design/assets/109994179/da4052b9-1276-42bd-ac13-bf8d0452b3f7)

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed button padding issue caused by CSS property `display: 'inline-block'`, ensuring consistent padding and alignment for users. |
| 🇨🇳 Chinese | 修复了由 CSS 属性 `display: 'inline-block'` 引起的按钮内边距问题，确保用户看到一致的内边距和对齐方式。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
