### PR TITLE
Fix MenuItem key type not string issue

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -16,7 +16,7 @@ import useItemRender from './useItemRender';
 import useItems from './useItems';
 
 export interface BreadcrumbItemType {
-  key?: React.Key;
+  key?: string;
   /**
    * Different with `path`. Directly set the link of this item.
    */

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -15,7 +15,7 @@ export interface SeparatorType {
 
 type MenuType = NonNullable<DropdownProps['menu']>;
 interface MenuItem {
-  key?: React.Key;
+  key?: string;
   title?: React.ReactNode;
   label?: React.ReactNode;
   path?: string;
@@ -67,7 +67,7 @@ export const InternalBreadcrumbItem: React.FC<BreadcrumbItemProps> = (props) => 
 
             return {
               ...itemProps,
-              key: key ?? index,
+              key: key ?? `${index}`,
               label: mergedLabel as string,
             };
           }),

--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -170,7 +170,7 @@ describe('Dropdown', () => {
               children: [
                 {
                   label: '1',
-                  key: 1,
+                  key: "1",
                 },
               ],
             },
@@ -275,7 +275,7 @@ describe('Dropdown', () => {
           items: [
             {
               label: <div className="bamboo" />,
-              key: 1,
+              key: "1",
             },
           ],
         }}
@@ -297,8 +297,8 @@ describe('Dropdown', () => {
           selectable: true,
           multiple: true,
           items: [
-            { label: '1', key: 1 },
-            { label: '2', key: 2 },
+            { label: '1', key: "1" },
+            { label: '2', key: "2" },
           ],
         }}
       >

--- a/components/layout/__tests__/token.test.tsx
+++ b/components/layout/__tests__/token.test.tsx
@@ -27,7 +27,7 @@ describe('Layout.Token', () => {
             mode="horizontal"
             defaultSelectedKeys={['2']}
             items={new Array(15).fill(null).map((_, index) => {
-              const key = index + 1;
+              const key = `${index + 1}`;
               return {
                 key,
                 label: `nav ${key}`,
@@ -64,7 +64,7 @@ describe('Layout.Token', () => {
             mode="horizontal"
             defaultSelectedKeys={['2']}
             items={new Array(15).fill(null).map((_, index) => {
-              const key = index + 1;
+              const key = `${index + 1}`;
               return {
                 key,
                 label: `nav ${key}`,

--- a/components/layout/demo/top.tsx
+++ b/components/layout/demo/top.tsx
@@ -4,7 +4,7 @@ import { Breadcrumb, Layout, Menu, theme } from 'antd';
 const { Header, Content, Footer } = Layout;
 
 const items = new Array(15).fill(null).map((_, index) => ({
-  key: index + 1,
+  key: `${index + 1}`,
   label: `nav ${index + 1}`,
 }));
 

--- a/components/menu/hooks/useItems.tsx
+++ b/components/menu/hooks/useItems.tsx
@@ -14,6 +14,7 @@ export interface MenuItemType extends RcMenuItemType {
   danger?: boolean;
   icon?: React.ReactNode;
   title?: string;
+  key: string;
 }
 
 export interface SubMenuType<T extends MenuItemType = MenuItemType>
@@ -26,12 +27,12 @@ export interface SubMenuType<T extends MenuItemType = MenuItemType>
 export interface MenuItemGroupType<T extends MenuItemType = MenuItemType>
   extends Omit<RcMenuItemGroupType, 'children'> {
   children?: ItemType<T>[];
-  key?: React.Key;
+  key?: string;
 }
 
 export interface MenuDividerType extends RcMenuDividerType {
   dashed?: boolean;
-  key?: React.Key;
+  key?: string;
 }
 
 export type ItemType<T extends MenuItemType = MenuItemType> =

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -81,7 +81,7 @@ function renderFilterItems({
 
     if (filter.children) {
       return {
-        key: key || index,
+        key: key || `${index}`,
         label: filter.text,
         popupClassName: `${prefixCls}-dropdown-submenu`,
         children: renderFilterItems({
@@ -98,7 +98,7 @@ function renderFilterItems({
     const Component = filterMultiple ? Checkbox : Radio;
 
     const item = {
-      key: filter.value !== undefined ? key : index,
+      key: filter.value !== undefined ? key : `${index}`,
       label: (
         <>
           <Component checked={filteredKeys.includes(key)} />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [v] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Fix https://github.com/ant-design/ant-design/issues/47837

### 💡 Background and solution

MenuItem 使用的key type是React.Key。更新成string

### 📝 Changelog

如果以前用户使用number作为key的话，会出现type不是string的报错。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [v] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

-----
<a href="https://stackblitz.com/~/github.com/chenyuf2/ant-design/tree/chenyuf2/issue47837"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/chenyuf2/ant-design/tree/chenyuf2/issue47837)._