### PR TITLE
type(QRProps): Support string type for size

### DIFF
--- a/components/qr-code/index.en-US.md
+++ b/components/qr-code/index.en-US.md
@@ -48,7 +48,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | scanned text | string | - |
 | type | render type | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | include image url (only image link are supported) | string | - |
-| size | QRCode size | number | 160 |
+| size | QRCode size | number \| string | 160 |
 | iconSize | include image size | number | 32 |
 | color | QRCode Color | string | `#000` |
 | bgColor | QRCode Background Color | string | `transparent` | 5.5.0 |

--- a/components/qr-code/index.zh-CN.md
+++ b/components/qr-code/index.zh-CN.md
@@ -48,7 +48,7 @@ tag: New
 | value | 扫描后的文本 | string | - |
 | type | 渲染类型 | `canvas \| svg ` | `canvas` | 5.6.0 |
 | icon | 二维码中图片的地址（目前只支持图片地址） | string | - |
-| size | 二维码大小 | number | 160 |
+| size | 二维码大小 | number \| string | 160 |
 | iconSize | 二维码中图片的大小 | number | 40 |
 | color | 二维码颜色 | string | `#000` |
 | bgColor | 二维码背景颜色 | string | `transparent` | 5.5.0 |

--- a/components/qr-code/interface.ts
+++ b/components/qr-code/interface.ts
@@ -12,7 +12,7 @@ interface ImageSettings {
 export interface QRProps {
   value: string;
   type?: 'canvas' | 'svg';
-  size?: number;
+  size?: number | string;
   color?: string;
   style?: CSSProperties;
   includeMargin?: boolean;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
qrcode 的size 也可以用string， '100%'也是生效的
![image](https://github.com/ant-design/ant-design/assets/117748716/225d6bc5-4304-48da-9667-71399d1492b2)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     type(QRProps): Support string type for size      |
| 🇨🇳 Chinese |    type(QRProps):  size 支持string类型       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
