### PR TITLE
Fix #47967 modal rendering issue

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
 import Dialog from 'rc-dialog';
+import * as React from 'react';
 
 import useClosable from '../_util/hooks/useClosable';
 import { useZIndex } from '../_util/hooks/useZIndex';
@@ -144,6 +144,13 @@ const Modal: React.FC<ModalProps> = (props) => {
             maskTransitionName={getTransitionName(rootPrefixCls, 'fade', props.maskTransitionName)}
             className={classNames(hashId, className, modal?.className)}
             style={{ ...modal?.style, ...style }}
+            bodyStyle={{
+              maxHeight: 'calc(70vh - 60px)',
+              overflowY: 'auto',
+              paddingRight: 16,
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+            }}
             classNames={{
               ...modal?.classNames,
               ...modalClassNames,


### PR DESCRIPTION
1.  This is a Bug Fix which fixes #47967 
2. Issue link [https://github.com/ant-design/ant-design/issues/47967](url)

Problem and Scenario.
1. If the modal has a vey long content it gets stuck at the expected position and then moved to the top of the screen which is not expected.

Changes
1. I have made the model size fixed and made it scrollable internally which make the modal to render in its actual expected postion.