### PR TITLE
可编辑tabs组件鼠标悬浮显示关闭图标

### DIFF
--- a/components/tabs/demo/component-token.tsx
+++ b/components/tabs/demo/component-token.tsx
@@ -14,6 +14,7 @@ const App: React.FC = () => (
           titleFontSize: 20,
           titleFontSizeLG: 20,
           titleFontSizeSM: 20,
+          titleHoverCloseIcon: 'block',
           inkBarColor: '#52C41A',
           horizontalMargin: `0 0 12px 0`,
           horizontalItemGutter: 12, // Fixed Value

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -7,6 +7,11 @@ import genMotionStyle from './motion';
 
 export interface ComponentToken {
   /**
+   * @desc 可编辑卡片标签标题鼠标悬浮显示关闭图标
+   * @descEN Editable card label title, hovering mouse display, off icon
+   */
+  titleHoverCloseIcon: string;
+  /**
    * @desc 下拉菜单 z-index
    * @descEN z-index of dropdown menu
    */
@@ -697,6 +702,7 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
       },
       '&-remove': {
         flex: 'none',
+        display: token.titleHoverCloseIcon,
         marginRight: {
           _skip_check_: true,
           value: token.calc(token.marginXXS).mul(-1).equal(),
@@ -718,6 +724,10 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
       },
       '&:hover': {
         color: itemHoverColor,
+      },
+
+      [`&:hover ${tabCls}-remove`]: {
+        display: 'block'
       },
 
       [`&${tabCls}-active ${tabCls}-btn`]: {
@@ -1027,6 +1037,7 @@ export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
     titleFontSize: token.fontSize,
     titleFontSizeLG: token.fontSizeLG,
     titleFontSizeSM: token.fontSize,
+    titleHoverCloseIcon: token.hoverDisplay,
     inkBarColor: token.colorPrimary,
     horizontalMargin: `0 0 ${token.margin}px 0`,
     horizontalItemGutter: 32, // Fixed Value

--- a/components/theme/interface/maps/style.ts
+++ b/components/theme/interface/maps/style.ts
@@ -40,4 +40,14 @@ export interface StyleMapToken {
    * @descEN Outer border radius
    */
   borderRadiusOuter: number;
+
+  // hover
+  /**
+   * @nameZH 布局（悬浮）
+   * @nameEN display (hover)
+   * @desc 布局（悬浮），用于组件鼠标悬浮后样式变换
+   * @descEN display (hover)， Used for style transformation after hovering the mouse over components
+   * @default 'block''
+   */
+  hoverDisplay: string;
 }

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -164,6 +164,8 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
     screenXXL,
     screenXXLMin: screenXXL,
 
+    hoverDisplay: 'block',
+
     boxShadowPopoverArrow: '2px 2px 5px rgba(0, 0, 0, 0.05)',
     boxShadowCard: `
       0 1px 2px -2px ${new TinyColor('rgba(0, 0, 0, 0.16)').toRgbString()},

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -827,6 +827,7 @@ export default App;
 | `@tabs-title-font-size` | `titleFontSize` | - |
 | `@tabs-title-font-size-lg` | `titleFontSizeLG` | - |
 | `@tabs-title-font-size-sm` | `titleFontSizeSM` | - |
+| `@tabs-title-hover-close-icon` | `titleHoverCloseIcon` | - |
 | `@tabs-ink-bar-color` | `inkBarColor` | - |
 | `@tabs-bar-margin` | `horizontalMargin` | - |
 | `@tabs-horizontal-gutter` | `horizontalItemGutter` | - |

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -827,6 +827,7 @@ Mentions 提及
 | `@tabs-title-font-size` | `titleFontSize` | - |
 | `@tabs-title-font-size-lg` | `titleFontSizeLG` | - |
 | `@tabs-title-font-size-sm` | `titleFontSizeSM` | - |
+| `@tabs-title-hover-close-icon` | `titleHoverCloseIcon` | - |
 | `@tabs-ink-bar-color` | `inkBarColor` | - |
 | `@tabs-bar-margin` | `horizontalMargin` | - |
 | `@tabs-horizontal-gutter` | `horizontalItemGutter` | - |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ √] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/164474889/03226118-083a-40ec-8605-81ca54da5de1)
![image](https://github.com/ant-design/ant-design/assets/164474889/2f7370a2-8b95-460f-9a05-c70deef4a3dd)
后台管理系统打开多个菜单后，缓存菜单使用editable-card类tabs组件时，大多数需求期望此时的关闭图标默认不显示，鼠标悬浮时显示体验更好，页面看起来更简洁

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  editable-card type tabs component, which can display the close icon when hovering over the title with the mouse         |
| 🇨🇳 Chinese | 编辑类型tabs组件 ，可鼠标悬浮标题时显示关闭图标         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
