### PR TITLE
docs: add global message use case

### DIFF
--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -121,6 +121,76 @@ export default () => {
 };
 ```
 
+### Global scene (JS/TS)
+
+Here is an example of using `Message` to handle request errors in axios global interceptors:
+
+```tsx
+// toast.ts
+import { App } from 'antd';
+import type { MessageInstance } from 'antd/es/message/interface';
+import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
+import type { NotificationInstance } from 'antd/es/notification/interface';
+
+let message: MessageInstance;
+let notification: NotificationInstance;
+let modal: Omit<ModalStaticFunctions, 'warn'>;
+
+export default function Toast() {
+  const staticFunction = App.useApp();
+  message = staticFunction.message;
+  modal = staticFunction.modal;
+  notification = staticFunction.notification;
+  return null;
+}
+
+export { message, notification, modal };
+```
+
+```tsx
+// App.tsx
+// Wrap the Toast component in the antd's App component to get the context
+import { App as AntdApp, ConfigProvider, Layout } from 'antd';
+
+import Toast from './toast';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AntdApp>
+        <Toast />
+      </AntdApp>
+    </ConfigProvider>
+  );
+}
+
+export default App;
+```
+
+```ts
+// fetch.ts
+// Instead of directly import from antd, import the message from the toast file
+import { message } from './toast';
+
+axios.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  function (error: AxiosError) {
+    if (error.response) {
+      if (error.response.status === 401) {
+        void message.error('user not login');
+      } else {
+        void message.error('error occur');
+      }
+    } else {
+      void message.error(error.message);
+    }
+    return Promise.reject(error);
+  },
+);
+```
+
 ## API
 
 Common props ref：[Common props](/docs/react/common-props)

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -122,6 +122,76 @@ export default () => {
 };
 ```
 
+### 全局 JS/TS 使用场景
+
+这里是一个在 Axios 拦截器中使用 Message 统一处理请求错误的例子：
+
+```tsx
+// toast.ts
+import { App } from 'antd';
+import type { MessageInstance } from 'antd/es/message/interface';
+import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
+import type { NotificationInstance } from 'antd/es/notification/interface';
+
+let message: MessageInstance;
+let notification: NotificationInstance;
+let modal: Omit<ModalStaticFunctions, 'warn'>;
+
+export default function Toast() {
+  const staticFunction = App.useApp();
+  message = staticFunction.message;
+  modal = staticFunction.modal;
+  notification = staticFunction.notification;
+  return null;
+}
+
+export { message, notification, modal };
+```
+
+```tsx
+// App.tsx
+// 将 Toast 组件包裹在 antd 的 App 组件中，以获取上下文
+import { App as AntdApp, ConfigProvider, Layout } from 'antd';
+
+import Toast from './toast';
+
+function App() {
+  return (
+    <ConfigProvider>
+      <AntdApp>
+        <Toast />
+      </AntdApp>
+    </ConfigProvider>
+  );
+}
+
+export default App;
+```
+
+```ts
+// fetch.ts
+// 从 toast 中导入 message，而不是直接从 antd 中导入
+import { message } from './toast';
+
+axios.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  function (error: AxiosError) {
+    if (error.response) {
+      if (error.response.status === 401) {
+        void message.error('user not login');
+      } else {
+        void message.error('error occur');
+      }
+    } else {
+      void message.error(error.message);
+    }
+    return Promise.reject(error);
+  },
+);
+```
+
 ## API
 
 通用属性参考：[通用属性](/docs/react/common-props)

--- a/components/message/demo/hooks.md
+++ b/components/message/demo/hooks.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过 `message.useMessage` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过顶层注册的方式代替 `message` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
+通过 `message.useMessage` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过 [顶层注册](/components/app-cn) 的方式代替 `message` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
 
 ## en-US
 
-Use `message.useMessage` to get `contextHolder` with context accessible issue. Please note that, we recommend to use top level registration instead of `message` static method, because static method cannot consume context, and ConfigProvider data will not work.
+Use `message.useMessage` to get `contextHolder` with context accessible issue. Please note that, we recommend to use [top level registration](/components/app-cn) instead of `message` static method, because static method cannot consume context, and ConfigProvider data will not work.

--- a/components/notification/demo/hooks.md
+++ b/components/notification/demo/hooks.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过 `notification.useNotification` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过顶层注册的方式代替 `notification` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
+通过 `notification.useNotification` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过 [顶层注册](/components/app-cn) 的方式代替 `notification` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
 
 ## en-US
 
-Use `notification.useNotification` to get `contextHolder` with context accessible issue. Please note that, we recommend to use top level registration instead of `notification` static method, because static method cannot consume context, and ConfigProvider data will not work.
+Use `notification.useNotification` to get `contextHolder` with context accessible issue. Please note that, we recommend to use [top level registration](/components/app-cn) instead of `notification` static method, because static method cannot consume context, and ConfigProvider data will not work.


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
**CN:**
文档中的全局使用 `message` 用例不够全面。在纯 JS/TS 中使用全局 `message` 这种场景非常常见，按照现有文档中的写法，用户自己做出来比较困难，需要增加例子引导。
**EN:**
The use of the global message in the document is not comprehensive enough. The scenario of using the global message in pure JS/TS is very common. According to the current document, it is difficult for users to do it themselves, and examples need to be added for users.
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Added document examples of global use of message, and added top-level registration links in the message and notification documents.      |
| 🇨🇳 Chinese |     增加了全局使用 `message` 的文档例子，在 `message` 和 `notification` 的文档中加入了顶层注册的跳转链接。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
