### PR TITLE
fix: confirm content not centered when no icon

### DIFF
--- a/components/modal/style/confirm.ts
+++ b/components/modal/style/confirm.ts
@@ -63,6 +63,9 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
         flexDirection: 'column',
         flex: 'auto',
         rowGap: token.marginXS,
+      },
+
+      [`${token.iconCls} + ${confirmComponentCls}-paragraph`]: {
         maxWidth: `calc(100% - ${unit(
           token.calc(token.modalConfirmIconSize).add(token.marginSM).equal(),
         )})`,

--- a/components/modal/style/confirm.ts
+++ b/components/modal/style/confirm.ts
@@ -65,6 +65,7 @@ const genModalConfirmStyle: GenerateStyle<ModalToken> = (token) => {
         rowGap: token.marginXS,
       },
 
+      // https://github.com/ant-design/ant-design/issues/48159
       [`${token.iconCls} + ${confirmComponentCls}-paragraph`]: {
         maxWidth: `calc(100% - ${unit(
           token.calc(token.modalConfirmIconSize).add(token.marginSM).equal(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/48159

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Modal.confirm content is not centered when icon is null.        |
| 🇨🇳 Chinese |  修复 Modal.confirm 无图标时内容不居中的问题。         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
