### PR TITLE
vertically center icons in icon-only buttons

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -419,6 +419,9 @@ const genButtonStyle = (token: ButtonToken, prefixCls: string = ''): CSSInterpol
         borderRadius,
 
         [`&${iconOnlyCls}`]: {
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           width: controlHeight,
           paddingInlineStart: 0,
           paddingInlineEnd: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix #48071
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Currently the icons on buttons aren't vertically centered. This is a regression of a prior issue prevalent in antd 4, namely https://github.com/ant-design/ant-design/issues/31701. To illustrate this I have created the following side-by-side screenshot, highlighting the affected buttons and the icons in different colors and with a dashed border. The left side shows the alignment as is whereas the right side shows the fixed version:

![vertically-center-icon-on-icon-ony-button](https://github.com/ant-design/ant-design/assets/12494/39de4b93-1ec8-4889-87f8-fe078b85c84e)

An alternative to the applied fix would've been the following code but I chose the former for brevity:
```css
diff --git a/components/button/style/index.ts b/components/button/style/index.ts
index 9b38143ae7..b7b28e774d 100644
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -419,9 +419,13 @@ const genButtonStyle = (token: ButtonToken, prefixCls: string = ''): CSSInterpol
         borderRadius,
 
         [`&${iconOnlyCls}`]: {
+          display: 'inline-flex',
           width: controlHeight,
           paddingInlineStart: 0,
           paddingInlineEnd: 0,
+          [`${componentCls}-icon`]: {
+            margin: 'auto',
+          },
           [`&${componentCls}-round`]: {
             width: 'auto',
           },
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | vertically center icons on icon-only buttons|
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
