### PR TITLE
feat(upload): support ref.nativeElenent

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -32,6 +32,11 @@ export interface UploadRef<T = any> {
   onError: (error: Error, response: any, file: RcFile) => void;
   fileList: UploadFile<T>[];
   upload: RcUpload | null;
+  /**
+   * Get native element for wrapping upload
+   * @since 5.17.0
+   */
+  nativeElement: HTMLSpanElement | null;
 }
 
 const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (props, ref) => {
@@ -79,6 +84,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   const [dragState, setDragState] = React.useState<string>('drop');
 
   const upload = React.useRef<RcUpload>(null);
+  const wrapRef = React.useRef<HTMLSpanElement>(null);
 
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Upload');
@@ -331,6 +337,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     onError,
     fileList: mergedFileList,
     upload: upload.current,
+    nativeElement: wrapRef.current,
   }));
 
   const { getPrefixCls, direction, upload: ctxUpload } = React.useContext(ConfigContext);
@@ -431,6 +438,8 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   const mergedStyle: React.CSSProperties = { ...ctxUpload?.style, ...style };
 
+  // ======================== Render ========================
+
   if (type === 'drag') {
     const dragCls = classNames(hashId, prefixCls, `${prefixCls}-drag`, {
       [`${prefixCls}-drag-uploading`]: mergedFileList.some((file) => file.status === 'uploading'),
@@ -440,7 +449,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     });
 
     return wrapCSSVar(
-      <span className={mergedCls}>
+      <span className={mergedCls} ref={wrapRef}>
         <div
           className={dragCls}
           style={mergedStyle}
@@ -469,12 +478,14 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   if (listType === 'picture-card' || listType === 'picture-circle') {
     return wrapCSSVar(
-      <span className={mergedCls}>{renderUploadList(uploadButton, !!children)}</span>,
+      <span className={mergedCls} ref={wrapRef}>
+        {renderUploadList(uploadButton, !!children)}
+      </span>,
     );
   }
 
   return wrapCSSVar(
-    <span className={mergedCls}>
+    <span className={mergedCls} ref={wrapRef}>
       {uploadButton}
       {renderUploadList()}
     </span>,

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -1082,4 +1082,12 @@ describe('Upload', () => {
       expect(file.status).toBe('done');
     });
   });
+
+  it('container ref', () => {
+    const ref = React.createRef<any>();
+    render(<Upload ref={ref} />);
+    expect(ref.current?.nativeElement).toBeTruthy();
+    // instanceof HTMLDivElement
+    expect(ref.current?.nativeElement instanceof HTMLElement).toBeTruthy();
+  });
 });

--- a/components/upload/__tests__/upload.test.tsx
+++ b/components/upload/__tests__/upload.test.tsx
@@ -1087,7 +1087,6 @@ describe('Upload', () => {
     const ref = React.createRef<any>();
     render(<Upload ref={ref} />);
     expect(ref.current?.nativeElement).toBeTruthy();
-    // instanceof HTMLDivElement
     expect(ref.current?.nativeElement instanceof HTMLElement).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref: https://github.com/ant-design/ant-design/pull/45410#issuecomment-2029161830

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     feat(upload): support ref.nativeElenent      |
| 🇨🇳 Chinese |     upload 组件 ref 支持对原生元素转发      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
