### PR TITLE
chore: do not update @ant-design/cssinjs

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -11,7 +11,12 @@ module.exports = {
   packageManager: 'npm',
   dep: ['prod'], // check only prod dependencies
   // https://github.com/raineorshine/npm-check-updates#filter
-  filter: (name) => check.some((prefix) => name.startsWith(prefix)),
+  filter: (name) => {
+    if (name === '@ant-design/cssinjs') {
+      return false;
+    }
+    return check.some((prefix) => name.startsWith(prefix));
+  },
   // https://github.com/raineorshine/npm-check-updates#target
   target: (name, semver) => {
     const { operator } = semver[0] ?? {};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
https://github.com/ant-design/ant-design/discussions/48139
same as https://github.com/ant-design/ant-design/pull/48141

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
@ant-design/cssinjs 依赖太精确容易导致应用上层有两份 @ant-design/cssinjs，dependabot 里忽略掉。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   --        |
| 🇨🇳 Chinese |   --        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
