### PR TITLE
fix: Upload has empty space

### DIFF
--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -107,7 +107,7 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
       ${componentCls}-wrapper${componentCls}-picture-circle-wrapper
     `]: {
       ...clearFix(),
-      display: 'inline-block',
+      display: 'block',
       width: '100%',
 
       [`${componentCls}${componentCls}-select`]: {

--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -108,7 +108,6 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
     `]: {
       ...clearFix(),
       display: 'block',
-      width: '100%',
 
       [`${componentCls}${componentCls}-select`]: {
         width: uploadPictureCardSize,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #48365

### 💡 Background and solution

- 来源于 #17897 为了以块状区域展示支持点击。当时因为看是 `span` 所以选择了 `inline-block`，但是实际上照片墙总是占满区域，因而切换成 `block` 是安全的。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Upload `listType` with `picture-card` or `picture-circle` has additional space on top.     |
| 🇨🇳 Chinese |     修复 Upload 配置 `listType` 为 `picture-card` 或 `picture-circle` 时，上方有额外空隙的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
