### PR TITLE
fix: OTP with controlled of `''` not working

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -45,7 +45,7 @@ export interface OTPProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'on
 }
 
 function strToArr(str: string) {
-  return str.split('');
+  return (str || '').split('');
 }
 
 const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
@@ -121,7 +121,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
   );
 
   React.useEffect(() => {
-    if (value) {
+    if (value !== undefined) {
       setValueCells(strToArr(value));
     }
   }, [value]);

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -82,6 +82,9 @@ describe('Input.OTP', () => {
 
     rerender(<OTP value="LITTLE" />);
     expect(getText(container)).toBe('LITTLE');
+
+    rerender(<OTP value="" />);
+    expect(getText(container)).toBe('');
   });
 
   it('focus to selection', async () => {

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -85,6 +85,12 @@ describe('Input.OTP', () => {
 
     rerender(<OTP value="" />);
     expect(getText(container)).toBe('');
+
+    rerender(<OTP value="EXCEED-RANGE" />);
+    expect(getText(container)).toBe('EXCEED');
+
+    rerender(<OTP value={null!} />);
+    expect(getText(container)).toBe('');
   });
 
   it('focus to selection', async () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #48395

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Input.OTP controlled `value` to `''` not work as expect.        |
| 🇨🇳 Chinese |    修复 Input.OTP 组件受控设置 `value` 为 `''` 时不生效的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
