### PR TITLE
fix: switch checkedChildren no height

### DIFF
--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -68,4 +68,12 @@ describe('Switch', () => {
   it('have static property for type detecting', () => {
     expect(Switch.__ANT_SWITCH).toBeTruthy();
   });
+
+  it('inner element have min-height', () => {
+    const { container, rerender } = render(<Switch unCheckedChildren="0" size="small" />);
+    expect(container.querySelector('.ant-switch-inner-unchecked')).toHaveStyle('min-height: 16px');
+
+    rerender(<Switch unCheckedChildren="0" />);
+    expect(container.querySelector('.ant-switch-inner-unchecked')).toHaveStyle('min-height: 22px');
+  });
 });

--- a/components/switch/style/index.ts
+++ b/components/switch/style/index.ts
@@ -109,6 +109,11 @@ const genSwitchSmallStyle: GenerateStyle<SwitchToken, CSSObject> = (token) => {
         [`${componentCls}-inner`]: {
           paddingInlineStart: innerMaxMarginSM,
           paddingInlineEnd: innerMinMarginSM,
+
+          [`${switchInnerCls}-checked, ${switchInnerCls}-unchecked`]: {
+            minHeight: trackHeightSM,
+          },
+
           [`${switchInnerCls}-checked`]: {
             marginInlineStart: `calc(-100% + ${trackPaddingCalc} - ${innerMaxMarginCalc})`,
             marginInlineEnd: `calc(100% - ${trackPaddingCalc} + ${innerMaxMarginCalc})`,
@@ -269,6 +274,7 @@ const genSwitchInnerStyle: GenerateStyle<SwitchToken, CSSObject> = (token) => {
           fontSize: token.fontSizeSM,
           transition: `margin-inline-start ${token.switchDuration} ease-in-out, margin-inline-end ${token.switchDuration} ease-in-out`,
           pointerEvents: 'none',
+          minHeight: trackHeight,
         },
 
         [`${switchInnerCls}-checked`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #48503 

### 💡 Background and solution
switch 组件 checkedChildren unCheckedChildren 没有默认高度
checkedChildren 为空时会造成 unCheckedChildren 定位错误


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  switch component props checkedChildren unCheckedChildren add min-height   |
| 🇨🇳 Chinese |  switch 组件 checkedChildren unCheckedChildren 添加 min-height     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
