### PR TITLE
fix: Input.Search large size button style

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -881,4 +881,7 @@ export default genStyleHooks(
     ];
   },
   initComponentToken,
+  {
+    resetStyle: 'strict',
+  },
 );

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -882,6 +882,6 @@ export default genStyleHooks(
   },
   initComponentToken,
   {
-    resetStyle: 'strict',
+    resetFont: false,
   },
 );

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -107,29 +107,36 @@ export const genCommonStyle = (
   token: DerivativeToken,
   componentPrefixCls: string,
   rootCls?: string,
+  strict = false,
 ): CSSObject => {
   const { fontFamily, fontSize } = token;
 
   const prefixSelector = `[class^="${componentPrefixCls}"], [class*=" ${componentPrefixCls}"]`;
   const rootPrefixSelector = rootCls ? `.${rootCls}` : prefixSelector;
 
+  const resetStyle: CSSObject = {
+    boxSizing: 'border-box',
+
+    '&::before, &::after': {
+      boxSizing: 'border-box',
+    },
+  };
+
+  if (strict) {
+    return rootCls
+      ? {
+          [`.${rootCls}`]: resetStyle,
+        }
+      : {};
+  }
+
   return {
     [rootPrefixSelector]: {
       fontFamily,
       fontSize,
-      boxSizing: 'border-box',
+      ...resetStyle,
 
-      '&::before, &::after': {
-        boxSizing: 'border-box',
-      },
-
-      [prefixSelector]: {
-        boxSizing: 'border-box',
-
-        '&::before, &::after': {
-          boxSizing: 'border-box',
-        },
-      },
+      [prefixSelector]: resetStyle,
     },
   };
 };

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -109,8 +109,6 @@ export const genCommonStyle = (
   rootCls?: string,
   strict = false,
 ): CSSObject => {
-  const { fontFamily, fontSize } = token;
-
   const prefixSelector = `[class^="${componentPrefixCls}"], [class*=" ${componentPrefixCls}"]`;
   const rootPrefixSelector = rootCls ? `.${rootCls}` : prefixSelector;
 
@@ -122,18 +120,18 @@ export const genCommonStyle = (
     },
   };
 
-  if (strict) {
-    return rootCls
-      ? {
-          [`.${rootCls}`]: resetStyle,
-        }
-      : {};
+  let resetFont: CSSObject = {};
+
+  if (!strict) {
+    resetFont = {
+      fontFamily: token.fontFamily,
+      fontSize: token.fontSize,
+    };
   }
 
   return {
     [rootPrefixSelector]: {
-      fontFamily,
-      fontSize,
+      ...resetFont,
       ...resetStyle,
 
       [prefixSelector]: resetStyle,

--- a/components/style/index.ts
+++ b/components/style/index.ts
@@ -107,7 +107,7 @@ export const genCommonStyle = (
   token: DerivativeToken,
   componentPrefixCls: string,
   rootCls?: string,
-  strict = false,
+  resetFont?: boolean,
 ): CSSObject => {
   const prefixSelector = `[class^="${componentPrefixCls}"], [class*=" ${componentPrefixCls}"]`;
   const rootPrefixSelector = rootCls ? `.${rootCls}` : prefixSelector;
@@ -120,10 +120,10 @@ export const genCommonStyle = (
     },
   };
 
-  let resetFont: CSSObject = {};
+  let resetFontStyle: CSSObject = {};
 
-  if (!strict) {
-    resetFont = {
+  if (resetFont !== false) {
+    resetFontStyle = {
       fontFamily: token.fontFamily,
       fontSize: token.fontSize,
     };
@@ -131,7 +131,7 @@ export const genCommonStyle = (
 
   return {
     [rootPrefixSelector]: {
-      ...resetFont,
+      ...resetFontStyle,
       ...resetStyle,
 
       [prefixSelector]: resetStyle,

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -132,7 +132,7 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
   styleFn: GenStyleFn<C>,
   getDefaultToken?: GetDefaultToken<C>,
   options: {
-    resetStyle?: boolean;
+    resetStyle?: boolean | 'strict';
     // Deprecated token key map [["oldTokenKey", "newTokenKey"], ["oldTokenKey", "newTokenKey"]]
     deprecatedTokens?: [ComponentTokenKey<C>, ComponentTokenKey<C>][];
     /**
@@ -243,7 +243,9 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
         });
         flush(component, componentToken);
         return [
-          options.resetStyle === false ? null : genCommonStyle(mergedToken, prefixCls, rootCls),
+          options.resetStyle === false
+            ? null
+            : genCommonStyle(mergedToken, prefixCls, rootCls, options.resetStyle === 'strict'),
           styleInterpolation,
         ];
       },
@@ -377,7 +379,7 @@ export const genStyleHooks = <C extends OverrideComponent>(
   styleFn: GenStyleFn<C>,
   getDefaultToken?: GetDefaultToken<C>,
   options?: {
-    resetStyle?: boolean;
+    resetStyle?: boolean | 'strict';
     deprecatedTokens?: [ComponentTokenKey<C>, ComponentTokenKey<C>][];
     /**
      * Component tokens that do not need unit.

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -132,7 +132,8 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
   styleFn: GenStyleFn<C>,
   getDefaultToken?: GetDefaultToken<C>,
   options: {
-    resetStyle?: boolean | 'strict';
+    resetStyle?: boolean;
+    resetFont?: boolean;
     // Deprecated token key map [["oldTokenKey", "newTokenKey"], ["oldTokenKey", "newTokenKey"]]
     deprecatedTokens?: [ComponentTokenKey<C>, ComponentTokenKey<C>][];
     /**
@@ -245,7 +246,7 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
         return [
           options.resetStyle === false
             ? null
-            : genCommonStyle(mergedToken, prefixCls, rootCls, options.resetStyle === 'strict'),
+            : genCommonStyle(mergedToken, prefixCls, rootCls, options.resetFont),
           styleInterpolation,
         ];
       },
@@ -379,7 +380,8 @@ export const genStyleHooks = <C extends OverrideComponent>(
   styleFn: GenStyleFn<C>,
   getDefaultToken?: GetDefaultToken<C>,
   options?: {
-    resetStyle?: boolean | 'strict';
+    resetStyle?: boolean;
+    resetFont?: boolean;
     deprecatedTokens?: [ComponentTokenKey<C>, ComponentTokenKey<C>][];
     /**
      * Component tokens that do not need unit.


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #48507

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input.Search with large size, the button font size is not in large size.      |
| 🇨🇳 Chinese |   修复 Input.Search 设置大尺寸时，按钮的文字不是大尺寸的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
