### PR TITLE
fix: Slider range exchange tooltip blink

### DIFF
--- a/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -27,11 +27,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -45,7 +40,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          30
+        </div>
       </div>
     </div>
   </div>,
@@ -159,11 +156,6 @@ Array [
       style="left: 30%; transform: translateX(-50%);"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -177,7 +169,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          30
+        </div>
       </div>
     </div>
   </div>,
@@ -267,11 +261,6 @@ Array [
         tabindex="0"
       />
       <div
-        aria-hidden="true"
-        class="ant-slider-handle"
-        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
-      />
-      <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
       >
@@ -285,7 +274,9 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          />
+          >
+            30
+          </div>
         </div>
       </div>
     </div>
@@ -556,11 +547,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -574,7 +560,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          30
+        </div>
       </div>
     </div>
   </div>,
@@ -689,11 +677,6 @@ exports[`renders components/slider/demo/icon-slider.tsx extend context correctly
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -707,7 +690,9 @@ exports[`renders components/slider/demo/icon-slider.tsx extend context correctly
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          0
+        </div>
       </div>
     </div>
   </div>
@@ -774,11 +759,6 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
             tabindex="0"
           />
           <div
-            aria-hidden="true"
-            class="ant-slider-handle"
-            style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-          />
-          <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
             style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
           >
@@ -792,7 +772,9 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
               <div
                 class="ant-tooltip-inner"
                 role="tooltip"
-              />
+              >
+                1
+              </div>
             </div>
           </div>
         </div>
@@ -914,11 +896,6 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
             tabindex="0"
           />
           <div
-            aria-hidden="true"
-            class="ant-slider-handle"
-            style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-          />
-          <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
             style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
           >
@@ -932,7 +909,9 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
               <div
                 class="ant-tooltip-inner"
                 role="tooltip"
-              />
+              >
+                0
+              </div>
             </div>
           </div>
         </div>
@@ -1072,11 +1051,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1090,7 +1064,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          37
+        </div>
       </div>
     </div>
     <div
@@ -1270,11 +1246,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1288,7 +1259,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          37
+        </div>
       </div>
     </div>
     <div
@@ -1367,11 +1340,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1385,7 +1353,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          37
+        </div>
       </div>
     </div>
     <div
@@ -1464,11 +1434,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1482,7 +1447,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          37
+        </div>
       </div>
     </div>
     <div
@@ -1630,11 +1597,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1648,7 +1610,9 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        />
+        >
+          30
+        </div>
       </div>
     </div>
   </div>,
@@ -1812,11 +1776,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
-    />
-    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1831,7 +1790,7 @@ Array [
           class="ant-tooltip-inner"
           role="tooltip"
         >
-          undefined%
+          0%
         </div>
       </div>
     </div>
@@ -1859,11 +1818,6 @@ Array [
       role="slider"
       style="left: 0%; transform: translateX(-50%);"
       tabindex="0"
-    />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -1918,11 +1872,6 @@ Array [
         tabindex="0"
       />
       <div
-        aria-hidden="true"
-        class="ant-slider-handle"
-        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
-      />
-      <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
       >
@@ -1936,7 +1885,9 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          />
+          >
+            30
+          </div>
         </div>
       </div>
     </div>

--- a/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -27,6 +27,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -40,9 +45,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          30
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -71,25 +74,6 @@ Array [
       tabindex="0"
     />
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          role="tooltip"
-        >
-          20
-        </div>
-      </div>
-    </div>
-    <div
       aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
@@ -99,6 +83,11 @@ Array [
       role="slider"
       style="left: 50%; transform: translateX(-50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -114,9 +103,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          50
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -172,6 +159,11 @@ Array [
       style="left: 30%; transform: translateX(-50%);"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -185,9 +177,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          30
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -216,25 +206,6 @@ Array [
       tabindex="0"
     />
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          role="tooltip"
-        >
-          20
-        </div>
-      </div>
-    </div>
-    <div
       aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
@@ -244,6 +215,11 @@ Array [
       role="slider"
       style="left: 50%; transform: translateX(-50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -259,9 +235,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          50
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -293,6 +267,11 @@ Array [
         tabindex="0"
       />
       <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
+      />
+      <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
       >
@@ -306,9 +285,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            30
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -341,25 +318,6 @@ Array [
         tabindex="0"
       />
       <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            role="tooltip"
-          >
-            20
-          </div>
-        </div>
-      </div>
-      <div
         aria-disabled="false"
         aria-orientation="vertical"
         aria-valuemax="100"
@@ -369,6 +327,11 @@ Array [
         role="slider"
         style="bottom: 50%; transform: translateY(50%);"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
       />
       <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
@@ -384,9 +347,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            50
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -436,25 +397,6 @@ Array [
         tabindex="0"
       />
       <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            role="tooltip"
-          >
-            26
-          </div>
-        </div>
-      </div>
-      <div
         aria-disabled="false"
         aria-orientation="vertical"
         aria-valuemax="100"
@@ -464,6 +406,11 @@ Array [
         role="slider"
         style="bottom: 37%; transform: translateY(50%);"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
       />
       <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
@@ -479,9 +426,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            37
-          </div>
+          />
         </div>
       </div>
       <div
@@ -547,25 +492,6 @@ exports[`renders components/slider/demo/draggableTrack.tsx extend context correc
     tabindex="0"
   />
   <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        role="tooltip"
-      >
-        20
-      </div>
-    </div>
-  </div>
-  <div
     aria-disabled="false"
     aria-orientation="horizontal"
     aria-valuemax="100"
@@ -575,6 +501,11 @@ exports[`renders components/slider/demo/draggableTrack.tsx extend context correc
     role="slider"
     style="left: 50%; transform: translateX(-50%);"
     tabindex="0"
+  />
+  <div
+    aria-hidden="true"
+    class="ant-slider-handle"
+    style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
   />
   <div
     class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -590,9 +521,7 @@ exports[`renders components/slider/demo/draggableTrack.tsx extend context correc
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-      >
-        50
-      </div>
+      />
     </div>
   </div>
 </div>
@@ -627,6 +556,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -640,9 +574,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          30
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -671,25 +603,6 @@ Array [
       tabindex="0"
     />
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          role="tooltip"
-        >
-          20
-        </div>
-      </div>
-    </div>
-    <div
       aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
@@ -699,6 +612,11 @@ Array [
       role="slider"
       style="left: 50%; transform: translateX(-50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -714,9 +632,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          50
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -773,6 +689,11 @@ exports[`renders components/slider/demo/icon-slider.tsx extend context correctly
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -786,9 +707,7 @@ exports[`renders components/slider/demo/icon-slider.tsx extend context correctly
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          0
-        </div>
+        />
       </div>
     </div>
   </div>
@@ -855,6 +774,11 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
             tabindex="0"
           />
           <div
+            aria-hidden="true"
+            class="ant-slider-handle"
+            style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+          />
+          <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
             style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
           >
@@ -868,9 +792,7 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
               <div
                 class="ant-tooltip-inner"
                 role="tooltip"
-              >
-                1
-              </div>
+              />
             </div>
           </div>
         </div>
@@ -992,6 +914,11 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
             tabindex="0"
           />
           <div
+            aria-hidden="true"
+            class="ant-slider-handle"
+            style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+          />
+          <div
             class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
             style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
           >
@@ -1005,9 +932,7 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
               <div
                 class="ant-tooltip-inner"
                 role="tooltip"
-              >
-                0
-              </div>
+              />
             </div>
           </div>
         </div>
@@ -1147,6 +1072,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1160,9 +1090,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          37
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1238,25 +1166,6 @@ Array [
       tabindex="0"
     />
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          role="tooltip"
-        >
-          26
-        </div>
-      </div>
-    </div>
-    <div
       aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
@@ -1266,6 +1175,11 @@ Array [
       role="slider"
       style="left: 37%; transform: translateX(-50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -1281,9 +1195,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          37
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1358,6 +1270,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1371,9 +1288,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          37
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1452,6 +1367,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1465,9 +1385,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          37
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1546,6 +1464,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1559,9 +1482,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          37
-        </div>
+        />
       </div>
     </div>
     <div
@@ -1634,25 +1555,6 @@ exports[`renders components/slider/demo/multiple.tsx extend context correctly 1`
     tabindex="0"
   />
   <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        role="tooltip"
-      >
-        0
-      </div>
-    </div>
-  </div>
-  <div
     aria-disabled="false"
     aria-orientation="horizontal"
     aria-valuemax="100"
@@ -1663,25 +1565,6 @@ exports[`renders components/slider/demo/multiple.tsx extend context correctly 1`
     style="left: 10%; transform: translateX(-50%);"
     tabindex="0"
   />
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    />
-    <div
-      class="ant-tooltip-content"
-    >
-      <div
-        class="ant-tooltip-inner"
-        role="tooltip"
-      >
-        10
-      </div>
-    </div>
-  </div>
   <div
     aria-disabled="false"
     aria-orientation="horizontal"
@@ -1694,6 +1577,11 @@ exports[`renders components/slider/demo/multiple.tsx extend context correctly 1`
     tabindex="0"
   />
   <div
+    aria-hidden="true"
+    class="ant-slider-handle"
+    style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+  />
+  <div
     class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
   >
@@ -1707,9 +1595,7 @@ exports[`renders components/slider/demo/multiple.tsx extend context correctly 1`
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-      >
-        20
-      </div>
+      />
     </div>
   </div>
 </div>
@@ -1744,6 +1630,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1757,9 +1648,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          30
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -1788,25 +1677,6 @@ Array [
       tabindex="0"
     />
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      />
-      <div
-        class="ant-tooltip-content"
-      >
-        <div
-          class="ant-tooltip-inner"
-          role="tooltip"
-        >
-          20
-        </div>
-      </div>
-    </div>
-    <div
       aria-disabled="false"
       aria-orientation="horizontal"
       aria-valuemax="100"
@@ -1816,6 +1686,11 @@ Array [
       role="slider"
       style="right: 50%; transform: translateX(50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -1831,9 +1706,7 @@ Array [
         <div
           class="ant-tooltip-inner"
           role="tooltip"
-        >
-          50
-        </div>
+        />
       </div>
     </div>
   </div>,
@@ -1939,6 +1812,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
+    />
+    <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
@@ -1953,7 +1831,7 @@ Array [
           class="ant-tooltip-inner"
           role="tooltip"
         >
-          0%
+          undefined%
         </div>
       </div>
     </div>
@@ -1981,6 +1859,11 @@ Array [
       role="slider"
       style="left: 0%; transform: translateX(-50%);"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="transform: translateX(-50%); pointer-events: none; visibility: hidden;"
     />
     <div
       class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-top"
@@ -2035,6 +1918,11 @@ Array [
         tabindex="0"
       />
       <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
+      />
+      <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
       >
@@ -2048,9 +1936,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            30
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -2083,25 +1969,6 @@ Array [
         tabindex="0"
       />
       <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            role="tooltip"
-          >
-            20
-          </div>
-        </div>
-      </div>
-      <div
         aria-disabled="false"
         aria-orientation="vertical"
         aria-valuemax="100"
@@ -2111,6 +1978,11 @@ Array [
         role="slider"
         style="bottom: 50%; transform: translateY(50%);"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
       />
       <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
@@ -2126,9 +1998,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            50
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -2178,25 +2048,6 @@ Array [
         tabindex="0"
       />
       <div
-        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
-        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-      >
-        <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        />
-        <div
-          class="ant-tooltip-content"
-        >
-          <div
-            class="ant-tooltip-inner"
-            role="tooltip"
-          >
-            26
-          </div>
-        </div>
-      </div>
-      <div
         aria-disabled="false"
         aria-orientation="vertical"
         aria-valuemax="100"
@@ -2206,6 +2057,11 @@ Array [
         role="slider"
         style="bottom: 37%; transform: translateY(50%);"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="transform: translateY(50%); pointer-events: none; visibility: hidden;"
       />
       <div
         class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-slider-tooltip ant-tooltip-placement-right"
@@ -2221,9 +2077,7 @@ Array [
           <div
             class="ant-tooltip-inner"
             role="tooltip"
-          >
-            37
-          </div>
+          />
         </div>
       </div>
       <div

--- a/components/slider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.ts.snap
@@ -26,6 +26,11 @@ Array [
       style="left:30%;transform:translateX(-50%)"
       tabindex="0"
     />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -61,6 +66,11 @@ Array [
       role="slider"
       style="left:50%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>,
   Disabled: ,
@@ -112,6 +122,11 @@ Array [
       role="slider"
       style="left:30%;transform:translateX(-50%)"
     />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -148,6 +163,11 @@ Array [
       style="left:50%;transform:translateX(-50%)"
       tabindex="0"
     />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
   </div>,
   <div
     style="display:inline-block;height:300px;margin-left:70px"
@@ -175,6 +195,11 @@ Array [
         role="slider"
         style="bottom:30%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,
@@ -215,6 +240,11 @@ Array [
         role="slider"
         style="bottom:50%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,
@@ -272,6 +302,11 @@ Array [
         role="slider"
         style="bottom:37%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
       <div
         class="ant-slider-mark"
@@ -344,6 +379,11 @@ exports[`renders components/slider/demo/draggableTrack.tsx correctly 1`] = `
     style="left:50%;transform:translateX(-50%)"
     tabindex="0"
   />
+  <div
+    aria-hidden="true"
+    class="ant-slider-handle"
+    style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+  />
 </div>
 `;
 
@@ -372,6 +412,11 @@ Array [
       role="slider"
       style="left:30%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>,
   <div
@@ -408,6 +453,11 @@ Array [
       role="slider"
       style="left:50%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>,
 ]
@@ -459,6 +509,11 @@ exports[`renders components/slider/demo/icon-slider.tsx correctly 1`] = `
       role="slider"
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>
   <span
@@ -520,6 +575,11 @@ exports[`renders components/slider/demo/input-number.tsx correctly 1`] = `
             role="slider"
             style="left:0%;transform:translateX(-50%)"
             tabindex="0"
+          />
+          <div
+            aria-hidden="true"
+            class="ant-slider-handle"
+            style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
           />
         </div>
       </div>
@@ -638,6 +698,11 @@ exports[`renders components/slider/demo/input-number.tsx correctly 1`] = `
             role="slider"
             style="left:0%;transform:translateX(-50%)"
             tabindex="0"
+          />
+          <div
+            aria-hidden="true"
+            class="ant-slider-handle"
+            style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
           />
         </div>
       </div>
@@ -774,6 +839,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
+    <div
       class="ant-slider-mark"
     >
       <span
@@ -857,6 +927,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
+    <div
       class="ant-slider-mark"
     >
       <span
@@ -926,6 +1001,11 @@ Array [
       role="slider"
       style="left:37%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
     <div
       class="ant-slider-mark"
@@ -1003,6 +1083,11 @@ Array [
       tabindex="0"
     />
     <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
+    <div
       class="ant-slider-mark"
     >
       <span
@@ -1076,6 +1161,11 @@ Array [
       role="slider"
       style="left:37%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
     <div
       class="ant-slider-mark"
@@ -1166,6 +1256,11 @@ exports[`renders components/slider/demo/multiple.tsx correctly 1`] = `
     style="left:20%;transform:translateX(-50%)"
     tabindex="0"
   />
+  <div
+    aria-hidden="true"
+    class="ant-slider-handle"
+    style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+  />
 </div>
 `;
 
@@ -1194,6 +1289,11 @@ Array [
       role="slider"
       style="right:30%;transform:translateX(50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="right:NaN%;transform:translateX(50%);pointer-events:none;visibility:hidden"
     />
   </div>,
   <div
@@ -1230,6 +1330,11 @@ Array [
       role="slider"
       style="right:50%;transform:translateX(50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="right:NaN%;transform:translateX(50%);pointer-events:none;visibility:hidden"
     />
   </div>,
   Reversed: ,
@@ -1282,6 +1387,11 @@ Array [
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
     />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
+    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -1306,6 +1416,11 @@ Array [
       role="slider"
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      class="ant-slider-handle"
+      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>,
 ]
@@ -1339,6 +1454,11 @@ Array [
         role="slider"
         style="bottom:30%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,
@@ -1379,6 +1499,11 @@ Array [
         role="slider"
         style="bottom:50%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,
@@ -1436,6 +1561,11 @@ Array [
         role="slider"
         style="bottom:37%;transform:translateY(50%)"
         tabindex="0"
+      />
+      <div
+        aria-hidden="true"
+        class="ant-slider-handle"
+        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
       <div
         class="ant-slider-mark"

--- a/components/slider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo.test.ts.snap
@@ -26,11 +26,6 @@ Array [
       style="left:30%;transform:translateX(-50%)"
       tabindex="0"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -122,11 +117,6 @@ Array [
       role="slider"
       style="left:30%;transform:translateX(-50%)"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -195,11 +185,6 @@ Array [
         role="slider"
         style="bottom:30%;transform:translateY(50%)"
         tabindex="0"
-      />
-      <div
-        aria-hidden="true"
-        class="ant-slider-handle"
-        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,
@@ -413,11 +398,6 @@ Array [
       style="left:30%;transform:translateX(-50%)"
       tabindex="0"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -510,11 +490,6 @@ exports[`renders components/slider/demo/icon-slider.tsx correctly 1`] = `
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
   </div>
   <span
     aria-label="smile"
@@ -575,11 +550,6 @@ exports[`renders components/slider/demo/input-number.tsx correctly 1`] = `
             role="slider"
             style="left:0%;transform:translateX(-50%)"
             tabindex="0"
-          />
-          <div
-            aria-hidden="true"
-            class="ant-slider-handle"
-            style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
           />
         </div>
       </div>
@@ -698,11 +668,6 @@ exports[`renders components/slider/demo/input-number.tsx correctly 1`] = `
             role="slider"
             style="left:0%;transform:translateX(-50%)"
             tabindex="0"
-          />
-          <div
-            aria-hidden="true"
-            class="ant-slider-handle"
-            style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
           />
         </div>
       </div>
@@ -837,11 +802,6 @@ Array [
       role="slider"
       style="left:37%;transform:translateX(-50%)"
       tabindex="0"
-    />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
     <div
       class="ant-slider-mark"
@@ -1003,11 +963,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
-    <div
       class="ant-slider-mark"
     >
       <span
@@ -1083,11 +1038,6 @@ Array [
       tabindex="0"
     />
     <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
-    <div
       class="ant-slider-mark"
     >
       <span
@@ -1161,11 +1111,6 @@ Array [
       role="slider"
       style="left:37%;transform:translateX(-50%)"
       tabindex="0"
-    />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
     <div
       class="ant-slider-mark"
@@ -1290,11 +1235,6 @@ Array [
       style="right:30%;transform:translateX(50%)"
       tabindex="0"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="right:NaN%;transform:translateX(50%);pointer-events:none;visibility:hidden"
-    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -1387,11 +1327,6 @@ Array [
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
     />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
-    />
   </div>,
   <div
     class="ant-slider ant-slider-horizontal"
@@ -1416,11 +1351,6 @@ Array [
       role="slider"
       style="left:0%;transform:translateX(-50%)"
       tabindex="0"
-    />
-    <div
-      aria-hidden="true"
-      class="ant-slider-handle"
-      style="left:NaN%;transform:translateX(-50%);pointer-events:none;visibility:hidden"
     />
   </div>,
 ]
@@ -1454,11 +1384,6 @@ Array [
         role="slider"
         style="bottom:30%;transform:translateY(50%)"
         tabindex="0"
-      />
-      <div
-        aria-hidden="true"
-        class="ant-slider-handle"
-        style="bottom:NaN%;transform:translateY(50%);pointer-events:none;visibility:hidden"
       />
     </div>
   </div>,

--- a/components/slider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,11 +25,6 @@ exports[`Slider rtl render component should be rendered correctly in RTL directi
     style="right: 0%; transform: translateX(50%);"
     tabindex="0"
   />
-  <div
-    aria-hidden="true"
-    class="ant-slider-handle"
-    style="transform: translateX(50%); pointer-events: none; visibility: hidden;"
-  />
 </div>
 `;
 

--- a/components/slider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`Slider rtl render component should be rendered correctly in RTL directi
     style="right: 0%; transform: translateX(50%);"
     tabindex="0"
   />
+  <div
+    aria-hidden="true"
+    class="ant-slider-handle"
+    style="transform: translateX(50%); pointer-events: none; visibility: hidden;"
+  />
 </div>
 `;
 

--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import Slider from '..';
+import { resetWarned } from '../../_util/warning';
+import focusTest from '../../../tests/shared/focusTest';
+import mountTest from '../../../tests/shared/mountTest';
+import rtlTest from '../../../tests/shared/rtlTest';
+import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import type { TooltipProps, TooltipRef } from '../../tooltip';
+import SliderTooltip from '../SliderTooltip';
+
+function tooltipProps(): TooltipProps {
+  return (global as any).tooltipProps;
+}
+
+jest.mock('../../tooltip', () => {
+  const ReactReal: typeof React = jest.requireActual('react');
+  const Tooltip = jest.requireActual('../../tooltip');
+  const TooltipComponent = Tooltip.default;
+  return ReactReal.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
+    (global as any).tooltipProps = props;
+    return <TooltipComponent {...props} ref={ref} />;
+  });
+});
+
+describe('Slider.Tooltip', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('Correct show the tooltip', async () => {
+    const { container } = render(<Slider defaultValue={30} />);
+
+    const handleEle = container.querySelector('.ant-slider-handle')!;
+
+    // Enter
+    fireEvent.mouseEnter(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeTruthy();
+
+    // Down
+    fireEvent.mouseDown(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeTruthy();
+
+    // Move(Leave)
+    fireEvent.mouseLeave(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeTruthy();
+
+    // Up
+    fireEvent.mouseUp(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeFalsy();
+  });
+});

--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 
 import Slider from '..';
-import { resetWarned } from '../../_util/warning';
-import focusTest from '../../../tests/shared/focusTest';
-import mountTest from '../../../tests/shared/mountTest';
-import rtlTest from '../../../tests/shared/rtlTest';
-import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
-import ConfigProvider from '../../config-provider';
+import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import type { TooltipProps, TooltipRef } from '../../tooltip';
-import SliderTooltip from '../SliderTooltip';
 
 function tooltipProps(): TooltipProps {
   return (global as any).tooltipProps;

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import type { SliderProps as RcSliderProps } from 'rc-slider';
 import RcSlider from 'rc-slider';
 import type { SliderProps, SliderRef } from 'rc-slider/lib/Slider';
+import raf from 'rc-util/lib/raf';
 
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
@@ -240,7 +241,11 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   // ============================== Handle ==============================
   React.useEffect(() => {
     const onMouseUp = () => {
-      setFocusOpen(false);
+      // Delay for 1 frame to make the click to enable hide tooltip
+      // even when the handle is focused
+      raf(() => {
+        setFocusOpen(false);
+      }, 1);
     };
     document.addEventListener('mouseup', onMouseUp);
 

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -312,7 +312,12 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   const activeHandleRender: SliderProps['activeHandleRender'] = lockOpen
     ? undefined
     : (handle, info) => {
-        const cloneNode = React.cloneElement(handle);
+        const cloneNode = React.cloneElement(handle, {
+          style: {
+            ...handle.props.style,
+            visibility: 'hidden',
+          },
+        });
 
         return (
           <SliderTooltip

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -151,7 +151,6 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   const mergedDisabled = disabled ?? contextDisabled;
 
   // =============================== Open ===============================
-  // const [opens, setOpens] = React.useState<Opens>({});
   const [hoverOpen, setHoverOpen] = useRafLock();
   const [focusOpen, setFocusOpen] = useRafLock();
   const activeOpen = hoverOpen || focusOpen;
@@ -168,10 +167,6 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   } = tooltipProps;
 
   const lockOpen = tooltipOpen ?? legacyTooltipVisible;
-
-  // const toggleTooltipOpen = (index: number, open: boolean) => {
-  //   setOpens((prev: Opens) => ({ ...prev, [index]: open }));
-  // };
 
   const mergedTipFormatter = getTipFormatter(tipFormatter, legacyTipFormatter);
 

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -255,23 +255,17 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   }, []);
 
   const handleRender: RcSliderProps['handleRender'] = (node, info) => {
-    // const { index, dragging } = info;
     const { index } = info;
-
-    // const isTipFormatter = mergedTipFormatter ? opens[index] || dragging : false;
-    // const open = lockOpen ?? (tooltipOpen === undefined && isTipFormatter);
 
     const nodeProps = node.props;
 
     const passedProps: typeof nodeProps = {
       ...nodeProps,
       onMouseEnter: (e) => {
-        // toggleTooltipOpen(index, true);
         setHoverOpen(true);
         nodeProps.onMouseEnter?.(e);
       },
       onMouseLeave: (e) => {
-        // toggleTooltipOpen(index, false);
         setHoverOpen(false);
         nodeProps.onMouseLeave?.(e);
       },
@@ -280,18 +274,12 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
         setDragging(true);
         nodeProps.onMouseDown?.(e);
       },
-      // onMouseUp: (e) => {
-      //   setFocusOpen(false);
-      //   nodeProps.onMouseUp?.(e);
-      // },
       onFocus: (e) => {
-        // toggleTooltipOpen(index, true);
         setFocusOpen(true);
         restProps.onFocus?.(e);
         nodeProps.onFocus?.(e);
       },
       onBlur: (e) => {
-        // toggleTooltipOpen(index, false);
         setFocusOpen(false);
         restProps.onBlur?.(e);
         nodeProps.onBlur?.(e);

--- a/components/slider/style/index.ts
+++ b/components/slider/style/index.ts
@@ -256,6 +256,12 @@ const genBaseStyle: GenerateStyle<SliderToken> = (token) => {
         },
       },
 
+      [`&-lock ${componentCls}-handle`]: {
+        [`&::before, &::after`]: {
+          transition: 'none',
+        },
+      },
+
       [`${componentCls}-mark`]: {
         position: 'absolute',
         fontSize: token.fontSize,

--- a/components/slider/useRafLock.ts
+++ b/components/slider/useRafLock.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import raf from 'rc-util/lib/raf';
+
+export default function useRafLock(): [state: boolean, setState: (nextState: boolean) => void] {
+  const [state, setState] = React.useState(false);
+
+  const rafRef = React.useRef<number>();
+  const cleanup = () => {
+    raf.cancel(rafRef.current!);
+  };
+
+  const setDelayState = (nextState: boolean) => {
+    if (nextState) {
+      setState(nextState);
+    } else {
+      rafRef.current = raf(() => {
+        setState(nextState);
+      });
+    }
+  };
+
+  React.useEffect(() => cleanup, []);
+
+  return [state, setDelayState];
+}

--- a/components/slider/useRafLock.ts
+++ b/components/slider/useRafLock.ts
@@ -10,6 +10,8 @@ export default function useRafLock(): [state: boolean, setState: (nextState: boo
   };
 
   const setDelayState = (nextState: boolean) => {
+    cleanup();
+
     if (nextState) {
       setState(nextState);
     } else {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "rc-resize-observer": "^1.4.0",
     "rc-segmented": "~2.3.0",
     "rc-select": "~14.13.1",
-    "rc-slider": "~10.6.0-4",
+    "rc-slider": "~10.6.0",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.45.4",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "rc-resize-observer": "^1.4.0",
     "rc-segmented": "~2.3.0",
     "rc-select": "~14.13.1",
-    "rc-slider": "~10.6.0-3",
+    "rc-slider": "~10.6.0-4",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.45.4",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "rc-resize-observer": "^1.4.0",
     "rc-segmented": "~2.3.0",
     "rc-select": "~14.13.1",
-    "rc-slider": "~10.6.0",
+    "rc-slider": "~10.6.1",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.45.4",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "rc-resize-observer": "^1.4.0",
     "rc-segmented": "~2.3.0",
     "rc-select": "~14.13.1",
-    "rc-slider": "~10.5.0",
+    "rc-slider": "~10.6.0-3",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.45.4",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #48149

### 💡 Background and solution

`rc-slider` 在拖动释放时，会将元素顺序重新排序以确保无障碍访问顺序正确。这导致松开瞬间，两个元素互换导致 Tooltip 移动到另一个元素上再消失。看了一下 mui 的实现，在越过时也会有一个小闪动。解法：

- 额外做一个虚元素对齐到激活态的元素上，并将 Tooltip 绑定到虚元素上实现与实际元素的隔离效果。
- 添加一个 `useRafLock` 控制状态更新，使其在拖拽结束时一段时间内处理 滑块 的动画，这样就保证了滑块本身也不会出现闪动。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Slider in `range` tooltip blink when drag the handle over another one.      |
| 🇨🇳 Chinese |     修复 Slider 在范围选择下，拖动滑块越过另一个滑块时提示框闪动的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
