### PR TITLE
fix: Select token with paddingXXS

### DIFF
--- a/components/date-picker/style/token.ts
+++ b/components/date-picker/style/token.ts
@@ -109,10 +109,14 @@ export type PickerPanelToken = {
   pickerControlIconBorderWidth: number;
 };
 
-export type PickerToken = FullToken<'DatePicker'> &
-  PickerPanelToken &
-  SharedInputToken &
-  SelectorToken;
+export interface PickerToken
+  extends FullToken<'DatePicker'>,
+    PickerPanelToken,
+    SharedInputToken,
+    SelectorToken {
+  /** @private Used for internal calculation */
+  INTERNAL_FIXED_ITEM_MARGIN: number;
+}
 
 export type SharedPickerToken = TokenWithCommonCls<GlobalToken> &
   PickerPanelToken &
@@ -139,8 +143,30 @@ export const initPickerPanelToken = (token: TokenWithCommonCls<GlobalToken>): Pi
 };
 
 export const initPanelComponentToken = (token: GlobalToken): PanelComponentToken => {
-  const { colorBgContainerDisabled, controlHeight, controlHeightSM, controlHeightLG, paddingXXS } =
-    token;
+  const {
+    colorBgContainerDisabled,
+    controlHeight,
+    controlHeightSM,
+    controlHeightLG,
+    paddingXXS,
+    lineWidth,
+  } = token;
+
+  // Item height default use `controlHeight - 2 * paddingXXS`,
+  // but some case `paddingXXS=0`.
+  // Let's fallback it.
+  const dblPaddingXXS = paddingXXS * 2;
+  const dblLineWidth = lineWidth * 2;
+
+  const multipleItemHeight = Math.min(controlHeight - dblPaddingXXS, controlHeight - dblLineWidth);
+  const multipleItemHeightSM = Math.min(
+    controlHeightSM - dblPaddingXXS,
+    controlHeightSM - dblLineWidth,
+  );
+  const multipleItemHeightLG = Math.min(
+    controlHeightLG - dblPaddingXXS,
+    controlHeightLG - dblLineWidth,
+  );
 
   return {
     cellHoverBg: token.controlItemBgHover,
@@ -157,9 +183,9 @@ export const initPanelComponentToken = (token: GlobalToken): PanelComponentToken
     withoutTimeCellHeight: controlHeightLG * 1.65,
     multipleItemBg: token.colorFillSecondary,
     multipleItemBorderColor: 'transparent',
-    multipleItemHeight: controlHeight - paddingXXS * 2,
-    multipleItemHeightSM: controlHeightSM - paddingXXS * 2,
-    multipleItemHeightLG: controlHeightLG - paddingXXS * 2,
+    multipleItemHeight,
+    multipleItemHeightSM,
+    multipleItemHeightLG,
     multipleSelectorBgDisabled: colorBgContainerDisabled,
     multipleItemColorDisabled: token.colorTextDisabled,
     multipleItemBorderColorDisabled: 'transparent',

--- a/components/date-picker/style/token.ts
+++ b/components/date-picker/style/token.ts
@@ -168,7 +168,11 @@ export const initPanelComponentToken = (token: GlobalToken): PanelComponentToken
     controlHeightLG - dblLineWidth,
   );
 
-  return {
+  // FIXED_ITEM_MARGIN is a hardcode calculation since calc not support rounding
+  const INTERNAL_FIXED_ITEM_MARGIN = Math.floor(paddingXXS / 2);
+
+  const filledToken = {
+    INTERNAL_FIXED_ITEM_MARGIN,
     cellHoverBg: token.controlItemBgHover,
     cellActiveWithRangeBg: token.controlItemBgActive,
     cellHoverWithRangeBg: new TinyColor(token.colorPrimary).lighten(35).toHexString(),
@@ -190,6 +194,8 @@ export const initPanelComponentToken = (token: GlobalToken): PanelComponentToken
     multipleItemColorDisabled: token.colorTextDisabled,
     multipleItemBorderColorDisabled: 'transparent',
   };
+
+  return filledToken;
 };
 
 export const prepareComponentToken: GetDefaultToken<'DatePicker'> = (token) => ({

--- a/components/select/demo/component-token.tsx
+++ b/components/select/demo/component-token.tsx
@@ -11,10 +11,6 @@ for (let i = 10; i < 36; i++) {
   });
 }
 
-const handleChange = (value: string[]) => {
-  console.log(`selected ${value}`);
-};
-
 const App: React.FC = () => (
   <Space direction="vertical">
     <ConfigProvider
@@ -35,7 +31,6 @@ const App: React.FC = () => (
           style={{ width: '100%' }}
           placeholder="Please select"
           defaultValue={['a10', 'c12']}
-          onChange={handleChange}
           options={options}
         />
         <Select
@@ -44,7 +39,6 @@ const App: React.FC = () => (
           style={{ width: '100%' }}
           placeholder="Please select"
           defaultValue={['a10', 'c12']}
-          onChange={handleChange}
           options={options}
         />
       </Space>
@@ -64,7 +58,6 @@ const App: React.FC = () => (
           style={{ width: '100%' }}
           placeholder="Please select"
           defaultValue={['a10', 'c12']}
-          onChange={handleChange}
           options={options}
         />
         <Select
@@ -73,7 +66,26 @@ const App: React.FC = () => (
           style={{ width: '100%' }}
           placeholder="Please select"
           defaultValue={['a10', 'c12']}
-          onChange={handleChange}
+          options={options}
+        />
+      </Space>
+    </ConfigProvider>
+    <ConfigProvider
+      theme={{
+        components: {
+          Select: {
+            paddingXXS: 0,
+            controlHeight: 28,
+          },
+        },
+      }}
+    >
+      <Space style={{ width: '100%' }} direction="vertical">
+        <Select style={{ width: '100%' }} defaultValue="a10" options={options} />
+        <Select
+          mode="multiple"
+          style={{ width: '100%' }}
+          defaultValue={['a10', 'c12']}
           options={options}
         />
       </Space>

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -7,8 +7,6 @@ import type { AliasToken } from '../../theme/internal';
 import type { TokenWithCommonCls } from '../../theme/util/genComponentStyleHook';
 import type { SelectToken } from './token';
 
-export const FIXED_ITEM_MARGIN = 2;
-
 type SelectItemToken = Pick<
   SelectToken,
   | 'multipleSelectItemHeight'
@@ -19,6 +17,7 @@ type SelectItemToken = Pick<
   | 'lineWidth'
   | 'calc'
   | 'inputPaddingHorizontalBase'
+  | 'INTERNAL_FIXED_ITEM_MARGIN'
 >;
 
 /**
@@ -41,13 +40,21 @@ type SelectItemToken = Pick<
 export const getMultipleSelectorUnit = (
   token: Pick<
     SelectToken,
-    'max' | 'calc' | 'multipleSelectItemHeight' | 'paddingXXS' | 'lineWidth'
+    | 'max'
+    | 'calc'
+    | 'multipleSelectItemHeight'
+    | 'paddingXXS'
+    | 'lineWidth'
+    | 'INTERNAL_FIXED_ITEM_MARGIN'
   >,
 ) => {
-  const { multipleSelectItemHeight, paddingXXS, lineWidth } = token;
+  const { multipleSelectItemHeight, paddingXXS, lineWidth, INTERNAL_FIXED_ITEM_MARGIN } = token;
 
   const basePadding = token.max(token.calc(paddingXXS).sub(lineWidth).equal(), 0);
-  const containerPadding = token.max(token.calc(basePadding).sub(FIXED_ITEM_MARGIN).equal(), 0);
+  const containerPadding = token.max(
+    token.calc(basePadding).sub(INTERNAL_FIXED_ITEM_MARGIN).equal(),
+    0,
+  );
 
   return {
     basePadding,
@@ -87,6 +94,7 @@ export const genOverflowStyle = (
     | 'multipleItemBorderColorDisabled'
     | 'colorIcon'
     | 'colorIconHover'
+    | 'INTERNAL_FIXED_ITEM_MARGIN'
   >,
 ): CSSObject => {
   const {
@@ -99,6 +107,7 @@ export const genOverflowStyle = (
     multipleItemBorderColorDisabled,
     colorIcon,
     colorIconHover,
+    INTERNAL_FIXED_ITEM_MARGIN,
   } = token;
 
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
@@ -130,11 +139,11 @@ export const genOverflowStyle = (
         flex: 'none',
         boxSizing: 'border-box',
         maxWidth: '100%',
-        marginBlock: FIXED_ITEM_MARGIN,
+        marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
         borderRadius: borderRadiusSM,
         cursor: 'default',
         transition: `font-size ${motionDurationSlow}, line-height ${motionDurationSlow}, height ${motionDurationSlow}`,
-        marginInlineEnd: token.calc(FIXED_ITEM_MARGIN).mul(2).equal(),
+        marginInlineEnd: token.calc(INTERNAL_FIXED_ITEM_MARGIN).mul(2).equal(),
         paddingInlineStart: paddingXS,
         paddingInlineEnd: token.calc(paddingXS).div(2).equal(),
 
@@ -181,7 +190,7 @@ const genSelectionStyle = (
   token: TokenWithCommonCls<AliasToken> & SelectItemToken,
   suffix?: string,
 ): CSSObject => {
-  const { componentCls } = token;
+  const { componentCls, INTERNAL_FIXED_ITEM_MARGIN } = token;
 
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
 
@@ -216,7 +225,7 @@ const genSelectionStyle = (
         '&:after': {
           display: 'inline-block',
           width: 0,
-          margin: `${unit(FIXED_ITEM_MARGIN)} 0`,
+          margin: `${unit(INTERNAL_FIXED_ITEM_MARGIN)} 0`,
           lineHeight: unit(selectItemHeight),
           visibility: 'hidden',
           content: '"\\a0"',

--- a/components/select/style/token.ts
+++ b/components/select/style/token.ts
@@ -167,7 +167,7 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
   );
 
   // FIXED_ITEM_MARGIN is a hardcode calculation since calc not support rounding
-  const INTERNAL_FIXED_ITEM_MARGIN = paddingXXS / 2;
+  const INTERNAL_FIXED_ITEM_MARGIN = Math.floor(paddingXXS / 2);
 
   return {
     INTERNAL_FIXED_ITEM_MARGIN,

--- a/components/select/style/token.ts
+++ b/components/select/style/token.ts
@@ -120,12 +120,16 @@ export interface SelectorToken {
 
 export interface SelectToken extends FullToken<'Select'>, SelectorToken {
   rootPrefixCls: string;
+
+  /** @private Used for internal calculation */
+  INTERNAL_FIXED_ITEM_MARGIN: number;
 }
 
 export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
   const {
     fontSize,
     lineHeight,
+    lineWidth,
 
     controlHeight,
     controlHeightSM,
@@ -146,11 +150,28 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     colorTextDisabled,
   } = token;
 
-  const multipleItemHeight = controlHeight - paddingXXS * 2;
-  const multipleItemHeightSM = controlHeightSM - paddingXXS * 2;
-  const multipleItemHeightLG = controlHeightLG - paddingXXS * 2;
+  // Item height default use `controlHeight - 2 * paddingXXS`,
+  // but some case `paddingXXS=0`.
+  // Let's fallback it.
+  const dblPaddingXXS = paddingXXS * 2;
+  const dblLineWidth = lineWidth * 2;
+
+  const multipleItemHeight = Math.min(controlHeight - dblPaddingXXS, controlHeight - dblLineWidth);
+  const multipleItemHeightSM = Math.min(
+    controlHeightSM - dblPaddingXXS,
+    controlHeightSM - dblLineWidth,
+  );
+  const multipleItemHeightLG = Math.min(
+    controlHeightLG - dblPaddingXXS,
+    controlHeightLG - dblLineWidth,
+  );
+
+  // FIXED_ITEM_MARGIN is a hardcode calculation since calc not support rounding
+  const INTERNAL_FIXED_ITEM_MARGIN = paddingXXS / 2;
 
   return {
+    INTERNAL_FIXED_ITEM_MARGIN,
+
     zIndexPopup: zIndexPopupBase + 50,
     optionSelectedColor: colorText,
     optionSelectedFontWeight: fontWeightStrong,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #48043

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Select with `multiple` and `paddingXXS=0` will break the height align of `controlHeight` token.        |
| 🇨🇳 Chinese |    修复 Select 配置 `paddingXXS=0` 时，多选下超出设定的 `controlHeight` token 的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
