### PR TITLE
fix: clearedColor should be changed when initial value is undefined

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -700,8 +700,8 @@ describe('ColorPicker', () => {
   });
 
   describe('default clearValue should be changed', () => {
-    const Demo = () => {
-      const [color, setColor] = useState<string>('');
+    const Demo = ({ defaultValue }: { defaultValue?: string }) => {
+      const [color, setColor] = useState<string | undefined>(defaultValue);
       useEffect(() => {
         setColor('#1677ff');
       }, []);
@@ -709,12 +709,28 @@ describe('ColorPicker', () => {
     };
 
     it('normal', () => {
-      const { container } = render(<Demo />);
+      const { container } = render(<Demo defaultValue="" />);
 
       expect(container.querySelector('.ant-color-picker-clear')).toBeFalsy();
     });
 
     it('strict', () => {
+      const { container } = render(
+        <React.StrictMode>
+          <Demo defaultValue="" />
+        </React.StrictMode>,
+      );
+
+      expect(container.querySelector('.ant-color-picker-clear')).toBeFalsy();
+    });
+
+    it('default undefined, normal', () => {
+      const { container } = render(<Demo />);
+
+      expect(container.querySelector('.ant-color-picker-clear')).toBeFalsy();
+    });
+
+    it('default undefined, strict', () => {
       const { container } = render(
         <React.StrictMode>
           <Demo />

--- a/components/color-picker/hooks/useColorState.ts
+++ b/components/color-picker/hooks/useColorState.ts
@@ -43,13 +43,11 @@ const useColorState = (
       return;
     }
     prevValue.current = value;
-    if (hasValue(value)) {
-      const newColor = generateColor(value || '');
-      if (prevColor.current.cleared === true) {
-        newColor.cleared = 'controlled';
-      }
-      setColorValue(newColor);
+    const newColor = generateColor(hasValue(value) ? value || '' : prevColor.current);
+    if (prevColor.current.cleared === true) {
+      newColor.cleared = 'controlled';
     }
+    setColorValue(newColor);
   }, [value]);
 
   return [colorValue, setColorValue, prevColor] as const;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/48577
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ColorPicker that cleared icon should change when initial value is `undefined`.       |
| 🇨🇳 Chinese |     修复 ColorPicker 在初始未受控时清除图标不会改变的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
