### PR TITLE
fix: Missing generic of Upload `customRequest` prop

### DIFF
--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -118,7 +118,7 @@ export interface UploadProps<T = any> extends Pick<RcUploadProps, 'capture' | 'h
   style?: React.CSSProperties;
   disabled?: boolean;
   prefixCls?: string;
-  customRequest?: (options: RcCustomRequestOptions) => void;
+  customRequest?: (options: RcCustomRequestOptions<T>) => void;
   withCredentials?: boolean;
   openFileDialogOnClick?: boolean;
   locale?: UploadLocale;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

`UploadProps` 的 `customRequest` 参数丢失泛型定义传参，导致对应的 `onSuccess` 类型丢失：

<img width="979" alt="image" src="https://github.com/ant-design/ant-design/assets/3380894/b741abaa-cdea-4119-bbce-d915d88e488a">

修复之后：

<img width="1130" alt="image" src="https://github.com/ant-design/ant-design/assets/3380894/65ff6530-48c1-4d0e-9ba1-1a761e47d046">

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix missing generic of Upload `customRequest` prop |
| 🇨🇳 Chinese | 修复 Upload `customRequest` 参数丢失泛型的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
