### PR TITLE
type: add miss generic of Upload prop

### DIFF
--- a/components/table/demo/drag-sorting-handler.tsx
+++ b/components/table/demo/drag-sorting-handler.tsx
@@ -19,7 +19,7 @@ interface RowContextProps {
   listeners?: SyntheticListenerMap;
 }
 
-const RowContext = React.createContext<RowContextProps>({} as RowContextProps);
+const RowContext = React.createContext<RowContextProps>({});
 
 const DragHandle = () => {
   const { setActivatorNodeRef, listeners } = useContext(RowContext);

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import type { UploadProps } from '..';
+import type { UploadListProps, UploadProps } from '..';
 import Upload from '..';
+import UploadList from '../UploadList';
 
 describe('Upload.typescript', () => {
   it('Upload', () => {
@@ -209,5 +210,15 @@ describe('Upload.typescript', () => {
     expect(upload1).toBeTruthy();
     expect(upload2).toBeTruthy();
     expect(upload3).toBeTruthy();
+  });
+
+  it('UploadListProps type', () => {
+    const props: UploadListProps<number | string> = {
+      locale: {},
+      removeIcon: (file) => <span>{file.response}</span>,
+      downloadIcon: (file) => <span>{file.response}</span>,
+      previewIcon: (file) => <span>{file.response}</span>,
+    };
+    expect(<UploadList {...props} />).toBeTruthy();
   });
 });

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -212,13 +212,23 @@ describe('Upload.typescript', () => {
     expect(upload3).toBeTruthy();
   });
 
-  it('UploadListProps type', () => {
-    const props: UploadListProps<number | string> = {
-      locale: {},
-      removeIcon: (file) => <span>{file.response}</span>,
-      downloadIcon: (file) => <span>{file.response}</span>,
-      previewIcon: (file) => <span>{file.response}</span>,
+  it('UploadProps type', () => {
+    const uploadProps: UploadProps<number | string> = {
+      customRequest({ onSuccess }) {
+        onSuccess?.(1234);
+        onSuccess?.('test');
+      },
     };
-    expect(<UploadList {...props} />).toBeTruthy();
+    expect(<Upload {...uploadProps} />).toBeTruthy();
+  });
+
+  it('UploadListProps type', () => {
+    const uploadListProps: UploadListProps<number | string> = {
+      locale: {},
+      removeIcon: (file) => <div>{JSON.stringify(file.response)}</div>,
+      downloadIcon: (file) => <div>{JSON.stringify(file.response)}</div>,
+      previewIcon: (file) => <div>{JSON.stringify(file.response)}</div>,
+    };
+    expect(<UploadList {...uploadListProps} />).toBeTruthy();
   });
 });

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -152,9 +152,9 @@ export interface UploadListProps<T = any> {
   showRemoveIcon?: boolean;
   showDownloadIcon?: boolean;
   showPreviewIcon?: boolean;
-  removeIcon?: React.ReactNode | ((file: UploadFile) => React.ReactNode);
-  downloadIcon?: React.ReactNode | ((file: UploadFile) => React.ReactNode);
-  previewIcon?: React.ReactNode | ((file: UploadFile) => React.ReactNode);
+  removeIcon?: React.ReactNode | ((file: UploadFile<T>) => React.ReactNode);
+  downloadIcon?: React.ReactNode | ((file: UploadFile<T>) => React.ReactNode);
+  previewIcon?: React.ReactNode | ((file: UploadFile<T>) => React.ReactNode);
   locale: UploadLocale;
   previewFile?: PreviewFileHandler;
   iconRender?: (file: UploadFile<T>, listType?: UploadListType) => React.ReactNode;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

https://github.com/ant-design/ant-design/blob/decfac3540791abc9a9b166bd411ce5cfd6b65f6/components/upload/interface.ts#L56-L58

这里应该和上面是保持一致的：

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | type: add miss generic of Upload prop |
| 🇨🇳 Chinese | type: 补充 Upload 组件缺失的泛型 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed