### PR TITLE
fix: ajust the input border style in validation

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -70,7 +70,7 @@ const genOutlinedStatusStyle = (
     affixColor: string;
   },
 ): CSSObject => ({
-  [`&${token.componentCls}-status-${options.status}:not(${token.componentCls}-disabled)`]: {
+  [`&${token.componentCls}-status-${options.status}`]: {
     ...genBaseOutlinedStyle(token, options),
 
     [`${token.componentCls}-prefix, ${token.componentCls}-suffix`]: {

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -70,12 +70,15 @@ const genOutlinedStatusStyle = (
     affixColor: string;
   },
 ): CSSObject => ({
-  [`&${token.componentCls}-status-${options.status}`]: {
+  [`&${token.componentCls}-status-${options.status}:not(${token.componentCls}-disabled)`]: {
     ...genBaseOutlinedStyle(token, options),
 
     [`${token.componentCls}-prefix, ${token.componentCls}-suffix`]: {
       color: options.affixColor,
     },
+  },
+  [`&${token.componentCls}-status-${options.status}${token.componentCls}-disabled`]: {
+    borderColor: options.borderColor,
   },
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

#48532

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Related to PR #46435. The `Input` component should have the same border style as other form components, I make a little ajustment to keep the style consistent.

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Ajust the `Input` component border style in form validation when disabled  |
| 🇨🇳 Chinese |     调整了`Input`组件在禁用的时候在表单校验的时候的边框颜色      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
