### PR TITLE
refactor(color): @ctrl/tinycolor to color2k

### DIFF
--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -6,7 +6,6 @@ import {
   HomeOutlined,
   QuestionCircleOutlined,
 } from '@ant-design/icons';
-import { TinyColor } from '@ctrl/tinycolor';
 import type { MenuProps } from 'antd';
 import {
   Breadcrumb,
@@ -25,6 +24,7 @@ import { createStyles, css, useTheme } from 'antd-style';
 import type { Color } from 'antd/es/color-picker';
 import { generateColor } from 'antd/es/color-picker/util';
 import classNames from 'classnames';
+import { parseToRgba } from 'color2k';
 import { useLocation } from 'dumi';
 
 import useDark from '../../../../hooks/useDark';
@@ -290,8 +290,7 @@ const ThemesInfo: Record<THEME, Partial<ThemeData>> = {
 const normalize = (value: number) => value / 255;
 
 function rgbToColorMatrix(color: string) {
-  const rgb = new TinyColor(color).toRgb();
-  const { r, g, b } = rgb;
+  const [r, g, b] = parseToRgba(color);
 
   const invertValue = normalize(r) * 100;
   const sepiaValue = 100;

--- a/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -1,38 +1,35 @@
-import { TinyColor, type ColorInput } from '@ctrl/tinycolor';
-import { createStyles } from 'antd-style';
 import * as React from 'react';
+import { createStyles } from 'antd-style';
+import { toHex } from 'color2k';
 
 interface ColorChunkProps {
   children?: React.ReactNode;
-  value?: ColorInput;
+  value: string;
 }
 
 const useStyle = createStyles(({ token, css }) => ({
   codeSpan: css`
-      padding: 0.2em 0.4em;
-      font-size: 0.9em;
-      background: ${token.siteMarkdownCodeBg};
-      border-radius: ${token.borderRadius}px;
-      font-family: monospace;
-    `,
+    padding: 0.2em 0.4em;
+    font-size: 0.9em;
+    background: ${token.siteMarkdownCodeBg};
+    border-radius: ${token.borderRadius}px;
+    font-family: monospace;
+  `,
   dot: css`
-      display: inline-block;
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      margin-inline-end: 4px;
-      border: 1px solid ${token.colorSplit};
-    `,
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-inline-end: 4px;
+    border: 1px solid ${token.colorSplit};
+  `,
 }));
 
 const ColorChunk: React.FC<ColorChunkProps> = (props) => {
   const { styles } = useStyle();
   const { value, children } = props;
 
-  const dotColor = React.useMemo(() => {
-    const _color = new TinyColor(value).toHex8String();
-    return _color.endsWith('ff') ? _color.slice(0, -2) : _color;
-  }, [value]);
+  const dotColor = React.useMemo(() => toHex(value || '#fff'), [value]);
 
   return (
     <span className={styles.codeSpan}>

--- a/.dumi/theme/builtins/TokenCompare/index.tsx
+++ b/.dumi/theme/builtins/TokenCompare/index.tsx
@@ -1,10 +1,11 @@
 // 用于 color.md 中的颜色对比
 import React from 'react';
-import classNames from 'classnames';
-import { TinyColor } from '@ctrl/tinycolor';
+import { Space, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import tokenMeta from 'antd/es/version/token-meta.json';
-import { Space, theme } from 'antd';
+import classNames from 'classnames';
+import { toHex } from 'color2k';
+
 import useLocale from '../../../hooks/useLocale';
 
 const useStyle = createStyles(({ token, css }) => {
@@ -29,7 +30,7 @@ const useStyle = createStyles(({ token, css }) => {
       display: flex;
       align-items: center;
       justify-content: center;
-      color: rgba(0,0,0,0.88);
+      color: rgba(0, 0, 0, 0.88);
       border-right: 1px solid rgba(0, 0, 0, 0.1);
     `,
 
@@ -54,7 +55,7 @@ const useStyle = createStyles(({ token, css }) => {
 });
 
 function color2Rgba(color: string) {
-  return `#${new TinyColor(color).toHex8().toUpperCase()}`;
+  return `#${toHex(color).toUpperCase()}`;
 }
 
 interface ColorCircleProps {

--- a/.dumi/theme/common/styles/Markdown.tsx
+++ b/.dumi/theme/common/styles/Markdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { TinyColor } from '@ctrl/tinycolor';
 import { css, Global } from '@emotion/react';
 import { useTheme } from 'antd-style';
+import { transparentize } from 'color2k';
 
 const GlobalStyle: React.FC = () => {
   const token = useTheme();
@@ -400,7 +400,7 @@ const GlobalStyle: React.FC = () => {
             background: ${demoGridColor};
 
             &:nth-child(2n + 1) {
-              background: ${new TinyColor(demoGridColor).setAlpha(0.75).toHex8String()};
+              background: ${transparentize(demoGridColor, 0.75)};
             }
           }
 
@@ -416,12 +416,12 @@ const GlobalStyle: React.FC = () => {
           }
 
           ${antCls}-row .demo-col-1 {
-            background: ${new TinyColor(demoGridColor).setAlpha(0.75).toHexString()};
+            background: ${transparentize(demoGridColor, 0.75)};
           }
 
           ${antCls}-row .demo-col-2,
             .code-box-demo ${antCls}-row .demo-col-2 {
-            background: ${new TinyColor(demoGridColor).setAlpha(0.75).toHexString()};
+            background: ${transparentize(demoGridColor, 0.75)};
           }
 
           ${antCls}-row .demo-col-3,
@@ -432,7 +432,7 @@ const GlobalStyle: React.FC = () => {
 
           ${antCls}-row .demo-col-4,
             .code-box-demo ${antCls}-row .demo-col-4 {
-            background: ${new TinyColor(demoGridColor).setAlpha(0.6).toHexString()};
+            background: ${transparentize(demoGridColor, 0.6)};
           }
 
           ${antCls}-row .demo-col-5,

--- a/.dumi/theme/slots/Footer/index.tsx
+++ b/.dumi/theme/slots/Footer/index.tsx
@@ -1,3 +1,4 @@
+import React, { useContext } from 'react';
 import {
   AntDesignOutlined,
   BgColorsOutlined,
@@ -12,13 +13,13 @@ import {
   UsergroupAddOutlined,
   ZhihuOutlined,
 } from '@ant-design/icons';
-import { TinyColor } from '@ctrl/tinycolor';
 import { createStyles } from 'antd-style';
+import { onBackground } from 'antd/es/_util/colors';
+import getAlphaColor from 'antd/es/theme/util/getAlphaColor';
 import { FormattedMessage, Link } from 'dumi';
 import RcFooter from 'rc-footer';
 import type { FooterColumn } from 'rc-footer/lib/column';
-import React, { useContext } from 'react';
-import getAlphaColor from 'antd/es/theme/util/getAlphaColor';
+
 import useLocale from '../../../hooks/useLocale';
 import useLocation from '../../../hooks/useLocation';
 import SiteContext from '../SiteContext';
@@ -36,53 +37,51 @@ const locales = {
 const useStyle = () => {
   const { isMobile } = useContext(SiteContext);
   return createStyles(({ token, css }) => {
-    const background = new TinyColor(getAlphaColor('#f0f3fa', '#fff'))
-      .onBackground(token.colorBgContainer)
-      .toHexString();
+    const background = onBackground(getAlphaColor('#f0f3fa', '#fff'), token.colorBgContainer);
 
     return {
       holder: css`
-      background: ${background};
-    `,
+        background: ${background};
+      `,
 
       footer: css`
-      background: ${background};
-      color: ${token.colorTextSecondary};
-      box-shadow: inset 0 106px 36px -116px rgba(0, 0, 0, 0.14);
-
-      * {
-        box-sizing: border-box;
-      }
-
-      h2,
-      a {
-        color: ${token.colorText};
-      }
-
-      .rc-footer-column {
-        margin-bottom: ${isMobile ? 60 : 0}px;
-        :last-child {
-          margin-bottom: ${isMobile ? 20 : 0}px;
-        }
-      }
-
-      .rc-footer-item-icon {
-        top: -1.5px;
-      }
-
-      .rc-footer-container {
-        max-width: 1208px;
-        margin-inline: auto;
-        padding-inline: ${token.marginXXL}px;
-      }
-
-      .rc-footer-bottom {
+        background: ${background};
+        color: ${token.colorTextSecondary};
         box-shadow: inset 0 106px 36px -116px rgba(0, 0, 0, 0.14);
-        .rc-footer-bottom-container {
-          font-size: ${token.fontSize}px;
+
+        * {
+          box-sizing: border-box;
         }
-      }
-    `,
+
+        h2,
+        a {
+          color: ${token.colorText};
+        }
+
+        .rc-footer-column {
+          margin-bottom: ${isMobile ? 60 : 0}px;
+          :last-child {
+            margin-bottom: ${isMobile ? 20 : 0}px;
+          }
+        }
+
+        .rc-footer-item-icon {
+          top: -1.5px;
+        }
+
+        .rc-footer-container {
+          max-width: 1208px;
+          margin-inline: auto;
+          padding-inline: ${token.marginXXL}px;
+        }
+
+        .rc-footer-bottom {
+          box-shadow: inset 0 106px 36px -116px rgba(0, 0, 0, 0.14);
+          .rc-footer-bottom-container {
+            font-size: ${token.fontSize}px;
+          }
+        }
+      `,
     };
   })();
 };
@@ -246,7 +245,7 @@ const Footer: React.FC = () => {
           en: 'JoinUs',
         }),
         LinkComponent: Link,
-      } as unknown as typeof col2['items'][number]);
+      } as unknown as (typeof col2)['items'][number]);
     }
 
     const col3 = {

--- a/components/_util/colors.ts
+++ b/components/_util/colors.ts
@@ -1,3 +1,5 @@
+import { parseToRgba, rgba } from 'color2k';
+
 import type { PresetColorKey } from '../theme/interface';
 import { PresetColors } from '../theme/interface';
 
@@ -14,7 +16,7 @@ export const PresetStatusColorTypes = [
 
 export type PresetColorType = PresetColorKey | InverseColor;
 
-export type PresetStatusColorType = typeof PresetStatusColorTypes[number];
+export type PresetStatusColorType = (typeof PresetStatusColorTypes)[number];
 
 /**
  * determine if the color keyword belongs to the `Ant Design` {@link PresetColors}.
@@ -31,4 +33,17 @@ export function isPresetColor(color?: any, includeInverse = true) {
 
 export function isPresetStatusColor(color?: any): color is PresetStatusColorType {
   return PresetStatusColorTypes.includes(color);
+}
+
+export function onBackground(foreground: string, background: string): string {
+  const [fr, fg, fb, fa] = parseToRgba(foreground);
+  const [br, bg, bb, ba] = parseToRgba(background);
+  const a = fa + ba * (1 - fa);
+
+  return rgba(
+    (fr * fa + br * ba * (1 - fa)) / a,
+    (fg * fa + bg * ba * (1 - fa)) / a,
+    (fb * fa + bb * ba * (1 - fa)) / a,
+    a,
+  );
 }

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -1,4 +1,3 @@
-import { TinyColor } from '@ctrl/tinycolor';
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from '../interface';
 import seedToken from '../themes/seed';
 import getAlphaColor from './getAlphaColor';
@@ -166,9 +165,9 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
 
     boxShadowPopoverArrow: '2px 2px 5px rgba(0, 0, 0, 0.05)',
     boxShadowCard: `
-      0 1px 2px -2px ${new TinyColor('rgba(0, 0, 0, 0.16)').toRgbString()},
-      0 3px 6px 0 ${new TinyColor('rgba(0, 0, 0, 0.12)').toRgbString()},
-      0 5px 12px 4px ${new TinyColor('rgba(0, 0, 0, 0.09)').toRgbString()}
+      0 1px 2px -2px rgba(0, 0, 0, 0.16),
+      0 3px 6px 0 rgba(0, 0, 0, 0.12,
+      0 5px 12px 4px rgba(0, 0, 0, 0.09)
     `,
     boxShadowDrawerRight: `
       -6px 0 16px 0 rgba(0, 0, 0, 0.08),

--- a/components/theme/util/getAlphaColor.ts
+++ b/components/theme/util/getAlphaColor.ts
@@ -1,29 +1,29 @@
-import { TinyColor } from '@ctrl/tinycolor';
+import { parseToRgba, rgba } from 'color2k';
 
 function isStableColor(color: number): boolean {
   return color >= 0 && color <= 255;
 }
 
 function getAlphaColor(frontColor: string, backgroundColor: string): string {
-  const { r: fR, g: fG, b: fB, a: originAlpha } = new TinyColor(frontColor).toRgb();
+  const [fR, fG, fB, originAlpha] = parseToRgba(frontColor);
   if (originAlpha < 1) {
     return frontColor;
   }
 
-  const { r: bR, g: bG, b: bB } = new TinyColor(backgroundColor).toRgb();
+  const [bR, bG, bB] = parseToRgba(backgroundColor);
 
   for (let fA = 0.01; fA <= 1; fA += 0.01) {
     const r = Math.round((fR - bR * (1 - fA)) / fA);
     const g = Math.round((fG - bG * (1 - fA)) / fA);
     const b = Math.round((fB - bB * (1 - fA)) / fA);
     if (isStableColor(r) && isStableColor(g) && isStableColor(b)) {
-      return new TinyColor({ r, g, b, a: Math.round(fA * 100) / 100 }).toRgbString();
+      return rgba(r, g, b, Math.round(fA * 100) / 100);
     }
   }
 
   // fallback
   /* istanbul ignore next */
-  return new TinyColor({ r: fR, g: fG, b: fB, a: 1 }).toRgbString();
+  return rgba(fR, fG, fB, 1);
 }
 
 export default getAlphaColor;

--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -1,16 +1,17 @@
-import { TinyColor } from '@ctrl/tinycolor';
+import { unit } from '@ant-design/cssinjs';
+import { transparentize } from 'color2k';
 
+import { onBackground } from '../../_util/colors';
 import { resetComponent } from '../../style';
 import type { ArrowOffsetToken } from '../../style/placementArrow';
 import getArrowStyle, {
   getArrowOffsetToken,
   MAX_VERTICAL_CONTENT_RADIUS,
 } from '../../style/placementArrow';
-import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
-import { genStyleHooks, mergeToken } from '../../theme/internal';
 import type { ArrowToken } from '../../style/roundedArrow';
 import { getArrowToken } from '../../style/roundedArrow';
-import { unit } from '@ant-design/cssinjs';
+import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
+import { genStyleHooks, mergeToken } from '../../theme/internal';
 
 export interface ComponentToken extends ArrowOffsetToken, ArrowToken {
   /**
@@ -270,11 +271,9 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
 export const prepareComponentToken: GetDefaultToken<'Tour'> = (token) => ({
   zIndexPopup: token.zIndexPopupBase + 70,
   closeBtnSize: token.fontSize * token.lineHeight,
-  primaryPrevBtnBg: new TinyColor(token.colorTextLightSolid).setAlpha(0.15).toRgbString(),
+  primaryPrevBtnBg: transparentize(token.colorTextLightSolid, 0.15),
   closeBtnHoverBg: token.wireframe ? 'transparent' : token.colorFillContent,
-  primaryNextBtnHoverBg: new TinyColor(token.colorBgTextHover)
-    .onBackground(token.colorWhite)
-    .toRgbString(),
+  primaryNextBtnHoverBg: onBackground(token.colorBgTextHover, token.colorWhite),
   ...getArrowOffsetToken({
     contentRadius: token.borderRadiusLG,
     limitVerticalRadius: true,

--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -1,10 +1,10 @@
 import { blue } from '@ant-design/colors';
-import { TinyColor } from '@ctrl/tinycolor';
+import { unit } from '@ant-design/cssinjs';
+import { transparentize } from 'color2k';
 
 import type { UploadToken } from '.';
 import { clearFix, textEllipsis } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
-import { unit } from '@ant-design/cssinjs';
 
 const genPictureStyle: GenerateStyle<UploadToken> = (token) => {
   const { componentCls, iconCls, uploadThumbnailSize, uploadProgressOffset, calc } = token;
@@ -200,7 +200,7 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
 
         [`${itemCls}-actions, ${itemCls}-actions:hover`]: {
           [`${iconCls}-eye, ${iconCls}-download, ${iconCls}-delete`]: {
-            color: new TinyColor(colorTextLightSolid).setAlpha(0.65).toRgbString(),
+            color: transparentize(colorTextLightSolid, 0.65),
             '&:hover': {
               color: colorTextLightSolid,
             },
@@ -252,4 +252,4 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
   };
 };
 
-export { genPictureStyle, genPictureCardStyle };
+export { genPictureCardStyle, genPictureStyle };

--- a/docs/blog/color-picker.en-US.md
+++ b/docs/blog/color-picker.en-US.md
@@ -30,7 +30,7 @@ This is also the most common way of representing colors because it can be used d
 
 ## Conversion of Color Models
 
-Different algorithms are needed for the conversion of color models. There are many mature libraries on the market that can be selected. In the implementation, we chose the library [tinycolor](https://github.com/scttcper/tinycolor), which supports the conversion of multiple color models such as `RGB`, `HSL`, `HSV`, `HEX`, etc. Moreover, its size is very small, only about 10KB, which is very suitable for use in browsers.
+Different algorithms are needed for the conversion of color models. There are many mature libraries on the market that can be selected. In the implementation, we chose the library [color2k](https://github.com/ricokahler/color2k/), which supports the conversion of multiple color models such as `RGB`, `HSL`, `HSV`, `HEX`, etc. Moreover, its size is very small, only about 2KB, which is very suitable for use in browsers.
 
 ## Selection of Color Models
 

--- a/docs/blog/color-picker.zh-CN.md
+++ b/docs/blog/color-picker.zh-CN.md
@@ -30,7 +30,7 @@ author: Redjue
 
 ## 色彩模型的转换
 
-颜色模型的转换需要不同的算法，市面上已经有很多成熟的类库可以进行选择，在实现上我们选择了 [tinycolor](https://github.com/scttcper/tinycolor) 这个类库，它支持 `RGB`、`HSL`、`HSV`、`HEX` 等多种色彩模型的转换，而且它的体积非常小，只有 10KB 左右，非常适合在浏览器中使用。
+颜色模型的转换需要不同的算法，市面上已经有很多成熟的类库可以进行选择，在实现上我们选择了 [color2k](https://github.com/ricokahler/color2k/) 这个类库，它支持 `RGB`、`HSL`、`HSV`、`HEX` 等多种色彩模型的转换，而且它的体积非常小，只有 2KB 左右，非常适合在浏览器中使用。
 
 ## 色彩模型的选择
 

--- a/package.json
+++ b/package.json
@@ -116,12 +116,13 @@
     "@ant-design/icons": "^5.2.6",
     "@ant-design/react-slick": "~1.0.2",
     "@babel/runtime": "^7.23.4",
-    "@ctrl/tinycolor": "^3.6.1",
+    "@ctrl/tinycolor": "^4.1.0",
     "@rc-component/color-picker": "~1.4.1",
     "@rc-component/mutate-observer": "^1.1.0",
     "@rc-component/tour": "~1.11.1",
     "@rc-component/trigger": "^1.18.2",
     "classnames": "^2.3.2",
+    "color2k": "^2.0.3",
     "copy-to-clipboard": "^3.3.3",
     "dayjs": "^1.11.1",
     "qrcode.react": "^3.1.0",
@@ -325,7 +326,6 @@
       "dumi": "^2.3.0-alpha.4"
     }
   },
-  "packageManager": "npm@10.2.4",
   "size-limit": [
     {
       "path": "./dist/antd.min.js",


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

@ctrl/tinycolor 的大小为 6.4KB，而 color2k 为 2.9KB，理论上可以让总体积减少 3.5KB

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor(color): replace @ctrl/tinycolor with color2k to reduce bundle size by 3.5KB (minified + gzipped) |
| 🇨🇳 Chinese | refactor(color): 将 @ctrl/tinycolor 替换为 color2k 以减少 3.5KB 打包体积 (minified + gzipped)  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
