### PR TITLE
fix: Slider show empty tooltip when tooltip.formatter is falsy

### DIFF
--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -54,7 +54,8 @@ describe('Slider.Tooltip', () => {
     expect(tooltipProps().open).toBeFalsy();
   });
 
-  it('not show tooltip', async () => {
+  it('When format equals null, tooltip does not display', async () => {
+    // https://github.com/ant-design/ant-design/issues/48668
     const { container } = render(<Slider defaultValue={30} tooltip={{ formatter: null }} />);
 
     const handleEle = container.querySelector('.ant-slider-handle')!;

--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -53,4 +53,25 @@ describe('Slider.Tooltip', () => {
     await waitFakeTimer();
     expect(tooltipProps().open).toBeFalsy();
   });
+
+  it('not show tooltip', async () => {
+    const { container } = render(<Slider defaultValue={30} tooltip={{ formatter: null }} />);
+
+    const handleEle = container.querySelector('.ant-slider-handle')!;
+
+    // Enter
+    fireEvent.mouseEnter(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeFalsy();
+
+    // Down
+    fireEvent.mouseDown(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeFalsy();
+
+    // Move(Leave)
+    fireEvent.mouseLeave(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeFalsy();
+  });
 });

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -291,6 +291,8 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
 
     const cloneNode = React.cloneElement(node, passedProps);
 
+    const open = (!!lockOpen || activeOpen) && mergedTipFormatter !== null;
+
     // Wrap on handle with Tooltip when is single mode or multiple with all show tooltip
     if (!useActiveTooltipHandle) {
       return (
@@ -298,7 +300,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
           {...tooltipProps}
           prefixCls={getPrefixCls('tooltip', customizeTooltipPrefixCls ?? legacyTooltipPrefixCls)}
           title={mergedTipFormatter ? mergedTipFormatter(info.value) : ''}
-          open={!!lockOpen || activeOpen}
+          open={open}
           placement={getTooltipPlacement(tooltipPlacement ?? legacyTooltipPlacement, vertical)}
           key={index}
           overlayClassName={`${prefixCls}-tooltip`}
@@ -329,7 +331,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
             {...tooltipProps}
             prefixCls={getPrefixCls('tooltip', customizeTooltipPrefixCls ?? legacyTooltipPrefixCls)}
             title={mergedTipFormatter ? mergedTipFormatter(info.value) : ''}
-            open={activeOpen}
+            open={mergedTipFormatter !== null && activeOpen}
             placement={getTooltipPlacement(tooltipPlacement ?? legacyTooltipPlacement, vertical)}
             key="tooltip"
             overlayClassName={`${prefixCls}-tooltip`}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/48668

### 💡 Background and solution

 formatter=null  时没有隐藏 tooltip

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Slider tooltip cannot be hidden when `tooltip={{ formatter: null }}`.    |
| 🇨🇳 Chinese |  修复 Slider `tooltip={{ formatter: null }}` 无法隐藏 Tooltip 的问题。   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
