### PR TITLE
fix: Slider tooltip should not display when open is false

### DIFF
--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -54,25 +54,31 @@ describe('Slider.Tooltip', () => {
     expect(tooltipProps().open).toBeFalsy();
   });
 
-  it('When format equals null, tooltip does not display', async () => {
+  it('tooltip should not display when formatter is null or open is false', async () => {
     // https://github.com/ant-design/ant-design/issues/48668
-    const { container } = render(<Slider defaultValue={30} tooltip={{ formatter: null }} />);
+    const { container: container1 } = render(
+      <Slider defaultValue={30} tooltip={{ formatter: null }} />,
+    );
+    // https://github.com/ant-design/ant-design/issues/48707
+    const { container: container2 } = render(
+      <Slider defaultValue={30} tooltip={{ open: false }} />,
+    );
 
-    const handleEle = container.querySelector('.ant-slider-handle')!;
+    const handler1 = container1.querySelector('.ant-slider-handle')!;
+    const handler2 = container2.querySelector('.ant-slider-handle')!;
 
     // Enter
-    fireEvent.mouseEnter(handleEle);
+    fireEvent.mouseEnter(handler1);
+    fireEvent.mouseEnter(handler2);
     await waitFakeTimer();
-    expect(tooltipProps().open).toBeFalsy();
+    expect(container1.querySelector('.ant-tooltip-open')).toBeFalsy();
+    expect(container2.querySelector('.ant-tooltip-open')).toBeFalsy();
 
     // Down
-    fireEvent.mouseDown(handleEle);
+    fireEvent.focus(handler1);
+    fireEvent.focus(handler2);
     await waitFakeTimer();
-    expect(tooltipProps().open).toBeFalsy();
-
-    // Move(Leave)
-    fireEvent.mouseLeave(handleEle);
-    await waitFakeTimer();
-    expect(tooltipProps().open).toBeFalsy();
+    expect(container1.querySelector('.ant-tooltip-open')).toBeFalsy();
+    expect(container2.querySelector('.ant-tooltip-open')).toBeFalsy();
   });
 });

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -154,7 +154,6 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   // =============================== Open ===============================
   const [hoverOpen, setHoverOpen] = useRafLock();
   const [focusOpen, setFocusOpen] = useRafLock();
-  const activeOpen = hoverOpen || focusOpen;
 
   const tooltipProps: SliderTooltipProps = {
     ...tooltip,
@@ -168,6 +167,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
   } = tooltipProps;
 
   const lockOpen = tooltipOpen ?? legacyTooltipVisible;
+  const activeOpen = (hoverOpen || focusOpen) && lockOpen !== false;
 
   const mergedTipFormatter = getTipFormatter(tipFormatter, legacyTipFormatter);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/48707

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Slider tooltip should not display when `tooltip={{ open: false }}`.          |
| 🇨🇳 Chinese | 修复 Slider `tooltip={{ open: false }}` 时提示框未正确隐藏的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
