### PR TITLE
fix: Fix fails when using tabs minHeight inside the small card

### DIFF
--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -87,7 +87,6 @@ describe('Card', () => {
       </Card>,
     );
     expect(container.querySelectorAll('.ant-tabs-small').length === 0).toBeFalsy();
-    expect(container.querySelector('.ant-card-head')).toHaveStyle('min-height: 0;');
   });
 
   it('tab size extend card size', () => {

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -87,6 +87,7 @@ describe('Card', () => {
       </Card>,
     );
     expect(container.querySelectorAll('.ant-tabs-small').length === 0).toBeFalsy();
+    expect(container.querySelector('.ant-card-head')).toHaveStyle('min-height: 0;');
   });
 
   it('tab size extend card size', () => {

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -364,7 +364,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-contain-tabs`]: {
-      [`> ${componentCls}-head`]: {
+      [`& > div${componentCls}-head`]: {
         minHeight: '0 !important',
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
           paddingTop: cardHeadPadding,

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -365,7 +365,7 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
 
     [`${componentCls}-contain-tabs`]: {
       [`> ${componentCls}-head`]: {
-        minHeight: 0,
+        minHeight: '0 !important',
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
           paddingTop: cardHeadPadding,
         },

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -364,8 +364,8 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
     },
 
     [`${componentCls}-contain-tabs`]: {
-      [`& > div${componentCls}-head`]: {
-        minHeight: '0 !important',
+      [`> div${componentCls}-head`]: {
+        minHeight: 0,
         [`${componentCls}-head-title, ${componentCls}-extra`]: {
           paddingTop: cardHeadPadding,
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix: https://github.com/ant-design/ant-design/issues/48781

### 💡 Background and solution
Card 组件在 small 尺寸下的卡片式页签 head minheight 样式权重不够 

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the issue of missing bottom border when Card size="small"      |
| 🇨🇳 Chinese |    修复 Card size="small" 时下边框丢失的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
