### PR TITLE
demo(ConfigProvider): replace 'popupPlacement' and 'TabPane'

### DIFF
--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -93,7 +93,7 @@ const cascaderOptions = [
 
 type Placement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
 
-const Page: React.FC<{ popupPlacement: Placement }> = ({ popupPlacement }) => {
+const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
   const [currentStep, setCurrentStep] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
   const [badgeCount, setBadgeCount] = useState(5);
@@ -169,7 +169,7 @@ const Page: React.FC<{ popupPlacement: Placement }> = ({ popupPlacement }) => {
             options={cascaderOptions}
             onChange={onCascaderChange}
             placeholder="یک مورد انتخاب کنید"
-            popupPlacement={popupPlacement}
+            placement={placement}
           />
           &nbsp;&nbsp;&nbsp;&nbsp;With search:&nbsp;&nbsp;
           <Cascader
@@ -177,7 +177,7 @@ const Page: React.FC<{ popupPlacement: Placement }> = ({ popupPlacement }) => {
             options={cascaderOptions}
             onChange={onCascaderChange}
             placeholder="Select an item"
-            popupPlacement={popupPlacement}
+            placement={placement}
             showSearch={{ filter: cascaderFilter }}
           />
         </Col>
@@ -495,15 +495,15 @@ const Page: React.FC<{ popupPlacement: Placement }> = ({ popupPlacement }) => {
 
 const App: React.FC = () => {
   const [direction, setDirection] = useState<DirectionType>('ltr');
-  const [popupPlacement, setPopupPlacement] = useState<Placement>('bottomLeft');
+  const [placement, setPlacement] = useState<Placement>('bottomLeft');
 
   const changeDirection = (e: RadioChangeEvent) => {
     const directionValue = e.target.value;
     setDirection(directionValue);
     if (directionValue === 'rtl') {
-      setPopupPlacement('bottomRight');
+      setPlacement('bottomRight');
     } else {
-      setPopupPlacement('bottomLeft');
+      setPlacement('bottomLeft');
     }
   };
 
@@ -521,7 +521,7 @@ const App: React.FC = () => {
         </Radio.Group>
       </div>
       <ConfigProvider direction={direction}>
-        <Page popupPlacement={popupPlacement} />
+        <Page placement={placement} />
       </ConfigProvider>
     </>
   );

--- a/components/config-provider/demo/size.tsx
+++ b/components/config-provider/demo/size.tsx
@@ -16,8 +16,6 @@ import type { ConfigProviderProps } from 'antd';
 
 type SizeType = ConfigProviderProps['componentSize'];
 
-const { TabPane } = Tabs;
-
 const App: React.FC = () => {
   const [componentSize, setComponentSize] = useState<SizeType>('small');
 
@@ -37,17 +35,26 @@ const App: React.FC = () => {
       <ConfigProvider componentSize={componentSize}>
         <Space size={[0, 16]} style={{ width: '100%' }} direction="vertical">
           <Input />
-          <Tabs defaultActiveKey="1">
-            <TabPane tab="Tab 1" key="1">
-              Content of Tab Pane 1
-            </TabPane>
-            <TabPane tab="Tab 2" key="2">
-              Content of Tab Pane 2
-            </TabPane>
-            <TabPane tab="Tab 3" key="3">
-              Content of Tab Pane 3
-            </TabPane>
-          </Tabs>
+          <Tabs
+            defaultActiveKey="1"
+            items={[
+              {
+                label: 'Tab 1',
+                key: '1',
+                children: 'Content of Tab Pane 1',
+              },
+              {
+                label: 'Tab 2',
+                key: '2',
+                children: 'Content of Tab Pane 2',
+              },
+              {
+                label: 'Tab 3',
+                key: '3',
+                children: 'Content of Tab Pane 3',
+              },
+            ]}
+          />
           <Input.Search allowClear />
           <Input.TextArea allowClear />
           <Select defaultValue="demo" options={[{ value: 'demo' }]} />


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
替换ConfigProvider全局化配置demo中废弃的api：'popupPlacement' 和'TabPane'
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     demo(ConfigProvider): replace 'popupPlacement' and 'TabPane'      |
| 🇨🇳 Chinese |      demo(ConfigProvider): 替换'popupPlacement' 和'TabPane'废弃的api     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
