### PR TITLE
site: fix home page horizontal scrollbar

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -31,7 +31,7 @@ const useStyle = createStyles(({ token, css }) => ({
   history: css`
     position: absolute;
     top: 0;
-    inset-inline-end: 0;
+    inset-inline-end: ${token.marginXS}px;
   `,
 
   li: css`

--- a/.dumi/theme/common/Link.tsx
+++ b/.dumi/theme/common/Link.tsx
@@ -10,6 +10,8 @@ export interface LinkProps {
   onClick?: MouseEventHandler;
 }
 
+nprogress.configure({ showSpinner: false });
+
 const Link = forwardRef<HTMLAnchorElement, React.PropsWithChildren<LinkProps>>((props, ref) => {
   const { to, children, ...rest } = props;
   const [isPending, startTransition] = useTransition();

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -106,7 +106,7 @@ const useStyle = createStyles(({ token, css }) => {
       align-items: center;
       margin: 0;
       column-gap: ${token.paddingSM}px;
-      padding-inline-end: 16px;
+      padding-inline-end: ${token.padding}px;
 
       > * {
         flex: none;

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -54,12 +54,11 @@ const useStyle = createStyles(({ token, css }) => {
         border: none;
       }
 
-      .nav-search-wrapper {
-        display: flex;
-        flex: auto;
-      }
-
       .dumi-default-search-bar {
+        display: inline-flex;
+        align-items: center;
+        flex: auto;
+        margin: 0;
         border-inline-start: 1px solid rgba(0, 0, 0, 0.06);
 
         > svg {
@@ -70,6 +69,7 @@ const useStyle = createStyles(({ token, css }) => {
         > input {
           height: 22px;
           border: 0;
+          max-width: calc(100vw - 768px);
 
           &:focus {
             box-shadow: none;
@@ -85,6 +85,9 @@ const useStyle = createStyles(({ token, css }) => {
           background-color: rgba(150, 150, 150, 0.06);
           border-color: rgba(100, 100, 100, 0.2);
           border-radius: ${token.borderRadiusSM}px;
+          position: static;
+          top: unset;
+          transform: unset;
         }
 
         .dumi-default-search-popover {
@@ -103,12 +106,11 @@ const useStyle = createStyles(({ token, css }) => {
       align-items: center;
       margin: 0;
       column-gap: ${token.paddingSM}px;
+      padding-inline-end: 16px;
+
       > * {
         flex: none;
         margin: 0;
-        &:last-child {
-          margin-inline-end: 40px;
-        }
       }
     `,
     dataDirectionIcon: css`
@@ -405,11 +407,11 @@ const Header: React.FC = () => {
         <Col {...colProps[0]}>
           <Logo {...sharedProps} location={location} />
         </Col>
-        <Col {...colProps[1]} className={styles.menuRow}>
-          <div className="nav-search-wrapper">
+        <Col {...colProps[1]}>
+          <div className={styles.menuRow}>
             <DumiSearchBar />
+            {!isMobile && menu}
           </div>
-          {!isMobile && menu}
         </Col>
       </Row>
     </header>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
fix https://github.com/ant-design/ant-design/issues/48793
close https://github.com/ant-design/ant-design/pull/48795

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
修复移动端下首页出现横向滚动条的问题，原因顶部导航里 ant-col-sm-0 的 display 样式被覆盖了。

<img width="1781" alt="截屏2024-05-07 16 40 32" src="https://github.com/ant-design/ant-design/assets/507615/6fe1577e-f8d6-4cf3-b717-a128f8f1ec03">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  --         |
| 🇨🇳 Chinese |  --         |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
