### PR TITLE
fix: fix Button findDOMNode error

### DIFF
--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import type { CSSMotionProps } from 'rc-motion';
 
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
@@ -12,6 +13,12 @@ import { TARGET_CLS } from '../wave/interface';
 jest.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => (global as any).isVisible;
   return mockFn;
+});
+
+jest.mock('rc-motion', () => (props: CSSMotionProps) => {
+  (global as any).motionChildren = jest.fn(props.children);
+  const CSSMotion = jest.requireActual('rc-motion').default;
+  return <CSSMotion {...props}>{(global as any).motionChildren}</CSSMotion>;
 });
 
 describe('Wave component', () => {
@@ -89,6 +96,8 @@ describe('Wave component', () => {
     fireEvent.click(container.querySelector('button')!);
     waitRaf();
     expect(document.querySelector('.ant-wave')).toBeTruthy();
+
+    expect((global as any).motionChildren.mock.calls[0].length).toBe(2);
 
     // Match deadline
     await waitFakeTimer();

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import type { CSSMotionProps } from 'rc-motion';
 
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
@@ -13,18 +12,6 @@ import { TARGET_CLS } from '../wave/interface';
 jest.mock('rc-util/lib/Dom/isVisible', () => {
   const mockFn = () => (global as any).isVisible;
   return mockFn;
-});
-
-jest.mock('rc-motion', () => (props: CSSMotionProps) => {
-  const CSSMotion = jest.requireActual('rc-motion').default;
-  return (
-    <CSSMotion {...props}>
-      {(props2: any, ref: (node: any) => void) => {
-        (global as any).motionRef = jest.fn(ref);
-        return props.children?.(props2, (global as any).motionRef);
-      }}
-    </CSSMotion>
-  );
 });
 
 describe('Wave component', () => {
@@ -106,10 +93,10 @@ describe('Wave component', () => {
     // Match deadline
     await waitFakeTimer();
 
-    // Is Ref called
-    expect((global as any).motionRef).toHaveBeenCalled();
-
     expect(document.querySelector('.ant-wave')).toBeFalsy();
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(errorSpy).not.toHaveBeenCalled();
 
     unmount();
   });

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -80,6 +80,7 @@ describe('Wave component', () => {
   }
 
   it('work', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const { container, unmount } = render(
       <Wave>
         <button type="button">button</button>
@@ -95,7 +96,6 @@ describe('Wave component', () => {
 
     expect(document.querySelector('.ant-wave')).toBeFalsy();
 
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     expect(errorSpy).not.toHaveBeenCalled();
 
     unmount();

--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -16,9 +16,15 @@ jest.mock('rc-util/lib/Dom/isVisible', () => {
 });
 
 jest.mock('rc-motion', () => (props: CSSMotionProps) => {
-  (global as any).motionChildren = jest.fn(props.children);
   const CSSMotion = jest.requireActual('rc-motion').default;
-  return <CSSMotion {...props}>{(global as any).motionChildren}</CSSMotion>;
+  return (
+    <CSSMotion {...props}>
+      {(props2: any, ref: (node: any) => void) => {
+        (global as any).motionRef = jest.fn(ref);
+        return props.children?.(props2, (global as any).motionRef);
+      }}
+    </CSSMotion>
+  );
 });
 
 describe('Wave component', () => {
@@ -97,10 +103,11 @@ describe('Wave component', () => {
     waitRaf();
     expect(document.querySelector('.ant-wave')).toBeTruthy();
 
-    expect((global as any).motionChildren.mock.calls[0].length).toBe(2);
-
     // Match deadline
     await waitFakeTimer();
+
+    // Is Ref called
+    expect((global as any).motionRef).toHaveBeenCalled();
 
     expect(document.querySelector('.ant-wave')).toBeFalsy();
 

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import raf from 'rc-util/lib/raf';
 import { render, unmount } from 'rc-util/lib/React/render';
-import { composeRef } from 'rc-util/lib/ref';
+import { composeRef } from 'rc-util/es/ref';
 
 import { TARGET_CLS } from './interface';
 import type { ShowWaveEffect } from './interface';

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -20,7 +20,7 @@ export interface WaveEffectProps {
 
 const WaveEffect: React.FC<WaveEffectProps> = (props) => {
   const { className, target, component } = props;
-  const divRef = React.useRef<HTMLDivElement>(null);
+  const divRef = React.useRef<HTMLDivElement | null>(null);
 
   const [color, setWaveColor] = React.useState<string | null>(null);
   const [borderRadius, setBorderRadius] = React.useState<number[]>([]);
@@ -125,9 +125,12 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
         return false;
       }}
     >
-      {({ className: motionClassName }) => (
+      {({ className: motionClassName }, setNodeRef) => (
         <div
-          ref={divRef}
+          ref={(node) => {
+            divRef.current = node;
+            setNodeRef(node);
+          }}
           className={classNames(
             className,
             {

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import raf from 'rc-util/lib/raf';
 import { render, unmount } from 'rc-util/lib/React/render';
+import { composeRef } from 'rc-util/lib/ref';
 
 import { TARGET_CLS } from './interface';
 import type { ShowWaveEffect } from './interface';
@@ -125,12 +126,9 @@ const WaveEffect: React.FC<WaveEffectProps> = (props) => {
         return false;
       }}
     >
-      {({ className: motionClassName }, setNodeRef) => (
+      {({ className: motionClassName }, ref) => (
         <div
-          ref={(node) => {
-            divRef.current = node;
-            setNodeRef(node);
-          }}
+          ref={composeRef(divRef, ref)}
           className={classNames(
             className,
             {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/48809

### 💡 Background and solution

Button 组件点击时 WaveEffect 组件没有使用 setNodeRef 

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix Button findDOMNode error     |
| 🇨🇳 Chinese |      修复 Button 组件 findDOMNode 报错    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
