### PR TITLE
refactor(iconSearch): use message hooks usage

### DIFF
--- a/.dumi/theme/builtins/IconSearch/Category.tsx
+++ b/.dumi/theme/builtins/IconSearch/Category.tsx
@@ -13,12 +13,13 @@ interface CategoryProps {
 }
 
 const Category: React.FC<CategoryProps> = (props) => {
+  const [messageApi, contextHolder] = message.useMessage();
   const { icons, title, newIcons, theme } = props;
   const intl = useIntl();
   const [justCopied, setJustCopied] = React.useState<string | null>(null);
   const copyId = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const onCopied = React.useCallback((type: string, text: string) => {
-    message.success(
+    messageApi.success(
       <span>
         <code className="copied-code">{text}</code> copied 🎉
       </span>,
@@ -38,6 +39,7 @@ const Category: React.FC<CategoryProps> = (props) => {
   );
   return (
     <div>
+      {contextHolder}
       <h3>{intl.formatMessage({ id: `app.docs.components.icon.category.${title}` })}</h3>
       <ul className="anticons-list">
         {icons.map((name) => (

--- a/.dumi/theme/builtins/IconSearch/Category.tsx
+++ b/.dumi/theme/builtins/IconSearch/Category.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useIntl } from 'dumi';
-import { message } from 'antd';
+import { App } from 'antd';
 import CopyableIcon from './CopyableIcon';
 import type { ThemeType } from './index';
 import type { CategoriesKeys } from './fields';
@@ -13,13 +13,13 @@ interface CategoryProps {
 }
 
 const Category: React.FC<CategoryProps> = (props) => {
-  const [messageApi, contextHolder] = message.useMessage();
+  const { message } = App.useApp();
   const { icons, title, newIcons, theme } = props;
   const intl = useIntl();
   const [justCopied, setJustCopied] = React.useState<string | null>(null);
   const copyId = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const onCopied = React.useCallback((type: string, text: string) => {
-    messageApi.success(
+    message.success(
       <span>
         <code className="copied-code">{text}</code> copied 🎉
       </span>,
@@ -39,7 +39,6 @@ const Category: React.FC<CategoryProps> = (props) => {
   );
   return (
     <div>
-      {contextHolder}
       <h3>{intl.formatMessage({ id: `app.docs.components.icon.category.${title}` })}</h3>
       <ul className="anticons-list">
         {icons.map((name) => (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [x] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
![image](https://github.com/ant-design/ant-design/assets/117748716/41f6ea5f-b8fe-4fc2-b687-7fe4611a660d)

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      refactor(iconSearch): use message hooks usage     |
| 🇨🇳 Chinese |      refactor(iconSearch): message 使用hook调用     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
