### PR TITLE
fix: status config not working with custom input in AutoComplete

### DIFF
--- a/components/auto-complete/index.tsx
+++ b/components/auto-complete/index.tsx
@@ -8,6 +8,7 @@ import { useZIndex } from '../_util/hooks/useZIndex';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
+import { cloneElement } from '../_util/reactNode';
 import type { ConfigConsumerProps } from '../config-provider';
 import { ConfigContext } from '../config-provider';
 import type {
@@ -55,6 +56,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 ) => {
   const {
     prefixCls: customizePrefixCls,
+    status,
     className,
     popupClassName,
     dropdownClassName,
@@ -74,7 +76,12 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     [customizeInput] = childNodes;
   }
 
-  const getInputElement = customizeInput ? (): React.ReactElement => customizeInput! : undefined;
+  const getInputElement = customizeInput
+    ? (): React.ReactElement =>
+        cloneElement(customizeInput, {
+          status: customizeInput.props.status || status,
+        })
+    : undefined;
 
   // ============================ Options ============================
   let optionChildren: React.ReactNode;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/48864

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

issues 反馈 AutoComplete 自定义输入组件的时候，配置的 status 不生效

原因是因为 status 属性没有透传到 childNode 上

解决办法就是： 如果是自定义的输入组件，如果输入组件自己没有 status 属性，则使用 AutoComplete 传入的 status 属性

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix `status` config not working with custom input box in AutoComplete     |
| 🇨🇳 Chinese |       修复 AutoComplete 组件使用自定义输入组件时 `status` 配置无效的问题    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
