### PR TITLE
fix: button component add colorErrorBgActive token

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -374,7 +374,7 @@ const genTextButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
       },
       {
         color: token.colorErrorHover,
-        background: token.colorErrorBg,
+        background: token.colorErrorBgActive,
       },
     ),
   },

--- a/components/theme/interface/maps/colors.ts
+++ b/components/theme/interface/maps/colors.ts
@@ -477,6 +477,14 @@ interface ColorErrorMapToken {
   colorErrorBgHover: string; // 2
 
   /**
+   * @nameZH 错误色的浅色背景色激活态
+   * @nameEN Error background color active state
+   * @desc 错误色的浅色背景色激活态
+   * @descEN The active state background color of the error state.
+   */
+  colorErrorBgActive: string; // 3
+
+  /**
    * @nameZH 错误色的描边色
    * @nameEN Error border color
    * @desc 错误色的描边色

--- a/components/theme/themes/shared/genColorMapToken.ts
+++ b/components/theme/themes/shared/genColorMapToken.ts
@@ -60,6 +60,7 @@ export default function genColorMapToken(
 
     colorErrorBg: errorColors[1],
     colorErrorBgHover: errorColors[2],
+    colorErrorBgActive: errorColors[3],
     colorErrorBorder: errorColors[3],
     colorErrorBorderHover: errorColors[4],
     colorErrorHover: errorColors[5],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

-  close：https://github.com/ant-design/ant-design/issues/46288

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

Button component add color error background active token

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Button component add color error background active token |
| 🇨🇳 Chinese | 按钮组件新增错误激活态浅色背景 token |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
