### PR TITLE
fix: fix Badge CSSMotion setref use error and add test case

### DIFF
--- a/components/badge/__tests__/index.test.tsx
+++ b/components/badge/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
 
 import type { GetRef } from '../../_util/type';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Tooltip from '../../tooltip';
 import Badge from '../index';
 
@@ -26,19 +26,31 @@ describe('Badge', () => {
     jest.useRealTimers();
   });
 
-  it('no strict warning', () => {
+  it('no strict warning', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { rerender } = render(
-      <Badge dot>
-        <span />
-      </Badge>,
-    );
+    const Comp = () => {
+      const [count, setCount] = React.useState<number | null>(9999);
 
-    rerender(
-      <Badge>
-        <span />
-      </Badge>,
-    );
+      return (
+        <>
+          <Badge count={count}>
+            <span>Badge</span>
+          </Badge>
+
+          <br />
+          <br />
+          <br />
+
+          <button type="button" onClick={() => setCount(null)}>
+            click
+          </button>
+        </>
+      );
+    };
+    const { container } = render(<Comp />);
+
+    fireEvent.click(container.querySelector('button')!);
+    await waitFakeTimer();
 
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -216,7 +216,7 @@ const InternalBadge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref)
         motionAppear={false}
         motionDeadline={1000}
       >
-        {({ className: motionClassName, ref: scrollNumberRef }) => {
+        {({ className: motionClassName }) => {
           const scrollNumberPrefixCls = getPrefixCls(
             'scroll-number',
             customizeScrollNumberPrefixCls,
@@ -255,7 +255,6 @@ const InternalBadge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref)
               title={titleNode}
               style={scrollNumberStyle}
               key="scrollNumber"
-              ref={scrollNumberRef}
             >
               {displayNode}
             </ScrollNumber>


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [X] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix one of https://github.com/ant-design/ant-design/issues/48709


### 💡 Background and solution

修复 Badge 内部使用 CSSMotion setref 错误问题 

![image](https://github.com/ant-design/ant-design/assets/38714194/283d46cb-20fa-4884-8341-b6c7aface023)


### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix Badge CSSMotion setref use error and add test case      |
| 🇨🇳 Chinese |    修复 Badge 内部使用 CSSMotion setref 错误问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed
