### PR TITLE
fix: Tour onClose wrong current argument

### DIFF
--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -565,6 +565,31 @@ describe('Tour', () => {
     expect(document.querySelector('.should-be-primary')).toHaveClass('ant-tour-primary');
   });
 
+  // https://github.com/ant-design/ant-design/issues/49117
+  it('onClose current is correct', () => {
+    const onClose = jest.fn();
+    const { container } = render(
+      <Tour
+        onClose={onClose}
+        open
+        steps={[
+          {
+            title: '',
+            description: '',
+            type: 'primary',
+            className: 'should-be-primary',
+          },
+          {
+            title: '',
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(container.querySelector('.ant-tour-next-btn')!);
+    fireEvent.click(container.querySelector('.ant-tour-close-icon')!);
+    expect(onClose).toHaveBeenLastCalledWith(1);
+  });
+
   // This test is for PurePanel which means safe to remove.
   describe('PurePanel', () => {
     const PurePanel = Tour._InternalPanelDoNotUseOrYouWillBeFired;

--- a/components/tour/panelRender.tsx
+++ b/components/tour/panelRender.tsx
@@ -46,7 +46,7 @@ const TourPanel: React.FC<TourPanelProps> = (props) => {
 
   const mergedCloseIcon = (
     <button type="button" onClick={onClose} className={`${prefixCls}-close`}>
-      {closable?.closeIcon ?? <CloseOutlined className={`${prefixCls}-close-icon`} />}
+      {closable?.closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />}
     </button>
   );
 

--- a/components/tour/panelRender.tsx
+++ b/components/tour/panelRender.tsx
@@ -44,19 +44,11 @@ const TourPanel: React.FC<TourPanelProps> = (props) => {
 
   const mergedType = stepType ?? type;
 
-  const mergedCloseIcon = React.useMemo(() => {
-    let defaultCloseIcon: React.ReactNode = <CloseOutlined className={`${prefixCls}-close-icon`} />;
-
-    if (closable && closable.closeIcon) {
-      defaultCloseIcon = closable.closeIcon;
-    }
-
-    return (
-      <button type="button" onClick={onClose} className={`${prefixCls}-close`}>
-        {defaultCloseIcon}
-      </button>
-    );
-  }, [closable]);
+  const mergedCloseIcon = (
+    <button type="button" onClick={onClose} className={`${prefixCls}-close`}>
+      {closable?.closeIcon ?? <CloseOutlined className={`${prefixCls}-close-icon`} />}
+    </button>
+  );
 
   const isLastStep = current === total - 1;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/49117

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tour `current` argument of `onClose` is wrong.          |
| 🇨🇳 Chinese | 修复 Tour `onClose` 的 `current` 参数错误的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
