### PR TITLE
fix: Fix Spin missing default font size when customizing icons

### DIFF
--- a/components/spin/Indicator/index.tsx
+++ b/components/spin/Indicator/index.tsx
@@ -17,6 +17,7 @@ export default function Indicator(props: IndicatorProps) {
   if (indicator && React.isValidElement(indicator)) {
     return cloneElement(indicator, {
       className: classNames(indicator.props.className, dotClassName),
+      percent,
     });
   }
 

--- a/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -33,30 +33,125 @@ exports[`renders components/spin/demo/basic.tsx extend context correctly 2`] = `
 
 exports[`renders components/spin/demo/custom-indicator.tsx extend context correctly 1`] = `
 <div
-  aria-busy="true"
-  aria-live="polite"
-  class="ant-spin ant-spin-spinning"
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
 >
-  <span
-    aria-label="loading"
-    class="anticon anticon-loading anticon-spin ant-spin-dot"
-    role="img"
-    style="font-size: 24px;"
+  <div
+    class="ant-space-item"
   >
-    <svg
-      aria-hidden="true"
-      data-icon="loading"
-      fill="currentColor"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 1024 1024"
-      width="1em"
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-sm ant-spin-spinning"
     >
-      <path
-        d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-      />
-    </svg>
-  </span>
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-lg ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+        style="font-size: 48px;"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/spin/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo.test.ts.snap
@@ -31,30 +31,125 @@ exports[`renders components/spin/demo/basic.tsx correctly 1`] = `
 
 exports[`renders components/spin/demo/custom-indicator.tsx correctly 1`] = `
 <div
-  aria-busy="true"
-  aria-live="polite"
-  class="ant-spin ant-spin-spinning"
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
 >
-  <span
-    aria-label="loading"
-    class="anticon anticon-loading anticon-spin ant-spin-dot"
-    role="img"
-    style="font-size:24px"
+  <div
+    class="ant-space-item"
   >
-    <svg
-      aria-hidden="true"
-      data-icon="loading"
-      fill="currentColor"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 1024 1024"
-      width="1em"
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-sm ant-spin-spinning"
     >
-      <path
-        d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-      />
-    </svg>
-  </span>
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-lg ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      class="ant-spin ant-spin-spinning"
+    >
+      <span
+        aria-label="loading"
+        class="anticon anticon-loading anticon-spin ant-spin-dot"
+        role="img"
+        style="font-size:48px"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="loading"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -101,17 +101,27 @@ describe('Spin', () => {
     expect(element).not.toHaveStyle({ pointerEvents: 'none' });
   });
 
-  it('percent support auto', () => {
-    const { container } = render(<Spin percent="auto" />);
+  describe('percent', () => {
+    it('percent support auto', () => {
+      const { container } = render(<Spin percent="auto" />);
 
-    act(() => {
-      jest.advanceTimersByTime(100000);
+      act(() => {
+        jest.advanceTimersByTime(100000);
+      });
+
+      const nowPTG = Number(
+        container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow'),
+      );
+
+      expect(nowPTG).toBeGreaterThanOrEqual(1);
     });
 
-    const nowPTG = Number(
-      container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow'),
-    );
-
-    expect(nowPTG).toBeGreaterThanOrEqual(1);
+    it('custom indicator has percent', () => {
+      const MyIndicator = ({ percent }: { percent?: number }) => (
+        <div className="custom-indicator">{percent}</div>
+      );
+      const { container } = render(<Spin indicator={<MyIndicator />} percent={23} />);
+      expect(container.querySelector('.custom-indicator')?.textContent).toBe('23');
+    });
   });
 });

--- a/components/spin/demo/custom-indicator.tsx
+++ b/components/spin/demo/custom-indicator.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { LoadingOutlined } from '@ant-design/icons';
-import { Spin } from 'antd';
+import { Space, Spin } from 'antd';
 
-const App: React.FC = () => <Spin indicator={<LoadingOutlined style={{ fontSize: 24 }} spin />} />;
+const App: React.FC = () => (
+  <Space>
+    <Spin indicator={<LoadingOutlined spin />} size="small" />
+    <Spin indicator={<LoadingOutlined spin />} />
+    <Spin indicator={<LoadingOutlined spin />} size="large" />
+    <Spin indicator={<LoadingOutlined style={{ fontSize: 48 }} spin />} />
+  </Space>
+);
 
 export default App;

--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -222,6 +222,7 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
       [`${componentCls}-dot`]: {
         position: 'relative',
         display: 'inline-block',
+        fontSize: token.dotSize,
         width: '1em',
         height: '1em',
 
@@ -288,7 +289,7 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
         },
       },
       // small
-      [`&-sm ${componentCls}-dot-holder`]: {
+      [`&-sm ${componentCls}-dot-holder, &-sm ${componentCls}-dot`]: {
         fontSize: token.dotSizeSM,
         i: {
           width: calc(calc(token.dotSizeSM).sub(calc(token.marginXXS).div(2)))
@@ -300,7 +301,7 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
         },
       },
       // large
-      [`&-lg ${componentCls}-dot-holder`]: {
+      [`&-lg ${componentCls}-dot-holder, &-lg ${componentCls}-dot`]: {
         fontSize: token.dotSizeLG,
         i: {
           width: calc(calc(token.dotSizeLG).sub(token.marginXXS)).div(2).equal(),

--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -289,8 +289,10 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
         },
       },
       // small
-      [`&-sm ${componentCls}-dot-holder, &-sm ${componentCls}-dot`]: {
+      [`&-sm ${componentCls}-dot`]: {
         fontSize: token.dotSizeSM,
+      },
+      [`&-sm ${componentCls}-dot-holder`]: {
         i: {
           width: calc(calc(token.dotSizeSM).sub(calc(token.marginXXS).div(2)))
             .div(2)
@@ -301,8 +303,10 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
         },
       },
       // large
-      [`&-lg ${componentCls}-dot-holder, &-lg ${componentCls}-dot`]: {
+      [`&-lg ${componentCls}-dot`]: {
         fontSize: token.dotSizeLG,
+      },
+      [`&-lg ${componentCls}-dot-holder`]: {
         i: {
           width: calc(calc(token.dotSizeLG).sub(token.marginXXS)).div(2).equal(),
           height: calc(calc(token.dotSizeLG).sub(token.marginXXS)).div(2).equal(),


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/49205

### 💡 Background and solution

使用自定义图标时 缺失默认字体大小

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Spin with custom `indicator` that style missing and the `percent` prop was not being passed through.       |
| 🇨🇳 Chinese |     修复 Spin 自定义 `indicator` 时，样式不可见以及 `percent` 进度没有传递的问题。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
