### PR TITLE
fix: Safari ellipsis

### DIFF
--- a/components/_util/transButton.tsx
+++ b/components/_util/transButton.tsx
@@ -19,7 +19,7 @@ const inlineStyle: React.CSSProperties = {
   background: 'transparent',
   padding: 0,
   lineHeight: 'inherit',
-  display: 'inline-block',
+  display: 'inline-flex',
 };
 
 const TransButton = React.forwardRef<HTMLDivElement, TransButtonProps>((props, ref) => {

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -722,7 +722,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -449,7 +449,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8270,7 +8270,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span
@@ -8307,7 +8307,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span
@@ -8344,7 +8344,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span
@@ -8381,7 +8381,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span
@@ -8418,7 +8418,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span
@@ -8455,7 +8455,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
               tabindex="0"
             >
               <span

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -5331,7 +5331,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span
@@ -5368,7 +5368,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span
@@ -5405,7 +5405,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span
@@ -5442,7 +5442,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span
@@ -5479,7 +5479,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span
@@ -5516,7 +5516,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
               tabindex="0"
             >
               <span

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -444,7 +444,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -495,7 +495,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -546,7 +546,7 @@ Array [
       aria-label="click here"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -597,7 +597,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -645,7 +645,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy ant-typography-copy-icon-only"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -696,7 +696,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -754,7 +754,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -806,7 +806,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -857,7 +857,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -971,7 +971,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1022,7 +1022,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1073,7 +1073,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1124,7 +1124,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1173,7 +1173,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1225,7 +1225,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1277,7 +1277,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1329,7 +1329,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1381,7 +1381,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1433,7 +1433,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1656,7 +1656,7 @@ exports[`renders components/typography/demo/ellipsis-controlled.tsx extend conte
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1859,7 +1859,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1913,7 +1913,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -1967,7 +1967,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span
@@ -2021,7 +2021,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
       tabindex="0"
     >
       <span

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -442,7 +442,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -474,7 +474,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -506,7 +506,7 @@ Array [
       aria-label="click here"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -538,7 +538,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -569,7 +569,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy ant-typography-copy-icon-only"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -601,7 +601,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -638,7 +638,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -672,7 +672,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -704,7 +704,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -801,7 +801,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -833,7 +833,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -865,7 +865,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -897,7 +897,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -929,7 +929,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -962,7 +962,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -995,7 +995,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1028,7 +1028,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1061,7 +1061,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1094,7 +1094,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1237,7 +1237,7 @@ exports[`renders components/typography/demo/ellipsis-controlled.tsx correctly 1`
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1401,7 +1401,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1435,7 +1435,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1469,7 +1469,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span
@@ -1503,7 +1503,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
       tabindex="0"
     >
       <span


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #49215

### 💡 Background and solution

Safari 里这个 Ellipsis 时灵时不灵。只能做做 workaround。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Typography `ellipsis` sometime not working in Safari.      |
| 🇨🇳 Chinese |    修复 Typography `ellipsis` 在 Safari 中有时不生效的问题。       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
