### PR TITLE
fix: css var should skip zIndex

### DIFF
--- a/components/_util/__tests__/useUniqueMemo.test.tsx
+++ b/components/_util/__tests__/useUniqueMemo.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { act, render } from '../../../tests/utils';
+import useUniqueMemo from '../hooks/useUniqueMemo';
+
+describe('Table', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('useSyncState', () => {
+    const sharedObjDeps1 = {};
+    const sharedObjDeps2 = {};
+
+    let calledTimes = 0;
+
+    const Test = ({ depName }: { depName: string }) => {
+      useUniqueMemo(() => {
+        calledTimes += 1;
+        return depName;
+      }, [depName, sharedObjDeps1, 'bamboo', sharedObjDeps2]);
+      return null;
+    };
+
+    // Reuse the same memo
+    const { rerender } = render(
+      <>
+        <Test depName="light" />
+        <Test depName="light" />
+        <Test depName="light" />
+      </>,
+    );
+
+    expect(calledTimes).toBe(1);
+
+    // Different deps should clean up the cache
+    act(() => {
+      jest.advanceTimersByTime(1000 * 60 * 20);
+    });
+
+    for (let i = 0; i < 20000; i += 1) {
+      rerender(<Test depName="diff" key={i} />);
+    }
+    rerender(<Test depName="clear" />);
+    calledTimes = 0;
+
+    // Back should recompute
+    rerender(<Test depName="light" />);
+    expect(calledTimes).toBe(1);
+  });
+});

--- a/components/_util/hooks/useUniqueMemo.ts
+++ b/components/_util/hooks/useUniqueMemo.ts
@@ -1,0 +1,96 @@
+import React from 'react';
+
+const BEAT_LIMIT = 1000 * 60 * 10;
+
+/**
+ * A helper class to map keys to values.
+ * It supports both primitive keys and object keys.
+ */
+class ArrayKeyMap {
+  map = new Map();
+
+  // Use WeakMap to avoid memory leak
+  objectIDMap = new WeakMap();
+
+  nextID = 0;
+
+  lastAccessBeat = new Map();
+
+  // We will clean up the cache when reach the limit
+  accessBeat = 0;
+
+  set(keys: any[], value: any) {
+    // New set will trigger clear
+    this.clear();
+
+    // Set logic
+    const compositeKey = this.getCompositeKey(keys);
+    this.map.set(compositeKey, value);
+    this.lastAccessBeat.set(compositeKey, Date.now());
+  }
+
+  get(keys: any[]) {
+    const compositeKey = this.getCompositeKey(keys);
+
+    const cache = this.map.get(compositeKey);
+    this.lastAccessBeat.set(compositeKey, Date.now());
+    this.accessBeat += 1;
+
+    return cache;
+  }
+
+  getCompositeKey(keys: any[]) {
+    const ids = keys.map((key) => {
+      if (key && typeof key === 'object') {
+        return `obj_${this.getObjectID(key)}`;
+      }
+      return `${typeof key}_${key}`;
+    });
+    return ids.join('|');
+  }
+
+  getObjectID(obj: object) {
+    if (this.objectIDMap.has(obj)) {
+      return this.objectIDMap.get(obj);
+    }
+    const id = this.nextID;
+    this.objectIDMap.set(obj, id);
+
+    this.nextID += 1;
+
+    return id;
+  }
+
+  clear() {
+    if (this.accessBeat > 10000) {
+      const now = Date.now();
+
+      this.lastAccessBeat.forEach((beat, key) => {
+        if (now - beat > BEAT_LIMIT) {
+          this.map.delete(key);
+          this.lastAccessBeat.delete(key);
+        }
+      });
+
+      this.accessBeat = 0;
+    }
+  }
+}
+
+const uniqueMap = new ArrayKeyMap();
+
+/**
+ * Like `useMemo`, but this hook result will be shared across all instances.
+ */
+export default function useUniqueMemo<T>(memoFn: () => T, deps: any[]): T {
+  return React.useMemo(() => {
+    const cachedValue = uniqueMap.get(deps);
+    if (cachedValue) {
+      return cachedValue;
+    }
+
+    const newValue = memoFn();
+    uniqueMap.set(deps, newValue);
+    return newValue;
+  }, deps);
+}

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -189,7 +189,7 @@ export const genPreviewSwitchStyle = (token: ImageToken): CSSObject => {
     [`${previewCls}-switch-left, ${previewCls}-switch-right`]: {
       position: 'fixed',
       insetBlockStart: '50%',
-      zIndex: token.calc(zIndexPopup).add(1).equal({ unit: false }),
+      zIndex: token.calc(zIndexPopup).add(1).equal(),
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -308,7 +308,7 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
     {
       [`${componentCls}-preview-operations-wrapper`]: {
         position: 'fixed',
-        zIndex: token.calc(token.zIndexPopup).add(1).equal({ unit: false }),
+        zIndex: token.calc(token.zIndexPopup).add(1).equal(),
       },
       '&': [genPreviewOperationsStyle(token), genPreviewSwitchStyle(token)],
     },

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -659,7 +659,7 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
       // fix slight height diff in Firefox:
       // https://ant.design/components/auto-complete-cn/#components-auto-complete-demo-certain-category
       [`${componentCls}-lg`]: {
-        lineHeight: token.calc(token.lineHeightLG).sub(0.0002).equal({ unit: false }),
+        lineHeight: token.calc(token.lineHeightLG).sub(0.0002).equal(),
       },
 
       [`> ${componentCls}-group`]: {

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -293,9 +293,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         [`&${componentCls}-checked`]: {
           [radioInnerPrefixCls]: {
             '&::after': {
-              transform: `scale(${calc(radioDotDisabledSize)
-                .div(radioSize)
-                .equal({ unit: false })})`,
+              transform: `scale(${calc(radioDotDisabledSize).div(radioSize).equal()})`,
             },
           },
         },

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -145,7 +145,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
 
   const dotPadding = 4;
   const radioDotDisabledSize = calc(radioSize).sub(calc(dotPadding).mul(2));
-  const radioSizeCalc = calc(1).mul(radioSize).equal();
+  const radioSizeCalc = calc(1).mul(radioSize).equal({ unit: true });
 
   return {
     [`${componentCls}-wrapper`]: {
@@ -219,8 +219,8 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
           display: 'block',
           width: radioSizeCalc,
           height: radioSizeCalc,
-          marginBlockStart: calc(1).mul(radioSize).div(-2).equal(),
-          marginInlineStart: calc(1).mul(radioSize).div(-2).equal(),
+          marginBlockStart: calc(1).mul(radioSize).div(-2).equal({ unit: true }),
+          marginInlineStart: calc(1).mul(radioSize).div(-2).equal({ unit: true }),
           backgroundColor: radioColor,
           borderBlockStart: 0,
           borderInlineStart: 0,

--- a/components/theme/__tests__/util.test.tsx
+++ b/components/theme/__tests__/util.test.tsx
@@ -148,6 +148,11 @@ describe('util', () => {
         'calc(var(--var1) + var(--var2))',
       );
     });
+
+    it('css calc var should skip zIndex', () => {
+      const calc = genCalc('css');
+      expect(calc('var(--ant-z-index)').add(93).equal()).toBe('calc(var(--ant-z-index) + 10)');
+    });
   });
 
   describe('maxmin', () => {

--- a/components/theme/__tests__/util.test.tsx
+++ b/components/theme/__tests__/util.test.tsx
@@ -134,24 +134,24 @@ describe('util', () => {
 
     cases.forEach(([exp, { js, css }], index) => {
       it(`js calc ${index + 1}`, () => {
-        expect(exp(genCalc('js'))).toBe(js);
+        expect(exp(genCalc('js', new Set()))).toBe(js);
       });
 
       it(`css calc ${index + 1}`, () => {
-        expect(exp(genCalc('css'))).toBe(css);
+        expect(exp(genCalc('css', new Set()))).toBe(css);
       });
     });
 
     it('css calc should work with string', () => {
-      const calc = genCalc('css');
+      const calc = genCalc('css', new Set());
       expect(calc('var(--var1)').add('var(--var2)').equal()).toBe(
         'calc(var(--var1) + var(--var2))',
       );
     });
 
     it('css calc var should skip zIndex', () => {
-      const calc = genCalc('css');
-      expect(calc('var(--ant-z-index)').add(93).equal()).toBe('calc(var(--ant-z-index) + 10)');
+      const calc = genCalc('css', new Set(['--ant-z-index']));
+      expect(calc('var(--ant-z-index)').add(93).equal()).toBe('calc(var(--ant-z-index) + 93)');
     });
   });
 

--- a/components/theme/util/calc/CSSCalculator.ts
+++ b/components/theme/util/calc/CSSCalculator.ts
@@ -94,8 +94,6 @@ export default class CSSCalculator extends AbstractCalculator {
       mergedUnit = false;
     }
 
-    console.log('>>>>', this.result, cssUnit, mergedUnit, this.unitlessCssVar);
-
     this.result = this.result.replace(regexp, mergedUnit ? 'px' : '');
     if (typeof this.lowPriority !== 'undefined') {
       return `calc(${this.result})`;

--- a/components/theme/util/calc/index.ts
+++ b/components/theme/util/calc/index.ts
@@ -2,11 +2,10 @@ import type AbstractCalculator from './calculator';
 import CSSCalculator from './CSSCalculator';
 import NumCalculator from './NumCalculator';
 
-const genCalc = (type: 'css' | 'js') => {
+const genCalc = (type: 'css' | 'js', unitlessCssVar: Set<string>) => {
   const Calculator = type === 'css' ? CSSCalculator : NumCalculator;
 
-  return (num: number | string | AbstractCalculator, unitless?: boolean) =>
-    new Calculator(num, unitless);
+  return (num: number | string | AbstractCalculator) => new Calculator(num, unitlessCssVar);
 };
 
 export default genCalc;

--- a/components/theme/util/calc/index.ts
+++ b/components/theme/util/calc/index.ts
@@ -5,7 +5,8 @@ import NumCalculator from './NumCalculator';
 const genCalc = (type: 'css' | 'js') => {
   const Calculator = type === 'css' ? CSSCalculator : NumCalculator;
 
-  return (num: number | string | AbstractCalculator) => new Calculator(num);
+  return (num: number | string | AbstractCalculator, unitless?: boolean) =>
+    new Calculator(num, unitless);
 };
 
 export default genCalc;

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -169,18 +169,15 @@ export default function genComponentStyleHook<C extends OverrideComponent>(
 
     // Use unique memo to share the result across all instances
     const calc = useUniqueMemo(() => {
-      const unitlessCssVar = new Set<string>(
-        cssVar
-          ? Object.keys(options.unitless || {}).map((key) =>
-              token2CSSVar(
-                key,
-                // If from shared `unitless` use `cssVar.prefix` directly.
-                // Else it's from component, use component prefix.
-                (unitless as any)[key] ? cssVar.prefix : getCompVarPrefix(component, cssVar.prefix),
-              ),
-            )
-          : [],
-      );
+      const unitlessCssVar = new Set<string>();
+      if (cssVar) {
+        Object.keys(options.unitless || {}).forEach((key) => {
+          // Some component proxy the AliasToken (e.g. Image) and some not (e.g. Modal)
+          // We should both pass in `unitlessCssVar` to make sure the CSSVar can be unitless.
+          unitlessCssVar.add(token2CSSVar(key, cssVar.prefix));
+          unitlessCssVar.add(token2CSSVar(key, getCompVarPrefix(component, cssVar.prefix)));
+        });
+      }
 
       return genCalc(type, unitlessCssVar);
     }, [type, component, cssVar && cssVar.prefix]);

--- a/components/theme/util/genComponentStyleHook.tsx
+++ b/components/theme/util/genComponentStyleHook.tsx
@@ -3,7 +3,7 @@ import type { ComponentType, FC, ReactElement } from 'react';
 import React, { useContext } from 'react';
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { token2CSSVar, useCSSVarRegister, useStyleRegister } from '@ant-design/cssinjs';
-import useUniqueMemo from 'antd/es/_util/hooks/useUniqueMemo';
+import useUniqueMemo from '../../_util/hooks/useUniqueMemo';
 import { warning } from 'rc-util';
 
 import { ConfigContext } from '../../config-provider/context';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #49225

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Modal close button `zIndex` not working when in `cssVar` mode.     |
| 🇨🇳 Chinese |     修复 Modal 关闭按钮的 `zIndex` 在 `cssVar` 模式下不正确的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
