### PR TITLE
fix: padding unit for Progress text-inner

### DIFF
--- a/components/progress/style/index.ts
+++ b/components/progress/style/index.ts
@@ -1,5 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { unit, Keyframes } from '@ant-design/cssinjs';
 
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
@@ -189,7 +189,7 @@ const genBaseStyle: GenerateStyle<ProgressToken> = (token) => {
         width: '100%',
         height: '100%',
         marginInlineStart: 0,
-        padding: `0 ${token.paddingXXS}`,
+        padding: `0 ${unit(token.paddingXXS)}`,
         [`&${progressCls}-text-start`]: {
           justifyContent: 'start',
         },

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -215,18 +215,25 @@ export default function imageTest(
   }
 
   Object.entries(themes).forEach(([key, algorithm]) => {
+    const configTheme = {
+      algorithm,
+      token: {
+        fontFamily: 'Arial',
+      },
+    };
+
     test(
       `component image screenshot should correct ${key}`,
       `.${key}`,
       <div style={{ background: key === 'dark' ? '#000' : '', padding: `24px 12px` }} key={key}>
-        <ConfigProvider theme={{ algorithm }}>{component}</ConfigProvider>
+        <ConfigProvider theme={configTheme}>{component}</ConfigProvider>
       </div>,
     );
     test(
       `[CSS Var] component image screenshot should correct ${key}`,
       `.${key}.css-var`,
       <div style={{ background: key === 'dark' ? '#000' : '', padding: `24px 12px` }} key={key}>
-        <ConfigProvider theme={{ algorithm, cssVar: true }}>{component}</ConfigProvider>
+        <ConfigProvider theme={{ ...configTheme, cssVar: true }}>{component}</ConfigProvider>
       </div>,
     );
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix invalid padding of text in Progress when cssinjs      |
| 🇨🇳 Chinese |    修复 cssinjs 模式下 Progress 组件中文本的 padding 单位失效问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
