### PR TITLE
fix: bump rc-image version to 7.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rc-drawer": "~7.2.0",
     "rc-dropdown": "~4.2.0",
     "rc-field-form": "~2.2.0",
-    "rc-image": "~7.8.0",
+    "rc-image": "~7.8.1",
     "rc-input": "~1.5.1",
     "rc-input-number": "~9.1.0",
     "rc-mentions": "~2.13.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/ant-design/ant-design/discussions/49234
https://github.com/ant-design/ant-design/issues/49235

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

The code change in `rc-image` results in the width and height being applied to the preview image element, which I didn't notice previously. The fix PR is merged in `rc-image` repo, this PR is for antd. 

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the issue where the width and height property of `Image` is applied to preivew image incorrectly        |
| 🇨🇳 Chinese |     修复了`Image`组件的`width`和`height`属性被错误应用到预览图片上的问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
