### PR TITLE
style: fix DatePicker header text align

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -254,6 +254,9 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
           cursor: 'pointer',
           transition: `color ${motionDurationMid}`,
           fontSize: 'inherit',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
         },
 
         '> button': {
@@ -273,12 +276,10 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         '&-view': {
           flex: 'auto',
           fontWeight: fontWeightStrong,
-          lineHeight: unit(textHeight),
 
-          button: {
+          '> button': {
             color: 'inherit',
             fontWeight: 'inherit',
-            verticalAlign: 'top',
 
             '&:not(:first-child)': {
               marginInlineStart: paddingXS,

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -276,6 +276,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         '&-view': {
           flex: 'auto',
           fontWeight: fontWeightStrong,
+          lineHeight: unit(textHeight),
 
           '> button': {
             color: 'inherit',

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -297,7 +297,6 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         &-super-prev-icon,
         &-super-next-icon`]: {
         position: 'relative',
-        display: 'inline-block',
         width: pickerControlIconSize,
         height: pickerControlIconSize,
 
@@ -305,7 +304,6 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
           position: 'absolute',
           top: 0,
           insetInlineStart: 0,
-          display: 'inline-block',
           width: pickerControlIconSize,
           height: pickerControlIconSize,
           border: `0 solid currentcolor`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
<img width="366" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/9489782c-54a6-41e4-8f08-ec12d7ffa4f9">
箭头偏下了。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix DatePicker header not align well vertically.          |
| 🇨🇳 Chinese | 修复 DatePicker header 区域内容不居中对齐的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
