### PR TITLE
feat: drawer close icon placement

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -14217,7 +14217,7 @@ exports[`ConfigProvider components Drawer configProvider 1`] = `
         >
           <button
             aria-label="Close"
-            class="config-drawer-close"
+            class="config-drawer-close config-drawer-close-left"
             type="button"
           >
             <span
@@ -14288,7 +14288,7 @@ exports[`ConfigProvider components Drawer configProvider componentDisabled 1`] =
         >
           <button
             aria-label="Close"
-            class="config-drawer-close"
+            class="config-drawer-close config-drawer-close-left"
             type="button"
           >
             <span
@@ -14359,7 +14359,7 @@ exports[`ConfigProvider components Drawer configProvider componentSize large 1`]
         >
           <button
             aria-label="Close"
-            class="config-drawer-close"
+            class="config-drawer-close config-drawer-close-left"
             type="button"
           >
             <span
@@ -14430,7 +14430,7 @@ exports[`ConfigProvider components Drawer configProvider componentSize middle 1`
         >
           <button
             aria-label="Close"
-            class="config-drawer-close"
+            class="config-drawer-close config-drawer-close-left"
             type="button"
           >
             <span
@@ -14501,7 +14501,7 @@ exports[`ConfigProvider components Drawer configProvider componentSize small 1`]
         >
           <button
             aria-label="Close"
-            class="config-drawer-close"
+            class="config-drawer-close config-drawer-close-left"
             type="button"
           >
             <span
@@ -14572,7 +14572,7 @@ exports[`ConfigProvider components Drawer normal 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -14643,7 +14643,7 @@ exports[`ConfigProvider components Drawer prefixCls 1`] = `
         >
           <button
             aria-label="Close"
-            class="prefix-Drawer-close"
+            class="prefix-Drawer-close prefix-Drawer-close-left"
             type="button"
           >
             <span

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -7,6 +7,8 @@ import type { ClosableType } from '../_util/hooks/useClosable';
 import { ConfigContext } from '../config-provider';
 import Skeleton from '../skeleton';
 
+export type DrawerClosePlacement = 'right' | 'left';
+
 export interface DrawerClassNames extends NonNullable<RCDrawerProps['classNames']> {
   header?: string;
   body?: string;
@@ -32,6 +34,7 @@ export interface DrawerPanelProps {
    *
    * `<Drawer closeIcon={false} />`
    */
+  closePlacement?: DrawerClosePlacement;
   closable?: ClosableType;
   closeIcon?: React.ReactNode;
   onClose?: RCDrawerProps['onClose'];
@@ -62,6 +65,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     footer,
     extra,
     loading,
+    closePlacement = 'left',
     onClose,
     headerStyle,
     bodyStyle,
@@ -74,7 +78,12 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
 
   const customCloseIconRender = React.useCallback(
     (icon: React.ReactNode) => (
-      <button type="button" onClick={onClose} aria-label="Close" className={`${prefixCls}-close`}>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className={`${prefixCls}-close ${prefixCls}-close-${closePlacement}`}
+      >
         {icon}
       </button>
     ),
@@ -111,10 +120,11 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
         )}
       >
         <div className={`${prefixCls}-header-title`}>
-          {mergedCloseIcon}
+          {closePlacement === 'left' && mergedCloseIcon}
           {title && <div className={`${prefixCls}-title`}>{title}</div>}
         </div>
         {extra && <div className={`${prefixCls}-extra`}>{extra}</div>}
+        {closePlacement === 'right' && mergedCloseIcon}
       </div>
     );
   }, [mergedClosable, mergedCloseIcon, extra, headerStyle, prefixCls, title]);

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Drawer Drawer loading have a spinner 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -122,7 +122,7 @@ exports[`Drawer className is test_drawer 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -239,7 +239,7 @@ exports[`Drawer getContainer return undefined 2`] = `
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -313,7 +313,7 @@ exports[`Drawer have a footer 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -391,7 +391,7 @@ exports[`Drawer have a title 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -469,7 +469,7 @@ exports[`Drawer render correctly 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -542,7 +542,7 @@ exports[`Drawer render top drawer 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -621,7 +621,7 @@ exports[`Drawer style migrate match between styles and deprecated style prop 1`]
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -708,7 +708,7 @@ exports[`Drawer style migrate match between styles and deprecated style prop 2`]
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -794,7 +794,7 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span
@@ -868,7 +868,7 @@ exports[`Drawer support closeIcon 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span>

--- a/components/drawer/__tests__/__snapshots__/DrawerEvent.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/DrawerEvent.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Drawer render correctly 1`] = `
         >
           <button
             aria-label="Close"
-            class="ant-drawer-close"
+            class="ant-drawer-close ant-drawer-close-left"
             type="button"
           >
             <span

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -40,7 +40,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -160,7 +160,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -252,7 +252,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -333,7 +333,7 @@ exports[`renders components/drawer/demo/component-token.tsx extend context corre
       >
         <button
           aria-label="Close"
-          class="ant-drawer-close"
+          class="ant-drawer-close ant-drawer-close-left"
           type="button"
         >
           <span
@@ -423,7 +423,7 @@ exports[`renders components/drawer/demo/config-provider.tsx extend context corre
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -614,7 +614,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -770,7 +770,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -2821,7 +2821,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -3049,7 +3049,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -3361,7 +3361,7 @@ exports[`renders components/drawer/demo/render-panel.tsx extend context correctl
       >
         <button
           aria-label="Close"
-          class="ant-drawer-close"
+          class="ant-drawer-close ant-drawer-close-left"
           type="button"
         >
           <span
@@ -3558,7 +3558,7 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -3624,7 +3624,7 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
                   >
                     <button
                       aria-label="Close"
-                      class="ant-drawer-close"
+                      class="ant-drawer-close ant-drawer-close-left"
                       type="button"
                     >
                       <span
@@ -3709,7 +3709,7 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span
@@ -3819,7 +3819,7 @@ Array [
           >
             <button
               aria-label="Close"
-              class="ant-drawer-close"
+              class="ant-drawer-close ant-drawer-close-left"
               type="button"
             >
               <span

--- a/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
@@ -58,7 +58,7 @@ exports[`renders components/drawer/demo/component-token.tsx correctly 1`] = `
       >
         <button
           aria-label="Close"
-          class="ant-drawer-close"
+          class="ant-drawer-close ant-drawer-close-left"
           type="button"
         >
           <span
@@ -432,7 +432,7 @@ exports[`renders components/drawer/demo/render-panel.tsx correctly 1`] = `
       >
         <button
           aria-label="Close"
-          class="ant-drawer-close"
+          class="ant-drawer-close ant-drawer-close-left"
           type="button"
         >
           <span

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -56,6 +56,7 @@ v5 use `rootClassName` & `rootStyle` to config wrapper style instead of `classNa
 | className | Config Drawer Panel className. Use `rootClassName` if want to config top DOM style | string | - |  |
 | classNames | Semantic structure className | [Record<SemanticDOM, string>](#semantic-dom) | - | 5.10.0 |
 | closeIcon | Custom close icon. 5.7.0: close button will be hidden when setting to `null` or `false` | ReactNode | &lt;CloseOutlined /> |  |
+| closePlacement | The placement of the close button | `left` \| `right` | `left` | 5.18.0 |
 | destroyOnClose | Whether to unmount child components on closing drawer or not | boolean | false |  |
 | extra | Extra actions area at corner | ReactNode | - | 4.17.0 |
 | footer | The footer for Drawer | ReactNode | - |  |

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -56,6 +56,7 @@ v5 使用 `rootClassName` 与 `rootStyle` 来配置最外层元素样式。原 v
 | className | Drawer 容器外层 className 设置，如果需要设置最外层，请使用 rootClassName | string | - |  |
 | classNames | 语义化结构 className | [Record<SemanticDOM, string>](#semantic-dom) | - | 5.10.0 |
 | closeIcon | 自定义关闭图标。5.7.0：设置为 `null` 或 `false` 时隐藏关闭按钮 | ReactNode | &lt;CloseOutlined /> |  |
+| closePlacement | 關閉按鈕的位置 | `left` \| `right` | `left` | 5.18.0 |
 | destroyOnClose | 关闭时销毁 Drawer 里的子元素 | boolean | false |  |
 | extra | 抽屉右上角的操作区域 | ReactNode | - | 4.17.0 |
 | footer | 抽屉的页脚 | ReactNode | - |  |

--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -180,7 +180,6 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
         borderRadius: borderRadiusSM,
         justifyContent: 'center',
         alignItems: 'center',
-        marginInlineEnd: marginXS,
         color: colorIcon,
         fontWeight: fontWeightStrong,
         fontSize: fontSizeLG,
@@ -206,6 +205,14 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
         },
 
         ...genFocusStyle(token),
+      },
+
+      '&-left': {
+        marginInlineEnd: marginXS,
+      },
+
+      '&-right': {
+        marginInlineStart: marginXS,
       },
 
       [`${componentCls}-title`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
It would be nice to have option to control close button in drawer, now it's possible only by adding extra css. So solution is simple, add closePlacement prop to a drawer, property can have: left default or right value.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Add property to a Drawer to control close button placement        |
| 🇨🇳 Chinese |     在抽屜中新增屬性以控制關閉按鈕的位置      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
