### PR TITLE
chore: unique Empty text color

### DIFF
--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1020,7 +1020,9 @@ exports[`renders components/empty/demo/customize.tsx extend context correctly 1`
   <div
     class="ant-empty-description"
   >
-    <span>
+    <span
+      class="ant-typography"
+    >
       Customize 
       <a
         href="#API"

--- a/components/empty/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.ts.snap
@@ -738,7 +738,9 @@ exports[`renders components/empty/demo/customize.tsx correctly 1`] = `
   <div
     class="ant-empty-description"
   >
-    <span>
+    <span
+      class="ant-typography"
+    >
       Customize 
       <a
         href="#API"

--- a/components/empty/demo/customize.tsx
+++ b/components/empty/demo/customize.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Button, Empty } from 'antd';
+import { Button, Empty, Typography } from 'antd';
 
 const App: React.FC = () => (
   <Empty
     image="https://gw.alipayobjects.com/zos/antfincdn/ZHrcdLPrvN/empty.svg"
     imageStyle={{ height: 60 }}
     description={
-      <span>
+      <Typography.Text>
         Customize <a href="#API">Description</a>
-      </span>
+      </Typography.Text>
     }
   >
     <Button type="primary">Create Now</Button>

--- a/components/empty/style/index.ts
+++ b/components/empty/style/index.ts
@@ -42,7 +42,7 @@ const genSharedEmptyStyle: GenerateStyle<EmptyToken> = (token): CSSObject => {
       },
 
       [`${componentCls}-description`]: {
-        color: token.colorText,
+        color: token.colorTextDescription,
       },
 
       // 原来 &-footer 没有父子结构，现在为了外层承担我们的hashId，改成父子结果


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #49407

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix Empty sometime not take `colorTextDescription` as description text color.       |
| 🇨🇳 Chinese |   修复 Empty 部分样式下，描述的 `colorTextDescription` 不生效的问题。      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
