### PR TITLE
refactor(theme): move default theme into separate file

### DIFF
--- a/components/theme/context.ts
+++ b/components/theme/context.ts
@@ -1,12 +1,10 @@
 import React from 'react';
 import type { Theme } from '@ant-design/cssinjs';
-import { createTheme } from '@ant-design/cssinjs';
 
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from './interface';
-import defaultDerivative from './themes/default';
 import defaultSeedToken from './themes/seed';
 
-export const defaultTheme = createTheme(defaultDerivative);
+export { default as defaultTheme } from './themes/default/theme';
 
 // ================================ Context =================================
 // To ensure snapshot stable. We disable hashed in test env.

--- a/components/theme/getDesignToken.ts
+++ b/components/theme/getDesignToken.ts
@@ -2,12 +2,12 @@ import { createTheme, getComputedToken } from '@ant-design/cssinjs';
 
 import type { ThemeConfig } from '../config-provider/context';
 import type { AliasToken } from './interface';
-import defaultDerivative from './themes/default';
+import defaultTheme from './themes/default/theme';
 import seedToken from './themes/seed';
 import formatToken from './util/alias';
 
 const getDesignToken = (config?: ThemeConfig): AliasToken => {
-  const theme = config?.algorithm ? createTheme(config.algorithm) : createTheme(defaultDerivative);
+  const theme = config?.algorithm ? createTheme(config.algorithm) : defaultTheme;
   const mergedToken = {
     ...seedToken,
     ...config?.token,

--- a/components/theme/themes/default/theme.ts
+++ b/components/theme/themes/default/theme.ts
@@ -1,0 +1,6 @@
+import { createTheme } from '@ant-design/cssinjs';
+import defaultDerivative from './index';
+
+const defaultTheme = createTheme(defaultDerivative);
+
+export default defaultTheme;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#49278

### 💡 需求背景和解决方案

当前 ConfigProvider 会带来很大的性能问题，究其原因是 defaultTheme 引起了大量的 color 实例化与计算。defaultTheme 是算法实现，运行时资源消耗比较大。

而在实际应用场景中，我们是可以使用更简单轻量化的静态主题配置的。

defaultTheme 作为 Context 的初始值，是无法改变的，否则会引起破坏性变更。但是可以借助构建工具的 alias 能力，将其映射到用户自己的 theme 文件里。

因此我将 defaultTheme 的实例单独存放在了一个文件中，更方便用户去配置 alias 规则。以 Vite 为例：

```ts
export default defineConfig({
  resolve: {
    alias: {
      'antd/es/theme/themes/default/theme': '@foobar/theme'
    }
  }
})
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 无        |
| 🇨🇳 中文 | 无        |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供