### PR TITLE
fix: adjust the message content display attribute

### DIFF
--- a/components/message/style/index.ts
+++ b/components/message/style/index.ts
@@ -94,7 +94,6 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     },
 
     [`${componentCls}-custom-content > ${iconCls}`]: {
-      verticalAlign: 'text-bottom',
       marginInlineEnd: marginXS, // affected by ltr or rtl
       fontSize: fontSizeLG,
     },

--- a/components/message/style/index.ts
+++ b/components/message/style/index.ts
@@ -88,6 +88,11 @@ const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
     padding: paddingXS,
     textAlign: 'center',
 
+    [`${componentCls}-custom-content`]: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+
     [`${componentCls}-custom-content > ${iconCls}`]: {
       verticalAlign: 'text-bottom',
       marginInlineEnd: marginXS, // affected by ltr or rtl


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Close #49416

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

The message custom content is normally aligned, which leads to the problem where the icon and the text are not strictly centered, just like the picture below. Using `flex` can solve this problem.
![image](https://github.com/ant-design/ant-design/assets/97817985/08717747-fc14-48ea-b09c-a53b422c4461)
After change:
![image](https://github.com/ant-design/ant-design/assets/97817985/be0e9228-00f8-4415-b1b0-62330b2341a8)


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix the bug where the icon and the text aren't strictly centered in Message component. |
| 🇨🇳 Chinese | 修复了 `Message` 组件的图标与文本内容没有严格居中对齐的问题。          |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
