### PR TITLE
fix: Collapse header element alignItems change to center

### DIFF
--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -97,7 +97,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
           position: 'relative', // Compatible with old version of antd, should remove in next version
           display: 'flex',
           flexWrap: 'nowrap',
-          alignItems: 'flex-start',
+          alignItems: 'center',
           padding: headerPadding,
           color: colorTextHeading,
           lineHeight,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
- fix https://github.com/ant-design/ant-design/issues/49474

### 💡 Background and solution
Collapse 组件 header 内部元素没有水平对齐

### 📝 Changelog
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Collapse header element alignItems change to center      |
| 🇨🇳 Chinese |     Collapse 组件 header 内部元素修改为水平对齐       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
