### PR TITLE
docs: Alert demo remove Space comp

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,102 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders components/alert/demo/action.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
-      <div
-        class="ant-alert-action"
-      >
-        <button
-          class="ant-btn ant-btn-text ant-btn-sm"
-          type="button"
-        >
-          <span>
-            UNDO
-          </span>
-        </button>
-      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
       <button
-        class="ant-alert-close-icon"
-        tabindex="0"
+        class="ant-btn ant-btn-text ant-btn-sm"
         type="button"
       >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
+        <span>
+          UNDO
         </span>
       </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -105,186 +68,207 @@ exports[`renders components/alert/demo/action.tsx extend context correctly 1`] =
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <div
-        class="ant-alert-action"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-sm ant-btn-dangerous"
-          type="button"
-        >
-          <span>
-            Detail
-          </span>
-        </button>
-      </div>
-    </div>
-  </div>
+    </button>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
+        Error Text
       </div>
       <div
-        class="ant-alert-action"
+        class="ant-alert-description"
       >
-        <div
-          class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
-        >
-          <div
-            class="ant-space-item"
-          >
-            <button
-              class="ant-btn ant-btn-text ant-btn-sm"
-              type="button"
-            >
-              <span>
-                Done
-              </span>
-            </button>
-          </div>
-        </div>
+        Error Description Error Description Error Description Error Description
       </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
       <button
-        class="ant-alert-close-icon"
-        tabindex="0"
+        class="ant-btn ant-btn-default ant-btn-sm ant-btn-dangerous"
         type="button"
       >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
+        <span>
+          Detail
         </span>
       </button>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
+      >
+        Warning Text
+      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
+      <div
+        class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
       >
         <div
-          class="ant-alert-message"
+          class="ant-space-item"
         >
-          Info Text
+          <button
+            class="ant-btn ant-btn-text ant-btn-sm"
+            type="button"
+          >
+            <span>
+              Done
+            </span>
+          </button>
         </div>
-        <div
-          class="ant-alert-description"
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          Info Description Info Description Info Description Info Description
-        </div>
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Info Text
       </div>
       <div
-        class="ant-alert-action"
+        class="ant-alert-description"
+      >
+        Info Description Info Description Info Description Info Description
+      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
+      <div
+        class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
       >
         <div
-          class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+          class="ant-space-item"
         >
-          <div
-            class="ant-space-item"
+          <button
+            class="ant-btn ant-btn-primary ant-btn-sm"
+            type="button"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-btn-sm"
-              type="button"
-            >
-              <span>
-                Accept
-              </span>
-            </button>
-          </div>
-          <div
-            class="ant-space-item"
+            <span>
+              Accept
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-space-item"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-btn-dangerous"
+            type="button"
           >
-            <button
-              class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-btn-dangerous"
-              type="button"
-            >
-              <span>
-                Decline
-              </span>
-            </button>
-          </div>
+            <span>
+              Decline
+            </span>
+          </button>
         </div>
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-</div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/action.tsx extend context correctly 2`] = `
@@ -294,147 +278,88 @@ exports[`renders components/alert/demo/action.tsx extend context correctly 2`] =
 `;
 
 exports[`renders components/alert/demo/banner.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-banner"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-warning ant-alert-banner"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Warning text
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Very long warning text warning text text text text text text text
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning text
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Very long warning text warning text text text text text text text
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning text without icon
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -443,22 +368,65 @@ exports[`renders components/alert/demo/banner.tsx extend context correctly 1`] =
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-no-icon ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error text
-        </div>
+        Warning text without icon
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error text
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/banner.tsx extend context correctly 2`] = `[]`;
@@ -484,616 +452,556 @@ exports[`renders components/alert/demo/basic.tsx extend context correctly 1`] = 
 exports[`renders components/alert/demo/basic.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/closable.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
-        </div>
+        Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
-    >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <button
+      <span
         aria-label="close"
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
+        class="anticon anticon-close"
+        role="img"
       >
-        <span
-          aria-label="close-square"
-          class="anticon anticon-close-square"
-          role="img"
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="close-square"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description Error Description Error Description
+      </div>
     </div>
-  </div>
-</div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description Error Description Error Description
+      </div>
+    </div>
+    <button
+      aria-label="close"
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close-square"
+        class="anticon anticon-close-square"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close-square"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/closable.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/custom-icon.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          showIcon = false
-        </div>
+        showIcon = false
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
+        Informational Notes
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
+        Warning
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-error"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
+        Error
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Detailed description and advices about successful copywriting.
-        </div>
+        Success Tips
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Detailed description and advices about successful copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Additional description and informations about copywriting.
-        </div>
+        Informational Notes
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Additional description and informations about copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is a warning notice about copywriting.
-        </div>
+        Warning
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is a warning notice about copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is an error message about copywriting.
-        </div>
+        Error
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is an error message about copywriting.
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/custom-icon.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/description.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Success Description Success Description Success Description
-        </div>
+        Success Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Success Description Success Description Success Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Info Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Info Description Info Description Info Description Info Description
-        </div>
+        Info Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Info Description Info Description Info Description Info Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Warning Description Warning Description Warning Description Warning Description
-        </div>
+        Warning Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Warning Description Warning Description Warning Description Warning Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description
-        </div>
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/description.tsx extend context correctly 2`] = `[]`;
@@ -1112,166 +1020,123 @@ exports[`renders components/alert/demo/error-boundary.tsx extend context correct
 exports[`renders components/alert/demo/error-boundary.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/icon.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="info-circle"
+      class="anticon anticon-info-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="info-circle"
-        class="anticon anticon-info-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="info-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="info-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
+        Informational Notes
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
+        Warning
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -1280,192 +1145,180 @@ exports[`renders components/alert/demo/icon.tsx extend context correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-success ant-alert-with-description"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Success Tips
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Detailed description and advice about successful copywriting.
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-info ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="info-circle"
+      class="anticon anticon-info-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="info-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Informational Notes
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Additional description and information about copywriting.
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Warning
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is a warning notice about copywriting.
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Detailed description and advice about successful copywriting.
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-info ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="info-circle"
-        class="anticon anticon-info-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="info-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Additional description and information about copywriting.
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is a warning notice about copywriting.
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -1474,200 +1327,196 @@ exports[`renders components/alert/demo/icon.tsx extend context correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is an error message about copywriting.
-        </div>
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is an error message about copywriting.
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/icon.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Alert Message Text
-        </div>
+        Alert Message Text
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <p>
-      click the close button to see the effect
-    </p>
-  </div>
-  <div
-    class="ant-space-item"
-  >
     <button
-      aria-checked="true"
-      class="ant-switch ant-switch-checked ant-switch-disabled"
-      disabled=""
-      role="switch"
+      class="ant-alert-close-icon"
+      tabindex="0"
       type="button"
     >
-      <div
-        class="ant-switch-handle"
-      />
       <span
-        class="ant-switch-inner"
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
       >
-        <span
-          class="ant-switch-inner-checked"
-        />
-        <span
-          class="ant-switch-inner-unchecked"
-        />
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
       </span>
     </button>
-  </div>
-</div>
+  </div>,
+  <p>
+    click the close button to see the effect
+  </p>,
+  <button
+    aria-checked="true"
+    class="ant-switch ant-switch-checked ant-switch-disabled"
+    disabled=""
+    role="switch"
+    type="button"
+  >
+    <div
+      class="ant-switch-handle"
+    />
+    <span
+      class="ant-switch-inner"
+    >
+      <span
+        class="ant-switch-inner-checked"
+      />
+      <span
+        class="ant-switch-inner-unchecked"
+      />
+    </span>
+  </button>,
+]
 `;
 
 exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/style.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width: 100%;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Text
-        </div>
+        Success Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Info Text
-        </div>
+        Info Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
+        Warning Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-error ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
+        Error Text
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/style.tsx extend context correctly 2`] = `[]`;

--- a/components/alert/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,102 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders components/alert/demo/action.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
-      <div
-        class="ant-alert-action"
-      >
-        <button
-          class="ant-btn ant-btn-text ant-btn-sm"
-          type="button"
-        >
-          <span>
-            UNDO
-          </span>
-        </button>
-      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
       <button
-        class="ant-alert-close-icon"
-        tabindex="0"
+        class="ant-btn ant-btn-text ant-btn-sm"
         type="button"
       >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
+        <span>
+          UNDO
         </span>
       </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -105,330 +68,292 @@ exports[`renders components/alert/demo/action.tsx correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <div
-        class="ant-alert-action"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-sm ant-btn-dangerous"
-          type="button"
-        >
-          <span>
-            Detail
-          </span>
-        </button>
-      </div>
-    </div>
-  </div>
+    </button>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
+        Error Text
       </div>
       <div
-        class="ant-alert-action"
+        class="ant-alert-description"
       >
-        <div
-          class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
-        >
-          <div
-            class="ant-space-item"
-          >
-            <button
-              class="ant-btn ant-btn-text ant-btn-sm"
-              type="button"
-            >
-              <span>
-                Done
-              </span>
-            </button>
-          </div>
-        </div>
+        Error Description Error Description Error Description Error Description
       </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
       <button
-        class="ant-alert-close-icon"
-        tabindex="0"
+        class="ant-btn ant-btn-default ant-btn-sm ant-btn-dangerous"
         type="button"
       >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
+        <span>
+          Detail
         </span>
       </button>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
+      >
+        Warning Text
+      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
+      <div
+        class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
       >
         <div
-          class="ant-alert-message"
+          class="ant-space-item"
         >
-          Info Text
+          <button
+            class="ant-btn ant-btn-text ant-btn-sm"
+            type="button"
+          >
+            <span>
+              Done
+            </span>
+          </button>
         </div>
-        <div
-          class="ant-alert-description"
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          Info Description Info Description Info Description Info Description
-        </div>
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Info Text
       </div>
       <div
-        class="ant-alert-action"
+        class="ant-alert-description"
+      >
+        Info Description Info Description Info Description Info Description
+      </div>
+    </div>
+    <div
+      class="ant-alert-action"
+    >
+      <div
+        class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
       >
         <div
-          class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+          class="ant-space-item"
         >
-          <div
-            class="ant-space-item"
+          <button
+            class="ant-btn ant-btn-primary ant-btn-sm"
+            type="button"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-btn-sm"
-              type="button"
-            >
-              <span>
-                Accept
-              </span>
-            </button>
-          </div>
-          <div
-            class="ant-space-item"
+            <span>
+              Accept
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-space-item"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-btn-dangerous"
+            type="button"
           >
-            <button
-              class="ant-btn ant-btn-default ant-btn-sm ant-btn-background-ghost ant-btn-dangerous"
-              type="button"
-            >
-              <span>
-                Decline
-              </span>
-            </button>
-          </div>
+            <span>
+              Decline
+            </span>
+          </button>
         </div>
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-</div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/banner.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-banner"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-warning ant-alert-banner"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Warning text
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Very long warning text warning text text text text text text text
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning text
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Very long warning text warning text text text text text text text
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning text without icon
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-banner"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -437,22 +362,65 @@ exports[`renders components/alert/demo/banner.tsx correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-no-icon ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error text
-        </div>
+        Warning text without icon
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-banner"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error text
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/basic.tsx correctly 1`] = `
@@ -474,612 +442,552 @@ exports[`renders components/alert/demo/basic.tsx correctly 1`] = `
 `;
 
 exports[`renders components/alert/demo/closable.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
-        </div>
+        Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
-    >
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description Error Description Error Description
-        </div>
-      </div>
-      <button
+      <span
         aria-label="close"
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
+        class="anticon anticon-close"
+        role="img"
       >
-        <span
-          aria-label="close-square"
-          class="anticon anticon-close-square"
-          role="img"
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="close-square"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description Error Description Error Description
+      </div>
     </div>
-  </div>
-</div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
+  >
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description Error Description Error Description
+      </div>
+    </div>
+    <button
+      aria-label="close"
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-label="close-square"
+        class="anticon anticon-close-square"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="close-square"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/custom-icon.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          showIcon = false
-        </div>
+        showIcon = false
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
+        Informational Notes
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
+        Warning
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-error"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
+        Error
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Detailed description and advices about successful copywriting.
-        </div>
+        Success Tips
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Detailed description and advices about successful copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Additional description and informations about copywriting.
-        </div>
+        Informational Notes
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Additional description and informations about copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is a warning notice about copywriting.
-        </div>
+        Warning
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is a warning notice about copywriting.
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="smile"
+      class="anticon anticon-smile ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="smile"
-        class="anticon anticon-smile ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="smile"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="smile"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is an error message about copywriting.
-        </div>
+        Error
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is an error message about copywriting.
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/description.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Success Description Success Description Success Description
-        </div>
+        Success Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Success Description Success Description Success Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Info Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Info Description Info Description Info Description Info Description
-        </div>
+        Info Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Info Description Info Description Info Description Info Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Warning Description Warning Description Warning Description Warning Description
-        </div>
+        Warning Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Warning Description Warning Description Warning Description Warning Description
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-error ant-alert-with-description ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Error Description Error Description Error Description Error Description
-        </div>
+        Error Text
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Error Description Error Description Error Description Error Description
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/error-boundary.tsx correctly 1`] = `
@@ -1094,166 +1002,123 @@ exports[`renders components/alert/demo/error-boundary.tsx correctly 1`] = `
 `;
 
 exports[`renders components/alert/demo/icon.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-success"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
+        Success Tips
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-info"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="info-circle"
+      class="anticon anticon-info-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="info-circle"
-        class="anticon anticon-info-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="info-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="info-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
+        Informational Notes
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning"
+    data-show="true"
+    role="alert"
   >
-    <div
-      class="ant-alert ant-alert-warning"
-      data-show="true"
-      role="alert"
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
     >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
+        Warning
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error"
-      data-show="true"
-      role="alert"
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -1262,192 +1127,180 @@ exports[`renders components/alert/demo/icon.tsx correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-with-description"
+    data-show="true"
+    role="alert"
   >
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
     <div
-      class="ant-alert ant-alert-success ant-alert-with-description"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Success Tips
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Detailed description and advice about successful copywriting.
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-info ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="info-circle"
+      class="anticon anticon-info-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="info-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Informational Notes
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        Additional description and information about copywriting.
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-warning ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="exclamation-circle"
+      class="anticon anticon-exclamation-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="exclamation-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Warning
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is a warning notice about copywriting.
+      </div>
+    </div>
+    <button
+      class="ant-alert-close-icon"
+      tabindex="0"
+      type="button"
     >
       <span
-        aria-label="check-circle"
-        class="anticon anticon-check-circle ant-alert-icon"
+        aria-label="close"
+        class="anticon anticon-close"
         role="img"
       >
         <svg
           aria-hidden="true"
-          data-icon="check-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Success Tips
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Detailed description and advice about successful copywriting.
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-info ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="info-circle"
-        class="anticon anticon-info-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="info-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Informational Notes
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          Additional description and information about copywriting.
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-warning ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="exclamation-circle"
-        class="anticon anticon-exclamation-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="exclamation-circle"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
-          />
-        </svg>
-      </span>
-      <div
-        class="ant-alert-content"
-      >
-        <div
-          class="ant-alert-message"
-        >
-          Warning
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is a warning notice about copywriting.
-        </div>
-      </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-alert ant-alert-error ant-alert-with-description"
-      data-show="true"
-      role="alert"
-    >
-      <span
-        aria-label="close-circle"
-        class="anticon anticon-close-circle ant-alert-icon"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="close-circle"
+          data-icon="close"
           fill="currentColor"
           fill-rule="evenodd"
           focusable="false"
@@ -1456,194 +1309,190 @@ exports[`renders components/alert/demo/icon.tsx correctly 1`] = `
           width="1em"
         >
           <path
-            d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
           />
         </svg>
       </span>
-      <div
-        class="ant-alert-content"
+    </button>
+  </div>,
+  <br />,
+  <div
+    class="ant-alert ant-alert-error ant-alert-with-description"
+    data-show="true"
+    role="alert"
+  >
+    <span
+      aria-label="close-circle"
+      class="anticon anticon-close-circle ant-alert-icon"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close-circle"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error
-        </div>
-        <div
-          class="ant-alert-description"
-        >
-          This is an error message about copywriting.
-        </div>
+        <path
+          d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+        />
+      </svg>
+    </span>
+    <div
+      class="ant-alert-content"
+    >
+      <div
+        class="ant-alert-message"
+      >
+        Error
+      </div>
+      <div
+        class="ant-alert-description"
+      >
+        This is an error message about copywriting.
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/alert/demo/smooth-closed.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Alert Message Text
-        </div>
+        Alert Message Text
       </div>
-      <button
-        class="ant-alert-close-icon"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          aria-label="close"
-          class="anticon anticon-close"
-          role="img"
-        >
-          <svg
-            aria-hidden="true"
-            data-icon="close"
-            fill="currentColor"
-            fill-rule="evenodd"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
-          >
-            <path
-              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <p>
-      click the close button to see the effect
-    </p>
-  </div>
-  <div
-    class="ant-space-item"
-  >
     <button
-      aria-checked="true"
-      class="ant-switch ant-switch-checked ant-switch-disabled"
-      disabled=""
-      role="switch"
+      class="ant-alert-close-icon"
+      tabindex="0"
       type="button"
     >
-      <div
-        class="ant-switch-handle"
-      />
       <span
-        class="ant-switch-inner"
+        aria-label="close"
+        class="anticon anticon-close"
+        role="img"
       >
-        <span
-          class="ant-switch-inner-checked"
-        />
-        <span
-          class="ant-switch-inner-unchecked"
-        />
+        <svg
+          aria-hidden="true"
+          data-icon="close"
+          fill="currentColor"
+          fill-rule="evenodd"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+          />
+        </svg>
       </span>
     </button>
-  </div>
-</div>
+  </div>,
+  <p>
+    click the close button to see the effect
+  </p>,
+  <button
+    aria-checked="true"
+    class="ant-switch ant-switch-checked ant-switch-disabled"
+    disabled=""
+    role="switch"
+    type="button"
+  >
+    <div
+      class="ant-switch-handle"
+    />
+    <span
+      class="ant-switch-inner"
+    >
+      <span
+        class="ant-switch-inner-checked"
+      />
+      <span
+        class="ant-switch-inner-unchecked"
+      />
+    </span>
+  </button>,
+]
 `;
 
 exports[`renders components/alert/demo/style.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
-  style="width:100%"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-success ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-success ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Success Text
-        </div>
+        Success Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-info ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-info ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Info Text
-        </div>
+        Info Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-warning ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-warning ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Warning Text
-        </div>
+        Warning Text
       </div>
     </div>
-  </div>
+  </div>,
+  <br />,
   <div
-    class="ant-space-item"
+    class="ant-alert ant-alert-error ant-alert-no-icon"
+    data-show="true"
+    role="alert"
   >
     <div
-      class="ant-alert ant-alert-error ant-alert-no-icon"
-      data-show="true"
-      role="alert"
+      class="ant-alert-content"
     >
       <div
-        class="ant-alert-content"
+        class="ant-alert-message"
       >
-        <div
-          class="ant-alert-message"
-        >
-          Error Text
-        </div>
+        Error Text
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/components/alert/demo/action.tsx
+++ b/components/alert/demo/action.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert, Button, Space } from 'antd';
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert
       message="Success Tips"
       type="success"
@@ -14,6 +14,7 @@ const App: React.FC = () => (
       }
       closable
     />
+    <br />
     <Alert
       message="Error Text"
       showIcon
@@ -25,6 +26,7 @@ const App: React.FC = () => (
         </Button>
       }
     />
+    <br />
     <Alert
       message="Warning Text"
       type="warning"
@@ -37,6 +39,7 @@ const App: React.FC = () => (
       }
       closable
     />
+    <br />
     <Alert
       message="Info Text"
       description="Info Description Info Description Info Description Info Description"
@@ -53,7 +56,7 @@ const App: React.FC = () => (
       }
       closable
     />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/banner.tsx
+++ b/components/alert/demo/banner.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert message="Warning text" banner />
+    <br />
     <Alert
       message="Very long warning text warning text text text text text text text"
       banner
       closable
     />
+    <br />
     <Alert showIcon={false} message="Warning text without icon" banner />
+    <br />
     <Alert type="error" message="Error text" banner />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/closable.tsx
+++ b/components/alert/demo/closable.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { CloseSquareFilled } from '@ant-design/icons';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const onClose = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
   console.log(e, 'I was closed.');
 };
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert
       message="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
       type="warning"
       closable
       onClose={onClose}
     />
+    <br />
     <Alert
       message="Error Text"
       description="Error Description Error Description Error Description Error Description Error Description Error Description"
@@ -21,6 +22,7 @@ const App: React.FC = () => (
       closable
       onClose={onClose}
     />
+    <br />
     <Alert
       message="Error Text"
       description="Error Description Error Description Error Description Error Description Error Description Error Description"
@@ -31,7 +33,7 @@ const App: React.FC = () => (
       }}
       onClose={onClose}
     />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/custom-icon.tsx
+++ b/components/alert/demo/custom-icon.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { SmileOutlined } from '@ant-design/icons';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const icon = <SmileOutlined />;
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert icon={icon} message="showIcon = false" type="success" />
+    <br />
     <Alert icon={icon} message="Success Tips" type="success" showIcon />
+    <br />
     <Alert icon={icon} message="Informational Notes" type="info" showIcon />
+    <br />
     <Alert icon={icon} message="Warning" type="warning" showIcon />
+    <br />
     <Alert icon={icon} message="Error" type="error" showIcon />
+    <br />
     <Alert
       icon={icon}
       message="Success Tips"
@@ -18,6 +23,7 @@ const App: React.FC = () => (
       type="success"
       showIcon
     />
+    <br />
     <Alert
       icon={icon}
       message="Informational Notes"
@@ -25,6 +31,7 @@ const App: React.FC = () => (
       type="info"
       showIcon
     />
+    <br />
     <Alert
       icon={icon}
       message="Warning"
@@ -32,6 +39,7 @@ const App: React.FC = () => (
       type="warning"
       showIcon
     />
+    <br />
     <Alert
       icon={icon}
       message="Error"
@@ -39,7 +47,7 @@ const App: React.FC = () => (
       type="error"
       showIcon
     />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/description.tsx
+++ b/components/alert/demo/description.tsx
@@ -1,29 +1,32 @@
 import React from 'react';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert
       message="Success Text"
       description="Success Description Success Description Success Description"
       type="success"
     />
+    <br />
     <Alert
       message="Info Text"
       description="Info Description Info Description Info Description Info Description"
       type="info"
     />
+    <br />
     <Alert
       message="Warning Text"
       description="Warning Description Warning Description Warning Description Warning Description"
       type="warning"
     />
+    <br />
     <Alert
       message="Error Text"
       description="Error Description Error Description Error Description Error Description"
       type="error"
     />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/icon.tsx
+++ b/components/alert/demo/icon.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert message="Success Tips" type="success" showIcon />
+    <br />
     <Alert message="Informational Notes" type="info" showIcon />
+    <br />
     <Alert message="Warning" type="warning" showIcon closable />
+    <br />
     <Alert message="Error" type="error" showIcon />
+    <br />
     <Alert
       message="Success Tips"
       description="Detailed description and advice about successful copywriting."
       type="success"
       showIcon
     />
+    <br />
     <Alert
       message="Informational Notes"
       description="Additional description and information about copywriting."
       type="info"
       showIcon
     />
+    <br />
     <Alert
       message="Warning"
       description="This is a warning notice about copywriting."
@@ -26,13 +32,14 @@ const App: React.FC = () => (
       showIcon
       closable
     />
+    <br />
     <Alert
       message="Error"
       description="This is an error message about copywriting."
       type="error"
       showIcon
     />
-  </Space>
+  </>
 );
 
 export default App;

--- a/components/alert/demo/smooth-closed.tsx
+++ b/components/alert/demo/smooth-closed.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Space, Switch } from 'antd';
+import { Alert, Switch } from 'antd';
 
 const App: React.FC = () => {
   const [visible, setVisible] = useState(true);
@@ -9,13 +9,13 @@ const App: React.FC = () => {
   };
 
   return (
-    <Space direction="vertical" style={{ width: '100%' }}>
+    <>
       {visible && (
         <Alert message="Alert Message Text" type="success" closable afterClose={handleClose} />
       )}
       <p>click the close button to see the effect</p>
       <Switch onChange={setVisible} checked={visible} disabled={visible} />
-    </Space>
+    </>
   );
 };
 

--- a/components/alert/demo/style.tsx
+++ b/components/alert/demo/style.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { Alert, Space } from 'antd';
+import { Alert } from 'antd';
 
 const App: React.FC = () => (
-  <Space direction="vertical" style={{ width: '100%' }}>
+  <>
     <Alert message="Success Text" type="success" />
+    <br />
     <Alert message="Info Text" type="info" />
+    <br />
     <Alert message="Warning Text" type="warning" />
+    <br />
     <Alert message="Error Text" type="error" />
-  </Space>
+  </>
 );
 
 export default App;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/49477

### 💡 Background and solution

Space 组件会带有间距，Alert 组件卸载后那一块的间距没有了，会导致最后收缩一下

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     docs: Alert demo remove Space comp      |
| 🇨🇳 Chinese |    Alert 演示代码去掉 Space 组件       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
