### PR TITLE
docs: fix site FOUC

### DIFF
--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -181,6 +181,26 @@ const RoutesPlugin = (api: IApi) => {
       // exclude dynamic route path, to avoid deploy failed by `:id` directory
       .filter((f) => !f.path.includes(':'))
       .map((file) => {
+        let globalStyles = '';
+
+        // Debug for file content: uncomment this if need check raw out
+        // const tmpFileName = `_${file.path.replace(/\//g, '-')}`;
+        // const tmpFilePath = path.join(api.paths.absOutputPath, tmpFileName);
+        // fs.writeFileSync(tmpFilePath, file.content, 'utf8');
+
+        // extract all emotion style tags from body
+        file.content = file.content.replace(
+          /<style (data-emotion|data-sandpack)[\S\s]+?<\/style>/g,
+          (s) => {
+            globalStyles += s;
+
+            return '';
+          },
+        );
+
+        // insert emotion style tags to head
+        file.content = file.content.replace('</head>', `${globalStyles}</head>`);
+
         // 1. 提取 antd-style 样式
         const styles = extractEmotionStyle(file.content);
 
@@ -195,6 +215,30 @@ const RoutesPlugin = (api: IApi) => {
           const cssFile = writeCSSFile(result!.key, result!.ids.join(''), result!.css);
 
           file.content = addLinkStyle(file.content, cssFile);
+        });
+
+        // Insert antd style to head
+        const matchRegex = /<style data-type="antd-cssinjs">([\S\s]+?)<\/style>/;
+        const matchList = file.content.match(matchRegex) || [];
+
+        // Init to order the `@layer`
+        let antdStyle = '@layer global, antd;';
+
+        matchList.forEach((text) => {
+          file.content = file.content.replace(text, '');
+          antdStyle += text.replace(matchRegex, '$1');
+        });
+
+        const cssFile = writeCSSFile('antd', antdStyle, antdStyle);
+        file.content = addLinkStyle(file.content, cssFile, true);
+
+        // Insert antd cssVar to head
+        const cssVarMatchRegex = /<style data-type="antd-css-var"[\S\s]+?<\/style>/;
+        const cssVarMatchList = file.content.match(cssVarMatchRegex) || [];
+
+        cssVarMatchList.forEach((text) => {
+          file.content = file.content.replace(text, '');
+          file.content = file.content.replace('<head>', `<head>${text}`);
         });
 
         return file;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
由于 https://github.com/ant-design/ant-design/pull/49550 回滚了 dumi 版本，在 https://github.com/ant-design/ant-design/pull/49109 删掉的 cssinjs 的提取逻辑需要加回去。
升级 dumi ssr 时需要再删掉 @Jinbao1001 
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |      -     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
