### PR TITLE
fix: The emptyText field of the table

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -547,9 +547,10 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
 
   const mergedStyle: React.CSSProperties = { ...table?.style, ...style };
 
-  const emptyText = locale?.emptyText || renderEmpty?.('Table') || (
-    <DefaultRenderEmpty componentName="Table" />
-  );
+  const emptyText =
+    typeof locale?.emptyText !== 'undefined'
+      ? locale.emptyText
+      : renderEmpty?.('Table') || <DefaultRenderEmpty componentName="Table" />;
 
   // ========================== Render ==========================
   const TableComponent = virtual ? RcVirtualTable : RcTable;

--- a/components/table/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.tsx.snap
@@ -147,6 +147,104 @@ exports[`Table renders empty table 1`] = `
 </div>
 `;
 
+exports[`Table renders empty table when emptyText is null 1`] = `
+<div
+  class="ant-table-wrapper"
+>
+  <div
+    class="ant-spin-nested-loading"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table ant-table-empty"
+      >
+        <div
+          class="ant-table-container"
+        >
+          <div
+            class="ant-table-content"
+          >
+            <table
+              style="table-layout: auto;"
+            >
+              <colgroup />
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 1
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 2
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 3
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 4
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 5
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 6
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 7
+                  </th>
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Column 8
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-placeholder"
+                >
+                  <td
+                    class="ant-table-cell"
+                    colspan="8"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table renders empty table with custom emptyText 1`] = `
 <div
   class="ant-table-wrapper"

--- a/components/table/__tests__/empty.test.tsx
+++ b/components/table/__tests__/empty.test.tsx
@@ -89,6 +89,13 @@ describe('Table', () => {
     });
   });
 
+  it('renders empty table when emptyText is null', () => {
+    const { asFragment } = render(
+      <Table dataSource={[]} columns={columns} pagination={false} locale={{ emptyText: null }} />,
+    );
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
   it('renders empty table with custom emptyText', () => {
     const { asFragment } = render(
       <Table

--- a/components/table/__tests__/empty.test.tsx
+++ b/components/table/__tests__/empty.test.tsx
@@ -90,9 +90,14 @@ describe('Table', () => {
   });
 
   it('renders empty table when emptyText is null', () => {
-    const { asFragment } = render(
+    const { container, asFragment } = render(
       <Table dataSource={[]} columns={columns} pagination={false} locale={{ emptyText: null }} />,
     );
+
+    expect(container.querySelector('.ant-table-placeholder>.ant-table-cell')?.hasChildNodes()).toBe(
+      false,
+    );
+
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

Background: When setting locale.emptyText to null or '' (empty string) for a table component, there is still placeholder content.
expected: When the user sets locale.emptyText to not be undefined, the content set by the user should be displayed.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
If a user sets locale.emptyText to null or '', they expect to get the default placeholder content

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The table component, when the user sets locale.emptyText to not be undefined, should display the content set by the user.  |
| 🇨🇳 Chinese |      table 组件，当用户设置locale.emptyText不为undefined时，应该显示用户设置的内容。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
