### PR TITLE
ehance: borderless status

### DIFF
--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5643,6 +5643,44 @@ exports[`renders components/input/demo/borderless-debug.tsx extend context corre
       </span>
     </span>
   </span>
+  <input
+    class="ant-input ant-input-borderless ant-input-status-error"
+    type="text"
+    value="error"
+  />
+  <input
+    class="ant-input ant-input-borderless ant-input-status-warning"
+    type="text"
+    value="warning"
+  />
+  <span
+    class="ant-input-affix-wrapper ant-input-borderless ant-input-status-error"
+  >
+    <span
+      class="ant-input-prefix"
+    >
+      $
+    </span>
+    <input
+      class="ant-input"
+      type="text"
+      value="error"
+    />
+  </span>
+  <span
+    class="ant-input-affix-wrapper ant-input-borderless ant-input-status-warning"
+  >
+    <span
+      class="ant-input-prefix"
+    >
+      $
+    </span>
+    <input
+      class="ant-input"
+      type="text"
+      value="warning"
+    />
+  </span>
 </div>
 `;
 

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1548,6 +1548,44 @@ exports[`renders components/input/demo/borderless-debug.tsx correctly 1`] = `
       </span>
     </span>
   </span>
+  <input
+    class="ant-input ant-input-borderless ant-input-status-error"
+    type="text"
+    value="error"
+  />
+  <input
+    class="ant-input ant-input-borderless ant-input-status-warning"
+    type="text"
+    value="warning"
+  />
+  <span
+    class="ant-input-affix-wrapper ant-input-borderless ant-input-status-error"
+  >
+    <span
+      class="ant-input-prefix"
+    >
+      $
+    </span>
+    <input
+      class="ant-input"
+      type="text"
+      value="error"
+    />
+  </span>
+  <span
+    class="ant-input-affix-wrapper ant-input-borderless ant-input-status-warning"
+  >
+    <span
+      class="ant-input-prefix"
+    >
+      $
+    </span>
+    <input
+      class="ant-input"
+      type="text"
+      value="warning"
+    />
+  </span>
 </div>
 `;
 

--- a/components/input/demo/borderless-debug.tsx
+++ b/components/input/demo/borderless-debug.tsx
@@ -13,6 +13,12 @@ const App: React.FC = () => (
     <Input prefix="￥" suffix="RMB" variant="borderless" />
     <Input prefix="￥" suffix="RMB" disabled variant="borderless" />
     <TextArea allowClear style={{ border: '2px solid #000' }} />
+
+    {/* status */}
+    <Input defaultValue="error" variant="borderless" status="error" />
+    <Input defaultValue="warning" variant="borderless" status="warning" />
+    <Input prefix="$" defaultValue="error" variant="borderless" status="error" />
+    <Input prefix="$" defaultValue="warning" variant="borderless" status="warning" />
   </div>
 );
 

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -171,22 +171,40 @@ export const genOutlinedGroupStyle = (token: InputToken): CSSObject => ({
 });
 
 /* ============ Borderless ============ */
-export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): CSSObject => ({
-  '&-borderless': {
-    background: 'transparent',
-    border: 'none',
+export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): CSSObject => {
+  const { componentCls } = token;
 
-    '&:focus, &:focus-within': {
-      outline: 'none',
+  return {
+    '&-borderless': {
+      background: 'transparent',
+      border: 'none',
+
+      '&:focus, &:focus-within': {
+        outline: 'none',
+      },
+
+      // >>>>> Disabled
+      [`&${componentCls}-disabled, &[disabled]`]: {
+        color: token.colorTextDisabled,
+      },
+
+      // >>>>> Status
+      [`&${componentCls}-status-error`]: {
+        '&, & input, & textarea': {
+          color: token.colorError,
+        },
+      },
+
+      [`&${componentCls}-status-warning`]: {
+        '&, & input, & textarea': {
+          color: token.colorWarning,
+        },
+      },
+
+      ...extraStyles,
     },
-
-    [`&${token.componentCls}-disabled, &[disabled]`]: {
-      color: token.colorTextDisabled,
-    },
-
-    ...extraStyles,
-  },
-});
+  };
+};
 
 /* ============== Filled ============== */
 const genBaseFilledStyle = (

--- a/components/select/style/variants.ts
+++ b/components/select/style/variants.ts
@@ -201,6 +201,19 @@ const genBorderlessStyle = (token: SelectToken): CSSObject => ({
       background: token.multipleItemBg,
       border: `${unit(token.lineWidth)} ${token.lineType} ${token.multipleItemBorderColor}`,
     },
+
+    // Status
+    [`&${token.componentCls}-status-error`]: {
+      [`${token.componentCls}-selection-item`]: {
+        color: token.colorError,
+      },
+    },
+
+    [`&${token.componentCls}-status-warning`]: {
+      [`${token.componentCls}-selection-item`]: {
+        color: token.colorWarning,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #49587

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Optimize DatePicker, TimePicker, Select, TreeSelect, Input, InputNumber, Mentions `variant=borderless` style to make it distinguishable when with `status`.       |
| 🇨🇳 Chinese |     优化 DatePicker、TimePicker、Select、TreeSelect、Input、InputNumber、Mentions 的 `variant=borderless` 样式，使其在配置 `status` 属性时也可以被区分。     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
