### PR TITLE
chore: ignore generate-token-meta warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "tar-fs": "^3.0.6",
     "terser": "^5.31.1",
     "tsx": "4.11.2",
-    "typedoc": "^0.26.0",
+    "typedoc": "^0.26.3",
     "typescript": "~5.5.0",
     "vanilla-jsoneditor": "^0.23.7",
     "vanilla-tilt": "^1.8.1",

--- a/scripts/generate-token-meta.ts
+++ b/scripts/generate-token-meta.ts
@@ -46,6 +46,7 @@ const main = async () => {
       // typedoc options here
       entryPoints: ['components/theme/interface/index.ts', 'components/*/style/index.{ts,tsx}'],
       skipErrorChecking: true,
+      logLevel: 'Error',
     },
     [new TSConfigReader(), new TypeDocReader()],
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
npm run token:meta 时会输出很多 warning，隐藏掉。

<img width="922" alt="图片" src="https://github.com/ant-design/ant-design/assets/507615/1518c9a2-7a48-471c-90cb-8c7069cdde57">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |    --       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
