### PR TITLE
fix(dropdown): Modify the initialization style

### DIFF
--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -61,8 +61,6 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
   return [
     {
       [componentCls]: {
-        ...resetComponent(token),
-
         position: 'absolute',
         top: -9999,
         left: {
@@ -185,6 +183,8 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
       },
 
       [`${componentCls}, ${componentCls}-menu-submenu`]: {
+        ...resetComponent(token),
+
         [menuCls]: {
           padding: dropdownEdgeChildPadding,
           listStyleType: 'none',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/49616

### 💡 Background and solution

修改 dropdown 组件样式初始化，为 -menu-submenu 节点添加初始化样式

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Add initialization style for submenu node  |
| 🇨🇳 Chinese |     为 submenu 节点添加初始化样式     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
