### PR TITLE
chore: InputNumber add usage tips

### DIFF
--- a/components/input-number/__tests__/index.test.tsx
+++ b/components/input-number/__tests__/index.test.tsx
@@ -98,12 +98,18 @@ describe('InputNumber', () => {
     ).toBe(true);
   });
 
-  it('deprecate bordered', () => {
+  it('Deprecation and usage tips', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { container } = render(<InputNumber bordered={false} />);
-    expect(errorSpy).toHaveBeenCalledWith(
+    const { container } = render(<InputNumber bordered={false} type="number" changeOnWheel />);
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      1,
       'Warning: [antd: InputNumber] `bordered` is deprecated. Please use `variant` instead.',
     );
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      2,
+      'Warning: [antd: InputNumber] When `type=number` is used together with `changeOnWheel`, changeOnWheel may not work properly. Please delete `type=number` if it is not necessary.',
+    );
+
     expect(container.querySelector('.ant-input-number-borderless')).toBeTruthy();
     errorSpy.mockRestore();
   });

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -42,8 +42,13 @@ export interface InputNumberProps<T extends ValueType = ValueType>
 
 const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>((props, ref) => {
   if (process.env.NODE_ENV !== 'production') {
-    const { deprecated } = devUseWarning('InputNumber');
-    deprecated(!('bordered' in props), 'bordered', 'variant');
+    const typeWarning = devUseWarning('InputNumber');
+    typeWarning.deprecated(!('bordered' in props), 'bordered', 'variant');
+    typeWarning(
+      !(props.type === 'number' && props.changeOnWheel),
+      'usage',
+      'When `type=number` is used together with `changeOnWheel`, changeOnWheel may not work properly. Please delete `type=number` if it is not necessary.',
+    );
   }
 
   const { getPrefixCls, direction } = React.useContext(ConfigContext);


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [x] Other (usage)

### 🔗 Related issue link

- ref https://github.com/ant-design/ant-design/issues/48695

### 💡 Background and solution

当`type=number`与`changeOnWheel`同时使用时，changeOnWheel 会失效无法受控。
多人遇到此问题 故添加使用提示

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   An exception message appears when `type=number` and `changeOnWheel` are used at the same time    |
| 🇨🇳 Chinese |  当`type=number`与`changeOnWheel`同时使用时给出异常提示      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
