### PR TITLE
fix: Typography ellipsis not working when parent has `nowrap` style

### DIFF
--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -115,7 +115,7 @@ export interface EllipsisProps {
    * We need get to know the parent container style of `white-space`.
    * To make sure whether we need to force wrap the text.
    */
-  parentRef: React.RefObject<HTMLDivElement>;
+  parentRef: React.RefObject<HTMLElement>;
 }
 
 // Measure for the `text` is exceed the `rows` or not

--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -111,6 +111,11 @@ export interface EllipsisProps {
    * e.g. tooltip content update.
    */
   miscDeps: any[];
+  /**
+   * We need get to know the parent container style of `white-space`.
+   * To make sure whether we need to force wrap the text.
+   */
+  parentRef: React.RefObject<HTMLDivElement>;
 }
 
 // Measure for the `text` is exceed the `rows` or not
@@ -126,7 +131,8 @@ const lineClipStyle: React.CSSProperties = {
 };
 
 export default function EllipsisMeasure(props: EllipsisProps) {
-  const { enableMeasure, width, text, children, rows, expanded, miscDeps, onEllipsis } = props;
+  const { enableMeasure, width, text, children, rows, expanded, miscDeps, onEllipsis, parentRef } =
+    props;
 
   const nodeList = React.useMemo(() => toArray(text), [text]);
   const nodeLen = React.useMemo(() => getNodesLen(nodeList), [text]);
@@ -149,11 +155,18 @@ export default function EllipsisMeasure(props: EllipsisProps) {
   const [canEllipsis, setCanEllipsis] = React.useState(false);
   const [needEllipsis, setNeedEllipsis] = React.useState(STATUS_MEASURE_NONE);
   const [ellipsisHeight, setEllipsisHeight] = React.useState(0);
+  const [parentWhiteSpace, setParentWhiteSpace] = React.useState<
+    React.CSSProperties['whiteSpace'] | null
+  >(null);
 
   // Trigger start measure
   useLayoutEffect(() => {
     if (enableMeasure && width && nodeLen) {
       setNeedEllipsis(STATUS_MEASURE_START);
+
+      // Parent ref `white-space`
+      const nextWhiteSpace = parentRef.current && getComputedStyle(parentRef.current).whiteSpace;
+      setParentWhiteSpace(nextWhiteSpace);
     } else {
       setNeedEllipsis(STATUS_MEASURE_NONE);
     }
@@ -248,6 +261,10 @@ export default function EllipsisMeasure(props: EllipsisProps) {
     margin: 0,
     padding: 0,
   };
+
+  if (parentWhiteSpace === 'nowrap') {
+    measureStyle.whiteSpace = 'normal';
+  }
 
   return (
     <>

--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -260,11 +260,8 @@ export default function EllipsisMeasure(props: EllipsisProps) {
     width,
     margin: 0,
     padding: 0,
+    whiteSpace: parentWhiteSpace === 'nowrap' ? 'normal' : 'inherit',
   };
-
-  if (parentWhiteSpace === 'nowrap') {
-    measureStyle.whiteSpace = 'normal';
-  }
 
   return (
     <>

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -498,7 +498,6 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               onEllipsis={onJsEllipsis}
               expanded={expanded}
               miscDeps={[copied, expanded, copyLoading, enableEdit, enableCopy]}
-              parentRef={typographyRef}
             >
               {(node, canEllipsis) =>
                 wrapperDecorations(

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -498,6 +498,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               onEllipsis={onJsEllipsis}
               expanded={expanded}
               miscDeps={[copied, expanded, copyLoading, enableEdit, enableCopy]}
+              parentRef={typographyRef}
             >
               {(node, canEllipsis) =>
                 wrapperDecorations(

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2132,6 +2132,60 @@ Array [
   and that
     </div>
   </pre>,
+  <br />,
+  <span
+    aria-label="In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development."
+    class="ant-typography ant-typography-ellipsis"
+    style="width: 100px; white-space: nowrap;"
+  >
+    In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development.
+    <div
+      aria-label="Copy"
+      class="ant-typography-copy"
+      role="button"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      tabindex="0"
+    >
+      <span
+        aria-label="copy"
+        class="anticon anticon-copy"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="copy"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-tooltip-arrow"
+        style="position: absolute; bottom: 0px; left: 0px;"
+      />
+      <div
+        class="ant-tooltip-content"
+      >
+        <div
+          class="ant-tooltip-inner"
+          role="tooltip"
+        >
+          Copy
+        </div>
+      </div>
+    </div>
+  </span>,
 ]
 `;
 

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1571,6 +1571,40 @@ Array [
   and that
     </div>
   </pre>,
+  <br />,
+  <span
+    class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line"
+    style="width:100px;white-space:nowrap"
+  >
+    In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development.
+    <div
+      aria-label="Copy"
+      class="ant-typography-copy"
+      role="button"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      tabindex="0"
+    >
+      <span
+        aria-label="copy"
+        class="anticon anticon-copy"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="copy"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+          />
+        </svg>
+      </span>
+    </div>
+  </span>,
 ]
 `;
 

--- a/components/typography/demo/ellipsis-debug.tsx
+++ b/components/typography/demo/ellipsis-debug.tsx
@@ -102,6 +102,12 @@ const App: React.FC = () => {
       <pre>
         <Typography.Paragraph ellipsis={{ rows: 2, expandable: true }}>{text}</Typography.Paragraph>
       </pre>
+
+      <br />
+
+      <Text style={{ width: 100, whiteSpace: 'nowrap' }} ellipsis copyable>
+        {templateStr}
+      </Text>
     </>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #49649

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Typography `ellipsis` not working when parent has `nowrap` style.      |
| 🇨🇳 Chinese |     修复 Typography 在父元素存在 `nowrap` 样式时，`ellipsis` 不生效的问题。    |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
