### PR TITLE
fix: Input variant filled activeBorderColor token invalid

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -261,7 +261,7 @@ export const genFilledStyle = (token: InputToken, extraStyles?: CSSObject): CSSO
     ...genBaseFilledStyle(token, {
       bg: token.colorFillTertiary,
       hoverBg: token.colorFillSecondary,
-      activeBorderColor: token.colorPrimary,
+      activeBorderColor: token.activeBorderColor,
     }),
 
     [`&${token.componentCls}-disabled, &[disabled]`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/49689

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Input variant filled activeBorderColor token invalid      |
| 🇨🇳 Chinese |     修复 Input 组件`filled `变体下`activeBorderColor `不生效问题      |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
