### PR TITLE
fix(theme): use pre-compiled color presets to improve runtime performance

### DIFF
--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -56,6 +56,7 @@ describe('Theme', () => {
         theme={{
           token: {
             colorPrimary: '#ff0000',
+            orange: '#ff8800',
           },
         }}
       >
@@ -67,6 +68,8 @@ describe('Theme', () => {
       expect.objectContaining({
         colorPrimary: '#ff0000',
         colorPrimaryHover: '#ff3029', // It's safe to modify if theme logic changed
+        orange6: '#ff8800',
+        orange9: '#8c3d00', // It's safe to modify if theme logic changed
       }),
     );
   });

--- a/components/theme/themes/default/index.ts
+++ b/components/theme/themes/default/index.ts
@@ -1,4 +1,4 @@
-import { generate } from '@ant-design/colors';
+import { generate, presetPalettes, presetPrimaryColors } from '@ant-design/colors';
 
 import type { MapToken, PresetColorType, SeedToken } from '../../interface';
 import { defaultPresetColors } from '../seed';
@@ -10,9 +10,15 @@ import genSizeMapToken from '../shared/genSizeMapToken';
 import { generateColorPalettes, generateNeutralColorPalettes } from './colors';
 
 export default function derivative(token: SeedToken): MapToken {
+  // pink is deprecated name of magenta, keep this for backwards compatibility
+  presetPrimaryColors.pink = presetPrimaryColors.magenta;
+  presetPalettes.pink = presetPalettes.magenta;
   const colorPalettes = Object.keys(defaultPresetColors)
     .map((colorKey) => {
-      const colors = generate(token[colorKey as keyof PresetColorType]);
+      const colors =
+        token[colorKey as keyof PresetColorType] === presetPrimaryColors[colorKey]
+          ? presetPalettes[colorKey]
+          : generate(token[colorKey as keyof PresetColorType]);
       return new Array(10).fill(1).reduce((prev, _, i) => {
         prev[`${colorKey}-${i + 1}`] = colors[i];
         prev[`${colorKey}${i + 1}`] = colors[i];

--- a/components/theme/themes/seed.ts
+++ b/components/theme/themes/seed.ts
@@ -1,12 +1,15 @@
 import type { PresetColorType, SeedToken } from '../internal';
 
 export const defaultPresetColors: PresetColorType = {
-  blue: '#1677ff',
+  blue: '#1677FF',
   purple: '#722ED1',
   cyan: '#13C2C2',
   green: '#52C41A',
   magenta: '#EB2F96',
-  pink: '#eb2f96',
+  /**
+   * @deprecated Use magenta instead
+   */
+  pink: '#EB2F96',
   red: '#F5222D',
   orange: '#FA8C16',
   yellow: '#FADB14',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

之前发现 Ant Design 的初始化过程 JS 耗时非常高，其中有一部分原因是频繁调用 generate 函数来计算颜色表。在  https://github.com/ant-design/ant-design-colors/pull/91 中我们已经将颜色表预编译出来。此 PR 用预编译的颜色来替代动态计算。考虑到绝大多数项目并不会自己定义 magenta，geekblue 之类的颜色，这能大幅提升运行时性能。包体积会略微增加，但是我个人认为，在低端设备上，JS 执行耗时的影响会更大一些。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(theme): use pre-compiled color presets to improve runtime performance |
| 🇨🇳 Chinese | fix(theme): 使用预编译颜色预设来提升运行时性能 |
