### PR TITLE
chore: warning instead of block

### DIFF
--- a/components/_util/__tests__/useZIndex.test.tsx
+++ b/components/_util/__tests__/useZIndex.test.tsx
@@ -394,4 +394,20 @@ describe('Test useZIndex hooks', () => {
 
     jest.useRealTimers();
   });
+
+  it('warning for too large zIndex auto offset', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Drawer open zIndex={999999999}>
+        <Tooltip open title="test">
+          <div>test</div>
+        </Tooltip>
+      </Drawer>,
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Tooltip] `zIndex` is over design token `zIndexPopupBase` too much. It may cause unexpected override.',
+    );
+  });
 });

--- a/components/_util/hooks/useZIndex.ts
+++ b/components/_util/hooks/useZIndex.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import useToken from '../../theme/useToken';
+import { devUseWarning } from '../warning';
 import zIndexContext from '../zindexContext';
 
 export type ZIndexContainer = 'Modal' | 'Drawer' | 'Popover' | 'Popconfirm' | 'Tooltip' | 'Tour';
@@ -37,30 +38,47 @@ function isContainerType(type: ZIndexContainer | ZIndexConsumer): type is ZIndex
   return type in containerBaseZIndexOffset;
 }
 
+type ReturnResult = [zIndex: number | undefined, contextZIndex: number];
+
 export function useZIndex(
   componentType: ZIndexContainer | ZIndexConsumer,
   customZIndex?: number,
-): [zIndex: number | undefined, contextZIndex: number] {
+): ReturnResult {
   const [, token] = useToken();
   const parentZIndex = React.useContext(zIndexContext);
   const isContainer = isContainerType(componentType);
 
+  let result: ReturnResult;
+
   if (customZIndex !== undefined) {
-    return [customZIndex, customZIndex];
-  }
-
-  let zIndex = parentZIndex ?? 0;
-
-  if (isContainer) {
-    zIndex +=
-      // Use preset token zIndex by default but not stack when has parent container
-      (parentZIndex ? 0 : token.zIndexPopupBase) +
-      // Container offset
-      containerBaseZIndexOffset[componentType];
-
-    zIndex = Math.min(zIndex, token.zIndexPopupBase + CONTAINER_MAX_OFFSET);
+    result = [customZIndex, customZIndex];
   } else {
-    zIndex += consumerBaseZIndexOffset[componentType];
+    let zIndex = parentZIndex ?? 0;
+
+    if (isContainer) {
+      zIndex +=
+        // Use preset token zIndex by default but not stack when has parent container
+        (parentZIndex ? 0 : token.zIndexPopupBase) +
+        // Container offset
+        containerBaseZIndexOffset[componentType];
+    } else {
+      zIndex += consumerBaseZIndexOffset[componentType];
+    }
+    result = [parentZIndex === undefined ? customZIndex : zIndex, zIndex];
   }
-  return [parentZIndex === undefined ? customZIndex : zIndex, zIndex];
+
+  if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning(componentType);
+
+    const maxZIndex = token.zIndexPopupBase + CONTAINER_MAX_OFFSET;
+    const currentZIndex = result[0] || 0;
+
+    warning(
+      customZIndex !== undefined || currentZIndex <= maxZIndex,
+      'usage',
+      '`zIndex` is over design token `zIndexPopupBase` too much. It may cause unexpected override.',
+    );
+  }
+
+  return result;
 }

--- a/components/drawer/demo/basic-right.tsx
+++ b/components/drawer/demo/basic-right.tsx
@@ -1,28 +1,39 @@
 import React, { useState } from 'react';
-import { Button, Drawer } from 'antd';
+import { ConfigProvider, Drawer, Popover } from 'antd';
 
 const App: React.FC = () => {
-  const [open, setOpen] = useState(false);
-
-  const showDrawer = () => {
-    setOpen(true);
-  };
-
+  const [open, setOpen] = useState(true);
   const onClose = () => {
     setOpen(false);
   };
-
   return (
-    <>
-      <Button type="primary" onClick={showDrawer}>
-        Open
-      </Button>
-      <Drawer title="Basic Drawer" onClose={onClose} open={open}>
-        <p>Some contents...</p>
-        <p>Some contents...</p>
-        <p>Some contents...</p>
-      </Drawer>
-    </>
+    <div>
+      <ConfigProvider
+        theme={{
+          components: {
+            Select: {
+              zIndexPopup: 2147483698,
+            },
+            Popover: {
+              zIndexPopup: 2147483698,
+            },
+          },
+        }}
+      >
+        <Drawer
+          mask={false}
+          onClose={onClose}
+          open={open}
+          zIndex={2147483647}
+          width={428}
+          push={false}
+        >
+          <Popover title="Popover内容" open>
+            Popover内容
+          </Popover>
+        </Drawer>
+      </ConfigProvider>
+    </div>
   );
 };
 

--- a/components/drawer/demo/basic-right.tsx
+++ b/components/drawer/demo/basic-right.tsx
@@ -1,39 +1,28 @@
 import React, { useState } from 'react';
-import { ConfigProvider, Drawer, Popover } from 'antd';
+import { Button, Drawer } from 'antd';
 
 const App: React.FC = () => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
+
+  const showDrawer = () => {
+    setOpen(true);
+  };
+
   const onClose = () => {
     setOpen(false);
   };
+
   return (
-    <div>
-      <ConfigProvider
-        theme={{
-          components: {
-            Select: {
-              zIndexPopup: 2147483698,
-            },
-            Popover: {
-              zIndexPopup: 2147483698,
-            },
-          },
-        }}
-      >
-        <Drawer
-          mask={false}
-          onClose={onClose}
-          open={open}
-          zIndex={2147483647}
-          width={428}
-          push={false}
-        >
-          <Popover title="Popover内容" open>
-            Popover内容
-          </Popover>
-        </Drawer>
-      </ConfigProvider>
-    </div>
+    <>
+      <Button type="primary" onClick={showDrawer}>
+        Open
+      </Button>
+      <Drawer title="Basic Drawer" onClose={onClose} open={open}>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+      </Drawer>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Global: No more limit max auto `zIndex` increase but use warning instead.       |
| 🇨🇳 Chinese |     Global: 对于弹层类自动增长 `zIndex` 不再限制最大值，而是改成控制台警告。    |
