### PR TITLE
fix: table expandable descriptions auto style

### DIFF
--- a/components/table/style/expand.ts
+++ b/components/table/style/expand.ts
@@ -131,8 +131,8 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           display: 'flex',
 
           table: {
-            flex: '100%',
-            width: 'auto',
+            flex: 'auto',
+            width: '100%',
           },
         },
       },

--- a/components/table/style/expand.ts
+++ b/components/table/style/expand.ts
@@ -131,7 +131,7 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           display: 'flex',
 
           table: {
-            flex: 'auto',
+            flex: '100%',
             width: 'auto',
           },
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
Table expandedRowRender 状态下多行 Descriptions.Item 会出现样式问题
reproduce：
https://stackblitz.com/edit/react-9my4bb?file=demo.tsx


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed expandedRowRender multiple Descriptions.Item style exception      |
| 🇨🇳 Chinese |     修复了expandedRowRender多Descriptions.Item样式异常      |
