### PR TITLE
style: dot-progress repeated

### DIFF
--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -188,11 +188,6 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
 
       // holder
       // ------------------------------
-      [`${componentCls}-dot-progress`]: {
-        position: 'absolute',
-        top: 0,
-        insetInlineStart: 0,
-      },
       [`${componentCls}-dot-holder`]: {
         width: '1em',
         height: '1em',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在阅读源码的时候, 发现 spin 中的 progress 样式重复定义
这样会导致在后期维护/调整的过程出现漏改, 或者莫名覆盖的情况

![fb7eb785508001c45e92db4f43fbbe2](https://github.com/ant-design/ant-design/assets/60692794/fc041c02-d0a0-48eb-84a5-12c54652cb2e)

解决方案为, 只保留 `//progress` 注释下的样式

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- 请用面向开发者的角度和叙述方式撰写 changelog
- 描述用户第一现场的问题，对开发者有哪些影响，而非你的解决方式
- 参考：ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fix the issue of duplicate definition of the class name `dot-progress` in the `Spin` component.     |
| 🇨🇳 中文 |    修复 `Spin` 组件 `dot-progress` 类名重复定义问题   |