### PR TITLE
fix: spin lg progress center

### DIFF
--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -188,11 +188,6 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
 
       // holder
       // ------------------------------
-      [`${componentCls}-dot-progress`]: {
-        position: 'absolute',
-        top: 0,
-        insetInlineStart: 0,
-      },
       [`${componentCls}-dot-holder`]: {
         width: '1em',
         height: '1em',

--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -208,7 +208,8 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
       // ------------------------------
       [`${componentCls}-dot-progress`]: {
         position: 'absolute',
-        top: 0,
+        top: '50%',
+        transform: 'translateY(-50%)',
         insetInlineStart: 0,
       },
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

需求背景:
阅读 antd 文档的时候发现其中一个 `Spin` 组件 `percent` 属性的 `size="large"` 模式的展示效果没有居中.

![image](https://github.com/ant-design/ant-design/assets/60692794/6adc793d-f408-47bd-a832-cf6a38740bb7)

问题定位:
经过代码定位, 发现在 `lg` 的样式下, 会给 `-dot-holder` 下的 `-spin` 添加 `32px` 的字体大小, 导致将整个盒子撑高. 又因为在展示 `-dot-progress` 时, `-dot-holder` 的隐藏实现方式为透明度为 `0`, 而 `-dot-progress` 样式固定为 `top-0`. 最终导致在 `lg` 样式下, `-dot-progress` 显示靠上.

解决方案:
将 `top: 0` 调整为 top 50% 以及 translateY(-50%), 从而实现保持 32px 高度不变情况下, 将 `-dot-progress` 居中显示.

![image](https://github.com/ant-design/ant-design/assets/60692794/568050a3-3fc0-4c03-8d7e-25083fad2cb5)

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- 请用面向开发者的角度和叙述方式撰写 changelog
- 描述用户第一现场的问题，对开发者有哪些影响，而非你的解决方式
- 参考：ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fix the issue where the loading animation of the `Spin` component is not centered when used with `percent` and `large`     |
| 🇨🇳 中文 |    修复 `Spin` 组件 `percent` 与 `large` 搭配使用时, `process` 加载动画没有居中显示   |