### PR TITLE
fix: Tree filter node style lost

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -187,7 +187,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         },
 
         [`&:not(${treeNodeCls}-disabled).filter-node ${treeCls}-title`]: {
-          color: 'inherit',
+          color: token.colorPrimary,
           fontWeight: 500,
         },
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- fix https://github.com/ant-design/ant-design/issues/49767

### 💡 Background and solution

tree 组件 filter-node 缺少高亮

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Tree filter node style lost      |
| 🇨🇳 Chinese |      修复 tree 组件 filter-node 节点高亮样式丢失     |
