### PR TITLE
fix: `title` overflow issue of `popconfirm`

### DIFF
--- a/components/popconfirm/style/index.ts
+++ b/components/popconfirm/style/index.ts
@@ -51,6 +51,8 @@ const genBaseStyle: GenerateStyle<PopconfirmToken> = (token) => {
         [`${componentCls}-title`]: {
           fontWeight: fontWeightStrong,
           color: colorTextHeading,
+          wordBreak: 'break-word',
+          whiteSpace: 'pre-line',
 
           '&:only-child': {
             fontWeight: 'normal',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
当`popconfirm`的`title`是不间断的长段字符时，其`title`会溢出到屏幕外

通过添加`wordBreak`和`whiteSpace`进行限制

In the event that the `title` of `popconfirm` is a lengthy string of characters, the `title` will overflow the screen.

In order to impose a limit, it is necessary to add the parameters `wordBreak` and `whiteSpace`.

after:
![af](https://github.com/ant-design/ant-design/assets/36145660/8161ce68-3700-49e2-800e-2073739a0205)
before:
![bf](https://github.com/ant-design/ant-design/assets/36145660/600406c6-527e-411e-9ebf-accc881700fe)
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |fix `title` overflow issue of `popconfirm`|
| 🇨🇳 Chinese |修复`popconfirm`的`title`溢出问题|
