### PR TITLE
when columns changed,the defaultFilteredValue and defaultSortOrder sh…

### DIFF
--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -247,7 +247,7 @@ function useFilter<RecordType>({
   );
 
   const mergedFilterStates = React.useMemo(() => {
-    const collectedStates = collectFilterStates(mergedColumns, false);
+    const collectedStates = collectFilterStates(mergedColumns, true);
     if (collectedStates.length === 0) {
       return collectedStates;
     }

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -396,7 +396,7 @@ export default function useFilterSorter<RecordType>({
 
   const mergedSorterStates = React.useMemo<SortState<RecordType>[]>(() => {
     let validate = true;
-    const collectedStates = collectSortStates(mergedColumns, false);
+    const collectedStates = collectSortStates(mergedColumns, true);
 
     // Return if not controlled
     if (!collectedStates.length) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

[ 描述相关需求的来源，如相关的 issue 讨论链接](https://github.com/ant-design/ant-design/issues/49800)。



### 💡 需求背景和解决方案


- 当columns从空数组变成有内容的数组的时候，defaultFilteredValue 和defaultSortOrder不生效。


### 📝 更新日志


- 有时候会对table做一些封装，对于columns来讲可能会有二次封装，这样的话会导致column上面的defaulValue不生效.





| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Whenever columns change, re-obtain the defaultFilteredValu and defaultSortOrder of the column|
| 🇨🇳 中文 |  每当columns变化的时候，重新获取column的 defaultFilteredValu和 defaultSortOrder|