### PR TITLE
type: fix Tree icon and switcherIcon type

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -16,6 +16,7 @@ import SwitcherIconCom from './utils/iconUtil';
 
 export type SwitcherIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
 export type TreeLeafIcon = React.ReactNode | ((props: AntTreeNodeProps) => React.ReactNode);
+type TreeIcon = React.ReactNode | ((props: AntdTreeNodeAttribute) => React.ReactNode);
 
 export interface AntdTreeNodeAttribute {
   eventKey: string;
@@ -42,16 +43,16 @@ export interface AntTreeNodeProps {
   checkable?: boolean;
   disabled?: boolean;
   disableCheckbox?: boolean;
-  title?: string | React.ReactNode;
+  title?: React.ReactNode | ((data: DataNode) => React.ReactNode);
   key?: Key;
-  eventKey?: string;
+  eventKey?: Key;
   isLeaf?: boolean;
   checked?: boolean;
   expanded?: boolean;
   loading?: boolean;
   selected?: boolean;
   selectable?: boolean;
-  icon?: ((treeNode: AntdTreeNodeAttribute) => React.ReactNode) | React.ReactNode;
+  icon?: TreeIcon;
   children?: React.ReactNode;
   [customProp: string]: any;
 }
@@ -148,11 +149,8 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
   draggable?: DraggableFn | boolean | DraggableConfig;
   style?: React.CSSProperties;
   showIcon?: boolean;
-  icon?:
-    | ((nodeProps: AntdTreeNodeAttribute) => React.ReactNode)
-    | React.ReactNode
-    | RcTreeProps<T>['icon'];
-  switcherIcon?: SwitcherIcon | RcTreeProps<T>['switcherIcon'];
+  icon?: TreeIcon;
+  switcherIcon?: SwitcherIcon;
   prefixCls?: string;
   children?: React.ReactNode;
   blockNode?: boolean;
@@ -227,7 +225,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
   const renderSwitcherIcon: React.FC<AntTreeNodeProps> = (nodeProps) => (
     <SwitcherIconCom
       prefixCls={prefixCls}
-      switcherIcon={switcherIcon as SwitcherIcon}
+      switcherIcon={switcherIcon}
       treeNodeProps={nodeProps}
       showLine={showLine}
     />
@@ -258,7 +256,7 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}
       selectable={selectable}
-      switcherIcon={renderSwitcherIcon as RcTreeProps['switcherIcon']}
+      switcherIcon={renderSwitcherIcon}
       draggable={draggableConfig}
     >
       {children}

--- a/components/tree/__tests__/type.test.tsx
+++ b/components/tree/__tests__/type.test.tsx
@@ -77,7 +77,7 @@ describe('Tree.TypeScript', () => {
     expect(container).toBeTruthy();
   });
 
-  it('draggable params type', () => {
+  it('draggable/icon/switcherIcon params type', () => {
     const { container } = render(
       <Tree
         treeData={[
@@ -93,6 +93,8 @@ describe('Tree.TypeScript', () => {
           },
         ]}
         draggable={(node: DataNode) => node.title === 'Little'}
+        icon={(props) => (props.isLeaf ? 1 : 0)}
+        switcherIcon={(props) => (props.isLeaf ? 1 : 0)}
       />,
     );
     expect(container).toBeTruthy();


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close https://github.com/ant-design/ant-design/issues/49813

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tree icon and switcherIcon parameter types not being correctly inferred.          |
| 🇨🇳 Chinese | 修复 Tree `icon` 和 `switcherIcon` 参数类型未能正确推导的问题。           |
