### PR TITLE
fix: fix list.item actions empty

### DIFF
--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -107,7 +107,7 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   };
 
   const prefixCls = getPrefixCls('list', customizePrefixCls);
-  const actionsContent = (actions?.length && actions?.length > 0) && (
+  const actionsContent = actions?.length > 0 && (
     <ul
       className={classNames(`${prefixCls}-item-action`, moduleClass('actions'))}
       key="actions"

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -107,7 +107,7 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   };
 
   const prefixCls = getPrefixCls('list', customizePrefixCls);
-  const actionsContent = actions?.length > 0 && (
+  const actionsContent = (actions && actions.length > 0) && (
     <ul
       className={classNames(`${prefixCls}-item-action`, moduleClass('actions'))}
       key="actions"

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -107,7 +107,7 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   };
 
   const prefixCls = getPrefixCls('list', customizePrefixCls);
-  const actionsContent = actions?.length && (
+  const actionsContent = (actions?.length && actions?.length > 0) && (
     <ul
       className={classNames(`${prefixCls}-item-action`, moduleClass('actions'))}
       key="actions"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

it shows `0` when `actions` is `[]`.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix List render `0` when `actions={[]}`.          |
| 🇨🇳 Chinese | 修复 List `actions` 为空数组时会渲染 `0` 的问题。           |
