### PR TITLE
fix: Spin ptg style

### DIFF
--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -286,7 +286,9 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
       },
       // small
       [`&-sm ${componentCls}-dot`]: {
-        fontSize: token.dotSizeSM,
+        '&, &-holder': {
+          fontSize: token.dotSizeSM,
+        },
       },
       [`&-sm ${componentCls}-dot-holder`]: {
         i: {
@@ -300,7 +302,9 @@ const genSpinStyle: GenerateStyle<SpinToken> = (token: SpinToken): CSSObject => 
       },
       // large
       [`&-lg ${componentCls}-dot`]: {
-        fontSize: token.dotSizeLG,
+        '&, &-holder': {
+          fontSize: token.dotSizeLG,
+        },
       },
       [`&-lg ${componentCls}-dot-holder`]: {
         i: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

ref #49211

### 💡 Background and solution

发现原来的样式丢了，它其实不是丢失居中，而是应该是大一圈

<img width="182" alt="截屏2024-07-15 14 23 23" src="https://github.com/user-attachments/assets/7b8e2613-c459-42fc-bea0-a40d1a6be35d">


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Spin `percent` with `size` style issue.     |
| 🇨🇳 Chinese |     修复 Spin `percent` 和 `size` 一同使用时，样式不正确的问题。      |
