### PR TITLE
Revert "fix: Form.Item input-content no horizontal alignment (#49635)"

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -314,7 +314,6 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
           '&-content': {
             flex: 'auto',
             maxWidth: '100%',
-            lineHeight: '100%',
           },
         },
       },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- https://github.com/ant-design/ant-design/issues/50007

### 💡 Background and solution


### 📝 Changelog

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the issue that the internal elements of `Form.Item` did not inherit the line height   |
| 🇨🇳 Chinese |     修复 `Form.Item`内部元素没有继承行高问题    |
