### PR TITLE
style: antd-picker-content set direction ltr

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -341,6 +341,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         width: '100%',
         tableLayout: 'fixed',
         borderCollapse: 'collapse',
+        direction: 'ltr',
 
         'th, td': {
           position: 'relative',

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -214,6 +214,15 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
               ${componentCls}-super-next-icon`]: {
             transform: 'rotate(-135deg)',
           },
+
+          [`${componentCls}-time-panel`]: {
+            [`${componentCls}-content`]: {
+              direction: 'ltr',
+              '> *': {
+                direction: 'rtl',
+              },
+            },
+          },
         },
       },
 
@@ -341,7 +350,6 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
         width: '100%',
         tableLayout: 'fixed',
         borderCollapse: 'collapse',
-        direction: 'ltr',
 
         'th, td': {
           position: 'relative',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #50024 

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

In RTL, the datetime selection is not intuitive.

By adding direction: 'ltr' to solve

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Repair datetime selection under RTL is not intuitive     |
| 🇨🇳 Chinese |    修复 rtl 下 datetime 选择不符合直觉       |
