### PR TITLE
fix: the tour component had no translations in the Belgian locales

### DIFF
--- a/components/locale/fr_BE.ts
+++ b/components/locale/fr_BE.ts
@@ -33,6 +33,11 @@ const localeValues: Locale = {
     triggerAsc: 'Trier par ordre croissant',
     cancelSort: 'Annuler le tri',
   },
+  Tour: {
+    Next: 'Étape suivante',
+    Previous: 'Étape précédente',
+    Finish: 'Fin de la visite guidée',
+  },
   Modal: {
     okText: 'OK',
     cancelText: 'Annuler',

--- a/components/locale/fr_FR.ts
+++ b/components/locale/fr_FR.ts
@@ -33,15 +33,15 @@ const localeValues: Locale = {
     triggerAsc: 'Trier par ordre croissant',
     cancelSort: 'Annuler le tri',
   },
-  Modal: {
-    okText: 'OK',
-    cancelText: 'Annuler',
-    justOkText: 'OK',
-  },
   Tour: {
     Next: 'Étape suivante',
     Previous: 'Étape précédente',
     Finish: 'Fin de la visite guidée',
+  },
+  Modal: {
+    okText: 'OK',
+    cancelText: 'Annuler',
+    justOkText: 'OK',
   },
   Popconfirm: {
     okText: 'OK',

--- a/components/locale/nl_BE.ts
+++ b/components/locale/nl_BE.ts
@@ -34,6 +34,11 @@ const localeValues: Locale = {
     triggerAsc: 'Klik om oplopend te sorteren',
     triggerDesc: 'Klik om aflopend te sorteren',
   },
+  Tour: {
+    Next: 'Volgende',
+    Previous: 'Vorige',
+    Finish: 'Voltooien',
+  },
   Modal: {
     okText: 'OK',
     cancelText: 'Annuleer',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
I didn't make an issue for this as I could just make a PR

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
When using fr_BE or nl_BE, the tour component showed English buttons because the localizations were unavailable

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🌐 Locales: Add nl_BE and nl_FR translation for the tour component |
| 🇨🇳 Chinese | 🌐 区域设置：为旅游组件添加 nl_BE 和 nl_FR 翻译 |
