### PR TITLE
fix: when both title and content are false, do not display overlay

### DIFF
--- a/components/_util/getRenderPropValue.ts
+++ b/components/_util/getRenderPropValue.ts
@@ -9,5 +9,10 @@ export const getRenderPropValue = (
     return null;
   }
 
-  return typeof propValue === 'function' ? propValue() : propValue;
+  if (typeof propValue === 'function') {
+    const result = propValue();
+    return result === null ? null : result;
+  }
+
+  return propValue;
 };

--- a/components/_util/getRenderPropValue.ts
+++ b/components/_util/getRenderPropValue.ts
@@ -11,7 +11,7 @@ export const getRenderPropValue = (
 
   if (typeof propValue === 'function') {
     const result = propValue();
-    return result === null ? null : result;
+    return result || null;
   }
 
   return propValue;

--- a/components/_util/getRenderPropValue.ts
+++ b/components/_util/getRenderPropValue.ts
@@ -9,10 +9,5 @@ export const getRenderPropValue = (
     return null;
   }
 
-  if (typeof propValue === 'function') {
-    const result = propValue();
-    return result || null;
-  }
-
-  return propValue;
+  return typeof propValue === 'function' ? propValue() : propValue;
 };

--- a/components/popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,9 +27,6 @@ Array [
         >
           RTL
         </div>
-        <div
-          class="ant-popover-inner-content"
-        />
       </div>
     </div>
   </div>,

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -124,4 +124,17 @@ describe('Popover', () => {
     fireEvent.keyDown(triggerNode, { key: 'Escape', keyCode: 27 });
     expect(onOpenChange).toHaveBeenLastCalledWith(false, eventObject);
   });
+
+  it('should not display overlay when the content is null/undefined', () => {
+    [null, undefined].forEach((item) => {
+      const { container } = render(
+        <Popover title={() => item} content={() => item} trigger="click">
+          <span>show me your code</span>
+        </Popover>,
+      );
+      fireEvent.click(container.querySelector<HTMLSpanElement>('span')!);
+      const popup = document.querySelector('.ant-popover');
+      expect(popup).toBe(null);
+    });
+  });
 });

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -25,14 +25,14 @@ export interface PopoverProps extends AbstractTooltipProps {
 
 interface OverlayProps {
   prefixCls?: string;
-  title?: PopoverProps['title'];
-  content?: PopoverProps['content'];
+  title?: React.ReactNode;
+  content?: React.ReactNode;
 }
 
 const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => (
   <>
-    {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
-    <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
+    {title && <div className={`${prefixCls}-title`}>{title}</div>}
+    {content && <div className={`${prefixCls}-inner-content`}>{content}</div>}
   </>
 );
 
@@ -81,6 +81,9 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
     settingOpen(value);
   };
 
+  const titleNode = getRenderPropValue(title);
+  const contentNode = getRenderPropValue(content);
+
   return wrapCSSVar(
     <Tooltip
       placement={placement}
@@ -95,8 +98,8 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
       open={open}
       onOpenChange={onInternalOpenChange}
       overlay={
-        getRenderPropValue(title) || getRenderPropValue(content) ? (
-          <Overlay prefixCls={prefixCls} title={title} content={content} />
+        titleNode || contentNode ? (
+          <Overlay prefixCls={prefixCls} title={titleNode} content={contentNode} />
         ) : null
       }
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -95,7 +95,9 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
       open={open}
       onOpenChange={onInternalOpenChange}
       overlay={
-        title || content ? <Overlay prefixCls={prefixCls} title={title} content={content} /> : null
+        getRenderPropValue(title) || getRenderPropValue(content) ? (
+          <Overlay prefixCls={prefixCls} title={title} content={content} />
+        ) : null
       }
       transitionName={getTransitionName(rootPrefixCls, 'zoom-big', otherProps.transitionName)}
       data-popover-inject


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
fix https://github.com/ant-design/ant-design/issues/50055
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Popper component when both title and content are false, do not display overlay   |
| 🇨🇳 Chinese | Popver组件传入title与content都不存在的时候不显示overlay   |
