### PR TITLE
type(theme): improve color type

### DIFF
--- a/.dumi/pages/index/components/Theme/ColorPicker.tsx
+++ b/.dumi/pages/index/components/Theme/ColorPicker.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { ColorPicker, Flex, Input } from 'antd';
 import { createStyles } from 'antd-style';
-import type { Color } from 'antd/es/color-picker';
+import type { ColorPickerProps, GetProp } from 'antd';
 import { generateColor } from 'antd/es/color-picker/util';
 import classNames from 'classnames';
 
 import { PRESET_COLORS } from './colorUtil';
+
+type Color = GetProp<ColorPickerProps, 'value'>;
 
 const useStyle = createStyles(({ token, css }) => ({
   color: css`
@@ -34,13 +36,15 @@ const useStyle = createStyles(({ token, css }) => ({
   `,
 }));
 
-export interface ColorPickerProps {
+export interface DebouncedColorPickerProps {
   id?: string;
   value?: string | Color;
   onChange?: (value?: Color | string) => void;
 }
 
-const DebouncedColorPicker: React.FC<React.PropsWithChildren<ColorPickerProps>> = (props) => {
+const DebouncedColorPicker: React.FC<React.PropsWithChildren<DebouncedColorPickerProps>> = (
+  props,
+) => {
   const { value: color, children, onChange } = props;
   const [value, setValue] = useState(color);
 
@@ -66,7 +70,7 @@ const DebouncedColorPicker: React.FC<React.PropsWithChildren<ColorPickerProps>> 
   );
 };
 
-const ThemeColorPicker: React.FC<ColorPickerProps> = ({ value, onChange, id }) => {
+const ThemeColorPicker: React.FC<DebouncedColorPickerProps> = ({ value, onChange, id }) => {
   const { styles } = useStyle();
 
   const matchColors = React.useMemo(() => {

--- a/.dumi/pages/index/components/Theme/ColorPicker.tsx
+++ b/.dumi/pages/index/components/Theme/ColorPicker.tsx
@@ -36,15 +36,13 @@ const useStyle = createStyles(({ token, css }) => ({
   `,
 }));
 
-export interface DebouncedColorPickerProps {
+export interface ThemeColorPickerProps {
   id?: string;
   value?: string | Color;
   onChange?: (value?: Color | string) => void;
 }
 
-const DebouncedColorPicker: React.FC<React.PropsWithChildren<DebouncedColorPickerProps>> = (
-  props,
-) => {
+const DebouncedColorPicker: React.FC<React.PropsWithChildren<ThemeColorPickerProps>> = (props) => {
   const { value: color, children, onChange } = props;
   const [value, setValue] = useState(color);
 
@@ -70,7 +68,7 @@ const DebouncedColorPicker: React.FC<React.PropsWithChildren<DebouncedColorPicke
   );
 };
 
-const ThemeColorPicker: React.FC<DebouncedColorPickerProps> = ({ value, onChange, id }) => {
+const ThemeColorPicker: React.FC<ThemeColorPickerProps> = ({ value, onChange, id }) => {
   const { styles } = useStyle();
 
   const matchColors = React.useMemo(() => {

--- a/.dumi/pages/index/components/Theme/colorUtil.ts
+++ b/.dumi/pages/index/components/Theme/colorUtil.ts
@@ -1,5 +1,7 @@
-import type { Color } from 'antd/es/color-picker';
+import type { ColorPickerProps, GetProp } from 'antd';
 import { generateColor } from 'antd/es/color-picker/util';
+
+type Color = GetProp<ColorPickerProps, 'value'>;
 
 export const DEFAULT_COLOR = '#1677FF';
 export const PINK_COLOR = '#ED4192';

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -7,7 +7,7 @@ import {
   QuestionCircleOutlined,
 } from '@ant-design/icons';
 import { TinyColor } from '@ctrl/tinycolor';
-import type { MenuProps, ThemeConfig } from 'antd';
+import type { MenuProps, ThemeConfig, GetProp, ColorPickerProps } from 'antd';
 import {
   Breadcrumb,
   Card,
@@ -21,7 +21,6 @@ import {
   Typography,
 } from 'antd';
 import { createStyles } from 'antd-style';
-import type { ColorPickerProps, GetProp } from 'antd';
 import { generateColor } from 'antd/es/color-picker/util';
 import classNames from 'classnames';
 import { useLocation } from 'dumi';

--- a/.dumi/pages/index/components/Theme/index.tsx
+++ b/.dumi/pages/index/components/Theme/index.tsx
@@ -21,7 +21,7 @@ import {
   Typography,
 } from 'antd';
 import { createStyles } from 'antd-style';
-import type { Color } from 'antd/es/color-picker';
+import type { ColorPickerProps, GetProp } from 'antd';
 import { generateColor } from 'antd/es/color-picker/util';
 import classNames from 'classnames';
 import { useLocation } from 'dumi';
@@ -40,6 +40,8 @@ import MobileCarousel from './MobileCarousel';
 import RadiusPicker from './RadiusPicker';
 import type { THEME } from './ThemePicker';
 import ThemePicker from './ThemePicker';
+
+type Color = GetProp<ColorPickerProps, 'value'>;
 
 const { Header, Content, Sider } = Layout;
 
@@ -264,7 +266,7 @@ const sideMenuItems: MenuProps['items'] = [
 
 // ============================= Theme =============================
 
-function getTitleColor(colorPrimary: string | Color, isLight?: boolean) {
+function getTitleColor(colorPrimary: Color, isLight?: boolean) {
   if (!isLight) {
     return '#FFF';
   }
@@ -289,7 +291,7 @@ function getTitleColor(colorPrimary: string | Color, isLight?: boolean) {
 
 interface ThemeData {
   themeType: THEME;
-  colorPrimary: string | Color;
+  colorPrimary: Color;
   borderRadius: number;
   compact: 'default' | 'compact';
 }

--- a/.dumi/theme/common/Color/ColorPaletteToolDark.tsx
+++ b/.dumi/theme/common/Color/ColorPaletteToolDark.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Col, ColorPicker, Row } from 'antd';
 import { FormattedMessage } from 'dumi';
+import type { Color } from 'antd/es/color-picker';
 
 import useLocale from '../../../hooks/useLocale';
 import ColorPatterns from './ColorPatterns';
@@ -24,7 +25,7 @@ const locales = {
 const ColorPaletteTool: React.FC = () => {
   const [primaryColor, setPrimaryColor] = useState<string>('#1890ff');
   const [backgroundColor, setBackgroundColor] = useState<string>('#141414');
-  const [primaryColorInstance, setPrimaryColorInstance] = useState<Color>(null);
+  const [primaryColorInstance, setPrimaryColorInstance] = useState<Color | null>(null);
 
   const [locale] = useLocale(locales);
 


### PR DESCRIPTION
### 🤔 This is a ...


- [x] TypeScript definition update



### 💡 Background and solution
1. 用GetProp拿到Color 可以简写string | Color，并且也是和demo新推荐的风格保持一致。
2. 修改了ThemeColorPickerProps，ThemeColorPicker内部的props和ColorPickerProps是不同的，用ColorPickerProps 命名和color-picker 组件重复了，可以考虑改成ThemeColorPickerProps
3. primaryColorInstance.toHsb() 不能用string ，所以用了`import type { Color } from 'antd/es/color-picker';`,
![image](https://github.com/user-attachments/assets/bb91982a-9d3d-422f-8723-81b193290f67)


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      type(theme): improve color type     |
| 🇨🇳 Chinese |    type(theme): 优化color type       |
