### PR TITLE
fix: popup align position

### DIFF
--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -88,7 +88,11 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         textAlign: 'start',
         cursor: 'auto',
         userSelect: 'text',
-        transformOrigin: `var(--arrow-x, 50%) var(--arrow-y, 50%)`,
+
+        // When use `autoArrow`, origin will follow the arrow position
+        '--valid-offset-x': 'var(--arrow-offset-horizontal, --arrow-x)',
+        transformOrigin: [`var(--valid-offset-x, 50%)`, `var(--arrow-y, 50%)`].join(' '),
+
         '--antd-arrow-background-color': colorBgElevated,
         width: 'max-content',
         maxWidth: '100vw',

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -90,7 +90,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         userSelect: 'text',
 
         // When use `autoArrow`, origin will follow the arrow position
-        '--valid-offset-x': 'var(--arrow-offset-horizontal, --arrow-x)',
+        '--valid-offset-x': 'var(--arrow-offset-horizontal, var(--arrow-x))',
         transformOrigin: [`var(--valid-offset-x, 50%)`, `var(--arrow-y, 50%)`].join(' '),
 
         '--antd-arrow-background-color': colorBgElevated,

--- a/components/style/placementArrow.ts
+++ b/components/style/placementArrow.ts
@@ -1,4 +1,5 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 
 import type { AliasToken, TokenWithCommonCls } from '../theme/internal';
 import type { ArrowToken } from './roundedArrow';
@@ -95,17 +96,25 @@ export default function getArrowStyle<
           transform: 'translateX(-50%) translateY(100%) rotate(180deg)',
         },
 
-        [`&-placement-topLeft > ${componentCls}-arrow`]: {
-          left: {
-            _skip_check_: true,
-            value: arrowOffsetHorizontal,
+        '&-placement-topLeft': {
+          '--arrow-offset-horizontal': arrowOffsetHorizontal,
+
+          [`> ${componentCls}-arrow`]: {
+            left: {
+              _skip_check_: true,
+              value: arrowOffsetHorizontal,
+            },
           },
         },
 
-        [`&-placement-topRight > ${componentCls}-arrow`]: {
-          right: {
-            _skip_check_: true,
-            value: arrowOffsetHorizontal,
+        '&-placement-topRight': {
+          '--arrow-offset-horizontal': `calc(100% - ${unit(arrowOffsetHorizontal)})`,
+
+          [`> ${componentCls}-arrow`]: {
+            right: {
+              _skip_check_: true,
+              value: arrowOffsetHorizontal,
+            },
           },
         },
       }),
@@ -129,17 +138,25 @@ export default function getArrowStyle<
           transform: `translateX(-50%) translateY(-100%)`,
         },
 
-        [`&-placement-bottomLeft > ${componentCls}-arrow`]: {
-          left: {
-            _skip_check_: true,
-            value: arrowOffsetHorizontal,
+        '&-placement-bottomLeft': {
+          '--arrow-offset-horizontal': arrowOffsetHorizontal,
+
+          [`> ${componentCls}-arrow`]: {
+            left: {
+              _skip_check_: true,
+              value: arrowOffsetHorizontal,
+            },
           },
         },
 
-        [`&-placement-bottomRight > ${componentCls}-arrow`]: {
-          right: {
-            _skip_check_: true,
-            value: arrowOffsetHorizontal,
+        '&-placement-bottomRight': {
+          '--arrow-offset-horizontal': `calc(100% - ${unit(arrowOffsetHorizontal)})`,
+
+          [`> ${componentCls}-arrow`]: {
+            right: {
+              _skip_check_: true,
+              value: arrowOffsetHorizontal,
+            },
           },
         },
       }),

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -52,7 +52,13 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         width: 'max-content',
         maxWidth: tooltipMaxWidth,
         visibility: 'visible',
-        transformOrigin: `var(--arrow-x, 50%) var(--arrow-y, 50%)`,
+
+        // When use `autoArrow`, origin will follow the arrow position
+        transformOrigin: [
+          `var(var(--arrow-offset-horizontal, --arrow-x), 50%)`,
+          `var(--arrow-y, 50%)`,
+        ].join(' '),
+
         '&-hidden': {
           display: 'none',
         },

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -54,10 +54,8 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         visibility: 'visible',
 
         // When use `autoArrow`, origin will follow the arrow position
-        transformOrigin: [
-          `var(var(--arrow-offset-horizontal, --arrow-x), 50%)`,
-          `var(--arrow-y, 50%)`,
-        ].join(' '),
+        '--valid-offset-x': 'var(--arrow-offset-horizontal, --arrow-x)',
+        transformOrigin: [`var(--valid-offset-x, 50%)`, `var(--arrow-y, 50%)`].join(' '),
 
         '&-hidden': {
           display: 'none',

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -54,7 +54,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         visibility: 'visible',
 
         // When use `autoArrow`, origin will follow the arrow position
-        '--valid-offset-x': 'var(--arrow-offset-horizontal, --arrow-x)',
+        '--valid-offset-x': 'var(--arrow-offset-horizontal, var(--arrow-x))',
         transformOrigin: [`var(--valid-offset-x, 50%)`, `var(--arrow-y, 50%)`].join(' '),
 
         '&-hidden': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Popover & PopConfirm & Tooltip with `topLeft` `topRight` bottomLeft` `bottomRight` zoom in transform origin not correct when target element width is too large.        |
| 🇨🇳 Chinese |    修复 Popover & PopConfirm & Tooltip 在目标元素宽度过大时，使用 `topLeft` `topRight` bottomLeft` `bottomRight` 的弹出动画起始缩放中心有所偏移的问题。   |
