### PR TITLE
enhance: ColorPicker reset logic

### DIFF
--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -95,10 +95,37 @@ const PanelPicker: FC = () => {
     return new AggregationColor(nextColors);
   };
 
-  const onInternalChange = (colorValue: AggregationColor | Color, fromPicker?: boolean) => {
+  const onInternalChange = (
+    colorValue: AggregationColor | Color,
+    fromPicker?: boolean,
+    info?: {
+      type?: 'hue' | 'alpha';
+      value?: number;
+    },
+  ) => {
     const nextColor = generateColor(colorValue);
 
-    onChange(fillColor(value.cleared ? genAlphaColor(nextColor) : nextColor), fromPicker);
+    let submitColor = nextColor;
+
+    if (value.cleared) {
+      const rgb = submitColor.toRgb();
+
+      // Auto fill color if origin is `0/0/0` to enhance user experience
+      if (!rgb.r && !rgb.g && !rgb.b && info) {
+        const { type: infoType, value: infoValue = 0 } = info;
+
+        submitColor = new AggregationColor({
+          h: infoType === 'hue' ? infoValue : 0,
+          s: 1,
+          b: 1,
+          a: infoType === 'alpha' ? infoValue / 100 : 1,
+        });
+      } else {
+        submitColor = genAlphaColor(submitColor);
+      }
+    }
+
+    onChange(fillColor(submitColor), fromPicker);
   };
 
   const onInternalChangeComplete = (nextColor: AggregationColor) => {
@@ -140,8 +167,8 @@ const PanelPicker: FC = () => {
         prefixCls={prefixCls}
         value={activeColor?.toHsb()}
         disabledAlpha={disabledAlpha}
-        onChange={(colorValue) => {
-          onInternalChange(colorValue, true);
+        onChange={(colorValue, info) => {
+          onInternalChange(colorValue, true, info);
         }}
         onChangeComplete={(colorValue) => {
           onInternalChangeComplete(generateColor(colorValue));

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@ant-design/react-slick": "~1.1.2",
     "@babel/runtime": "^7.24.8",
     "@ctrl/tinycolor": "^3.6.1",
-    "@rc-component/color-picker": "~1.9.0",
+    "@rc-component/color-picker": "~2.0.0",
     "@rc-component/mutate-observer": "^1.1.0",
     "@rc-component/qrcode": "~1.0.0",
     "@rc-component/tour": "~1.15.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

resolve #50127

### 💡 Background and solution

当从 `transparent` 切换到实色时，优先填充一个 hsb filled 色值以提升用户体验。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Optimize ColorPicker when selecting a color from the `transparent` state, it defaults to using a bright color instead of black color to enhance the user interaction experience.        |
| 🇨🇳 Chinese |    优化 ColorPicker 当从 `transparent` 状态进行颜色选取时，默认使用亮色以代替原本的纯黑色以提升用户交互体验。       |
