### PR TITLE
fix(Spin): Fixed the indicator itself percent attribute being invalid

### DIFF
--- a/components/spin/Indicator/index.tsx
+++ b/components/spin/Indicator/index.tsx
@@ -17,7 +17,7 @@ export default function Indicator(props: IndicatorProps) {
   if (indicator && React.isValidElement(indicator)) {
     return cloneElement(indicator, {
       className: classNames(indicator.props.className, dotClassName),
-      percent,
+      percent: indicator.props.percent || percent,
     });
   }
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

- ref https://github.com/ant-design/ant-design/pull/49211
- demo https://stackblitz.com/edit/react-bmmhq9-jsygeb?file=demo.tsx

### 💡 Background and solution

使用 Progress 作为指示器时 原生的 percent 无效

![image](https://github.com/user-attachments/assets/da31d42f-612f-4823-8305-3ca4b66a52ce)


### 📝 Changelog


- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the indicator itself percent attribute being invalid      |
| 🇨🇳 Chinese |      修复自定义指示器 percent 属性无效问题     |
