### PR TITLE
fix: add missed translation in uk_UA

### DIFF
--- a/components/date-picker/locale/uk_UA.ts
+++ b/components/date-picker/locale/uk_UA.ts
@@ -7,15 +7,35 @@ import type { PickerLocale } from '../generatePicker';
 const locale: PickerLocale = {
   lang: {
     placeholder: 'Оберіть дату',
+    yearPlaceholder: 'Оберіть рік',
+    quarterPlaceholder: 'Оберіть квартал',
+    monthPlaceholder: 'Оберіть місяць',
+    weekPlaceholder: 'Оберіть тиждень',
     rangePlaceholder: ['Початкова дата', 'Кінцева дата'],
+    rangeYearPlaceholder: ['Початковий рік', 'Кінцевий рік'],
+    rangeMonthPlaceholder: ['Початковий місяць', 'Кінцевий місяць'],
+    rangeWeekPlaceholder: ['Початковий тиждень', 'Кінцевий тиждень'],
+    shortWeekDays: ['Нд', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'],
+    shortMonths: [
+      'Січ',
+      'Лют',
+      'Бер',
+      'Кві',
+      'Тра',
+      'Чер',
+      'Лип',
+      'Сер',
+      'Вер',
+      'Жов',
+      'Лис',
+      'Гру',
+    ],
     ...CalendarLocale,
   },
   timePickerLocale: {
     ...TimePickerLocale,
   },
 };
-
 // All settings at:
 // https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json
-
 export default locale;

--- a/components/locale/uk_UA.ts
+++ b/components/locale/uk_UA.ts
@@ -6,7 +6,7 @@ import Calendar from '../calendar/locale/uk_UA';
 import DatePicker from '../date-picker/locale/uk_UA';
 import TimePicker from '../time-picker/locale/uk_UA';
 
-const typeTemplate = '${label} не є типом ${type}';
+const typeTemplate: string = '${label} не є типом ${type}';
 
 const localeValues: Locale = {
   locale: 'uk',

--- a/components/time-picker/locale/uk_UA.ts
+++ b/components/time-picker/locale/uk_UA.ts
@@ -2,6 +2,7 @@ import type { TimePickerLocale } from '../index';
 
 const locale: TimePickerLocale = {
   placeholder: 'Оберіть час',
+  rangePlaceholder: ['Початковий час', 'Кінцевий час'],
 };
 
 export default locale;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 💡 Background and solution
1. The DatePicker does not have a lot of translations
2. ![image](https://github.com/user-attachments/assets/88dcf31e-ef4c-415f-98b5-bef1d2d05200)
3. Using antd's UK locale will include all new translations

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog
- Added ukranian translations for datepicker
<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
