### PR TITLE
fix: unit for line-height for ColorPicker

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -150,7 +150,7 @@ const GlobalLayout: React.FC = () => {
     () => ({
       algorithm: getAlgorithm(theme),
       token: { motion: !theme.includes('motion-off') },
-      cssVar: true,
+      cssVar: false,
       hashed: false,
     }),
     [theme],

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -150,7 +150,7 @@ const GlobalLayout: React.FC = () => {
     () => ({
       algorithm: getAlgorithm(theme),
       token: { motion: !theme.includes('motion-off') },
-      cssVar: false,
+      cssVar: true,
       hashed: false,
     }),
     [theme],

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -161,7 +161,7 @@ const genSizeStyle = (token: ColorPickerToken): CSSObject => {
       },
 
       [`${componentCls}-trigger-text`]: {
-        lineHeight: controlHeightXS,
+        lineHeight: unit(controlHeightXS),
       },
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

Fix https://github.com/ant-design/ant-design/pull/50218#issuecomment-2266490029

<img width="826" alt="image" src="https://github.com/user-attachments/assets/a504a81f-e5dd-4f99-b3d6-5ec993a3b3e8">

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where line-height is not effective in cssinjs mode for ColorPicker.       |
| 🇨🇳 Chinese |   修复 ColorPicker 在 cssinjs 模式下 line-height 失效的问题        |
