### PR TITLE
fix(Calendar): make Calendar locale overriding locale from ConfigProvider

### DIFF
--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -18,6 +18,7 @@ import Button from '../../radio/radioButton';
 import Select from '../../select';
 import Header from '../Header';
 import type { CalendarHeaderProps } from '../Header';
+import ConfigProvider from '../../config-provider';
 
 const ref: {
   calendarProps?: PickerPanelProps;
@@ -205,6 +206,23 @@ describe('Calendar', () => {
     const zhCN = require('../locale/zh_CN').default;
     const wrapper = render(<Calendar locale={zhCN} />);
     expect(wrapper.container.children[0]).toMatchSnapshot();
+    MockDate.reset();
+  });
+
+  it('Calendar locale support should override ConfigProvider locale', () => {
+    MockDate.set(Dayjs('2018-10-19').valueOf());
+    // eslint-disable-next-line global-require
+    const zhCN = require('../locale/zh_CN').default;
+    // eslint-disable-next-line global-require
+    const enUs = require('../../locale/en_US').default;
+    const wrapper = render(
+      <ConfigProvider locale={enUs}>
+        <Calendar locale={zhCN} />
+      </ConfigProvider>,
+    );
+    expect(wrapper.container.querySelector('.ant-picker-content thead')?.textContent).toBe(
+      '一二三四五六日',
+    );
     MockDate.reset();
   });
 

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -172,20 +172,6 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       onSelect?.(date, { source });
     };
 
-    // ====================== Locale ======================
-    const getDefaultLocale = () => {
-      const { locale } = props;
-      const result = {
-        ...enUS,
-        ...locale,
-      };
-      result.lang = {
-        ...result.lang,
-        ...locale?.lang,
-      };
-      return result;
-    };
-
     // ====================== Render ======================
     const dateRender = React.useCallback(
       (date: DateType, info: CellRenderInfo<DateType>): React.ReactNode => {
@@ -244,7 +230,9 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       [monthFullCellRender, monthCellRender, cellRender, fullCellRender],
     );
 
-    const [contextLocale] = useLocale('Calendar', getDefaultLocale);
+    const [contextLocale] = useLocale('Calendar', enUS);
+
+    const locale = { ...contextLocale, ...props.locale! };
 
     const mergedCellRender: RcBasePickerPanelProps['cellRender'] = (current, info) => {
       if (info.type === 'date') {
@@ -254,7 +242,7 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       if (info.type === 'month') {
         return monthRender(current, {
           ...info,
-          locale: contextLocale?.lang,
+          locale: locale?.lang,
         });
       }
     };
@@ -292,7 +280,7 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             generateConfig={generateConfig}
             mode={mergedMode}
             fullscreen={fullscreen}
-            locale={contextLocale?.lang}
+            locale={locale?.lang}
             validRange={validRange}
             onChange={onInternalSelect}
             onModeChange={triggerModeChange}
@@ -301,7 +289,7 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         <RCPickerPanel
           value={mergedValue}
           prefixCls={prefixCls}
-          locale={contextLocale?.lang}
+          locale={locale?.lang}
           generateConfig={generateConfig}
           cellRender={mergedCellRender}
           onSelect={(nextDate) => {


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

Today, if I inject parameters into the locale props in my Calendar component, it doesn't take them into account if I already have a locale in my ConfigProvider. This means that I can't have a global configuration that I override for specific cases. Here some exemple : https://stackblitz.com/edit/react-o7hv5j?file=demo.tsx
You can see that if you remove ConfigProvider locale, all we work fine

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Make Calendar locale overriding locale from ConfigProvider     |
| 🇨🇳 Chinese |      使 Calendar locale 覆盖来自 ConfigProvider 的 locale     |
