### PR TITLE
test(getScroll): When window is undef

### DIFF
--- a/components/_util/__tests__/getScroll.test.ts
+++ b/components/_util/__tests__/getScroll.test.ts
@@ -60,7 +60,7 @@ describe('When window is undef', () => {
   });
 
   it('getScroll value is zero', () => {
-    expect(getScroll(document)).toBe(0);
+    expect(getScroll(null)).toBe(0);
   });
 
   afterAll(() => {

--- a/components/_util/__tests__/getScroll.test.ts
+++ b/components/_util/__tests__/getScroll.test.ts
@@ -49,21 +49,10 @@ describe('getScroll', () => {
     expect(getScroll(div)).toBe(400);
     scrollToSpy.mockRestore();
   });
-});
 
-describe('When window is undef', () => {
-  let originalWindow: Window & typeof globalThis;
-
-  beforeAll(() => {
-    originalWindow = global.window;
-    delete (global as any).window;
-  });
-
-  it('getScroll value is zero', () => {
+  it('When window is undef, getScroll value is zero', () => {
+    const spy = jest.spyOn(global, 'window', 'get').mockImplementation(() => undefined as any);
     expect(getScroll(null)).toBe(0);
-  });
-
-  afterAll(() => {
-    global.window = originalWindow;
+    spy.mockRestore();
   });
 });

--- a/components/_util/__tests__/getScroll.test.ts
+++ b/components/_util/__tests__/getScroll.test.ts
@@ -50,3 +50,20 @@ describe('getScroll', () => {
     scrollToSpy.mockRestore();
   });
 });
+
+describe('When window is undef', () => {
+  let originalWindow: Window & typeof globalThis;
+
+  beforeAll(() => {
+    originalWindow = global.window;
+    delete (global as any).window;
+  });
+
+  it('getScroll value is zero', () => {
+    expect(getScroll(document)).toBe(0);
+  });
+
+  afterAll(() => {
+    global.window = originalWindow;
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/ant-design/ant-design/issues/50243
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | When window is undef,getScroll value is zero.          |
| 🇨🇳 Chinese | 当window为undefined的时候，getScroll返回值为0           |
