### PR TITLE
fix: tour default zIndex

### DIFF
--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -36,7 +36,6 @@ export interface ComponentToken extends ArrowOffsetToken, ArrowToken {
 }
 
 interface TourToken extends FullToken<'Tour'> {
-  tourZIndexPopup: number;
   indicatorWidth: number | string;
   indicatorHeight: number | string;
   tourBorderRadius: number;
@@ -55,7 +54,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
     indicatorHeight,
     indicatorWidth,
     boxShadowTertiary,
-    tourZIndexPopup,
+    zIndexPopup,
     colorBgElevated,
     fontWeightStrong,
     marginXS,
@@ -75,7 +74,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
         ...resetComponent(token),
 
         position: 'absolute',
-        zIndex: tourZIndexPopup,
+        zIndex: zIndexPopup,
         maxWidth: 'fit-content',
         visibility: 'visible',
         width: 520,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix #50298

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

- Use a developer-oriented tone and narrative style.
- Describe the user's first-hand experience of the issue and its impact on developers, rather than your solution approach.
- Refer to: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Tour default `z-index` not follow `zIndexPopup` token issue.       |
| 🇨🇳 Chinese |    修复 Tour 默认 `z-index` 没有使用 `zIndexPopup` token 的问题。       |
