### PR TITLE
fix: tree switch bg height

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -237,7 +237,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         ...getSwitchStyle(prefixCls, token),
         position: 'relative',
         flex: 'none',
-        alignSelf: 'flex-start',
+        alignSelf: 'stretch',
         width: titleHeight,
         margin: 0,
         lineHeight: unit(titleHeight),
@@ -245,13 +245,27 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         cursor: 'pointer',
         userSelect: 'none',
         transition: `all ${token.motionDurationSlow}`,
-        borderRadius: token.borderRadius,
 
         '&-noop': {
           cursor: 'unset',
         },
 
-        [`&:not(${treeCls}-switcher-noop):hover`]: {
+        '&:before': {
+          pointerEvents: 'none',
+          content: '""',
+          width: titleHeight,
+          height: titleHeight,
+          position: 'absolute',
+          left: {
+            _skip_check_: true,
+            value: 0,
+          },
+          top: 0,
+          borderRadius: token.borderRadius,
+          transition: `all ${token.motionDurationSlow}`,
+        },
+
+        [`&:not(${treeCls}-switcher-noop):hover:before`]: {
           backgroundColor: token.colorBgTextHover,
         },
 

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -237,7 +237,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         ...getSwitchStyle(prefixCls, token),
         position: 'relative',
         flex: 'none',
-        alignSelf: 'stretch',
+        alignSelf: 'flex-start',
         width: titleHeight,
         margin: 0,
         lineHeight: unit(titleHeight),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50255

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Tree switcher position not ping at top when title break the line.      |
| 🇨🇳 Chinese |     修复 Tree 展开按钮在标题折行时没有顶上对齐的问题。     |
