### PR TITLE
chore(tree-select): improve code style by restProps

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -89,7 +89,10 @@ const InternalTreeSelect = <
   ValueType = any,
   OptionType extends BaseOptionType | DefaultOptionType = BaseOptionType,
 >(
-  {
+  props: TreeSelectProps<ValueType, OptionType>,
+  ref: React.Ref<BaseSelectRef>,
+) => {
+  const {
     prefixCls: customizePrefixCls,
     size: customizeSize,
     disabled: customDisabled,
@@ -119,10 +122,8 @@ const InternalTreeSelect = <
     variant: customVariant,
     dropdownStyle,
     tagRender,
-    ...props
-  }: TreeSelectProps<ValueType, OptionType>,
-  ref: React.Ref<BaseSelectRef>,
-) => {
+    ...restProps
+  } = props;
   const {
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
@@ -203,7 +204,7 @@ const InternalTreeSelect = <
 
   // ===================== Icons =====================
   const { suffixIcon, removeIcon, clearIcon } = useIcons({
-    ...props,
+    ...restProps,
     multiple: isMultiple,
     showSuffixIcon,
     hasFeedback,
@@ -223,7 +224,7 @@ const InternalTreeSelect = <
   }
 
   // ==================== Render =====================
-  const selectProps = omit(props, [
+  const selectProps = omit(restProps, [
     'suffixIcon',
     'removeIcon',
     'clearIcon',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🎨 Code style optimization


### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
1. 和select 代码风格保持一致
2. 由于bordered 已经被解构出来了，所以warning.deprecated(!('bordered' in props), 'bordered', 'variant'); 是dead code，不太友好。 
综上所属，这个代码风格优化应该是有意义的。 
![image](https://github.com/user-attachments/assets/0d80b07b-1728-4de0-b878-05ff3b6eea6c)


![image](https://github.com/user-attachments/assets/8f192331-7a47-49c7-af02-b8d9c02cc76c)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    chore(tree-select): improve code style by restProps       |
| 🇨🇳 Chinese |       chore(tree-select): 使用 restProps 优化代码    |
