### PR TITLE
type: ts definition improvement

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -37,8 +37,8 @@ const AffixMounter: React.FC<AffixProps> = (props) => {
 };
 
 describe('Affix Render', () => {
-  rtlTest(Affix as any);
-  accessibilityTest(Affix as any);
+  rtlTest(() => <Affix>test</Affix>);
+  accessibilityTest(() => <Affix>test</Affix>);
 
   const domMock = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
 

--- a/components/affix/__tests__/__snapshots__/Affix.test.tsx.snap
+++ b/components/affix/__tests__/__snapshots__/Affix.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`Affix Render rtl render component should be rendered correctly in RTL d
 <div>
   <div
     class=""
-  />
+  >
+    test
+  </div>
 </div>
 `;

--- a/components/layout/__tests__/dynamic-breakpoint.test.tsx
+++ b/components/layout/__tests__/dynamic-breakpoint.test.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 
 import { fireEvent, render } from '../../../tests/utils';
 import Sider from '../Sider';
+import type { Breakpoint } from 'antd';
 
 const Content = () => {
-  const [breakpoint, setBreakpoint] = useState('sm');
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>('sm');
   const toggleBreakpoint = () => {
     if (breakpoint === 'sm') {
       setBreakpoint('lg');
@@ -13,7 +14,7 @@ const Content = () => {
     }
   };
   return (
-    <Sider breakpoint={breakpoint as any}>
+    <Sider breakpoint={breakpoint}>
       <button type="button" id="toggle" onClick={toggleBreakpoint}>
         Toggle
       </button>

--- a/components/layout/__tests__/dynamic-breakpoint.test.tsx
+++ b/components/layout/__tests__/dynamic-breakpoint.test.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { fireEvent, render } from '../../../tests/utils';
 import Sider from '../Sider';
-import type { Breakpoint } from 'antd';
+import type { Breakpoint } from '../..';
 
 const Content = () => {
   const [breakpoint, setBreakpoint] = useState<Breakpoint>('sm');

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -22,9 +22,9 @@ function waitRaf() {
 
 describe('Tag', () => {
   mountTest(Tag);
-  mountTest(Tag.CheckableTag as any);
+  mountTest(() => <Tag.CheckableTag checked={false} />);
   rtlTest(Tag);
-  rtlTest(Tag.CheckableTag as any);
+  rtlTest(() => <Tag.CheckableTag checked={false} />);
 
   beforeAll(() => {
     jest.useFakeTimers();

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -131,18 +131,14 @@ describe('Typography', () => {
             expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe('Copy');
           } else if (tooltips === false) {
             expect(container.querySelector('.ant-tooltip-inner')).toBeFalsy();
-          } else if ((tooltips as any)[0] === '' && (tooltips as any)[1] === '') {
+          } else if (tooltips[0] === '' && tooltips[1] === '') {
             expect(container.querySelector('.ant-tooltip-inner')).toBeFalsy();
-          } else if ((tooltips as any)[0] === '' && (tooltips as any)[1]) {
+          } else if (tooltips[0] === '' && tooltips[1]) {
             expect(container.querySelector('.ant-tooltip-inner')).toBeFalsy();
-          } else if ((tooltips as any)[1] === '' && (tooltips as any)[0]) {
-            expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe(
-              (tooltips as any)[0],
-            );
+          } else if (tooltips[1] === '' && tooltips[0]) {
+            expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe(tooltips[0]);
           } else {
-            expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe(
-              (tooltips as any)[0],
-            );
+            expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe(tooltips[0]);
           }
 
           // Click to copy

--- a/components/upload/demo/transform-file.tsx
+++ b/components/upload/demo/transform-file.tsx
@@ -23,7 +23,7 @@ const props: UploadProps = {
           ctx.textBaseline = 'middle';
           ctx.font = '33px Arial';
           ctx.fillText('Ant Design', 20, 20);
-          canvas.toBlob((result) => resolve(result as any));
+          canvas.toBlob((result) => resolve(result as Blob));
         };
       };
     });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement


### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

1. affix 组件必须要有一个children，所以加了个testchildren以替代 as any
![image](https://github.com/user-attachments/assets/72c40064-2a18-417a-be1b-84237468b7bc)
2. Tag.CheckableTag 组件 checked也是必填属性，通过给默认值false 以替代 as any
3. breakpoint 加上Breakpoint 以替代as any
4. tooltips 本身就支持string[]，去掉多余的any
![image](https://github.com/user-attachments/assets/43587435-d155-4e6b-85d8-704b74f232e0)


综上可以进一步减少项目中的 as any，让类型更加具体。

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       type: ts definition improvement    |
| 🇨🇳 Chinese |       type: ts 定义优化    |
