### PR TITLE
fix: default cssvarkey only picked when component themeconfig && parent th…

### DIFF
--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -64,7 +64,9 @@ export default function useTheme(
         prefix: config?.prefixCls, // Same as prefixCls by default
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
-        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key) || cssVarKey,
+        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key) ||
+             (typeof parentThemeConfig.cssVar === 'object' && parentThemeConfig.cssVar?.key) ||
+             cssVarKey,
       };
 
       // Base token

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -64,9 +64,7 @@ export default function useTheme(
         prefix: config?.prefixCls, // Same as prefixCls by default
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
-        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key) ||
-             (typeof parentThemeConfig.cssVar === 'object' && parentThemeConfig.cssVar?.key) ||
-             cssVarKey,
+        key: themeConfig.cssVar?.key || parentThemeConfig.cssVar?.key || cssVarKey,
       };
 
       // Base token

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -64,7 +64,7 @@ export default function useTheme(
         prefix: config?.prefixCls, // Same as prefixCls by default
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
-        key: themeConfig.cssVar?.key || parentThemeConfig.cssVar?.key || cssVarKey,
+        key: themeConfig.cssVar?.key ?? parentThemeConfig.cssVar?.key ?? cssVarKey,
       };
 
       // Base token

--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -64,7 +64,9 @@ export default function useTheme(
         prefix: config?.prefixCls, // Same as prefixCls by default
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
-        key: themeConfig.cssVar?.key ?? parentThemeConfig.cssVar?.key ?? cssVarKey,
+        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key)
+          || (typeof parentThemeConfig.cssVar === 'object' && parentThemeConfig.cssVar?.key)
+          || cssVarKey,
       };
 
       // Base token


### PR DESCRIPTION
…emeconfig both not set at the same time

只有当组件theme和parentTheme都没有设置cssvarkey时，才使用默认的cssvarkey

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

