### PR TITLE
fix: Select arrow disappearing when hovering it

### DIFF
--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -329,7 +329,7 @@ const genPaginationSimpleStyle: GenerateStyle<PaginationToken, CSSObject> = (tok
 };
 
 const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
-  const { componentCls, antCls } = token;
+  const { componentCls } = token;
 
   return {
     [`${componentCls}-jump-prev, ${componentCls}-jump-next`]: {

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -461,11 +461,6 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
       '&-size-changer': {
         display: 'inline-block',
         width: 'auto',
-
-        // https://github.com/ant-design/ant-design/issues/49258
-        [`${antCls}-select-arrow:not(:last-child)`]: {
-          opacity: 1,
-        },
       },
 
       '&-quick-jumper': {

--- a/components/select/demo/basic.tsx
+++ b/components/select/demo/basic.tsx
@@ -35,6 +35,7 @@ const App: React.FC = () => (
       style={{ width: 120 }}
       allowClear
       options={[{ value: 'lucy', label: 'Lucy' }]}
+      placeholder="select it"
     />
   </Space>
 );

--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -177,16 +177,9 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
         },
       },
 
-      '&:hover': {
-        [`${componentCls}-clear`]: {
-          opacity: 1,
-        },
-        // Should use the following selector, but since `:has` has poor compatibility,
-        // we use `:not(:last-child)` instead, which may cause some problems in some cases.
-        // [`${componentCls}-arrow:has(+ ${componentCls}-clear)`]: {
-        [`${componentCls}-arrow:not(:last-child)`]: {
-          opacity: 0,
-        },
+      [`&:hover ${componentCls}-clear`]: {
+        opacity: 1,
+        background: token.colorBgBase,
       },
     },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/50381

similar issue: https://github.com/ant-design/ant-design/issues/49258#issuecomment-2283500565

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

之前 https://github.com/ant-design/ant-design/pull/46549 引入了这段代码导致 Select 指定了 `getPopcontainer={node => node.parentNode}` 后，hover 时箭头会消失的问题。

问题原因：开启 allowClear 时，需要 hover 时出现清除图标。此时需要隐藏箭头，避免两者同时叠加。
<img width="143" alt="图片" src="https://github.com/user-attachments/assets/4f79dc51-3c18-4738-833a-69f824c0a06b">

之前的解法是通过 `${componentCls}-arrow:has(+ ${componentCls}-clear) { opacity: 0; }` 语法来解决。但是 `:has` 兼容性不好，就改成 `${antCls}-select-arrow:not(:last-child)` 了。

然而在 `getPopcontainer={node => node.parentNode}` 的用法下，由于 dropdown 节点会插入到 arrow 节点之后，从而触发了这段代码生效，因此导致了预期外的结果（箭头 hover 时消失）。

修复方式是不再使用隐藏箭头的方式，而是给清除图标加背景的方式盖住箭头，避免两者出现视觉重叠。

---

Previously, [PR #46549](https://github.com/ant-design/ant-design/pull/46549) introduced code that caused the arrow to disappear when hovering after specifying `getPopcontainer={node => node.parentNode}` for the Select component.

**Problem Reason**: When `allowClear` is enabled, a clear icon should appear on hover. At this point, the arrow needs to be hidden to avoid overlapping with the clear icon.
<img width="143" alt="图片" src="https://github.com/user-attachments/assets/4f79dc51-3c18-4738-833a-69f824c0a06b">

The previous solution used the syntax `${componentCls}-arrow:has(+ ${componentCls}-clear) { opacity: 0; }` to solve this. However, the `:has` selector has poor compatibility, so it was changed to `${antCls}-select-arrow:not(:last-child)`.

However, under the usage of `getPopcontainer={node => node.parentNode}`, the dropdown node is inserted after the arrow node, triggering the effect of this code, which leads to unexpected results (the arrow disappears on hover).

**Solution**: Instead of hiding the arrow, the fix involves giving the clear icon a background to cover the arrow, avoiding visual overlap between the two elements.

---

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Select to prevent the arrow icon from disappearing after hovering with `getPopupContainer={node => node.parentNode}`.          |
| 🇨🇳 Chinese | 修复 Select 指定 `getPopcontainer={node => node.parentNode}` 时箭头图标 hover 后会消失的问题。          |
