### PR TITLE
chore: Add comments to token interfaces

### DIFF
--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -193,8 +193,20 @@ export interface ComponentToken {
 }
 
 export interface ButtonToken extends FullToken<'Button'> {
+  /**
+   * @desc 按钮横向内边距
+   * @descEN Horizontal padding of button
+   */
   buttonPaddingHorizontal: CSSProperties['paddingInline'];
+  /**
+   * @desc 按钮纵向内边距
+   * @descEN Vertical padding of button
+   */
   buttonPaddingVertical: CSSProperties['paddingBlock'];
+  /**
+   * @desc 只有图标的按钮图标尺寸
+   * @descEN Icon size of button which only contains icon
+   */
   buttonIconOnlyFontSize: number;
 }
 

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -54,10 +54,30 @@ export interface ComponentToken {
 }
 
 interface CardToken extends FullToken<'Card'> {
+  /**
+   * @desc 卡片阴影
+   * @descEN Shadow of card
+   */
   cardShadow: string;
+  /**
+   * @desc 卡片头部内边距
+   * @descEN Padding of card header
+   */
   cardHeadPadding: number;
+  /**
+   * @desc 小号卡片内边距
+   * @descEN Padding of small card
+   */
   cardPaddingSM: number;
+  /**
+   * @desc 卡片基础内边距
+   * @descEN Padding of base card
+   */
   cardPaddingBase: number;
+  /**
+   * @desc 卡片操作区图标大小
+   * @descEN Size of card actions icon
+   */
   cardActionsIconSize: number;
 }
 

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -32,8 +32,20 @@ export interface ComponentToken {
 }
 
 type CollapseToken = FullToken<'Collapse'> & {
+  /**
+   * @desc 小号折叠面板头部内边距
+   * @descEN Padding of small header
+   */
   collapseHeaderPaddingSM: string;
+  /**
+   * @desc 大号折叠面板头部内边距
+   * @descEN Padding of large header
+   */
   collapseHeaderPaddingLG: string;
+  /**
+   * @desc 折叠面板边框圆角
+   * @descEN Border radius of collapse panel
+   */
   collapsePanelBorderRadius: number;
 };
 


### PR DESCRIPTION
Add comments for the `ButtonToken` interface in `components/button/style/token.ts`.

- **ButtonToken Interface**
  - Add comments for `buttonPaddingHorizontal`, `buttonPaddingVertical`, and `buttonIconOnlyFontSize`.

- **CardToken Interface**
  - Add comments for `cardShadow`, `cardHeadPadding`, `cardPaddingSM`, `cardPaddingBase`, and `cardActionsIconSize`.

- **CollapseToken Interface**
  - Add comments for `collapseHeaderPaddingSM`, `collapseHeaderPaddingLG`, and `collapsePanelBorderRadius`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ant-design/ant-design?shareId=1c2ce3c2-4ef5-4e11-930f-3634e48ae0ea).