### PR TITLE
fix: Upload.Dragger drag-and-drop upload directory issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rc-tooltip": "~6.2.0",
     "rc-tree": "~5.8.8",
     "rc-tree-select": "~5.22.1",
-    "rc-upload": "~4.6.0",
+    "rc-upload": "~4.7.0",
     "rc-util": "^5.43.0",
     "scroll-into-view-if-needed": "^3.1.0",
     "throttle-debounce": "^5.0.2"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - close #50080 

### 💡 Background and Solution

> - `Upload.Dragger` drag-and-drop upload directory does not work
> -  The reason is that the `readEntries` method is called asynchronously, but the file retrieval is executed synchronously, which results in not being able to obtain the file. Now, it's been changed to use async await for execution.
> - Source PR [react-component upload#562](https://github.com/react-component/upload/pull/562)

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the issue when `Upload.Dragger` drag-and-drop upload directory does not work     |
| 🇨🇳 Chinese |    修复 `Upload.Dragger` 拖拽上传文件夹时不工作问题        |
