### PR TITLE
fix: fix incorrect border-radius of trigger

### DIFF
--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -126,6 +126,7 @@ const FloatButtonGroup: React.FC<FloatButtonGroupProps> = (props) => {
               icon={open ? mergedCloseIcon : icon}
               description={description}
               aria-label={props['aria-label']}
+              className={`${groupPrefixCls}-trigger`}
               {...floatButtonProps}
             />
           </>

--- a/components/float-button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/float-button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -552,6 +552,27 @@ exports[`renders components/float-button/demo/basic.tsx extend context correctly
 
 exports[`renders components/float-button/demo/controlled.tsx extend context correctly 1`] = `
 Array [
+  <button
+    aria-checked="true"
+    class="ant-switch ant-switch-checked"
+    role="switch"
+    style="margin: 16px;"
+    type="button"
+  >
+    <div
+      class="ant-switch-handle"
+    />
+    <span
+      class="ant-switch-inner"
+    >
+      <span
+        class="ant-switch-inner-checked"
+      />
+      <span
+        class="ant-switch-inner-unchecked"
+      />
+    </span>
+  </button>,
   <div
     class="ant-float-btn-group ant-float-btn-group-circle"
     style="inset-inline-end: 24px;"
@@ -559,6 +580,42 @@ Array [
     <div
       class="ant-float-btn-group-wrap-appear ant-float-btn-group-wrap-appear-start ant-float-btn-group-wrap ant-float-btn-group-wrap"
     >
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
       <button
         class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
         type="button"
@@ -642,7 +699,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-circle"
       type="button"
     >
       <div
@@ -679,27 +736,169 @@ Array [
       </div>
     </button>
   </div>,
-  <button
-    aria-checked="true"
-    class="ant-switch ant-switch-checked"
-    role="switch"
-    style="margin: 16px;"
-    type="button"
+  <div
+    class="ant-float-btn-group ant-float-btn-group-square"
+    style="inset-inline-end: 88px;"
   >
     <div
-      class="ant-switch-handle"
-    />
-    <span
-      class="ant-switch-inner"
+      class="ant-float-btn-group-wrap-appear ant-float-btn-group-wrap-appear-start ant-float-btn-group-wrap ant-float-btn-group-wrap"
     >
-      <span
-        class="ant-switch-inner-checked"
-      />
-      <span
-        class="ant-switch-inner-unchecked"
-      />
-    </span>
-  </button>,
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="comment"
+                class="anticon anticon-comment"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="comment"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <defs>
+                    <style />
+                  </defs>
+                  <path
+                    d="M573 421c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40zm-280 0c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40z"
+                  />
+                  <path
+                    d="M894 345a343.92 343.92 0 00-189-130v.1c-17.1-19-36.4-36.5-58-52.1-163.7-119-393.5-82.7-513 81-96.3 133-92.2 311.9 6 439l.8 132.6c0 3.2.5 6.4 1.5 9.4a31.95 31.95 0 0040.1 20.9L309 806c33.5 11.9 68.1 18.7 102.5 20.6l-.5.4c89.1 64.9 205.9 84.4 313 49l127.1 41.4c3.2 1 6.5 1.6 9.9 1.6 17.7 0 32-14.3 32-32V753c88.1-119.6 90.4-284.9 1-408zM323 735l-12-5-99 31-1-104-8-9c-84.6-103.2-90.2-251.9-11-361 96.4-132.2 281.2-161.4 413-66 132.2 96.1 161.5 280.6 66 412-80.1 109.9-223.5 150.5-348 102zm505-17l-8 10 1 104-98-33-12 5c-56 20.8-115.7 22.5-171 7l-.2-.1A367.31 367.31 0 00729 676c76.4-105.3 88.8-237.6 44.4-350.4l.6.4c23 16.5 44.1 37.1 62 62 72.6 99.6 68.5 235.2-8 330z"
+                  />
+                  <path
+                    d="M433 421c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+    </div>
+    <button
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-square"
+      type="button"
+    >
+      <div
+        class="ant-float-btn-body"
+      >
+        <div
+          class="ant-float-btn-content"
+        >
+          <div
+            class="ant-float-btn-icon"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>,
 ]
 `;
 
@@ -1097,7 +1296,7 @@ Array [
     style="inset-inline-end: 24px;"
   >
     <button
-      class="ant-float-btn ant-float-btn-primary ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-primary ant-float-btn-circle"
       type="button"
     >
       <div
@@ -1138,7 +1337,7 @@ Array [
     style="inset-inline-end: 94px;"
   >
     <button
-      class="ant-float-btn ant-float-btn-primary ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-primary ant-float-btn-circle"
       type="button"
     >
       <div
@@ -1533,7 +1732,7 @@ exports[`renders components/float-button/demo/render-panel.tsx extend context co
       </button>
     </div>
     <button
-      class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-circle"
       type="button"
     >
       <div

--- a/components/float-button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/float-button/__tests__/__snapshots__/demo.test.ts.snap
@@ -504,6 +504,27 @@ exports[`renders components/float-button/demo/basic.tsx correctly 1`] = `
 
 exports[`renders components/float-button/demo/controlled.tsx correctly 1`] = `
 Array [
+  <button
+    aria-checked="true"
+    class="ant-switch ant-switch-checked"
+    role="switch"
+    style="margin:16px"
+    type="button"
+  >
+    <div
+      class="ant-switch-handle"
+    />
+    <span
+      class="ant-switch-inner"
+    >
+      <span
+        class="ant-switch-inner-checked"
+      />
+      <span
+        class="ant-switch-inner-unchecked"
+      />
+    </span>
+  </button>,
   <div
     class="ant-float-btn-group ant-float-btn-group-circle"
     style="inset-inline-end:24px"
@@ -511,6 +532,42 @@ Array [
     <div
       class="ant-float-btn-group-wrap"
     >
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
       <button
         class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
         type="button"
@@ -594,7 +651,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-circle"
       type="button"
     >
       <div
@@ -631,27 +688,169 @@ Array [
       </div>
     </button>
   </div>,
-  <button
-    aria-checked="true"
-    class="ant-switch ant-switch-checked"
-    role="switch"
-    style="margin:16px"
-    type="button"
+  <div
+    class="ant-float-btn-group ant-float-btn-group-square"
+    style="inset-inline-end:88px"
   >
     <div
-      class="ant-switch-handle"
-    />
-    <span
-      class="ant-switch-inner"
+      class="ant-float-btn-group-wrap"
     >
-      <span
-        class="ant-switch-inner-checked"
-      />
-      <span
-        class="ant-switch-inner-unchecked"
-      />
-    </span>
-  </button>,
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+      <button
+        class="ant-float-btn ant-float-btn-default ant-float-btn-square"
+        type="button"
+      >
+        <div
+          class="ant-float-btn-body"
+        >
+          <div
+            class="ant-float-btn-content"
+          >
+            <div
+              class="ant-float-btn-icon"
+            >
+              <span
+                aria-label="comment"
+                class="anticon anticon-comment"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="comment"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <defs>
+                    <style />
+                  </defs>
+                  <path
+                    d="M573 421c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40zm-280 0c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40z"
+                  />
+                  <path
+                    d="M894 345a343.92 343.92 0 00-189-130v.1c-17.1-19-36.4-36.5-58-52.1-163.7-119-393.5-82.7-513 81-96.3 133-92.2 311.9 6 439l.8 132.6c0 3.2.5 6.4 1.5 9.4a31.95 31.95 0 0040.1 20.9L309 806c33.5 11.9 68.1 18.7 102.5 20.6l-.5.4c89.1 64.9 205.9 84.4 313 49l127.1 41.4c3.2 1 6.5 1.6 9.9 1.6 17.7 0 32-14.3 32-32V753c88.1-119.6 90.4-284.9 1-408zM323 735l-12-5-99 31-1-104-8-9c-84.6-103.2-90.2-251.9-11-361 96.4-132.2 281.2-161.4 413-66 132.2 96.1 161.5 280.6 66 412-80.1 109.9-223.5 150.5-348 102zm505-17l-8 10 1 104-98-33-12 5c-56 20.8-115.7 22.5-171 7l-.2-.1A367.31 367.31 0 00729 676c76.4-105.3 88.8-237.6 44.4-350.4l.6.4c23 16.5 44.1 37.1 62 62 72.6 99.6 68.5 235.2-8 330z"
+                  />
+                  <path
+                    d="M433 421c-23.1 0-41 17.9-41 40s17.9 40 41 40c21.1 0 39-17.9 39-40s-17.9-40-39-40z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </button>
+    </div>
+    <button
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-square"
+      type="button"
+    >
+      <div
+        class="ant-float-btn-body"
+      >
+        <div
+          class="ant-float-btn-content"
+        >
+          <div
+            class="ant-float-btn-icon"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>,
 ]
 `;
 
@@ -1043,7 +1242,7 @@ Array [
     style="inset-inline-end:24px"
   >
     <button
-      class="ant-float-btn ant-float-btn-primary ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-primary ant-float-btn-circle"
       type="button"
     >
       <div
@@ -1084,7 +1283,7 @@ Array [
     style="inset-inline-end:94px"
   >
     <button
-      class="ant-float-btn ant-float-btn-primary ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-primary ant-float-btn-circle"
       type="button"
     >
       <div
@@ -1477,7 +1676,7 @@ exports[`renders components/float-button/demo/render-panel.tsx correctly 1`] = `
       </button>
     </div>
     <button
-      class="ant-float-btn ant-float-btn-default ant-float-btn-circle"
+      class="ant-float-btn ant-float-btn-group-trigger ant-float-btn-default ant-float-btn-circle"
       type="button"
     >
       <div

--- a/components/float-button/demo/controlled.md
+++ b/components/float-button/demo/controlled.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过 `open` 设置组件为受控模式，需要配合 trigger 一起使用。
+通过 `open` 设置组件为受控模式，需要配合 `trigger` 一起使用。
 
 ## en-US
 
-Set the component to controlled mode through `open`, which need to be used together with trigger.
+Set the component to controlled mode through `open`, which need to be used together with `trigger`.

--- a/components/float-button/demo/controlled.tsx
+++ b/components/float-button/demo/controlled.tsx
@@ -3,14 +3,10 @@ import { CommentOutlined, CustomerServiceOutlined } from '@ant-design/icons';
 import { FloatButton, Switch } from 'antd';
 
 const App: React.FC = () => {
-  const [open, setOpen] = useState(true);
-
-  const onChange = (checked: boolean) => {
-    setOpen(checked);
-  };
-
+  const [open, setOpen] = useState<boolean>(true);
   return (
     <>
+      <Switch onChange={setOpen} checked={open} style={{ margin: 16 }} />
       <FloatButton.Group
         open={open}
         trigger="click"
@@ -18,9 +14,20 @@ const App: React.FC = () => {
         icon={<CustomerServiceOutlined />}
       >
         <FloatButton />
+        <FloatButton />
         <FloatButton icon={<CommentOutlined />} />
       </FloatButton.Group>
-      <Switch onChange={onChange} checked={open} style={{ margin: 16 }} />
+      <FloatButton.Group
+        open={open}
+        shape="square"
+        trigger="click"
+        style={{ insetInlineEnd: 88 }}
+        icon={<CustomerServiceOutlined />}
+      >
+        <FloatButton />
+        <FloatButton />
+        <FloatButton icon={<CommentOutlined />} />
+      </FloatButton.Group>
     </>
   );
 };

--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -22,7 +22,6 @@ export interface ComponentToken {
   dotOffsetInSquare: number;
 }
 
-
 /**
  * @desc FloatButton 组件的 Token
  * @descEN Token for FloatButton component
@@ -193,8 +192,11 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
     },
     [`${groupPrefixCls}-square`]: {
       [`${componentCls}-square`]: {
-        borderRadius: 0,
         padding: 0,
+        borderRadius: 0,
+        [`&${groupPrefixCls}-trigger`]: {
+          borderRadius: borderRadiusLG,
+        },
         '&:first-child': {
           borderStartStartRadius: borderRadiusLG,
           borderStartEndRadius: borderRadiusLG,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

### before:
![image](https://github.com/user-attachments/assets/7edfed1a-c3bf-4488-8221-92de86a9a282)

### after:
![image](https://github.com/user-attachments/assets/5b75af1f-6957-4482-8636-e6bbb6415307)

顺便在 demo 中留了个快照做兜底

### 📝 Change Log

> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: 修复了 FloatButton 组件当 shape=“square” 时，并且在菜单模式下，菜单弹出时 trigger 元素圆角缺失的问题 |
| 🇨🇳 Chinese | fix: 修复了 FloatButton 组件当 shape=“square” 时，并且在菜单模式下，菜单弹出时 trigger 元素圆角缺失的问题 |