### PR TITLE
locale: add Transfer.deselectAll to ru_RU and uk_UA

### DIFF
--- a/components/locale/ru_RU.ts
+++ b/components/locale/ru_RU.ts
@@ -58,6 +58,7 @@ const localeValues: Locale = {
     itemsUnit: 'элем.',
     remove: 'Удалить',
     selectAll: 'Выбрать все данные',
+    deselectAll: 'Очистить все данные',
     selectCurrent: 'Выбрать текущую страницу',
     selectInvert: 'Инвертировать выбор',
     removeAll: 'Удалить все данные',

--- a/components/locale/uk_UA.ts
+++ b/components/locale/uk_UA.ts
@@ -59,6 +59,7 @@ const localeValues: Locale = {
     selectCurrent: 'Вибрати поточну сторінку',
     removeCurrent: 'Скасувати вибір на сторінці',
     selectAll: 'Вибрати всі дані',
+    deselectAll: 'Очистити вибір',
     removeAll: 'Скасувати вибір',
     selectInvert: 'Інвертувати поточну сторінку',
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Add missing Transfer.deselectAll translations for ru_RU and uk_UA locales (Both cases copy from Table.selectNone)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix missing Transfer.deselectAll for ru_RU and uk_UA locales   |
| 🇨🇳 Chinese |  补充俄罗斯语和乌克兰语本地化文案。  |
