### PR TITLE
demo(form): improve variant demo

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -30410,6 +30410,100 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
         class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
       >
         <label
+          class=""
+          for="variant"
+          title="Form variant"
+        >
+          Form variant
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+              id="variant"
+            >
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="outlined"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  outlined
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="filled"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  filled
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="borderless"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  borderless
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      >
+        <label
           class="ant-form-item-required"
           for="Input"
           title="Input"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -30427,67 +30427,56 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-segmented"
               id="variant"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              <div
+                class="ant-segmented-group"
               >
-                <span
-                  class="ant-radio-button"
+                <label
+                  class="ant-segmented-item"
                 >
                   <input
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="outlined"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  outlined
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-in-form-item"
-              >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                  <div
+                    class="ant-segmented-item-label"
+                    title="outlined"
+                  >
+                    outlined
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item ant-segmented-item-selected"
                 >
                   <input
                     checked=""
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="filled"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  filled
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
-              >
-                <span
-                  class="ant-radio-button"
+                  <div
+                    class="ant-segmented-item-label"
+                    title="filled"
+                  >
+                    filled
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item"
                 >
                   <input
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="borderless"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  borderless
-                </span>
-              </label>
+                  <div
+                    class="ant-segmented-item-label"
+                    title="borderless"
+                  >
+                    borderless
+                  </div>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -12646,67 +12646,56 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline"
+              class="ant-segmented"
               id="variant"
             >
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              <div
+                class="ant-segmented-group"
               >
-                <span
-                  class="ant-radio-button"
+                <label
+                  class="ant-segmented-item"
                 >
                   <input
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="outlined"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  outlined
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-in-form-item"
-              >
-                <span
-                  class="ant-radio-button ant-radio-button-checked"
+                  <div
+                    class="ant-segmented-item-label"
+                    title="outlined"
+                  >
+                    outlined
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item ant-segmented-item-selected"
                 >
                   <input
                     checked=""
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="filled"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  filled
-                </span>
-              </label>
-              <label
-                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
-              >
-                <span
-                  class="ant-radio-button"
+                  <div
+                    class="ant-segmented-item-label"
+                    title="filled"
+                  >
+                    filled
+                  </div>
+                </label>
+                <label
+                  class="ant-segmented-item"
                 >
                   <input
-                    class="ant-radio-button-input"
+                    class="ant-segmented-item-input"
                     type="radio"
-                    value="borderless"
                   />
-                  <span
-                    class="ant-radio-button-inner"
-                  />
-                </span>
-                <span>
-                  borderless
-                </span>
-              </label>
+                  <div
+                    class="ant-segmented-item-label"
+                    title="borderless"
+                  >
+                    borderless
+                  </div>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -12629,6 +12629,100 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
         class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
       >
         <label
+          class=""
+          for="variant"
+          title="Form variant"
+        >
+          Form variant
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control ant-col-xs-24 ant-col-sm-14"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-radio-group ant-radio-group-outline"
+              id="variant"
+            >
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="outlined"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  outlined
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-checked ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button ant-radio-button-checked"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="filled"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  filled
+                </span>
+              </label>
+              <label
+                class="ant-radio-button-wrapper ant-radio-button-wrapper-in-form-item"
+              >
+                <span
+                  class="ant-radio-button"
+                >
+                  <input
+                    class="ant-radio-button-input"
+                    type="radio"
+                    value="borderless"
+                  />
+                  <span
+                    class="ant-radio-button-inner"
+                  />
+                </span>
+                <span>
+                  borderless
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label ant-col-xs-24 ant-col-sm-6"
+      >
+        <label
           class="ant-form-item-required"
           for="Input"
           title="Input"

--- a/components/form/demo/variant.tsx
+++ b/components/form/demo/variant.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Button,
   Cascader,
@@ -9,7 +9,9 @@ import {
   Mentions,
   Select,
   TreeSelect,
+  Radio,
 } from 'antd';
+import type { FormProps } from 'antd';
 
 const { RangePicker } = DatePicker;
 
@@ -24,78 +26,103 @@ const formItemLayout = {
   },
 };
 
-const App: React.FC = () => (
-  <Form {...formItemLayout} variant="filled" style={{ maxWidth: 600 }}>
-    <Form.Item label="Input" name="Input" rules={[{ required: true, message: 'Please input!' }]}>
-      <Input />
-    </Form.Item>
+const App: React.FC = () => {
+  const [componentVariant, setComponentVariant] = useState<FormProps['variant']>('filled');
 
-    <Form.Item
-      label="InputNumber"
-      name="InputNumber"
-      rules={[{ required: true, message: 'Please input!' }]}
+  const onFormVariantChange = ({ variant }: { variant: FormProps['variant'] }) => {
+    setComponentVariant(variant);
+  };
+  return (
+    <Form
+      {...formItemLayout}
+      onValuesChange={onFormVariantChange}
+      variant={componentVariant}
+      style={{ maxWidth: 600 }}
+      initialValues={{ variant: componentVariant }}
     >
-      <InputNumber style={{ width: '100%' }} />
-    </Form.Item>
+      <Form.Item label="Form variant" name="variant">
+        <Radio.Group>
+          <Radio.Button value="outlined">outlined</Radio.Button>
+          <Radio.Button value="filled">filled</Radio.Button>
+          <Radio.Button value="borderless">borderless</Radio.Button>
+        </Radio.Group>
+      </Form.Item>
 
-    <Form.Item
-      label="TextArea"
-      name="TextArea"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <Input.TextArea />
-    </Form.Item>
+      <Form.Item label="Input" name="Input" rules={[{ required: true, message: 'Please input!' }]}>
+        <Input />
+      </Form.Item>
 
-    <Form.Item
-      label="Mentions"
-      name="Mentions"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <Mentions />
-    </Form.Item>
+      <Form.Item
+        label="InputNumber"
+        name="InputNumber"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <InputNumber style={{ width: '100%' }} />
+      </Form.Item>
 
-    <Form.Item label="Select" name="Select" rules={[{ required: true, message: 'Please input!' }]}>
-      <Select />
-    </Form.Item>
+      <Form.Item
+        label="TextArea"
+        name="TextArea"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <Input.TextArea />
+      </Form.Item>
 
-    <Form.Item
-      label="Cascader"
-      name="Cascader"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <Cascader />
-    </Form.Item>
+      <Form.Item
+        label="Mentions"
+        name="Mentions"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <Mentions />
+      </Form.Item>
 
-    <Form.Item
-      label="TreeSelect"
-      name="TreeSelect"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <TreeSelect />
-    </Form.Item>
+      <Form.Item
+        label="Select"
+        name="Select"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <Select />
+      </Form.Item>
 
-    <Form.Item
-      label="DatePicker"
-      name="DatePicker"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <DatePicker />
-    </Form.Item>
+      <Form.Item
+        label="Cascader"
+        name="Cascader"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <Cascader />
+      </Form.Item>
 
-    <Form.Item
-      label="RangePicker"
-      name="RangePicker"
-      rules={[{ required: true, message: 'Please input!' }]}
-    >
-      <RangePicker />
-    </Form.Item>
+      <Form.Item
+        label="TreeSelect"
+        name="TreeSelect"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <TreeSelect />
+      </Form.Item>
 
-    <Form.Item wrapperCol={{ offset: 6, span: 16 }}>
-      <Button type="primary" htmlType="submit">
-        Submit
-      </Button>
-    </Form.Item>
-  </Form>
-);
+      <Form.Item
+        label="DatePicker"
+        name="DatePicker"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <DatePicker />
+      </Form.Item>
+
+      <Form.Item
+        label="RangePicker"
+        name="RangePicker"
+        rules={[{ required: true, message: 'Please input!' }]}
+      >
+        <RangePicker />
+      </Form.Item>
+
+      <Form.Item wrapperCol={{ offset: 6, span: 16 }}>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
 
 export default App;

--- a/components/form/demo/variant.tsx
+++ b/components/form/demo/variant.tsx
@@ -9,7 +9,7 @@ import {
   Mentions,
   Select,
   TreeSelect,
-  Radio,
+  Segmented,
 } from 'antd';
 import type { FormProps } from 'antd';
 
@@ -41,11 +41,7 @@ const App: React.FC = () => {
       initialValues={{ variant: componentVariant }}
     >
       <Form.Item label="Form variant" name="variant">
-        <Radio.Group>
-          <Radio.Button value="outlined">outlined</Radio.Button>
-          <Radio.Button value="filled">filled</Radio.Button>
-          <Radio.Button value="borderless">borderless</Radio.Button>
-        </Radio.Group>
+        <Segmented options={['outlined', 'filled', 'borderless']} />
       </Form.Item>
 
       <Form.Item label="Input" name="Input" rules={[{ required: true, message: 'Please input!' }]}>


### PR DESCRIPTION

### 🤔 This is a ...


- [x] 📽️ Demo improvement


### 💡 Background and Solution
增加一个Radio.Group来切换variant 变体，方便预览不同变体的效果
![image](https://github.com/user-attachments/assets/2a751bcb-17d2-4217-aca4-1c6c0b91e4f0)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |          demo(form): improve variant demo |
| 🇨🇳 Chinese |     demo(form): 优化 variant demo      |
