### PR TITLE
fix: onComplete directly case

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -34,12 +34,15 @@ function doMouseMove(
   });
 
   fireEvent(ele, mouseDown);
-  // Drag
-  const mouseMove: any = new Event('mousemove');
-  mouseMove.pageX = end;
-  mouseMove.pageY = end;
 
-  fireEvent(document, mouseMove);
+  // Drag
+  if (start !== end) {
+    const mouseMove: any = new Event('mousemove');
+    mouseMove.pageX = end;
+    mouseMove.pageY = end;
+
+    fireEvent(document, mouseMove);
+  }
 
   const mouseUp = createEvent.mouseUp(document);
   fireEvent(document, mouseUp);
@@ -847,5 +850,33 @@ describe('ColorPicker', () => {
         'rgba(255,0,0,0.5)',
       );
     });
+  });
+
+  it('onChangeComplete with default empty color should not be alpha', async () => {
+    const spyRect = spyElementPrototypes(HTMLElement, {
+      getBoundingClientRect: () => ({
+        x: 0,
+        y: 100,
+        width: 100,
+        height: 100,
+      }),
+    });
+
+    const handleChangeComplete = jest.fn();
+    const { container } = render(<ColorPicker open onChangeComplete={handleChangeComplete} />);
+
+    // Move
+    doMouseMove(container, 50, 50);
+    expect(handleChangeComplete).toHaveBeenCalledTimes(1);
+
+    const color = handleChangeComplete.mock.calls[0][0];
+    expect(color.toRgb()).toEqual({
+      r: 255,
+      g: 128,
+      b: 128,
+      a: 1,
+    });
+
+    spyRect.mockRestore();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50499

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ColorPicker `onChangeComplete` not correct when click directly without move on the picker panel.     |
| 🇨🇳 Chinese |    修复 ColorPicker 在面板上不拖拽直接点击的时候，`onChangeComplete` 返回值不正确的问题。      |
