### PR TITLE
fix: ellipsis check for over

### DIFF
--- a/components/typography/Base/Ellipsis.tsx
+++ b/components/typography/Base/Ellipsis.tsx
@@ -224,6 +224,11 @@ export default function EllipsisMeasure(props: EllipsisProps) {
 
   // ========================= Text Content =========================
   const finalContent = React.useMemo(() => {
+    // Skip everything if `enableMeasure` is disabled
+    if (!enableMeasure) {
+      return children(nodeList, false);
+    }
+
     if (
       needEllipsis !== STATUS_MEASURE_NEED_ELLIPSIS ||
       !ellipsisCutIndex ||

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -25,7 +25,7 @@ import Typography from '../Typography';
 import CopyBtn from './CopyBtn';
 import Ellipsis from './Ellipsis';
 import EllipsisTooltip from './EllipsisTooltip';
-import { getEleSize } from './util';
+import { isEleEllipsis } from './util';
 
 export type BaseType = 'secondary' | 'success' | 'warning' | 'danger';
 
@@ -281,11 +281,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     const textEle = typographyRef.current;
 
     if (enableEllipsis && cssEllipsis && textEle) {
-      const [offsetWidth, offsetHeight, scrollWidth, scrollHeight] = getEleSize(textEle);
-
-      const currentEllipsis = cssLineClamp
-        ? offsetHeight < scrollHeight
-        : offsetWidth < scrollWidth;
+      const currentEllipsis = isEleEllipsis(textEle);
 
       if (isNativeEllipsis !== currentEllipsis) {
         setIsNativeEllipsis(currentEllipsis);

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -281,11 +281,11 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     const textEle = typographyRef.current;
 
     if (enableEllipsis && cssEllipsis && textEle) {
-      const [offsetWidth, offsetHeight] = getEleSize(textEle);
+      const [offsetWidth, offsetHeight, scrollWidth, scrollHeight] = getEleSize(textEle);
 
       const currentEllipsis = cssLineClamp
-        ? offsetHeight < textEle.scrollHeight
-        : offsetWidth < textEle.scrollWidth;
+        ? offsetHeight < scrollHeight
+        : offsetWidth < scrollWidth;
 
       if (isNativeEllipsis !== currentEllipsis) {
         setIsNativeEllipsis(currentEllipsis);

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -442,7 +442,6 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   };
 
   const renderOperations = (canEllipsis: boolean) => [
-    // (renderExpanded || ellipsisConfig.collapsible) && renderExpand(),
     canEllipsis && renderExpand(),
     renderEdit(),
     renderCopy(),

--- a/components/typography/Base/util.ts
+++ b/components/typography/Base/util.ts
@@ -13,47 +13,38 @@ export function getNode(dom: React.ReactNode, defaultNode: React.ReactNode, need
 }
 
 /**
- * Get React of element with precision.
- * ref: https://github.com/ant-design/ant-design/issues/50143
+ * Check for element is native ellipsis
+ * ref:
+ * - https://github.com/ant-design/ant-design/issues/50143
+ * - https://github.com/ant-design/ant-design/issues/50414
  */
-export function getEleSize(
-  ele: HTMLElement,
-): [width: number, height: number, scrollWidth: number, scrollHeight: number] {
-  const oriPosition = ele.style.position;
-
+export function isEleEllipsis(ele: HTMLElement): boolean {
   // Create a new div to get the size
-  ele.style.position = 'relative';
-  const childDiv = document.createElement('div');
-  childDiv.style.inset = '0';
-  childDiv.style.position = 'absolute';
+  const childDiv = document.createElement('em');
+  ele.appendChild(childDiv);
 
   // For test case
   if (process.env.NODE_ENV !== 'production') {
     childDiv.className = 'ant-typography-css-ellipsis-content-measure';
   }
-  ele.appendChild(childDiv);
 
   const rect = ele.getBoundingClientRect();
-  const { offsetWidth, offsetHeight, scrollWidth, scrollHeight } = ele;
-
-  let returnWidth = offsetWidth;
-  let returnHeight = offsetHeight;
-  let returnScrollWidth = scrollWidth;
-  let returnScrollHeight = scrollHeight;
-
-  if (Math.abs(offsetWidth - rect.width) < 1 && Math.abs(offsetHeight - rect.height) < 1) {
-    returnWidth = rect.width;
-    returnHeight = rect.height;
-
-    // Get children size
-    const childRect = childDiv.getBoundingClientRect();
-    returnScrollWidth = childRect.width;
-    returnScrollHeight = childRect.height;
-  }
+  const childRect = childDiv.getBoundingClientRect();
 
   // Reset
   ele.removeChild(childDiv);
-  ele.style.position = oriPosition;
 
-  return [returnWidth, returnHeight, returnScrollWidth, returnScrollHeight];
+  // Range checker
+  if (
+    // Horizontal in range
+    rect.left <= childRect.left &&
+    childRect.right <= rect.right &&
+    // Vertical in range
+    rect.top <= childRect.top &&
+    childRect.bottom <= rect.bottom
+  ) {
+    return false;
+  }
+
+  return true;
 }

--- a/components/typography/Base/util.ts
+++ b/components/typography/Base/util.ts
@@ -16,17 +16,44 @@ export function getNode(dom: React.ReactNode, defaultNode: React.ReactNode, need
  * Get React of element with precision.
  * ref: https://github.com/ant-design/ant-design/issues/50143
  */
-export function getEleSize(ele: HTMLElement): [width: number, height: number] {
+export function getEleSize(
+  ele: HTMLElement,
+): [width: number, height: number, scrollWidth: number, scrollHeight: number] {
+  const oriPosition = ele.style.position;
+
+  // Create a new div to get the size
+  ele.style.position = 'relative';
+  const childDiv = document.createElement('div');
+  childDiv.style.inset = '0';
+  childDiv.style.position = 'absolute';
+
+  // For test case
+  if (process.env.NODE_ENV !== 'production') {
+    childDiv.className = 'ant-typography-css-ellipsis-content-measure';
+  }
+  ele.appendChild(childDiv);
+
   const rect = ele.getBoundingClientRect();
-  const { offsetWidth, offsetHeight } = ele;
+  const { offsetWidth, offsetHeight, scrollWidth, scrollHeight } = ele;
 
   let returnWidth = offsetWidth;
   let returnHeight = offsetHeight;
+  let returnScrollWidth = scrollWidth;
+  let returnScrollHeight = scrollHeight;
 
   if (Math.abs(offsetWidth - rect.width) < 1 && Math.abs(offsetHeight - rect.height) < 1) {
     returnWidth = rect.width;
     returnHeight = rect.height;
+
+    // Get children size
+    const childRect = childDiv.getBoundingClientRect();
+    returnScrollWidth = childRect.width;
+    returnScrollHeight = childRect.height;
   }
 
-  return [returnWidth, returnHeight];
+  // Reset
+  ele.removeChild(childDiv);
+  ele.style.position = oriPosition;
+
+  return [returnWidth, returnHeight, returnScrollWidth, returnScrollHeight];
 }

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -367,6 +367,7 @@ describe('Typography.Ellipsis', () => {
     let containerWidth = 100;
     let contentWidth = 200;
     let rectContainerWidth = 100;
+    let rectContentWidth = 200;
 
     beforeAll(() => {
       domSpy = spyElementPrototypes(HTMLElement, {
@@ -376,10 +377,23 @@ describe('Typography.Ellipsis', () => {
         scrollWidth: {
           get: () => contentWidth,
         },
-        getBoundingClientRect: () => ({
-          width: rectContainerWidth,
-          height: 0,
-        }),
+        getBoundingClientRect() {
+          if (
+            (this as unknown as HTMLElement).classList.contains(
+              'ant-typography-css-ellipsis-content-measure',
+            )
+          ) {
+            return {
+              width: rectContentWidth,
+              height: 0,
+            };
+          }
+
+          return {
+            width: rectContainerWidth,
+            height: 0,
+          };
+        },
       });
     });
 
@@ -387,6 +401,7 @@ describe('Typography.Ellipsis', () => {
       containerWidth = 100;
       contentWidth = 200;
       rectContainerWidth = 100;
+      rectContentWidth = 200;
     });
 
     afterAll(() => {
@@ -453,21 +468,43 @@ describe('Typography.Ellipsis', () => {
       });
     });
 
-    // https://github.com/ant-design/ant-design/issues/50143
-    it('precision', async () => {
-      containerWidth = 100;
-      contentWidth = 100;
-      rectContainerWidth = 99.9;
+    describe('precision', () => {
+      // https://github.com/ant-design/ant-design/issues/50143
+      it('should show', async () => {
+        containerWidth = 100;
+        contentWidth = 100;
+        rectContainerWidth = 99.9;
+        rectContentWidth = 100;
 
-      const { container, baseElement } = await getWrapper({
-        title: true,
-        className: 'tooltip-class-name',
-      });
-      fireEvent.mouseEnter(container.firstChild!);
+        const { container, baseElement } = await getWrapper({
+          title: true,
+          className: 'tooltip-class-name',
+        });
+        fireEvent.mouseEnter(container.firstChild!);
 
-      await waitFor(() => {
+        await waitFakeTimer();
+
         expect(container.querySelector('.tooltip-class-name')).toBeTruthy();
         expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeNull();
+      });
+
+      // https://github.com/ant-design/ant-design/issues/50414
+      it('should not show', async () => {
+        containerWidth = 49;
+        contentWidth = 49;
+        rectContainerWidth = 48.52;
+        rectContentWidth = 48.52;
+
+        const { container, baseElement } = await getWrapper({
+          title: true,
+          className: 'tooltip-class-name',
+        });
+        fireEvent.mouseEnter(container.firstChild!);
+
+        await waitFakeTimer();
+
+        expect(container.querySelector('.tooltip-class-name')).toBeTruthy();
+        expect(baseElement.querySelector('.ant-tooltip-open')).toBeFalsy();
       });
     });
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50414

### 💡 Background and Solution

精度问题同时存在于 `clientWidth` 和 `scrollWidth` 上。相同数值下是无法直接知道哪个是向上、哪个是向下取整。换了一下实现，添加一个看不见的元素并且测量元素的坐标是否在 Text 的 rect 外。如果是则说明出现省略。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Refactor Typography native css ellipsis measure logic to handle precision edge case.        |
| 🇨🇳 Chinese |    重构 Typography 在使用 css 原生省略时的检查逻辑，以解决屏幕缩放等情况下的精度问题。      |
