### PR TITLE
Correct ColorPickerProps.onChange string parameter name

### DIFF
--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -85,7 +85,7 @@ export type ColorPickerProps = Omit<
   [key: `data-${string}`]: string;
   onOpenChange?: (open: boolean) => void;
   onFormatChange?: (format?: ColorFormatType) => void;
-  onChange?: (value: AggregationColor, hex: string) => void;
+  onChange?: (value: AggregationColor, css: string) => void;
   onClear?: () => void;
   onChangeComplete?: (value: AggregationColor) => void;
 } & Pick<PopoverProps, 'getPopupContainer' | 'autoAdjustOverflow' | 'destroyTooltipOnHide'>;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🤖 TypeScript definition improvement

### 💡 Background and Solution

Currently, the string parameter from ColorPickerProps.onChange is labeled as `hex`, when in reality it is always the generated css string. Hence the corrected name `css`. I considered `cssString` but given it is `: string`, that seemed repetitious to me.

The code was changed in https://github.com/ant-design/ant-design/pull/50050/files#diff-be92dd92152a780003d48ddc95ec6716367d327f9f890f1221b84614aaa8168fR123 but the type definition wasn't updated correspondingly.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - |
| 🇨🇳 Chinese |    -       |
