### PR TITLE
docs: update color-picker onChage Docs

### DIFF
--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -60,7 +60,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | size | Setting the trigger size | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | |
 | value | Value of color | string \| `Color` | - | |
-| onChange | Callback when `value` is changed | `(value: Color, hex: string) => void` | - | |
+| onChange | Callback when `value` is changed | `(value: Color, css: string) => void` | - | |
 | onChangeComplete | Called when color pick ends   | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -61,7 +61,7 @@ group:
 | size | 设置触发器大小 | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | |
 | value | 颜色的值 | string \| `Color` | - | |
-| onChange | 颜色变化的回调 | `(value: Color, hex: string) => void` | - | |
+| onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | |
 | onChangeComplete | 颜色选择完成的回调  | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - https://github.com/ant-design/ant-design/issues/50050


### 💡 Background and Solution

### 📝 Change Log

> - after 5.20.0 version, the second parameter of color-pick onChange props has changed from hex to cssString. 
However, Docs still says Hex, so I modified it

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  updaet docs, the second parameter of color-pick onChange  |
| 🇨🇳 Chinese |        |
