### PR TITLE
fix: Typography dead loop

### DIFF
--- a/BUG_VERSIONS.json
+++ b/BUG_VERSIONS.json
@@ -56,5 +56,6 @@
   ">= 5.16.0 <= 5.16.1": ["https://github.com/ant-design/ant-design/issues/48200"],
   "5.16.3": ["https://github.com/ant-design/ant-design/issues/48568"],
   "5.17.1": ["https://github.com/ant-design/ant-design/issues/48913"],
-  "5.18.2": ["https://github.com/ant-design/ant-design/pull/49487"]
+  "5.18.2": ["https://github.com/ant-design/ant-design/pull/49487"],
+  "5.20.4": ["https://github.com/ant-design/ant-design/issues/50687"]
 }

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -633,4 +633,15 @@ describe('Typography.Ellipsis', () => {
     rerender(renderDemo(true));
     expect(container.querySelector('.ant-typography-collapse')).toBeTruthy();
   });
+
+  it('no dead loop', () => {
+    const tooltipObj: any = {};
+    tooltipObj.loop = tooltipObj;
+
+    render(
+      <Base ellipsis={{ tooltip: tooltipObj }} component="p">
+        {fullStr}
+      </Base>,
+    );
+  });
 });

--- a/components/typography/hooks/useTooltipProps.ts
+++ b/components/typography/hooks/useTooltipProps.ts
@@ -17,6 +17,6 @@ const useTooltipProps = (
       return { title: editConfigText ?? children, ...tooltip };
     }
     return { title: tooltip };
-  }, [typeof tooltip === 'object' ? JSON.stringify(tooltip) : tooltip, editConfigText, children]);
+  }, [tooltip, editConfigText, children]);
 
 export default useTooltipProps;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50687

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Fix Typography `ellipsis.tooltip.title` with ReactNode will cause dead loop.     |
| 🇨🇳 Chinese |    修复 Typography `ellipsis.tooltip.title` 配置 ReactNode 会导致死循环的问题。      |
