### PR TITLE
type: narrow Collapse onChange argument to string[]

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -27,7 +27,7 @@ export interface CollapseProps extends Pick<RcCollapseProps, 'items'> {
   /** 手风琴效果 */
   accordion?: boolean;
   destroyInactivePanel?: boolean;
-  onChange?: (key: string | string[]) => void;
+  onChange?: (key: string[]) => void;
   style?: React.CSSProperties;
   className?: string;
   rootClassName?: string;


### PR DESCRIPTION
…omponent is incorrect.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [√ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - 现有 Collapse 组件参数 onChange 回调的类型定义为：(key: string | string[]) => void 。但实际上传递给 onChange 回调的参数只会是 string[] 类型


### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The ts type of the onChange callback parameter of the Collapse component is incorrect.      |
| 🇨🇳 Chinese |     修复  Collapse 组件参数 onChange 回调的类型定义    |
