### PR TITLE
fix: improve ts type definition of theme token

### DIFF
--- a/components/theme/interface/maps/style.ts
+++ b/components/theme/interface/maps/style.ts
@@ -15,7 +15,7 @@ export interface StyleMapToken {
    * @descEN XS size border radius, used in some small border radius components, such as Segmented, Arrow and other components with small border radius.
    * @default 2
    */
-  borderRadiusXS: number;
+  borderRadiusXS: number | string;
   /**
    * @nameZH SM号圆角
    * @nameEN SM Border Radius
@@ -23,7 +23,7 @@ export interface StyleMapToken {
    * @descEN SM size border radius, used in small size components, such as Button, Input, Select and other input components in small size
    * @default 4
    */
-  borderRadiusSM: number;
+  borderRadiusSM: number | string;
   /**
    * @nameZH LG号圆角
    * @nameEN LG Border Radius
@@ -31,7 +31,7 @@ export interface StyleMapToken {
    * @descEN LG size border radius, used in some large border radius components, such as Card, Modal and other components.
    * @default 8
    */
-  borderRadiusLG: number;
+  borderRadiusLG: number | string;
   /**
    * @nameZH 外部圆角
    * @nameEN Outer Border Radius
@@ -39,5 +39,5 @@ export interface StyleMapToken {
    * @desc 外部圆角
    * @descEN Outer border radius
    */
-  borderRadiusOuter: number;
+  borderRadiusOuter: number | string;
 }

--- a/components/theme/interface/seeds.ts
+++ b/components/theme/interface/seeds.ts
@@ -97,7 +97,7 @@ export interface SeedToken extends PresetColorType {
    * @descEN The most widely used font size in the design system, from which the text gradient will be derived.
    * @default 14
    */
-  fontSize: number;
+  fontSize: number | string;
 
   //  ----------   Line   ---------- //
 
@@ -125,7 +125,7 @@ export interface SeedToken extends PresetColorType {
    * @descEN Border radius of base components
    * @desc 基础组件的圆角大小，例如按钮、输入框、卡片等
    */
-  borderRadius: number;
+  borderRadius: number | string;
 
   //  ----------   Size   ---------- //
 
@@ -161,7 +161,7 @@ export interface SeedToken extends PresetColorType {
    * @descEN The height of the basic controls such as buttons and input boxes in Ant Design
    * @default 32
    */
-  controlHeight: number;
+  controlHeight: number | string;
 
   //  ----------   zIndex   ---------- //
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [✓] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 💡 Background and Solution
使用定制主题时，需要进行移动端适配，但token中的某些属性的类型定义仅有```number```
![image](https://github.com/user-attachments/assets/5ac23c1b-dd93-4951-b2a3-d11a3c9c5021)
显然这是不完善的，应该和```React.CSSProperties```保持一致
![image](https://github.com/user-attachments/assets/8e7b126c-0610-4e13-b608-a083b9e91b1c)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
