### PR TITLE
refactor: ColorPicker panel free for uncontrolled

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -108,7 +108,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     }
   };
 
-  const onInternalChange: ColorPickerPanelProps['onChange'] = (data, pickColor) => {
+  const onInternalChange: ColorPickerPanelProps['onChange'] = (data, changeFromPickerDrag) => {
     let color: AggregationColor = generateColor(data as AggregationColor);
 
     // ignore alpha color
@@ -125,7 +125,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     }
 
     // Only for drag-and-drop color picking
-    if (!pickColor) {
+    if (!changeFromPickerDrag) {
       onInternalChangeComplete(color);
     }
   };

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -782,347 +782,273 @@ Array [
 exports[`renders components/color-picker/demo/base.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/color-picker/demo/controlled.tsx extend context correctly 1`] = `
-Array [
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+>
   <div
-    class="ant-color-picker-trigger"
+    class="ant-space-item"
   >
     <div
-      class="ant-color-picker-color-block"
+      class="ant-color-picker-trigger"
     >
       <div
-        class="ant-color-picker-color-block-inner"
-        style="background: rgb(22, 119, 255);"
-      />
-    </div>
-  </div>,
-  <div
-    class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-  >
-    <div
-      class="ant-popover-arrow"
-      style="position: absolute;"
-    />
-    <div
-      class="ant-popover-content"
-    >
-      <div
-        class="ant-popover-inner"
-        role="tooltip"
+        class="ant-color-picker-color-block"
       >
         <div
-          class="ant-popover-inner-content"
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
         >
           <div
-            class="ant-color-picker-inner"
+            class="ant-popover-inner-content"
           >
             <div
-              class="ant-color-picker-inner-content"
+              class="ant-color-picker-inner"
             >
               <div
-                class="ant-color-picker-panel"
+                class="ant-color-picker-inner-content"
               >
                 <div
-                  class="ant-color-picker-select"
+                  class="ant-color-picker-panel"
                 >
                   <div
-                    class="ant-color-picker-palette"
-                    style="position: relative;"
+                    class="ant-color-picker-select"
                   >
                     <div
-                      style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
+                      class="ant-color-picker-palette"
+                      style="position: relative;"
                     >
                       <div
-                        class="ant-color-picker-handler"
-                        style="background-color: rgb(22, 119, 255);"
-                      />
-                    </div>
-                    <div
-                      class="ant-color-picker-saturation"
-                      style="background-color: rgb(0, 0, 0);"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="ant-color-picker-slider-container"
-                >
-                  <div
-                    class="ant-color-picker-slider-group"
-                  >
-                    <div
-                      class="ant-slider ant-color-picker-slider ant-slider-horizontal"
-                    >
-                      <div
-                        class="ant-slider-rail ant-color-picker-slider-rail"
-                      />
-                      <div
-                        class="ant-slider-step"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-orientation="horizontal"
-                        aria-valuemax="359"
-                        aria-valuemin="0"
-                        aria-valuenow="215"
-                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
-                        role="slider"
-                        style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 0, 0);"
-                        tabindex="0"
-                      />
-                    </div>
-                    <div
-                      class="ant-slider ant-color-picker-slider ant-slider-horizontal"
-                    >
-                      <div
-                        class="ant-slider-rail ant-color-picker-slider-rail"
-                      />
-                      <div
-                        class="ant-slider-step"
-                      />
-                      <div
-                        aria-disabled="false"
-                        aria-orientation="horizontal"
-                        aria-valuemax="100"
-                        aria-valuemin="0"
-                        aria-valuenow="100"
-                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
-                        role="slider"
-                        style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
-                        tabindex="0"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="ant-color-picker-color-block"
-                  >
-                    <div
-                      class="ant-color-picker-color-block-inner"
-                      style="background: rgb(22, 119, 255);"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div
-                class="ant-color-picker-input-container"
-              >
-                <div
-                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
-                >
-                  <div
-                    class="ant-select-selector"
-                  >
-                    <span
-                      class="ant-select-selection-search"
-                    >
-                      <input
-                        aria-autocomplete="list"
-                        aria-controls="rc_select_TEST_OR_SSR_list"
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        aria-owns="rc_select_TEST_OR_SSR_list"
-                        autocomplete="off"
-                        class="ant-select-selection-search-input"
-                        id="rc_select_TEST_OR_SSR"
-                        readonly=""
-                        role="combobox"
-                        style="opacity: 0;"
-                        type="search"
-                        unselectable="on"
-                        value=""
-                      />
-                    </span>
-                    <span
-                      class="ant-select-selection-item"
-                      title="HEX"
-                    >
-                      HEX
-                    </span>
-                  </div>
-                  <div
-                    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
-                    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1150; width: 68px;"
-                  >
-                    <div>
-                      <div
-                        id="rc_select_TEST_OR_SSR_list"
-                        role="listbox"
-                        style="height: 0px; width: 0px; overflow: hidden;"
+                        style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
                       >
                         <div
-                          aria-label="HEX"
-                          aria-selected="true"
-                          id="rc_select_TEST_OR_SSR_list_0"
-                          role="option"
-                        >
-                          hex
-                        </div>
-                        <div
-                          aria-label="HSB"
-                          aria-selected="false"
-                          id="rc_select_TEST_OR_SSR_list_1"
-                          role="option"
-                        >
-                          hsb
-                        </div>
+                          class="ant-color-picker-handler"
+                          style="background-color: rgb(22, 119, 255);"
+                        />
                       </div>
                       <div
-                        class="rc-virtual-list"
-                        style="position: relative;"
+                        class="ant-color-picker-saturation"
+                        style="background-color: rgb(0, 0, 0);"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-slider-container"
+                  >
+                    <div
+                      class="ant-color-picker-slider-group"
+                    >
+                      <div
+                        class="ant-slider ant-color-picker-slider ant-slider-horizontal"
                       >
                         <div
-                          class="rc-virtual-list-holder"
-                          style="max-height: 256px; overflow-y: auto;"
+                          class="ant-slider-rail ant-color-picker-slider-rail"
+                        />
+                        <div
+                          class="ant-slider-step"
+                        />
+                        <div
+                          aria-disabled="false"
+                          aria-orientation="horizontal"
+                          aria-valuemax="359"
+                          aria-valuemin="0"
+                          aria-valuenow="215"
+                          class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                          role="slider"
+                          style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 0, 0);"
+                          tabindex="0"
+                        />
+                      </div>
+                      <div
+                        class="ant-slider ant-color-picker-slider ant-slider-horizontal"
+                      >
+                        <div
+                          class="ant-slider-rail ant-color-picker-slider-rail"
+                        />
+                        <div
+                          class="ant-slider-step"
+                        />
+                        <div
+                          aria-disabled="false"
+                          aria-orientation="horizontal"
+                          aria-valuemax="100"
+                          aria-valuemin="0"
+                          aria-valuenow="100"
+                          class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                          role="slider"
+                          style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
+                          tabindex="0"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-color-block"
+                    >
+                      <div
+                        class="ant-color-picker-color-block-inner"
+                        style="background: rgb(22, 119, 255);"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1150; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
                         >
-                          <div>
-                            <div
-                              class="rc-virtual-list-holder-inner"
-                              style="display: flex; flex-direction: column;"
-                            >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
                               <div
-                                aria-selected="true"
-                                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
-                                title="HEX"
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
                               >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
                                 >
-                                  HEX
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
-                              </div>
-                              <div
-                                aria-selected="false"
-                                class="ant-select-item ant-select-item-option"
-                                title="HSB"
-                              >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
                                 >
-                                  HSB
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
-                              </div>
-                              <div
-                                aria-selected="false"
-                                class="ant-select-item ant-select-item-option"
-                                title="RGB"
-                              >
                                 <div
-                                  class="ant-select-item-option-content"
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
                                 >
-                                  RGB
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
                                 </div>
-                                <span
-                                  aria-hidden="true"
-                                  class="ant-select-item-option-state"
-                                  style="user-select: none;"
-                                  unselectable="on"
-                                />
                               </div>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <span
-                    aria-hidden="true"
-                    class="ant-select-arrow"
-                    style="user-select: none;"
-                    unselectable="on"
-                  >
                     <span
-                      aria-label="down"
-                      class="anticon anticon-down ant-select-suffix"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </span>
-                </div>
-                <div
-                  class="ant-color-picker-input"
-                >
-                  <span
-                    class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input"
-                  >
-                    <span
-                      class="ant-input-prefix"
-                    >
-                      #
-                    </span>
-                    <input
-                      class="ant-input ant-input-sm"
-                      type="text"
-                      value="1677ff"
-                    />
-                  </span>
-                </div>
-                <div
-                  class="ant-input-number ant-input-number-sm ant-input-number-outlined ant-color-picker-steppers ant-color-picker-alpha-input"
-                >
-                  <div
-                    class="ant-input-number-handler-wrap"
-                  >
-                    <span
-                      aria-disabled="true"
-                      aria-label="Increase Value"
-                      class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
-                      role="button"
-                      unselectable="on"
-                    >
-                      <span
-                        aria-label="up"
-                        class="anticon anticon-up ant-input-number-handler-up-inner"
-                        role="img"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          data-icon="up"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    <span
-                      aria-disabled="false"
-                      aria-label="Decrease Value"
-                      class="ant-input-number-handler ant-input-number-handler-down"
-                      role="button"
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
                       unselectable="on"
                     >
                       <span
                         aria-label="down"
-                        class="anticon anticon-down ant-input-number-handler-down-inner"
+                        class="anticon anticon-down ant-select-suffix"
                         role="img"
                       >
                         <svg
@@ -1142,18 +1068,98 @@ Array [
                     </span>
                   </div>
                   <div
-                    class="ant-input-number-input-wrap"
+                    class="ant-color-picker-input"
                   >
-                    <input
-                      aria-valuemax="100"
-                      aria-valuemin="0"
-                      aria-valuenow="100"
-                      autocomplete="off"
-                      class="ant-input-number-input"
-                      role="spinbutton"
-                      step="1"
-                      value="100%"
-                    />
+                    <span
+                      class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677ff"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-input-number-outlined ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1162,8 +1168,392 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
-]
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-color-picker ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      />
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popover-inner"
+          role="tooltip"
+        >
+          <div
+            class="ant-popover-inner-content"
+          >
+            <div
+              class="ant-color-picker-inner"
+            >
+              <div
+                class="ant-color-picker-inner-content"
+              >
+                <div
+                  class="ant-color-picker-panel"
+                >
+                  <div
+                    class="ant-color-picker-select"
+                  >
+                    <div
+                      class="ant-color-picker-palette"
+                      style="position: relative;"
+                    >
+                      <div
+                        style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
+                      >
+                        <div
+                          class="ant-color-picker-handler"
+                          style="background-color: rgb(22, 119, 255);"
+                        />
+                      </div>
+                      <div
+                        class="ant-color-picker-saturation"
+                        style="background-color: rgb(0, 0, 0);"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-slider-container"
+                  >
+                    <div
+                      class="ant-color-picker-slider-group"
+                    >
+                      <div
+                        class="ant-slider ant-color-picker-slider ant-slider-horizontal"
+                      >
+                        <div
+                          class="ant-slider-rail ant-color-picker-slider-rail"
+                        />
+                        <div
+                          class="ant-slider-step"
+                        />
+                        <div
+                          aria-disabled="false"
+                          aria-orientation="horizontal"
+                          aria-valuemax="359"
+                          aria-valuemin="0"
+                          aria-valuenow="215"
+                          class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                          role="slider"
+                          style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 0, 0);"
+                          tabindex="0"
+                        />
+                      </div>
+                      <div
+                        class="ant-slider ant-color-picker-slider ant-slider-horizontal"
+                      >
+                        <div
+                          class="ant-slider-rail ant-color-picker-slider-rail"
+                        />
+                        <div
+                          class="ant-slider-step"
+                        />
+                        <div
+                          aria-disabled="false"
+                          aria-orientation="horizontal"
+                          aria-valuemax="100"
+                          aria-valuemin="0"
+                          aria-valuenow="100"
+                          class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                          role="slider"
+                          style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
+                          tabindex="0"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="ant-color-picker-color-block"
+                    >
+                      <div
+                        class="ant-color-picker-color-block-inner"
+                        style="background: rgb(22, 119, 255);"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input-container"
+                >
+                  <div
+                    class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="HEX"
+                      >
+                        HEX
+                      </span>
+                    </div>
+                    <div
+                      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-placement-bottomRight"
+                      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1150; width: 68px;"
+                    >
+                      <div>
+                        <div
+                          id="rc_select_TEST_OR_SSR_list"
+                          role="listbox"
+                          style="height: 0px; width: 0px; overflow: hidden;"
+                        >
+                          <div
+                            aria-label="HEX"
+                            aria-selected="true"
+                            id="rc_select_TEST_OR_SSR_list_0"
+                            role="option"
+                          >
+                            hex
+                          </div>
+                          <div
+                            aria-label="HSB"
+                            aria-selected="false"
+                            id="rc_select_TEST_OR_SSR_list_1"
+                            role="option"
+                          >
+                            hsb
+                          </div>
+                        </div>
+                        <div
+                          class="rc-virtual-list"
+                          style="position: relative;"
+                        >
+                          <div
+                            class="rc-virtual-list-holder"
+                            style="max-height: 256px; overflow-y: auto;"
+                          >
+                            <div>
+                              <div
+                                class="rc-virtual-list-holder-inner"
+                                style="display: flex; flex-direction: column;"
+                              >
+                                <div
+                                  aria-selected="true"
+                                  class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                                  title="HEX"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HEX
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="HSB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    HSB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                                <div
+                                  aria-selected="false"
+                                  class="ant-select-item ant-select-item-option"
+                                  title="RGB"
+                                >
+                                  <div
+                                    class="ant-select-item-option-content"
+                                  >
+                                    RGB
+                                  </div>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ant-select-item-option-state"
+                                    style="user-select: none;"
+                                    unselectable="on"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-color-picker-input"
+                  >
+                    <span
+                      class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input"
+                    >
+                      <span
+                        class="ant-input-prefix"
+                      >
+                        #
+                      </span>
+                      <input
+                        class="ant-input ant-input-sm"
+                        type="text"
+                        value="1677ff"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="ant-input-number ant-input-number-sm ant-input-number-outlined ant-color-picker-steppers ant-color-picker-alpha-input"
+                  >
+                    <div
+                      class="ant-input-number-handler-wrap"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Increase Value"
+                        class="ant-input-number-handler ant-input-number-handler-up ant-input-number-handler-up-disabled"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="up"
+                          class="anticon anticon-up ant-input-number-handler-up-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="up"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        aria-disabled="false"
+                        aria-label="Decrease Value"
+                        class="ant-input-number-handler ant-input-number-handler-down"
+                        role="button"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-input-number-handler-down-inner"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="ant-input-number-input-wrap"
+                    >
+                      <input
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        autocomplete="off"
+                        class="ant-input-number-input"
+                        role="spinbutton"
+                        step="1"
+                        value="100%"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`renders components/color-picker/demo/controlled.tsx extend context correctly 2`] = `[]`;

--- a/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -32,15 +32,39 @@ exports[`renders components/color-picker/demo/base.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/controlled.tsx correctly 1`] = `
 <div
-  class="ant-color-picker-trigger"
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
 >
   <div
-    class="ant-color-picker-color-block"
+    class="ant-space-item"
   >
     <div
-      class="ant-color-picker-color-block-inner"
-      style="background:rgb(22,119,255)"
-    />
+      class="ant-color-picker-trigger"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22,119,255)"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22,119,255)"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -87,12 +87,13 @@ const PanelPicker: FC = () => {
 
   // ========================= Picker Color =========================
   const [pickerColor, setPickerColor] = React.useState<AggregationColor | null>(activeColor);
+  const [forceSync, setForceSync] = React.useState(0);
 
   const mergedPickerColor = pickerColor?.equals(activeColor) ? activeColor : pickerColor;
 
   useLayoutEffect(() => {
     setPickerColor(activeColor);
-  }, [activeColor?.toHexString()]);
+  }, [forceSync, activeColor?.toHexString()]);
 
   // ============================ Change ============================
   const fillColor = (nextColor: AggregationColor | Color, info?: Info) => {
@@ -147,7 +148,7 @@ const PanelPicker: FC = () => {
     // Back of origin color in case in controlled
     // This will set after `onChangeComplete` to avoid `setState` trigger rerender
     // which will make `fillColor` get wrong `color.cleared` state
-    setPickerColor(activeColor);
+    setForceSync((ori) => ori + 1);
   };
 
   const onInputChange = (colorValue: AggregationColor) => {

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -85,6 +85,13 @@ const PanelPicker: FC = () => {
     return colors[activeIndex]?.color;
   }, [value, activeIndex, isSingle, lockedColor, gradientDragging]);
 
+  // ========================= Picker Color =========================
+  const [pickerColor, setPickerColor] = React.useState<AggregationColor | null>(activeColor);
+
+  useLayoutEffect(() => {
+    setPickerColor(activeColor);
+  }, [activeColor?.toHexString()]);
+
   // ============================ Change ============================
   const fillColor = (nextColor: AggregationColor | Color, info?: Info) => {
     let submitColor = generateColor(nextColor);
@@ -121,16 +128,26 @@ const PanelPicker: FC = () => {
     return new AggregationColor(nextColors);
   };
 
-  const onInternalChange = (
+  const onPickerChange = (
     colorValue: AggregationColor | Color,
-    fromPicker?: boolean,
+    fromPicker: boolean,
     info?: Info,
   ) => {
-    onChange(fillColor(colorValue, info), fromPicker);
+    const nextColor = fillColor(colorValue, info);
+    setPickerColor(nextColor);
+    onChange(nextColor, fromPicker);
   };
 
   const onInternalChangeComplete = (nextColor: Color, info?: Info) => {
+    // Back of origin color in case in controlled
+    setPickerColor(activeColor);
+
+    // Trigger complete event
     onChangeComplete(fillColor(nextColor, info));
+  };
+
+  const onInputChange = (colorValue: AggregationColor) => {
+    onChange(fillColor(colorValue));
   };
 
   // ============================ Render ============================
@@ -166,10 +183,10 @@ const PanelPicker: FC = () => {
 
       <RcColorPicker
         prefixCls={prefixCls}
-        value={activeColor?.toHsb()}
+        value={pickerColor?.toHsb()}
         disabledAlpha={disabledAlpha}
         onChange={(colorValue, info) => {
-          onInternalChange(colorValue, true, info);
+          onPickerChange(colorValue, true, info);
         }}
         onChangeComplete={(colorValue, info) => {
           onInternalChangeComplete(colorValue, info);
@@ -178,7 +195,7 @@ const PanelPicker: FC = () => {
       />
       <ColorInput
         value={activeColor}
-        onChange={onInternalChange}
+        onChange={onInputChange}
         prefixCls={prefixCls}
         disabledAlpha={disabledAlpha}
         {...injectProps}

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react';
 import React, { useContext } from 'react';
 import RcColorPicker from '@rc-component/color-picker';
 import type { Color } from '@rc-component/color-picker';
-import { useEvent } from 'rc-util';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 
 import Segmented from '../../../segmented';
@@ -89,6 +88,8 @@ const PanelPicker: FC = () => {
   // ========================= Picker Color =========================
   const [pickerColor, setPickerColor] = React.useState<AggregationColor | null>(activeColor);
 
+  const mergedPickerColor = pickerColor?.equals(activeColor) ? activeColor : pickerColor;
+
   useLayoutEffect(() => {
     setPickerColor(activeColor);
   }, [activeColor?.toHexString()]);
@@ -139,13 +140,15 @@ const PanelPicker: FC = () => {
     onChange(nextColor, fromPicker);
   };
 
-  const onInternalChangeComplete = useEvent((nextColor: Color, info?: Info) => {
-    // Back of origin color in case in controlled
-    setPickerColor(activeColor);
-
+  const onInternalChangeComplete = (nextColor: Color, info?: Info) => {
     // Trigger complete event
     onChangeComplete(fillColor(nextColor, info));
-  });
+
+    // Back of origin color in case in controlled
+    // This will set after `onChangeComplete` to avoid `setState` trigger rerender
+    // which will make `fillColor` get wrong `color.cleared` state
+    setPickerColor(activeColor);
+  };
 
   const onInputChange = (colorValue: AggregationColor) => {
     onChange(fillColor(colorValue));
@@ -184,7 +187,7 @@ const PanelPicker: FC = () => {
 
       <RcColorPicker
         prefixCls={prefixCls}
-        value={pickerColor?.toHsb()}
+        value={mergedPickerColor?.toHsb()}
         disabledAlpha={disabledAlpha}
         onChange={(colorValue, info) => {
           onPickerChange(colorValue, true, info);

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import React, { useContext } from 'react';
 import RcColorPicker from '@rc-component/color-picker';
 import type { Color } from '@rc-component/color-picker';
+import { useEvent } from 'rc-util';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 
 import Segmented from '../../../segmented';
@@ -138,13 +139,13 @@ const PanelPicker: FC = () => {
     onChange(nextColor, fromPicker);
   };
 
-  const onInternalChangeComplete = (nextColor: Color, info?: Info) => {
+  const onInternalChangeComplete = useEvent((nextColor: Color, info?: Info) => {
     // Back of origin color in case in controlled
     setPickerColor(activeColor);
 
     // Trigger complete event
     onChangeComplete(fillColor(nextColor, info));
-  };
+  });
 
   const onInputChange = (colorValue: AggregationColor) => {
     onChange(fillColor(colorValue));

--- a/components/color-picker/demo/controlled.md
+++ b/components/color-picker/demo/controlled.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过 `value` 和 `onChange` 设置组件为受控模式。
+通过 `value` 和 `onChange` 设置组件为受控模式，如果通过 `onChangeComplete` 受控则会锁定展示颜色。
 
 ## en-US
 
-Set the component to controlled mode.
+Set the component to controlled mode. Will lock the display color if controlled by `onChangeComplete`.

--- a/components/color-picker/demo/controlled.tsx
+++ b/components/color-picker/demo/controlled.tsx
@@ -1,12 +1,18 @@
 import React, { useState } from 'react';
-import { ColorPicker } from 'antd';
+import { ColorPicker, Space } from 'antd';
 import type { ColorPickerProps, GetProp } from 'antd';
 
 type Color = GetProp<ColorPickerProps, 'value'>;
 
 const Demo: React.FC = () => {
   const [color, setColor] = useState<Color>('#1677ff');
-  return <ColorPicker value={color} onChange={setColor} />;
+
+  return (
+    <Space>
+      <ColorPicker value={color} onChange={setColor} />
+      <ColorPicker value={color} onChangeComplete={setColor} />
+    </Space>
+  );
 };
 
 export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -61,7 +61,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | |
 | value | Value of color | string \| `Color` | - | |
 | onChange | Callback when `value` is changed | `(value: Color, css: string) => void` | - | |
-| onChangeComplete | Called when color pick ends   | `(value: Color) => void` | - | 5.7.0 |
+| onChangeComplete | Called when color pick ends. Will not change the display color when `value` controlled by `onChangeComplete` | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | |
 | onClear | Called when clear | `() => void` | - | 5.6.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -62,7 +62,7 @@ group:
 | trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | |
 | value | 颜色的值 | string \| `Color` | - | |
 | onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | |
-| onChangeComplete | 颜色选择完成的回调  | `(value: Color) => void` | - | 5.7.0 |
+| onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色  | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |
 | onClear | 清除的回调 | `() => void` | - | 5.6.0 |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -62,7 +62,7 @@ group:
 | trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | |
 | value | 颜色的值 | string \| `Color` | - | |
 | onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | |
-| onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色  | `(value: Color) => void` | - | 5.7.0 |
+| onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色 | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |
 | onClear | 清除的回调 | `() => void` | - | 5.6.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

resolve #50744

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Adjust ColorPicker popup panel not lock by `value` to allow control mode with `onChangeComplete` scenarios.        |
| 🇨🇳 Chinese |    调整 ColorPicker 在受控时，弹出面板现在不会被 `value` 锁定从而允许与 `onChangeComplete` 配合使用的受控场景。       |
