### PR TITLE
fix(menu): css side effects caused by extra prop

### DIFF
--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -639,8 +639,8 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           alignItems: 'center',
           transition: `color ${motionDurationSlow}`,
 
-          '> a:first-child': {
-            flexGrow: 1,
+          '> *:first-child': {
+            flex: 'auto',
           },
 
           // https://github.com/ant-design/ant-design/issues/41143


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
起因是：`ant-menu-title-content -> display: inline-flex` （原本的 `flex: auto` 失效）, 此时 flex container的大小由子元素决定，恰好子元素又是用户自定义的，第一个元素设置为`auto`可不可行（多少都有点副作用，要么把新加的item-extra 改为float: right），（原来的a：flexGrow： 1 写错了）

Feat PR：https://github.com/ant-design/ant-design/pull/50431/files#diff-c25247b807ec2f52c363c570643f96ea7485c69baf56241c13bb617fb7e5abc0R638

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Side effects caused by the flex element |
| 🇨🇳 Chinese |   flex 元素引发的副作用        |
