### PR TITLE
fix: Typography copyable support array children

### DIFF
--- a/components/_util/toList.ts
+++ b/components/_util/toList.ts
@@ -1,5 +1,5 @@
-export default function toList<T>(candidate: T | T[]): T[] {
-  if (candidate === undefined || candidate === null) return [];
+export default function toList<T>(candidate: T | T[], skipEmpty = false): T[] {
+  if (skipEmpty && (candidate === undefined || candidate === null)) return [];
 
   return Array.isArray(candidate) ? candidate : [candidate];
 }

--- a/components/_util/toList.ts
+++ b/components/_util/toList.ts
@@ -1,0 +1,5 @@
+export default function toList<T>(candidate: T | T[]): T[] {
+  if (candidate === undefined || candidate === null) return [];
+
+  return Array.isArray(candidate) ? candidate : [candidate];
+}

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -13,12 +13,13 @@ import getAllowClear from '../_util/getAllowClear';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
+import toList from '../_util/toList';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
+import type { Variant } from '../config-provider';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { FormItemInputContext } from '../form/context';
-import type { Variant } from '../config-provider';
 import useVariant from '../form/hooks/useVariants';
 import Spin from '../spin';
 import useStyle from './style';
@@ -238,7 +239,7 @@ Mentions._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
 
 Mentions.getMentions = (value = '', config: MentionsConfig = {}): MentionsEntity[] => {
   const { prefix = '@', split = ' ' } = config;
-  const prefixList: string[] = Array.isArray(prefix) ? prefix : [prefix];
+  const prefixList: string[] = toList(prefix);
 
   return value
     .split(split)

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -352,4 +352,24 @@ describe('Typography copy', () => {
     fireEvent.click(container.querySelectorAll('.ant-typography-copy')[0]);
     expect(container.querySelector('.ant-tooltip-inner')?.textContent).toBe('Copied');
   });
+
+  it('copy array children', () => {
+    const spy = jest.spyOn(copyObj, 'default');
+
+    const bamboo = 'bamboo';
+    const little = 'little';
+
+    const { container } = render(
+      <Base component="p" copyable>
+        {bamboo}
+        {little}
+      </Base>,
+    );
+    fireEvent.click(container.querySelector('.ant-typography-copy')!);
+
+    // Check copy content
+    expect(spy.mock.calls[0][0]).toBe(`${bamboo}${little}`);
+
+    spy.mockRestore();
+  });
 });

--- a/components/typography/hooks/useCopyClick.ts
+++ b/components/typography/hooks/useCopyClick.ts
@@ -39,7 +39,7 @@ const useCopyClick = ({
     try {
       const text =
         typeof copyConfig.text === 'function' ? await copyConfig.text() : copyConfig.text;
-      copy(text || toList(children).join('') || '', copyOptions);
+      copy(text || toList(children, true).join('') || '', copyOptions);
       setCopyLoading(false);
 
       setCopied(true);

--- a/components/typography/hooks/useCopyClick.ts
+++ b/components/typography/hooks/useCopyClick.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import copy from 'copy-to-clipboard';
 import { useEvent } from 'rc-util';
 
+import toList from '../../_util/toList';
 import type { CopyConfig } from '../Base';
 
 const useCopyClick = ({
@@ -38,7 +39,7 @@ const useCopyClick = ({
     try {
       const text =
         typeof copyConfig.text === 'function' ? await copyConfig.text() : copyConfig.text;
-      copy(text || String(children) || '', copyOptions);
+      copy(text || toList(children).join('') || '', copyOptions);
       setCopyLoading(false);
 
       setCopied(true);

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -10,6 +10,7 @@ import useClips, { FontGap } from './useClips';
 import useRafDebounce from './useRafDebounce';
 import useWatermark from './useWatermark';
 import { getPixelRatio, reRendering } from './utils';
+import toList from '../_util/toList';
 
 export interface WatermarkProps {
   zIndex?: number;
@@ -145,7 +146,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
     let defaultHeight = 64;
     if (!image && ctx.measureText) {
       ctx.font = `${Number(fontSize)}px ${fontFamily}`;
-      const contents = Array.isArray(content) ? content : [content];
+      const contents = toList(content);
       const sizes = contents.map((item) => {
         const metrics = ctx.measureText(item!);
 

--- a/components/watermark/useClips.ts
+++ b/components/watermark/useClips.ts
@@ -1,4 +1,5 @@
 import type { WatermarkProps } from '.';
+import toList from '../_util/toList';
 
 export const FontGap = 3;
 
@@ -55,7 +56,7 @@ export default function useClips() {
       ctx.fillStyle = color;
       ctx.textAlign = textAlign;
       ctx.textBaseline = 'top';
-      const contents = Array.isArray(content) ? content : [content];
+      const contents = toList(content);
       contents?.forEach((item, index) => {
         ctx.fillText(item ?? '', contentWidth / 2, index * (mergedFontSize + FontGap * ratio));
       });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #49879

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Typography `copyable` with array `children` has additional `,` string issue.        |
| 🇨🇳 Chinese |    修复 Typography `copyable` 对数组 `children` 复制时会有额外 `,` 字符的问题。      |
