### PR TITLE
chore: Form export ValidateErrorEntity type

### DIFF
--- a/components/form/interface.ts
+++ b/components/form/interface.ts
@@ -1,3 +1,9 @@
-export type { InternalNamePath, NamePath, Store, StoreValue } from 'rc-field-form/lib/interface';
+export type {
+  InternalNamePath,
+  NamePath,
+  Store,
+  StoreValue,
+  ValidateErrorEntity,
+} from 'rc-field-form/lib/interface';
 export type { Options as ScrollOptions } from 'scroll-into-view-if-needed';
 export type FormLabelAlign = 'left' | 'right';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
> - close #50814 

### 💡 Background and Solution

> - The onFinishFailed method of the Form component requires the ValidateErrorEntity type, but this type is not exported.
```
export { ValidateErrorEntity } from 'rc-field-form/lib/interface';
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Form export ValidateErrorEntity type        |
| 🇨🇳 Chinese |  Form组件导出ValidateErrorEntity类型         |
