### PR TITLE
feat: Add missing Greek translation for form and date-picker

### DIFF
--- a/components/date-picker/locale/el_GR.ts
+++ b/components/date-picker/locale/el_GR.ts
@@ -7,7 +7,15 @@ import type { PickerLocale } from '../generatePicker';
 const locale: PickerLocale = {
   lang: {
     placeholder: 'Επιλέξτε ημερομηνία',
+    yearPlaceholder: 'Επιλέξτε έτος',
+    quarterPlaceholder: 'Επιλέξτε τρίμηνο',
+    monthPlaceholder: 'Επιλέξτε μήνα',
+    weekPlaceholder: 'Επιλέξτε εβδομάδα',
     rangePlaceholder: ['Αρχική ημερομηνία', 'Τελική ημερομηνία'],
+    rangeYearPlaceholder: ['Αρχικό έτος', 'Τελικό έτος'],
+    rangeMonthPlaceholder: ['Αρχικός μήνας', 'Τελικός μήνας'],
+    rangeQuarterPlaceholder: ['Αρχικό τρίμηνο', 'Τελικό τρίμηνο'],
+    rangeWeekPlaceholder: ['Αρχική εβδομάδα', 'Τελική εβδομάδα'],
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/locale/el_GR.ts
+++ b/components/locale/el_GR.ts
@@ -5,23 +5,45 @@ import Calendar from '../calendar/locale/el_GR';
 import DatePicker from '../date-picker/locale/el_GR';
 import TimePicker from '../time-picker/locale/el_GR';
 
+const typeTemplate = 'Το ${label} δεν είναι έγκυρο ${type}';
+
 const localeValues: Locale = {
   locale: 'el',
   Pagination,
   DatePicker,
   TimePicker,
   Calendar,
+  global: {
+    placeholder: 'Παρακαλώ επιλέξτε',
+  },
   Table: {
     filterTitle: 'Μενού φίλτρων',
     filterConfirm: 'ΟΚ',
     filterReset: 'Επαναφορά',
+    filterEmptyText: 'Χωρίς φίλτρα',
+    filterCheckall: 'Επιλογή όλων',
+    filterSearchPlaceholder: 'Αναζήτηση στα φίλτρα',
+    emptyText: 'Δεν υπάρχουν δεδομένα',
     selectAll: 'Επιλογή τρέχουσας σελίδας',
     selectInvert: 'Αντιστροφή τρέχουσας σελίδας',
+    selectNone: 'Εκκαθάριση όλων των δεδομένων',
+    selectionAll: 'Επιλογή όλων των δεδομένων',
+    sortTitle: 'Ταξινόμηση',
+    expand: 'Ανάπτυξη σειράς',
+    collapse: 'Σύμπτυξη σειράς',
+    triggerDesc: 'Κλικ για φθίνουσα ταξινόμηση',
+    triggerAsc: 'Κλικ για αύξουσα ταξινόμηση',
+    cancelSort: 'Κλικ για ακύρωση ταξινόμησης',
   },
   Modal: {
     okText: 'ΟΚ',
     cancelText: 'Άκυρο',
-    justOkText: 'ΟΚ',
+    justOkText: 'Εντάξει',
+  },
+  Tour: {
+    Next: 'Επόμενο',
+    Previous: 'Προηγούμενο',
+    Finish: 'Τέλος',
   },
   Popconfirm: {
     okText: 'ΟΚ',
@@ -32,6 +54,12 @@ const localeValues: Locale = {
     searchPlaceholder: 'Αναζήτηση',
     itemUnit: 'αντικείμενο',
     itemsUnit: 'αντικείμενα',
+    remove: 'Αφαίρεση',
+    selectCurrent: 'Επιλογή τρέχουσας σελίδας',
+    removeCurrent: 'Αφαίρεση τρέχουσας σελίδας',
+    selectAll: 'Επιλογή όλων των δεδομένων',
+    removeAll: 'Αφαίρεση όλων των δεδομένων',
+    selectInvert: 'Αντιστροφή τρέχουσας σελίδας',
   },
   Upload: {
     uploading: 'Μεταφόρτωση...',
@@ -42,6 +70,80 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Δεν υπάρχουν δεδομένα',
+  },
+  Icon: {
+    icon: 'εικονίδιο',
+  },
+  Text: {
+    edit: 'Επεξεργασία',
+    copy: 'Αντιγραφή',
+    copied: 'Αντιγράφηκε',
+    expand: 'Ανάπτυξη',
+    collapse: 'Σύμπτυξη',
+  },
+  Form: {
+    optional: '(προαιρετικό)',
+    defaultValidateMessages: {
+      default: 'Σφάλμα επικύρωσης πεδίου για ${label}',
+      required: 'Παρακαλώ εισάγετε ${label}',
+      enum: 'Το ${label} πρέπει να είναι ένα από [${enum}]',
+      whitespace: 'Το ${label} δεν μπορεί να είναι κενός χαρακτήρας',
+      date: {
+        format: 'Η μορφή ημερομηνίας του ${label} είναι άκυρη',
+        parse: 'Το ${label} δεν μπορεί να μετατραπεί σε ημερομηνία',
+        invalid: 'Το ${label} είναι μια άκυρη ημερομηνία',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: 'Το ${label} πρέπει να είναι ${len} χαρακτήρες',
+        min: 'Το ${label} πρέπει να είναι τουλάχιστον ${min} χαρακτήρες',
+        max: 'Το ${label} πρέπει να είναι το πολύ ${max} χαρακτήρες',
+        range: 'Το ${label} πρέπει να είναι μεταξύ ${min}-${max} χαρακτήρων',
+      },
+      number: {
+        len: 'Το ${label} πρέπει να είναι ίσο με ${len}',
+        min: 'Το ${label} πρέπει να είναι τουλάχιστον ${min}',
+        max: 'Το ${label} πρέπει να είναι το πολύ ${max}',
+        range: 'Το ${label} πρέπει να είναι μεταξύ ${min}-${max}',
+      },
+      array: {
+        len: 'Πρέπει να είναι ${len} ${label}',
+        min: 'Τουλάχιστον ${min} ${label}',
+        max: 'Το πολύ ${max} ${label}',
+        range: 'Το ποσό του ${label} πρέπει να είναι μεταξύ ${min}-${max}',
+      },
+      pattern: {
+        mismatch: 'Το ${label} δεν ταιριάζει με το μοτίβο ${pattern}',
+      },
+    },
+  },
+  Image: {
+    preview: 'Προεπισκόπηση',
+  },
+  QRCode: {
+    expired: 'Ο κωδικός QR έληξε',
+    refresh: 'Ανανέωση',
+    scanned: 'Σαρώθηκε',
+  },
+  ColorPicker: {
+    presetEmpty: 'Κενό',
+    transparent: 'Διαφανές',
+    singleColor: 'Μονόχρωμο',
+    gradientColor: 'Διαβάθμιση χρώματος',
   },
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> Form add defaultValidateMessages.i18n language
> https://github.com/ant-design/ant-design/issues/23369

### 💡 Background and Solution

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add missing Greek translation for form  |
| 🇨🇳 Chinese |  完善本地化 为表格添加希腊语 |
