### PR TITLE
fix: invalid useApp warning

### DIFF
--- a/components/_util/hooks/useZIndex.ts
+++ b/components/_util/hooks/useZIndex.ts
@@ -18,6 +18,13 @@ const CONTAINER_OFFSET_MAX_COUNT = 10;
 
 export const CONTAINER_MAX_OFFSET = CONTAINER_OFFSET * CONTAINER_OFFSET_MAX_COUNT;
 
+/**
+ * Static function will default be the `CONTAINER_MAX_OFFSET`.
+ * But it still may have children component like Select, Dropdown.
+ * So the warning zIndex should exceed the `CONTAINER_MAX_OFFSET`.
+ */
+const CONTAINER_MAX_OFFSET_WITH_CHILDREN = CONTAINER_MAX_OFFSET + CONTAINER_OFFSET;
+
 export const containerBaseZIndexOffset: Record<ZIndexContainer, number> = {
   Modal: CONTAINER_OFFSET,
   Drawer: CONTAINER_OFFSET,
@@ -70,7 +77,7 @@ export function useZIndex(
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning(componentType);
 
-    const maxZIndex = token.zIndexPopupBase + CONTAINER_MAX_OFFSET;
+    const maxZIndex = token.zIndexPopupBase + CONTAINER_MAX_OFFSET_WITH_CHILDREN;
     const currentZIndex = result[0] || 0;
 
     warning(

--- a/components/app/demo/basic.tsx
+++ b/components/app/demo/basic.tsx
@@ -1,47 +1,20 @@
 import React from 'react';
-import { App, Button, Space } from 'antd';
+import { App, Button, Select } from 'antd';
 
-// Sub page
-const MyPage = () => {
-  const { message, modal, notification } = App.useApp();
-
-  const showMessage = () => {
-    message.success('Success!');
-  };
-
-  const showModal = () => {
-    modal.warning({
-      title: 'This is a warning message',
-      content: 'some messages...some messages...',
-    });
-  };
-
-  const showNotification = () => {
-    notification.info({
-      message: 'Notification topLeft',
-      description: 'Hello, Ant Design!!',
-      placement: 'topLeft',
-    });
-  };
+const TheModal = () => {
+  const { modal } = App.useApp();
 
   return (
-    <Space wrap>
-      <Button type="primary" onClick={showMessage}>
-        Open message
-      </Button>
-      <Button type="primary" onClick={showModal}>
-        Open modal
-      </Button>
-      <Button type="primary" onClick={showNotification}>
-        Open notification
-      </Button>
-    </Space>
+    <Button type="primary" onClick={() => modal.confirm({ content: <Select /> })}>
+      Open Modal
+    </Button>
   );
 };
 
-// Entry component
-export default () => (
+const ReactApp = () => (
   <App>
-    <MyPage />
+    <TheModal />
   </App>
 );
+
+export default ReactApp;

--- a/components/app/demo/basic.tsx
+++ b/components/app/demo/basic.tsx
@@ -1,20 +1,47 @@
 import React from 'react';
-import { App, Button, Select } from 'antd';
+import { App, Button, Space } from 'antd';
 
-const TheModal = () => {
-  const { modal } = App.useApp();
+// Sub page
+const MyPage = () => {
+  const { message, modal, notification } = App.useApp();
+
+  const showMessage = () => {
+    message.success('Success!');
+  };
+
+  const showModal = () => {
+    modal.warning({
+      title: 'This is a warning message',
+      content: 'some messages...some messages...',
+    });
+  };
+
+  const showNotification = () => {
+    notification.info({
+      message: 'Notification topLeft',
+      description: 'Hello, Ant Design!!',
+      placement: 'topLeft',
+    });
+  };
 
   return (
-    <Button type="primary" onClick={() => modal.confirm({ content: <Select /> })}>
-      Open Modal
-    </Button>
+    <Space wrap>
+      <Button type="primary" onClick={showMessage}>
+        Open message
+      </Button>
+      <Button type="primary" onClick={showModal}>
+        Open modal
+      </Button>
+      <Button type="primary" onClick={showNotification}>
+        Open notification
+      </Button>
+    </Space>
   );
 };
 
-const ReactApp = () => (
+// Entry component
+export default () => (
   <App>
-    <TheModal />
+    <MyPage />
   </App>
 );
-
-export default ReactApp;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50826

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed App warn about  `zIndex` too large when using the `modal` with having popup component method via `useApp`.     |
| 🇨🇳 Chinese |      修复 App 的 `useApp` 调用 `modal` 方法时，填入弹层组件会警告 `zIndex` 过大的问题。     |
