### PR TITLE
fix: ColorPicker hex precision

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,6 +34,7 @@
         "useImportType": "off",
         "useNumberNamespace": "off",
         "useNodejsImportProtocol": "off",
+        "useSemanticElements": "off",
         "noNonNullAssertion": "off",
         "noUnusedTemplateLiteral": "off"
       },

--- a/biome.json
+++ b/biome.json
@@ -57,6 +57,9 @@
         "noAccumulatingSpread": "off"
       },
       "a11y": {
+        "noAriaHiddenOnFocusable": "off",
+        "noLabelWithoutControl": "off",
+        "useFocusableInteractive": "off",
         "useKeyWithClickEvents": "off",
         "useSemanticElements": "off"
       }

--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,8 @@
         "noAccumulatingSpread": "off"
       },
       "a11y": {
-        "useKeyWithClickEvents": "off"
+        "useKeyWithClickEvents": "off",
+        "useSemanticElements": "off"
       }
     }
   },

--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,6 @@
         "useImportType": "off",
         "useNumberNamespace": "off",
         "useNodejsImportProtocol": "off",
-        "useSemanticElements": "off",
         "noNonNullAssertion": "off",
         "noUnusedTemplateLiteral": "off"
       },

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -936,4 +936,16 @@ describe('ColorPicker', () => {
       });
     });
   });
+
+  it('input precision', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<ColorPicker open onChange={onChange} />);
+
+    fireEvent.change(container.querySelector('.ant-color-picker-hex-input input')!, {
+      target: { value: '2ddcb4' },
+    });
+
+    const onChangeColor = onChange.mock.calls[0][0];
+    expect(onChangeColor.toHexString()).toBe('#2ddcb4');
+  });
 });

--- a/components/color-picker/util.ts
+++ b/components/color-picker/util.ts
@@ -21,7 +21,7 @@ export const getColorAlpha = (color: AggregationColor) => getRoundNumber(color.t
 export const genAlphaColor = (color: AggregationColor, alpha?: number) => {
   const rgba = color.toRgb();
 
-  // Color from HSB input only provide hsb info but no rgb info
+  // Color from hsb input may get `rgb` is (0/0/0) when `hsb.b` is 0
   // So if rgb is empty, we should get from hsb
   if (!rgba.r && !rgba.g && !rgba.b) {
     const hsba = color.toHsb();

--- a/components/color-picker/util.ts
+++ b/components/color-picker/util.ts
@@ -19,9 +19,18 @@ export const getColorAlpha = (color: AggregationColor) => getRoundNumber(color.t
 
 /** Return the color whose `alpha` is 1 */
 export const genAlphaColor = (color: AggregationColor, alpha?: number) => {
-  const hsba = color.toHsb();
-  hsba.a = alpha || 1;
-  return generateColor(hsba);
+  const rgba = color.toRgb();
+
+  // Color from HSB input only provide hsb info but no rgb info
+  // So if rgb is empty, we should get from hsb
+  if (!rgba.r && !rgba.g && !rgba.b) {
+    const hsba = color.toHsb();
+    hsba.a = alpha || 1;
+    return generateColor(hsba);
+  }
+
+  rgba.a = alpha || 1;
+  return generateColor(rgba);
 };
 
 /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #50818

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix ColorPicker when type hex input may not get correct color with precision issue.       |
| 🇨🇳 Chinese |      修复 ColorPicker 在 hex 输入框输入颜色时，部分颜色会因为精度问题得到不正确的颜色的问题。       |
