### PR TITLE
fix: search component inconsistent height of button and input

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -664,6 +664,11 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
         },
       },
 
+      [`${componentCls}, ${componentCls}-affix-wrapper`]: {
+        height: token.controlHeight,
+        padding: `0 ${unit(token.paddingSM)}`,
+      },
+
       [`${componentCls}-affix-wrapper`]: {
         borderRadius: 0,
       },
@@ -725,6 +730,18 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
 
       [`&-small ${searchPrefixCls}-button`]: {
         height: token.controlHeightSM,
+      },
+
+      '&-large': {
+        [`${componentCls}, ${componentCls}-affix-wrapper, ${searchPrefixCls}-button`]: {
+          height: token.controlHeightLG,
+        },
+      },
+
+      '&-small': {
+        [`${componentCls}, ${componentCls}-affix-wrapper, ${searchPrefixCls}-button`]: {
+          height: token.controlHeightSM,
+        },
       },
 
       '&-rtl': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixed #50839 

### 💡 Background and Solution

#### Background: 
The issue was that at different zoom levels in browsers (zoom out to 90% could reproduce the problem), the input box and button in the Search component were misaligned due to a mismatch in height calculation between the input and the button. The input box height could include fractional pixels, whereas the button had fixed height values, leading to inconsistencies.

在不同的浏览器缩放级别下（缩小到 90% 时可以重现问题），Search 组件中的输入框和按钮由于高度计算不一致导致未对齐。输入框的高度可能包含小数像素，而按钮的高度是固定的，因此产生了不一致的问题

#### Solution: 
I updated the CSS styles to ensure that both the input field and the search button use consistent height values. I added height values to the input wrapper (affix-wrapper) and the input field itself, based on the controlHeight, controlHeightLG, and controlHeightSM token values. The input field and the button will remain aligned.

我更新了 CSS 样式，确保输入框和搜索按钮使用一致的高度值。我根据 controlHeight、controlHeightLG 和 controlHeightSM 这几个 token 值，给输入框包装器（affix-wrapper）和输入框本身添加了高度值。这样无论在任何缩放级别下，输入框和按钮都能够保持对齐。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed alignment issue between the input field and search button in the Search component at different zoom levels |
| 🇨🇳 Chinese |   修复了 Search 组件中在不同缩放级别下输入框和按钮的对齐问题  |
