### PR TITLE
fix: Typography ellipsis insufficient width

### DIFF
--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -209,7 +209,7 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken> = (token) => {
           [`${componentCls}-item-content`]: {
             display: 'inline-flex',
             alignItems: 'baseline',
-            minWidth: 0,
+            minWidth: '1em',
           },
         },
       },


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

修复 #50732 

### 💡 需求背景和解决方案

![image](https://github.com/user-attachments/assets/d3361cb9-d9a6-4a52-8b1a-f18d66593703)

-item-content的min-width设置为0是不是不太合适，即便是父元素宽度小于子元素宽度，也应该保持descriptions组件的最小宽度至少为一个相对单位1em，至少显示一个字符以表现此处是有元素内容

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Change the minimum width value to non-0     |
| 🇨🇳 中文 |    修改最小宽度值为非0      |