### PR TITLE
fix(select): background color appears when allowClear and filled

### DIFF
--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -180,6 +180,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
       [`&:hover ${componentCls}-clear`]: {
         opacity: 1,
         background: token.colorBgBase,
+        borderRadius: '50%',
       },
     },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix


### 🔗 Related Issues
fix #50912 



> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

before：
![image](https://github.com/user-attachments/assets/433b4ad2-7c11-4124-8bc7-d0a2147eb4e4)

after：
![image](https://github.com/user-attachments/assets/ec4252a3-794d-4d98-9143-c59253c22425)

在 #50382 中用给清除图标加背景的方式盖住箭头，避免两者出现视觉重叠，但是 token.colorBgBase 默认是白色，在 filled 灰色背景下会露出一部分白色，所以采用 borderRadius: '50%'来解决，这边本身就是一个圆形的 <CloseCircleFilled /> 组件。

![image](https://github.com/user-attachments/assets/54565359-20d7-41bd-9cac-f0e3e71f4783)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       fix(select): background color appears when allowClear and filled    |
| 🇨🇳 Chinese |        fix(select): select组件开启allowClear 和 variant="filled" 鼠标hover后关闭X的图标背景有白框 |
