### PR TITLE
fix: Repair missing inner spacing

### DIFF
--- a/components/select/style/single.ts
+++ b/components/select/style/single.ts
@@ -6,11 +6,16 @@ import { mergeToken } from '../../theme/internal';
 import type { SelectToken } from './token';
 
 function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
-  const { componentCls, inputPaddingHorizontalBase, borderRadius } = token;
+  const { componentCls, inputPaddingHorizontalBase, borderRadius, fontSizeIcon } = token;
 
   const selectHeightWithoutBorder = token
     .calc(token.controlHeight)
     .sub(token.calc(token.lineWidth).mul(2))
+    .equal();
+
+  const singleInputPaddingHorizontal = token
+    .calc(inputPaddingHorizontalBase)
+    .add(fontSizeIcon)
     .equal();
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
@@ -31,7 +36,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
           position: 'absolute',
           top: 0,
           insetInlineStart: inputPaddingHorizontalBase,
-          insetInlineEnd: inputPaddingHorizontalBase,
+          insetInlineEnd: unit(singleInputPaddingHorizontal),
           bottom: 0,
 
           '&-input': {


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #50904 

### 💡 需求背景和解决方案

非多选模式下的选择器，开启输入时，内边距应该考虑有操作图标字体大小


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Repair missing inner spacing     |
| 🇨🇳 中文 |     修复内编剧缺失     |