### PR TITLE
Revert "fix: remove Icon default fill="currentColor""

### DIFF
--- a/components/icon/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/icon/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -319,6 +319,7 @@ exports[`renders components/icon/demo/iconfont.tsx extend context correctly 1`] 
     <span
       class="anticon"
       role="img"
+      style="color: rgb(24, 119, 242);"
     >
       <svg
         aria-hidden="true"

--- a/components/icon/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/icon/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -238,6 +238,7 @@ exports[`renders components/icon/demo/custom.tsx extend context correctly 1`] = 
         aria-hidden="true"
         aria-label="home"
         class="anticon anticon-home"
+        fill="currentColor"
         focusable="false"
         height="1em"
         role="img"
@@ -301,6 +302,7 @@ exports[`renders components/icon/demo/iconfont.tsx extend context correctly 1`] 
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -321,6 +323,7 @@ exports[`renders components/icon/demo/iconfont.tsx extend context correctly 1`] 
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -341,6 +344,7 @@ exports[`renders components/icon/demo/iconfont.tsx extend context correctly 1`] 
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -370,6 +374,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx extend context correctly 1`]
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -390,6 +395,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx extend context correctly 1`]
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -410,6 +416,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx extend context correctly 1`]
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -430,6 +437,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx extend context correctly 1`]
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"

--- a/components/icon/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/icon/__tests__/__snapshots__/demo.test.ts.snap
@@ -315,6 +315,7 @@ exports[`renders components/icon/demo/iconfont.tsx correctly 1`] = `
     <span
       class="anticon"
       role="img"
+      style="color:#1877F2"
     >
       <svg
         aria-hidden="true"

--- a/components/icon/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/icon/__tests__/__snapshots__/demo.test.ts.snap
@@ -236,6 +236,7 @@ exports[`renders components/icon/demo/custom.tsx correctly 1`] = `
         aria-hidden="true"
         aria-label="home"
         class="anticon anticon-home"
+        fill="currentColor"
         focusable="false"
         height="1em"
         role="img"
@@ -297,6 +298,7 @@ exports[`renders components/icon/demo/iconfont.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -317,6 +319,7 @@ exports[`renders components/icon/demo/iconfont.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -337,6 +340,7 @@ exports[`renders components/icon/demo/iconfont.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -364,6 +368,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -384,6 +389,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -404,6 +410,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"
@@ -424,6 +431,7 @@ exports[`renders components/icon/demo/scriptUrl.tsx correctly 1`] = `
       <svg
         aria-hidden="true"
         class=""
+        fill="currentColor"
         focusable="false"
         height="1em"
         width="1em"

--- a/components/icon/demo/iconfont.tsx
+++ b/components/icon/demo/iconfont.tsx
@@ -9,7 +9,7 @@ const IconFont = createFromIconfontCN({
 const App: React.FC = () => (
   <Space>
     <IconFont type="icon-tuichu" />
-    <IconFont type="icon-facebook" />
+    <IconFont type="icon-facebook" style={{ color: '#1877F2' }} />
     <IconFont type="icon-twitter" />
   </Space>
 );

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@ant-design/colors": "^7.1.0",
     "@ant-design/cssinjs": "^1.21.1",
     "@ant-design/cssinjs-utils": "^1.1.0",
-    "@ant-design/icons": "^5.5.0",
+    "@ant-design/icons": "^5.4.0",
     "@ant-design/react-slick": "~1.1.2",
     "@babel/runtime": "^7.25.6",
     "@ctrl/tinycolor": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@ant-design/colors": "^7.1.0",
     "@ant-design/cssinjs": "^1.21.1",
     "@ant-design/cssinjs-utils": "^1.1.0",
-    "@ant-design/icons": "^5.4.0",
+    "@ant-design/icons": "^5.5.1",
     "@ant-design/react-slick": "~1.1.2",
     "@babel/runtime": "^7.25.6",
     "@ctrl/tinycolor": "^3.6.1",


### PR DESCRIPTION
Reverts ant-design/ant-design#50880

fix https://github.com/ant-design/ant-design-icons/issues/671

发现不能去掉 `fill="currentColor"`，会导致 `createFromIconfontCN` `iconfont` 的去色图标就无法设置颜色了（[点此查看重现](https://github.com/ant-design/ant-design/pull/50880#issuecomment-2359896886)）。在 https://github.com/ant-design/ant-design-icons/pull/672 里回滚了。


