### PR TITLE
fix: Splitter.Panel style is invalid

### DIFF
--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -80,6 +80,8 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
   } = token;
 
   const splitBarCls = `${componentCls}-bar`;
+  const splitMaskCls = `${componentCls}-mask`;
+  const splitPanelCls = `${componentCls}-panel`;
 
   const halfTriggerSize = token.calc(splitTriggerSize).div(2).equal();
 
@@ -186,7 +188,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
 
       // =========================== Mask =========================
       // Util dom for handle cursor
-      '&-mask': {
+      [splitMaskCls]: {
         position: 'fixed',
         zIndex: token.zIndexPopupBase,
         inset: 0,
@@ -302,13 +304,13 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
       },
 
       // ========================= Panels =========================
-      '&-panel': {
+      [splitPanelCls]: {
         overflow: 'auto',
         padding: '0 1px',
         scrollbarWidth: 'thin',
         boxSizing: 'border-box',
       },
-      '&-panel-hidden': {
+      [`${splitPanelCls}-hidden`]: {
         padding: 0,
       },
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/51022

### 💡 Background and Solution

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix: Splitter.Panel style is invalid       |
| 🇨🇳 Chinese |    修复 Splitter.Panel 样式无效问题      |
