### PR TITLE
fix(select): Incorrect activeBorderColor token when variant is filled

### DIFF
--- a/components/select/style/variants.ts
+++ b/components/select/style/variants.ts
@@ -146,7 +146,7 @@ const genFilledStyle = (token: SelectToken): CSSObject => ({
     ...genBaseFilledStyle(token, {
       bg: token.colorFillTertiary,
       hoverBg: token.colorFillSecondary,
-      activeBorderColor: token.colorPrimary,
+      activeBorderColor: token.activeBorderColor,
       color: token.colorText,
     }),
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/51052

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Incorrect activeBorderColor token when variant is filled.         |
| 🇨🇳 Chinese | 当变体为填充时，不正确的 activeBorderColor token |
