### PR TITLE
type: Remove unused className from Tour props

### DIFF
--- a/components/tour/interface.ts
+++ b/components/tour/interface.ts
@@ -6,7 +6,6 @@ import type {
 
 export interface TourProps extends Omit<RCTourProps, 'renderPanel'> {
   steps?: TourStepProps[];
-  className?: string;
   prefixCls?: string;
   current?: number;
   indicatorsRender?: (current: number, total: number) => ReactNode;


### PR DESCRIPTION
`TourStepProps` has a `className` property which is confusing because it is not used neither in `Tour` nor `@rc-component/tour` and therefore might be removed.

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Remove `className` from `TourStepProps`     |
| 🇨🇳 Chinese |           |
