### PR TITLE
fix: Typography copyable icon not aligned

### DIFF
--- a/components/_util/transButton.tsx
+++ b/components/_util/transButton.tsx
@@ -19,7 +19,7 @@ const inlineStyle: React.CSSProperties = {
   background: 'transparent',
   padding: 0,
   lineHeight: 'inherit',
-  display: 'inline-flex',
+  display: 'inline-block',
 };
 
 const TransButton = React.forwardRef<HTMLDivElement, TransButtonProps>((props, ref) => {

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -725,7 +725,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -449,7 +449,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8282,7 +8282,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span
@@ -8319,7 +8319,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span
@@ -8356,7 +8356,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span
@@ -8393,7 +8393,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span
@@ -8430,7 +8430,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span
@@ -8467,7 +8467,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+              style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
               tabindex="0"
             >
               <span

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -5361,7 +5361,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span
@@ -5398,7 +5398,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span
@@ -5435,7 +5435,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span
@@ -5472,7 +5472,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span
@@ -5509,7 +5509,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span
@@ -5546,7 +5546,7 @@ Array [
               aria-label="Remove"
               class="ant-transfer-list-content-item-remove"
               role="button"
-              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+              style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
               tabindex="0"
             >
               <span

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -444,7 +444,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -495,7 +495,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -546,7 +546,7 @@ Array [
       aria-label="click here"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -597,7 +597,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -646,7 +646,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -696,7 +696,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy ant-typography-copy-icon-only"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -754,7 +754,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -806,7 +806,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -857,7 +857,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -971,7 +971,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1022,7 +1022,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1073,7 +1073,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1124,7 +1124,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1173,7 +1173,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1225,7 +1225,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1277,7 +1277,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1329,7 +1329,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1381,7 +1381,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1433,7 +1433,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1656,7 +1656,7 @@ exports[`renders components/typography/demo/ellipsis-controlled.tsx extend conte
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1859,7 +1859,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1913,7 +1913,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -1967,7 +1967,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -2021,7 +2021,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span
@@ -2143,7 +2143,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-flex;"
+      style="border: 0px; background: transparent; padding: 0px; line-height: inherit; display: inline-block;"
       tabindex="0"
     >
       <span

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -442,7 +442,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -474,7 +474,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -506,7 +506,7 @@ Array [
       aria-label="click here"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -538,7 +538,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -570,7 +570,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -601,7 +601,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy ant-typography-copy-icon-only"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -638,7 +638,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -672,7 +672,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -704,7 +704,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -801,7 +801,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -833,7 +833,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -865,7 +865,7 @@ Array [
       aria-label="click to edit text"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -897,7 +897,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -929,7 +929,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -962,7 +962,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -995,7 +995,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1028,7 +1028,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1061,7 +1061,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1094,7 +1094,7 @@ Array [
       aria-label="Edit"
       class="ant-typography-edit"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1237,7 +1237,7 @@ exports[`renders components/typography/demo/ellipsis-controlled.tsx correctly 1`
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1401,7 +1401,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1435,7 +1435,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1469,7 +1469,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1503,7 +1503,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span
@@ -1581,7 +1581,7 @@ Array [
       aria-label="Copy"
       class="ant-typography-copy"
       role="button"
-      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-flex"
+      style="border:0;background:transparent;padding:0;line-height:inherit;display:inline-block"
       tabindex="0"
     >
       <span

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -240,7 +240,7 @@ export const getEllipsisStyles = (): CSSObject => ({
   a&-ellipsis,
   span&-ellipsis
   `]: {
-    display: 'inline-flex',
+    display: 'inline-block',
     maxWidth: '100%',
   },
 
@@ -248,6 +248,11 @@ export const getEllipsisStyles = (): CSSObject => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+
+    // https://blog.csdn.net/iefreer/article/details/50421025
+    'a&, span&': {
+      verticalAlign: 'bottom',
+    },
 
     '> code': {
       paddingBlock: 0,

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -240,7 +240,7 @@ export const getEllipsisStyles = (): CSSObject => ({
   a&-ellipsis,
   span&-ellipsis
   `]: {
-    display: 'inline-block',
+    display: 'inline-flex',
     maxWidth: '100%',
   },
 
@@ -248,11 +248,6 @@ export const getEllipsisStyles = (): CSSObject => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-
-    // https://blog.csdn.net/iefreer/article/details/50421025
-    'a&, span&': {
-      verticalAlign: 'bottom',
-    },
 
     '> code': {
       paddingBlock: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/50240

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Revert #49221

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Revert [#49221](#https://github.com/ant-design/ant-design/pull/49221) to fix Typography `copyable` icon align issue.        |
| 🇨🇳 Chinese | 回滚 [#49221](#https://github.com/ant-design/ant-design/pull/49221) 以修复 Typography `copyable` 图标位置偏上的问题。          |
