### PR TITLE
site: add version update date for component changedoc

### DIFF
--- a/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
+++ b/.dumi/theme/common/ComponentChangelog/ComponentChangelog.tsx
@@ -19,6 +19,7 @@ interface ChangelogInfo {
   version: string;
   changelog: string;
   refs: string[];
+  releaseDate: string;
 }
 
 function matchDeprecated(v: string): MatchDeprecatedResult {
@@ -243,6 +244,7 @@ const ComponentChangelog: React.FC<ComponentChangelogProps> = (props) => {
                 </Popover>
               )}
             </Typography.Title>
+            {changelogList[0].releaseDate}
             <RenderChangelogList changelogList={changelogList} styles={styles} />
           </Typography>
         ),

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -92,6 +92,7 @@ const miscKeys = [
 
     // let lastGroup = '';
     let lastVersion = '';
+    let lastReleaseDate = '';
 
     // Split with lines
     const lines = content.split(/[\n\r]+/).filter((line) => line.trim());
@@ -99,7 +100,7 @@ const miscKeys = [
     // Changelog map
     const componentChangelog: Record<
       string,
-      { version: string; changelog: string; refs: string[] }[]
+      { version: string; changelog: string; refs: string[]; releaseDate: string }[]
     > = {};
     Object.keys(componentNameMap).forEach((name) => {
       componentChangelog[name] = [];
@@ -117,6 +118,10 @@ const miscKeys = [
       if (line.startsWith('## ')) {
         lastVersion = line.replace('## ', '');
         continue;
+      }
+
+      if (line.match(/\d{4}-\d{2}-\d{2}/)) {
+        lastReleaseDate = line.replaceAll('`', '');
       }
 
       // Start when get version
@@ -175,6 +180,7 @@ const miscKeys = [
             version: lastVersion,
             changelog: changelogLine,
             refs,
+            releaseDate: lastReleaseDate,
           });
           matched = true;
         }

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -121,9 +121,9 @@ const miscKeys = [
       }
 
       // Get release date
-      const match = line.match(/`(\d{4}-\d{2}-\d{2})`/);
-      if (match) {
-        lastReleaseDate = match[1];
+      const matchReleaseDate = line.match(/`(\d{4}-\d{2}-\d{2})`/);
+      if (matchReleaseDate) {
+        lastReleaseDate = matchReleaseDate[1];
       }
 
       // Start when get version

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -120,8 +120,10 @@ const miscKeys = [
         continue;
       }
 
-      if (line.match(/\d{4}-\d{2}-\d{2}/)) {
-        lastReleaseDate = line.replaceAll('`', '');
+      // Get release date
+      const match = line.match(/`(\d{4}-\d{2}-\d{2})`/);
+      if (match) {
+        lastReleaseDate = match[1];
       }
 
       // Start when get version


### PR DESCRIPTION


### 🤔 This is a ...

- [x] 📝 Site / documentation improvement


### 💡 Background and Solution

`2024-08-03` 看了一下日期格式是这样的 应该不需要调整为 `line.match(/`(\d{4}-\d{1,2}-\d{1,2})`/)`。
添加一个时间方便用户查看当前组件是哪儿个时间更新的。有时候可能起到一定作用，比如大概知道什么时候更新了antd，就不需要去查看完整的changelog了。
![image](https://github.com/user-attachments/assets/babd3adb-5200-4681-a3e4-49bd7e1a475d)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      site: add release date for component changedoc     |
| 🇨🇳 Chinese |       site:  组件changelog增加发布时间    |
