### PR TITLE
style: Make tall dropdowns have scroll bar

### DIFF
--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -96,6 +96,12 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
           content: '""',
         },
 
+        // Makes vertical dropdowns have a scrollbar once they become taller than the viewport.
+        [`&-menu-vertical`]: {
+          maxHeight: '100vh',
+          overflowY: 'auto',
+        },
+
         [`&-trigger${antCls}-btn`]: {
           [`& > ${iconCls}-down, & > ${antCls}-btn-icon > ${iconCls}-down`]: {
             fontSize: fontSizeIcon,

--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -97,7 +97,7 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
         },
 
         // Makes vertical dropdowns have a scrollbar once they become taller than the viewport.
-        [`&-menu-vertical`]: {
+        '&-menu-vertical': {
           maxHeight: '100vh',
           overflowY: 'auto',
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None that I could find.

### 💡 Background and Solution

The Problem:
Dropdowns with very many items spill out of the viewport so you can't access the items at the very bottom.

The Solution:
This adds `max-height: 100vh` and `overflow-y: auto` to `ant-dropdown-menu-vertical`s so that they become scrollable once they are taller than the viewport. The scrollbar is not there if the dropdown isn't tall enough, due to how `auto` works.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added a scroll bar to `Dropdown`s once they become taller than the viewport. |
| 🇨🇳 Chinese |           |

(I do not speak Chinese so I cannot write the Chinese changelog, sorry.)