### PR TITLE
fix: ColorPicker gradient slider not draggable

### DIFF
--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -307,6 +307,8 @@ describe('ColorPicker.gradient', () => {
     expect(container.querySelector('.ant-color-picker-gradient-slider')).toBeTruthy();
   });
 
+  // This test case may easily break by jsdom update
+  // https://github.com/ant-design/ant-design/issues/51159
   it('change color 2 should not be color 1', () => {
     const { container } = render(
       <ColorPicker

--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -307,7 +307,7 @@ describe('ColorPicker.gradient', () => {
     expect(container.querySelector('.ant-color-picker-gradient-slider')).toBeTruthy();
   });
 
-  // This test case may easily break by jsdom update
+  // This test case may easily break by jsdom update.
   // https://github.com/ant-design/ant-design/issues/51159
   it('change color 2 should not be color 1', () => {
     const { container } = render(

--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -307,7 +307,7 @@ describe('ColorPicker.gradient', () => {
     expect(container.querySelector('.ant-color-picker-gradient-slider')).toBeTruthy();
   });
 
-  // This test case may easily break by jsdom update.
+  // This test case may easily break by jsdom update
   // https://github.com/ant-design/ant-design/issues/51159
   it('change color 2 should not be color 1', () => {
     const { container } = render(

--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -306,4 +306,36 @@ describe('ColorPicker.gradient', () => {
 
     expect(container.querySelector('.ant-color-picker-gradient-slider')).toBeTruthy();
   });
+
+  it('change color 2 should not be color 1', () => {
+    const { container } = render(
+      <ColorPicker
+        mode={['gradient']}
+        open
+        defaultValue={[
+          {
+            color: '#FF0000',
+            percent: 0,
+          },
+          {
+            color: '#0000FF',
+            percent: 100,
+          },
+        ]}
+      />,
+    );
+
+    // Select second one
+    const handle2 = container.querySelector<HTMLElement>('.ant-slider-handle-2')!;
+    doDrag(container, 0, 0, handle2, true);
+
+    // Drag in the color panel
+    const panelHandle = container.querySelector('.ant-color-picker-saturation')!;
+    const mouseDown = createEvent.mouseDown(panelHandle);
+    fireEvent(panelHandle, mouseDown);
+
+    expect(handle2).not.toHaveStyle({
+      backgroundColor: 'rgb(255,0,0)',
+    });
+  });
 });

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -137,7 +137,7 @@ const PanelPicker: FC = () => {
     info?: Info,
   ) => {
     const nextColor = fillColor(colorValue, info);
-    setPickerColor(nextColor);
+    setPickerColor(nextColor.isGradient() ? nextColor.getColors()[activeIndex].color : nextColor);
     onChange(nextColor, fromPicker);
   };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51159

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ColorPicker with gradient mode, sometime handle color will be force sync back to first handle color issue.       |
| 🇨🇳 Chinese |     修复 ColorPicker 渐变色时，部分节点颜色拖拽会被强制重置为第一个节点颜色的问题。      |
