### PR TITLE
type(switch): improve eventHandler type

### DIFF
--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
 import RcSwitch from 'rc-switch';
+import type { SwitchChangeEventHandler, SwitchClickEventHandler } from 'rc-switch';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
 import Wave from '../_util/wave';
@@ -11,11 +12,7 @@ import useSize from '../config-provider/hooks/useSize';
 import useStyle from './style';
 
 export type SwitchSize = 'small' | 'default';
-export type SwitchChangeEventHandler = (
-  checked: boolean,
-  event: React.MouseEvent<HTMLButtonElement>,
-) => void;
-export type SwitchClickEventHandler = SwitchChangeEventHandler;
+export type { SwitchChangeEventHandler, SwitchClickEventHandler };
 
 export interface SwitchProps {
   prefixCls?: string;
@@ -110,11 +107,10 @@ const InternalSwitch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, 
 
   return wrapCSSVar(
     <Wave component="Switch">
-      {/* @ts-ignore */}
       <RcSwitch
         {...restProps}
         checked={checked}
-        onChange={changeHandler as any}
+        onChange={changeHandler}
         prefixCls={prefixCls}
         className={classes}
         style={mergedStyle}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
- [x] 🤖 TypeScript definition improvement

### 💡 Background and Solution
https://github.com/react-component/switch/blob/master/src/index.tsx#L8
这一块type的定义其实是一样的是不是可以直接从 rc-switch 中导出，antd的switch也支持鼠标和键盘左右键(需要补充`| React.KeyboardEvent<HTMLButtonElement>` , 直接导出的话就不用改了，还可以更简洁)。
![image](https://github.com/user-attachments/assets/08a9f602-9db9-4a0e-8fb9-a2a6194d567c)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      type(switch): improve eventHandler type     |
| 🇨🇳 Chinese |      type(switch): 优化eventHandler type     |
