### PR TITLE
fix: Splitter token rename

### DIFF
--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -8,8 +8,14 @@ export interface ComponentToken {
   /**
    * @desc 拖拽标识元素大小
    * @descEN Drag and drop the identity element size
+   * @deprecated
    */
-  dragIdentitySize: number;
+  resizeSpinnerSize: number;
+  /**
+   * @desc 拖拽标识元素大小
+   * @descEN Drag and drop the identity element size
+   */
+  draggerIdentitySize: number;
   /**
    * @desc 拖拽元素大小
    * @descEN Drag the element size
@@ -71,7 +77,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
   const {
     componentCls,
     colorFill,
-    dragIdentitySize,
+    draggerIdentitySize,
     splitBarSize,
     splitTriggerSize,
     controlItemBgHover,
@@ -223,7 +229,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              height: dragIdentitySize,
+              height: draggerIdentitySize,
               width: splitBarSize,
             },
           },
@@ -278,7 +284,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              width: dragIdentitySize,
+              width: draggerIdentitySize,
               height: splitBarSize,
             },
           },
@@ -329,12 +335,15 @@ export const prepareComponentToken: GetDefaultToken<'Splitter'> = (token) => {
   const splitBarSize = token.splitBarSize || 2;
   const splitTriggerSize = token.splitTriggerSize || 6;
 
-  const dragIdentitySize = token.dragIdentitySize || 20;
+  // https://github.com/ant-design/ant-design/pull/51223
+  const resizeSpinnerSize = token.resizeSpinnerSize || 20;
+  const draggerIdentitySize = token.draggerIdentitySize || resizeSpinnerSize;
 
   return {
     splitBarSize,
     splitTriggerSize,
-    dragIdentitySize,
+    resizeSpinnerSize,
+    draggerIdentitySize,
   };
 };
 

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -8,7 +8,7 @@ export interface ComponentToken {
   /**
    * @desc 拖拽标识元素大小
    * @descEN Drag and drop the identity element size
-   * @deprecated
+   * @deprecated Please use `splitBarDraggableSize` instead.
    */
   resizeSpinnerSize: number;
   /**

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -15,7 +15,7 @@ export interface ComponentToken {
    * @desc 拖拽标识元素大小
    * @descEN Drag and drop the identity element size
    */
-  draggerIdentitySize: number;
+  splitBarDraggableSize: number;
   /**
    * @desc 拖拽元素大小
    * @descEN Drag the element size
@@ -77,7 +77,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
   const {
     componentCls,
     colorFill,
-    draggerIdentitySize,
+    splitBarDraggableSize,
     splitBarSize,
     splitTriggerSize,
     controlItemBgHover,
@@ -229,7 +229,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              height: draggerIdentitySize,
+              height: splitBarDraggableSize,
               width: splitBarSize,
             },
           },
@@ -284,7 +284,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              width: draggerIdentitySize,
+              width: splitBarDraggableSize,
               height: splitBarSize,
             },
           },
@@ -337,13 +337,13 @@ export const prepareComponentToken: GetDefaultToken<'Splitter'> = (token) => {
 
   // https://github.com/ant-design/ant-design/pull/51223
   const resizeSpinnerSize = token.resizeSpinnerSize || 20;
-  const draggerIdentitySize = token.draggerIdentitySize || resizeSpinnerSize;
+  const splitBarDraggableSize = token.splitBarDraggableSize || resizeSpinnerSize;
 
   return {
     splitBarSize,
     splitTriggerSize,
+    splitBarDraggableSize,
     resizeSpinnerSize,
-    draggerIdentitySize,
   };
 };
 

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -6,12 +6,12 @@ import { genStyleHooks } from '../../theme/internal';
 
 export interface ComponentToken {
   /**
-   * @desc 可改变大小标识 元素大小
-   * @descEN Height of content area
-   */
-  resizeSpinnerSize: number;
-  /**
    * @desc 拖拽标识元素大小
+   * @descEN Drag and drop the identity element size
+   */
+  dragIdentitySize: number;
+  /**
+   * @desc 拖拽元素大小
    * @descEN Drag the element size
    */
   splitBarSize: number;
@@ -71,7 +71,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
   const {
     componentCls,
     colorFill,
-    resizeSpinnerSize,
+    dragIdentitySize,
     splitBarSize,
     splitTriggerSize,
     controlItemBgHover,
@@ -223,7 +223,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              height: resizeSpinnerSize,
+              height: dragIdentitySize,
               width: splitBarSize,
             },
           },
@@ -278,7 +278,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             },
 
             '&:after': {
-              width: resizeSpinnerSize,
+              width: dragIdentitySize,
               height: splitBarSize,
             },
           },
@@ -329,12 +329,12 @@ export const prepareComponentToken: GetDefaultToken<'Splitter'> = (token) => {
   const splitBarSize = token.splitBarSize || 2;
   const splitTriggerSize = token.splitTriggerSize || 6;
 
-  const resizeSpinnerSize = token.resizeSpinnerSize || 20;
+  const dragIdentitySize = token.dragIdentitySize || 20;
 
   return {
     splitBarSize,
     splitTriggerSize,
-    resizeSpinnerSize,
+    dragIdentitySize,
   };
 };
 

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -337,7 +337,7 @@ export const prepareComponentToken: GetDefaultToken<'Splitter'> = (token) => {
 
   // https://github.com/ant-design/ant-design/pull/51223
   const resizeSpinnerSize = token.resizeSpinnerSize || 20;
-  const splitBarDraggableSize = token.splitBarDraggableSize || resizeSpinnerSize;
+  const splitBarDraggableSize = token.splitBarDraggableSize ?? resizeSpinnerSize;
 
   return {
     splitBarSize,


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ❓ Other (about what?)

### 🔗 Related Issues

 - fix https://github.com/ant-design/ant-design/issues/51218

### 💡 Background and Solution

重命名 拖拽标识元素大小 token 

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Rename the token to make it semantically correct      |
| 🇨🇳 Chinese |     重命名 token 使其符合语义      |
