### PR TITLE
Due to the inclusion of transformations in elements, canvas elements in child elements cannot be updated and rendered in a timely manner, mainly due to issues caused by transformations in CSS. Therefore, it needs to be deleted

### DIFF
--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -146,6 +146,13 @@ const Drawer: React.FC<DrawerProps> & {
     motionEnter: true,
     motionLeave: true,
     motionDeadline: 500,
+    onAppearEnd: (e) => {
+      // Due to the inclusion of transformations in elements, canvas elements in child elements cannot be updated and rendered in a timely manner, mainly due to issues caused by transformations in CSS. Therefore, it needs to be deleted
+      e.style.transition = 'none';
+    },
+    onLeavePrepare: (e) => {
+      e.style.transition = 'all 0.3s';
+    },
   });
 
   // ============================ Refs ============================


### PR DESCRIPTION
Due to the inclusion of transformations in elements, canvas elements in child elements cannot be updated and rendered in a timely manner, mainly due to issues caused by transformations in CSS. Therefore, it needs to be deleted

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 💡 Background and Solution
> -In Drawer, the canvas resizing event on the window triggers this error, and the transition delays the canvas rendering

```ts
  const panelMotion: DrawerProps['motion'] = (motionPlacement) => ({
    motionName: getTransitionName(prefixCls, `panel-motion-${motionPlacement}`),
    motionAppear: true,
    motionEnter: true,
    motionLeave: true,
    motionDeadline: 500,
    onAppearEnd: (e) => { 
      e.style.transition = 'none';
    },
    onLeavePrepare: (e) => {
      e.style.transition = 'all 0.3s';
    },
  });
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
