### PR TITLE
chore(deps): bump rc-cascader from 3.28.1 to 3.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",
     "dayjs": "^1.11.11",
-    "rc-cascader": "~3.28.1",
+    "rc-cascader": "~3.28.2",
     "rc-checkbox": "~3.3.0",
     "rc-collapse": "~3.8.0",
     "rc-dialog": "~9.6.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix


### 🔗 Related Issues
fixed pr： https://github.com/react-component/cascader/pull/541
releate issue：  #51248 

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

https://github.com/react-component/cascader/compare/v3.28.1...v3.28.2


### 💡 Background and Solution

修复Cascader showSearch 的 limit 设为 false 后依然只展示前 50 条匹配结果

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix(Cascader)：when showSearch limit is false and actually uses the default value of 50       |
| 🇨🇳 Chinese |     fix(Cascader)：当显示搜索限制为 false 时，实际使用默认值 50      |
