### PR TITLE
fix: Propagate inputMode to individual Cells in Input.OTP #51239

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -69,6 +69,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     autoFocus,
     mask,
     type,
+    inputMode,
     ...restProps
   } = props;
 
@@ -217,6 +218,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     status: mergedStatus as InputStatus,
     mask,
     type,
+    inputMode,
   };
 
   return wrapCSSVar(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
- [x] 🐞 Bug fix

### 🔗 Related Issues

> - fix #51239 

### 💡 Background and Solution

> - input Mode was not propagated to individual cells of Input.OTP

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Input.OTP cannot accept `inputMode` prop.    |
| 🇨🇳 Chinese |  修复 Input.OTP 无法指定 `inputMode` 的问题。         |
