### PR TITLE
feat(input-otp): add onInput api for otp

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -24,7 +24,8 @@ export interface OTPRef {
   nativeElement: HTMLDivElement;
 }
 
-export interface OTPProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface OTPProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onInput'> {
   prefixCls?: string;
   length?: number;
 
@@ -48,6 +49,8 @@ export interface OTPProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'on
   mask?: boolean | string;
 
   type?: React.HTMLInputTypeAttribute;
+
+  onInput?: (value: string) => void;
 }
 
 function strToArr(str: string) {
@@ -69,6 +72,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     autoFocus,
     mask,
     type,
+    onInput,
     ...restProps
   } = props;
 
@@ -145,6 +149,10 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
   const triggerValueCellsChange = useEvent((nextValueCells: string[]) => {
     setValueCells(nextValueCells);
+
+    if (onInput) {
+      onInput(nextValueCells.join(''));
+    }
 
     // Trigger if all cells are filled
     if (

--- a/components/input/demo/otp.tsx
+++ b/components/input/demo/otp.tsx
@@ -11,8 +11,13 @@ const App: React.FC = () => {
     console.log('onChange:', text);
   };
 
+  const onInput: OTPProps['onInput'] = (value) => {
+    console.log('onInput:', value);
+  };
+
   const sharedProps: OTPProps = {
     onChange,
+    onInput,
   };
 
   return (

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -141,6 +141,7 @@ Added in `5.16.0`.
 | variant | Variants of Input | `outlined` \| `borderless` \| `filled` | `outlined` |  |
 | value | The input content value | string | - |  |
 | onChange | Trigger when all the fields are filled | function(value: string) | - |  |
+| onInput | Trigger when the input value changes | function(value: string) | - |  |
 
 #### VisibilityToggle
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -73,6 +73,7 @@ demo:
 | onChange | 输入框内容变化时的回调 | function(e) | - |  |
 | onPressEnter | 按下回车的回调 | function(e) | - |  |
 | onClear | 按下清除按钮的回调 | () => void | - | 5.20.0 |
+| onInput | 输入值变化时触发的回调 | (value: string) => void | - |  |
 
 > 如果 `Input` 在 `Form.Item` 内，并且 `Form.Item` 设置了 `id` 属性，则 `value` `defaultValue` 和 `id` 属性会被自动设置。
 
@@ -142,6 +143,7 @@ interface CountConfig {
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` | `outlined` |  |
 | value | 输入框内容 | string | - |  |
 | onChange | 当输入框内容全部填充时触发回调 | function(value: string) | - |  |
+| onInput | 输入值变化时触发的回调 | (value: string) => void | - |  |
 
 #### VisibilityToggle
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 这是什么？

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ 示例改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 定义改进
- [ ] 📦 打包大小优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ❓ 其他（关于什么？）

### 🔗 相关问题

- related to #51042 

### 💡 背景和解决方案

在 `OTP` 组件中，新增`onInput`事件，用于获取用户每一次输入的值

同时，更新了相关文档，确保新接口的正确使用和描述。

### 📝 更新日志

> - 阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
> - 描述更改对开发者的影响，而不是解决方案的方法
> - 参考: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add `onInput` event to get the value of each input by the user.At the same time, the related documentation has been updated  |
| 🇨🇳 Chinese | 在 `OTP` 组件中，新增`onInput`事件，用于获取用户每一次输入的值。同时更新了相关文档说明。 |
