### PR TITLE
fix: remove pointer-events: 'none' for disabled items in date-picker panel

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -124,7 +124,7 @@ const genPickerCellInnerStyle = (token: SharedPickerToken): CSSObject => {
     // >>> Disabled
     '&-disabled': {
       color: colorTextDisabled,
-      cursor: 'default',
+      cursor: 'not-allowed',
 
       [pickerCellInnerCls]: {
         background: 'transparent',

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -48,8 +48,8 @@ const genPickerCellInnerStyle = (token: SharedPickerToken): CSSObject => {
     },
 
     // >>> Hover
-    [`&:hover:not(${pickerCellCls}-in-view),
-    &:hover:not(${pickerCellCls}-selected):not(${pickerCellCls}-range-start):not(${pickerCellCls}-range-end)`]:
+    [`&:hover:not(${pickerCellCls}-in-view):not(${pickerCellCls}-disabled),
+    &:hover:not(${pickerCellCls}-selected):not(${pickerCellCls}-range-start):not(${pickerCellCls}-range-end):not(${pickerCellCls}-disabled)`]:
       {
         [pickerCellInnerCls]: {
           background: cellHoverBg,
@@ -124,7 +124,7 @@ const genPickerCellInnerStyle = (token: SharedPickerToken): CSSObject => {
     // >>> Disabled
     '&-disabled': {
       color: colorTextDisabled,
-      pointerEvents: 'none',
+      cursor: 'default',
 
       [pickerCellInnerCls]: {
         background: 'transparent',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 🐞 Bug fix

### 🔗 Related Issues

Closes https://github.com/ant-design/ant-design/issues/51293

### 💡 Background and Solution

> Tooltips/Popovers were non-functional when used inside `cellRender` if an item was disabled via `disabledDate`
> Remove `pointer-events: none` from the style of disabled items and adjust hover styles accordingly.

### 📝 Change Log

> Allows usage of Tooltips/Popovers inside of `cellRender` for disabled items.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixes inability to use Tooltip/Popover inside `cellRender` when dealing with disabled dates |
| 🇨🇳 Chinese | 修复了处理禁用日期时无法在 `cellRender` 内使用 Tooltip/Popover 的问题  |
