### PR TITLE
fix(Layout): Fix Layout collapse trigger missing style

### DIFF
--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -74,7 +74,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
           overflow: 'hidden',
         },
 
-        [`${componentCls}-trigger`]: {
+        '&-trigger': {
           position: 'absolute',
           top: headerHeight,
           insetInlineEnd: token.calc(zeroTriggerWidth).mul(-1).equal(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 这是一个...

- [x] 🐞 Bug 修复

### 🔗 相关 Issues
fix #51224

> - 修复 `ant-layout-sider-zero-width-trigger` 和 `ant-layout-sider-zero-width-trigger-left` 类名未正确应用样式的问题。

### 💡 背景和解决方案

> - **问题描述**:
>   当前 `sider.ts` 文件中，`ant-layout-sider-zero-width-trigger` 和 `ant-layout-sider-zero-width-trigger-left` 两个类名没有正确赋予样式，导致在特定情况下触发器样式无法正常显示和交互。
>
> - **解决方案**:
>   在 `components/layout/style/sider.ts` 文件中，修正了 `ant-layout-sider-zero-width-trigger-left` 的样式定义，确保左侧触发器在零宽度状态下能够正确应用样式。

### 📝 变更日志

> - **修复了** `ant-layout-sider-zero-width-trigger` 和 `ant-layout-sider-zero-width-trigger-left` 类名的样式未生效的问题，确保在零宽度状态下触发器能够正确显示和响应用户交互。

| 语言   | 变更日志                                                             |
| ------ | -------------------------------------------------------------------- |
| 🇺🇸 English | - Fixed the issue where `ant-layout-sider-zero-width-trigger` and `ant-layout-sider-zero-width-trigger-left` classes were not correctly applying styles. This ensures that the triggers display and function properly in zero-width state. |
| 🇨🇳 Chinese | - 修复了 `ant-layout-sider-zero-width-trigger` 和 `ant-layout-sider-zero-width-trigger-left` 类名的样式未生效的问题，确保在零宽度状态下触发器能够正确显示和响应用户交互。 |

