### PR TITLE
fix: The onRefresh method is missing from the QRCode component's statusRender params

### DIFF
--- a/components/qr-code/QrcodeStatus.tsx
+++ b/components/qr-code/QrcodeStatus.tsx
@@ -49,5 +49,6 @@ export default function QRcodeStatus({
   return mergedStatusRender({
     status,
     locale,
+    onRefresh,
   });
 }

--- a/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,15 @@ exports[`QRCode test custom status render 1`] = `
       <div
         class="custom-expired"
       >
-        QR code expired
+        <span>
+          QR code expired
+        </span>
+        <button
+          id="refresh"
+          type="button"
+        >
+          refresh
+        </button>
       </div>
     </div>
     <canvas

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -99,10 +99,18 @@ describe('QRCode test', () => {
     );
   });
   it('custom status render', () => {
+    const refreshCb = jest.fn();
     const customStatusRender: QRCodeProps['statusRender'] = (info) => {
       switch (info.status) {
         case 'expired':
-          return <div className="custom-expired">{info.locale?.expired}</div>;
+          return (
+            <div className="custom-expired">
+              <span>{info.locale?.expired}</span>
+              <button id="refresh" onClick={info.onRefresh} type="button">
+                refresh
+              </button>
+            </div>
+          );
         case 'loading':
           return <div className="custom-loading">Loading</div>;
         case 'scanned':
@@ -118,6 +126,7 @@ describe('QRCode test', () => {
           value="test"
           status="expired"
           statusRender={customStatusRender}
+          onRefresh={refreshCb}
         />
         <QRCode
           className="qrcode-loading"
@@ -134,8 +143,10 @@ describe('QRCode test', () => {
       </>,
     );
     expect(
-      container.querySelector<HTMLDivElement>('.qrcode-expired .custom-expired')?.textContent,
+      container.querySelector<HTMLDivElement>('.qrcode-expired .custom-expired>span')?.textContent,
     ).toBe('QR code expired');
+    fireEvent.click(container?.querySelector<HTMLButtonElement>('#refresh')!);
+    expect(refreshCb).toHaveBeenCalled();
     expect(
       container.querySelector<HTMLDivElement>('.qrcode-loading .custom-loading')?.textContent,
     ).toBe('Loading');


### PR DESCRIPTION


<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51286

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  The onRefresh method is missing from the QRCode component's statusRender params |
| 🇨🇳 Chinese |  QRCode 组件的 statusRender 参数缺失 onRefresh 方法  |
