### PR TITLE
demo: improve the use of Segmented

### DIFF
--- a/components/flex/demo/align.tsx
+++ b/components/flex/demo/align.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Flex, Segmented } from 'antd';
-import type { FlexProps, SegmentedProps } from 'antd';
+import type { FlexProps } from 'antd';
 
 const boxStyle: React.CSSProperties = {
   width: '100%',
@@ -26,9 +26,9 @@ const App: React.FC = () => {
   return (
     <Flex gap="middle" align="start" vertical>
       <p>Select justify :</p>
-      <Segmented options={justifyOptions} onChange={setJustify as SegmentedProps['onChange']} />
+      <Segmented options={justifyOptions} onChange={setJustify} />
       <p>Select align :</p>
-      <Segmented options={alignOptions} onChange={setAlignItems as SegmentedProps['onChange']} />
+      <Segmented options={alignOptions} onChange={setAlignItems} />
       <Flex style={boxStyle} justify={justify} align={alignItems}>
         <Button type="primary">Primary</Button>
         <Button type="primary">Primary</Button>

--- a/components/popover/demo/arrow.tsx
+++ b/components/popover/demo/arrow.tsx
@@ -34,7 +34,7 @@ const App: React.FC = () => {
     <ConfigProvider button={{ style: { width: buttonWidth, margin: 4 } }}>
       <Segmented
         options={['Show', 'Hide', 'Center']}
-        onChange={(val: 'Show' | 'Hide' | 'Center') => setArrow(val)}
+        onChange={setArrow}
         style={{ marginBottom: 24 }}
       />
       <Flex vertical justify="center" align="center" className="demo">

--- a/components/qr-code/demo/download.tsx
+++ b/components/qr-code/demo/download.tsx
@@ -32,10 +32,7 @@ const App: React.FC = () => {
   const [renderType, setRenderType] = React.useState<QRCodeProps['type']>('canvas');
   return (
     <Space id="myqrcode" direction="vertical">
-      <Segmented
-        options={['canvas', 'svg']}
-        onChange={(val) => setRenderType(val as QRCodeProps['type'])}
-      />
+      <Segmented options={['canvas', 'svg']} value={renderType} onChange={setRenderType} />
       <div>
         <QRCode
           type={renderType}

--- a/components/table/demo/virtual-list.tsx
+++ b/components/table/demo/virtual-list.tsx
@@ -168,7 +168,7 @@ const App: React.FC = () => {
           />
           <Segmented
             value={count}
-            onChange={(value: number) => setCount(value)}
+            onChange={setCount}
             options={[
               { label: 'None', value: 0 },
               { label: 'Less', value: 4 },

--- a/components/tabs/demo/custom-indicator.tsx
+++ b/components/tabs/demo/custom-indicator.tsx
@@ -19,9 +19,9 @@ const App: React.FC = () => {
   return (
     <>
       <Segmented
-        defaultValue="center"
+        value={alignValue}
         style={{ marginBottom: 8 }}
-        onChange={(value) => setAlignValue(value as Align)}
+        onChange={setAlignValue}
         options={['start', 'center', 'end']}
       />
       <Tabs

--- a/components/tooltip/demo/arrow.tsx
+++ b/components/tooltip/demo/arrow.tsx
@@ -28,7 +28,7 @@ const App: React.FC = () => {
       <Segmented
         value={arrow}
         options={['Show', 'Hide', 'Center']}
-        onChange={(val: 'Show' | 'Hide' | 'Center') => setArrow(val)}
+        onChange={setArrow}
         style={{ marginBottom: 24 }}
       />
       <Flex vertical justify="center" align="center" className="demo">


### PR DESCRIPTION


### 🤔 This is a ...

- [x] 📽️ Demo improvement

### 💡 Background and Solution
参考了官网的受控demo发现这几处的类型似乎不需要额外的断言
![image](https://github.com/user-attachments/assets/105f528e-1f22-44bc-9e4c-5d81265fe628)

![image](https://github.com/user-attachments/assets/28e6c336-d3d3-4d75-b651-562d82df965a)
![image](https://github.com/user-attachments/assets/f242c500-b813-4118-a0c8-012b992fec0b)
![image](https://github.com/user-attachments/assets/8057ee84-2d17-4b2e-8eb1-9d353c54c704)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    demo: improve the use of Segmented       |
| 🇨🇳 Chinese |        demo:  改进Segmented的使用   |
