### PR TITLE
fix: use locale of empty img title

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -761,7 +761,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -912,7 +912,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -1201,7 +1201,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -1420,7 +1420,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -1652,7 +1652,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1923,7 +1923,7 @@ exports[`renders components/cascader/demo/panel.tsx extend context correctly 1`]
           xmlns="http://www.w3.org/2000/svg"
         >
           <title>
-            Simple Empty
+            No data
           </title>
           <g
             fill="none"
@@ -3475,7 +3475,7 @@ exports[`renders components/cascader/demo/status.tsx extend context correctly 1`
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <title>
-                          Simple Empty
+                          No data
                         </title>
                         <g
                           fill="none"
@@ -3628,7 +3628,7 @@ exports[`renders components/cascader/demo/status.tsx extend context correctly 1`
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <title>
-                          Simple Empty
+                          No data
                         </title>
                         <g
                           fill="none"

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -904,7 +904,7 @@ exports[`renders components/cascader/demo/panel.tsx correctly 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title>
-            Simple Empty
+            No data
           </title>
           <g
             fill="none"

--- a/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
@@ -1704,7 +1704,7 @@ exports[`Cascader should render not found content 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"
@@ -1782,7 +1782,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -15000,7 +15000,7 @@ exports[`ConfigProvider components Empty configProvider 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15078,7 +15078,7 @@ exports[`ConfigProvider components Empty configProvider componentDisabled 1`] = 
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15156,7 +15156,7 @@ exports[`ConfigProvider components Empty configProvider componentSize large 1`] 
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15234,7 +15234,7 @@ exports[`ConfigProvider components Empty configProvider componentSize middle 1`]
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15312,7 +15312,7 @@ exports[`ConfigProvider components Empty configProvider componentSize small 1`] 
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15390,7 +15390,7 @@ exports[`ConfigProvider components Empty normal 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -15468,7 +15468,7 @@ exports[`ConfigProvider components Empty prefixCls 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -26829,7 +26829,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -27138,7 +27138,7 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -27445,7 +27445,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -27752,7 +27752,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -28059,7 +28059,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -28366,7 +28366,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -28673,7 +28673,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -39299,7 +39299,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -39469,7 +39469,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -39584,7 +39584,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -39754,7 +39754,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -39869,7 +39869,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40039,7 +40039,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40154,7 +40154,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40324,7 +40324,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize middle 
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40439,7 +40439,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40609,7 +40609,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40724,7 +40724,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -40894,7 +40894,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -41009,7 +41009,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -41179,7 +41179,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/config-provider/__tests__/__snapshots__/renderEmpty.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/renderEmpty.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renderEmpty should render Cascader empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -65,7 +65,7 @@ exports[`renderEmpty should render List empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -116,7 +116,7 @@ exports[`renderEmpty should render Mentions empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -167,7 +167,7 @@ exports[`renderEmpty should render Select empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -218,7 +218,7 @@ exports[`renderEmpty should render Table empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -271,7 +271,7 @@ exports[`renderEmpty should render Transfer empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -322,7 +322,7 @@ exports[`renderEmpty should render TreeSelect empty 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"
@@ -373,7 +373,7 @@ exports[`renderEmpty should return empty when componentName is not matched 1`] =
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -14,7 +14,7 @@ exports[`renders components/empty/demo/basic.tsx extend context correctly 1`] = 
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -1065,7 +1065,7 @@ exports[`renders components/empty/demo/description.tsx extend context correctly 
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -1140,7 +1140,7 @@ exports[`renders components/empty/demo/simple.tsx extend context correctly 1`] =
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"

--- a/components/empty/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.ts.snap
@@ -14,7 +14,7 @@ exports[`renders components/empty/demo/basic.tsx correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -781,7 +781,7 @@ exports[`renders components/empty/demo/description.tsx correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -854,7 +854,7 @@ exports[`renders components/empty/demo/simple.tsx correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        Simple Empty
+        No data
       </title>
       <g
         fill="none"

--- a/components/empty/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/empty/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Empty rtl render component should be rendered correctly in RTL directio
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"
@@ -92,7 +92,7 @@ exports[`Empty should render in RTL direction 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        empty image
+        No data
       </title>
       <g
         fill="none"

--- a/components/empty/empty.tsx
+++ b/components/empty/empty.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { TinyColor } from '@ctrl/tinycolor';
 
+import { useLocale } from '../locale';
 import { useToken } from '../theme/internal';
 
 const Empty: React.FC = () => {
   const [, token] = useToken();
+  const [locale] = useLocale('Empty');
 
   const bgColor = new TinyColor(token.colorBgBase);
 
@@ -19,7 +21,7 @@ const Empty: React.FC = () => {
       viewBox="0 0 184 152"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title>empty image</title>
+      <title>{locale?.description || 'Empty'}</title>
       <g fill="none" fillRule="evenodd">
         <g transform="translate(24 31.67)">
           <ellipse

--- a/components/empty/simple.tsx
+++ b/components/empty/simple.tsx
@@ -3,9 +3,11 @@ import { useMemo } from 'react';
 import { TinyColor } from '@ctrl/tinycolor';
 
 import { useToken } from '../theme/internal';
+import { useLocale } from '../locale';
 
 const Simple: React.FC = () => {
   const [, token] = useToken();
+  const [locale] = useLocale('Empty');
 
   const { colorFill, colorFillTertiary, colorFillQuaternary, colorBgContainer } = token;
 
@@ -24,7 +26,7 @@ const Simple: React.FC = () => {
 
   return (
     <svg width="64" height="41" viewBox="0 0 64 41" xmlns="http://www.w3.org/2000/svg">
-      <title>Simple Empty</title>
+      <title>{locale?.description || 'Empty'}</title>
       <g transform="translate(0 1)" fill="none" fillRule="evenodd">
         <ellipse fill={shadowColor} cx="32" cy="33" rx="32" ry="7" />
         <g fillRule="nonzero" stroke={borderColor}>

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -31124,7 +31124,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -31286,7 +31286,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <title>
-                                  Simple Empty
+                                  No data
                                 </title>
                                 <g
                                   fill="none"
@@ -31439,7 +31439,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"

--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -698,7 +698,7 @@ exports[`renders components/input-number/demo/addon.tsx extend context correctly
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <title>
-                                Simple Empty
+                                No data
                               </title>
                               <g
                                 fill="none"

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -520,7 +520,7 @@ exports[`renders components/input/demo/addon.tsx extend context correctly 1`] = 
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <title>
-                                Simple Empty
+                                No data
                               </title>
                               <g
                                 fill="none"
@@ -3527,7 +3527,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -784,7 +784,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -1721,7 +1721,7 @@ exports[`renders components/list/demo/infinite-load.tsx extend context correctly
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <title>
-                      Simple Empty
+                      No data
                     </title>
                     <g
                       fill="none"

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -787,7 +787,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -1718,7 +1718,7 @@ exports[`renders components/list/demo/infinite-load.tsx correctly 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <title>
-                      Simple Empty
+                      No data
                     </title>
                     <g
                       fill="none"

--- a/components/list/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/empty.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`List renders empty list 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/list/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/index.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`List rtl render component should be rendered correctly in RTL direction
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13402,7 +13402,7 @@ exports[`renders components/select/demo/status.tsx extend context correctly 1`] 
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"
@@ -13525,7 +13525,7 @@ exports[`renders components/select/demo/status.tsx extend context correctly 1`] 
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11200,7 +11200,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <title>
-                                  Simple Empty
+                                  No data
                                 </title>
                                 <g
                                   fill="none"
@@ -12379,7 +12379,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
@@ -546,7 +546,7 @@ exports[`Table.pagination should not crash when trigger onChange in render 1`] =
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"

--- a/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -595,7 +595,7 @@ exports[`Table should render title 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -700,7 +700,7 @@ exports[`Table support wireframe 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"

--- a/components/table/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Table renders empty table 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"
@@ -583,7 +583,7 @@ exports[`Table renders empty table with fixed columns should work 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -759,7 +759,7 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <title>
-                            Simple Empty
+                            No data
                           </title>
                           <g
                             fill="none"

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1598,7 +1598,7 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2829,7 +2829,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -3072,7 +3072,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -3324,7 +3324,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -3634,7 +3634,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -9631,7 +9631,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -9874,7 +9874,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -10126,7 +10126,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -10436,7 +10436,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -11704,7 +11704,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <title>
-                                      Simple Empty
+                                      No data
                                     </title>
                                     <g
                                       fill="none"
@@ -12190,7 +12190,7 @@ exports[`renders components/transfer/demo/tree-transfer.tsx extend context corre
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -144,7 +144,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -403,7 +403,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -1926,7 +1926,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -2098,7 +2098,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -2279,7 +2279,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -2518,7 +2518,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -3911,7 +3911,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -4084,7 +4084,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -4621,7 +4621,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -4777,7 +4777,7 @@ Array [
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -5732,7 +5732,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -5971,7 +5971,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -6091,7 +6091,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -6263,7 +6263,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -6444,7 +6444,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -6683,7 +6683,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title>
-                  Simple Empty
+                  No data
                 </title>
                 <g
                   fill="none"
@@ -7749,7 +7749,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <title>
-                                      Simple Empty
+                                      No data
                                     </title>
                                     <g
                                       fill="none"
@@ -8239,7 +8239,7 @@ exports[`renders components/transfer/demo/tree-transfer.tsx correctly 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -244,7 +244,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -1022,7 +1022,7 @@ exports[`Transfer should support render value and label in item 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"
@@ -1280,7 +1280,7 @@ exports[`immutable data dataSource is frozen 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <title>
-                Simple Empty
+                No data
               </title>
               <g
                 fill="none"

--- a/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2011,7 +2011,7 @@ exports[`renders components/tree-select/demo/status.tsx extend context correctly
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"
@@ -2150,7 +2150,7 @@ exports[`renders components/tree-select/demo/status.tsx extend context correctly
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Simple Empty
+                    No data
                   </title>
                   <g
                     fill="none"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [x] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

resolve #51363

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Adjust Empty preset svg image `title` with locale description to improve a11y.       |
| 🇨🇳 Chinese |    调整 Empty 预设 svg 图片的 `title` 使用本地化配置的描述使其更具有语义从而提升无障碍体验。     |
