### PR TITLE
test: add a11y test for all components demo

### DIFF
--- a/components/affix/__tests__/a11y.test.ts
+++ b/components/affix/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('affix demo a11y', () => {
-  accessibilityDemoTest('affix');
-});
+accessibilityDemoTest('affix');

--- a/components/alert/__tests__/a11y.test.ts
+++ b/components/alert/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('alert demo a11y', () => {
-  accessibilityDemoTest('alert', { disabledRules: ['button-name'] });
-});
+accessibilityDemoTest('alert', { disabledRules: ['button-name'] });

--- a/components/anchor/__tests__/a11y.test.ts
+++ b/components/anchor/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('anchor demo a11y', () => {
-  accessibilityDemoTest('anchor');
-});
+accessibilityDemoTest('anchor');

--- a/components/app/__tests__/a11y.test.ts
+++ b/components/app/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('app demo a11y', () => {
-  accessibilityDemoTest('app');
-});
+accessibilityDemoTest('app');

--- a/components/auto-complete/__tests__/a11y.test.ts
+++ b/components/auto-complete/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('auto-complete demo a11y', () => {
+  accessibilityDemoTest('auto-complete', {
+    disabledRules: ['label'],
+    skip: ['render-panel.tsx', 'custom.tsx'],
+  });
+});

--- a/components/auto-complete/__tests__/a11y.test.ts
+++ b/components/auto-complete/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('auto-complete demo a11y', () => {
-  accessibilityDemoTest('auto-complete', {
-    disabledRules: ['label'],
-    skip: ['render-panel.tsx', 'custom.tsx'],
-  });
+accessibilityDemoTest('auto-complete', {
+  disabledRules: ['label'],
+  skip: ['render-panel.tsx', 'custom.tsx'],
 });

--- a/components/avatar/__tests__/a11y.test.ts
+++ b/components/avatar/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('avatar demo a11y', () => {
-  accessibilityDemoTest('avatar', { disabledRules: ['image-alt'] });
-});
+accessibilityDemoTest('avatar', { disabledRules: ['image-alt'] });

--- a/components/back-top/__tests__/a11y.test.ts
+++ b/components/back-top/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('back-top demo a11y', () => {
-  accessibilityDemoTest('back-top');
-});
+accessibilityDemoTest('back-top');

--- a/components/badge/__tests__/a11y.test.ts
+++ b/components/badge/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('badge demo a11y', () => {
-  accessibilityDemoTest('badge', { disabledRules: ['button-name'] });
-});
+accessibilityDemoTest('badge', { disabledRules: ['button-name'] });

--- a/components/button/__tests__/a11y.test.ts
+++ b/components/button/__tests__/a11y.test.ts
@@ -1,5 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('button demo a11y', () => {
-  accessibilityDemoTest('button');
-});
+accessibilityDemoTest('button');

--- a/components/calendar/__tests__/a11y.test.ts
+++ b/components/calendar/__tests__/a11y.test.ts
@@ -1,0 +1,10 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('calendar demo a11y', () => {
+  accessibilityDemoTest('calendar', {
+    // waiting for rc-picker fix
+    skip: ['week.tsx'],
+    // fix in another pr
+    disabledRules: ['label'],
+  });
+});

--- a/components/calendar/__tests__/a11y.test.ts
+++ b/components/calendar/__tests__/a11y.test.ts
@@ -1,10 +1,8 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('calendar demo a11y', () => {
-  accessibilityDemoTest('calendar', {
-    // waiting for rc-picker fix
-    skip: ['week.tsx'],
-    // fix in another pr
-    disabledRules: ['label'],
-  });
+accessibilityDemoTest('calendar', {
+  // waiting for rc-picker fix
+  skip: ['week.tsx'],
+  // fix in another pr
+  disabledRules: ['label'],
 });

--- a/components/card/__tests__/a11y.test.ts
+++ b/components/card/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('card demo a11y', () => {
+  accessibilityDemoTest('card', {
+    disabledRules: ['button-name', 'image-alt'],
+    skip: ['tabs.tsx'],
+  });
+});

--- a/components/card/__tests__/a11y.test.ts
+++ b/components/card/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('card demo a11y', () => {
-  accessibilityDemoTest('card', {
-    disabledRules: ['button-name', 'image-alt'],
-    skip: ['tabs.tsx'],
-  });
+accessibilityDemoTest('card', {
+  disabledRules: ['button-name', 'image-alt'],
+  skip: ['tabs.tsx'],
 });

--- a/components/carousel/__tests__/a11y.test.ts
+++ b/components/carousel/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('carousel demo a11y', () => {
-  // skip _InternalPanelDoNotUseOrYouWillBeFired
-  accessibilityDemoTest('carousel');
-});
+accessibilityDemoTest('carousel');

--- a/components/carousel/__tests__/a11y.test.ts
+++ b/components/carousel/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('carousel demo a11y', () => {
+  // skip _InternalPanelDoNotUseOrYouWillBeFired
+  accessibilityDemoTest('carousel');
+});

--- a/components/checkbox/__tests__/a11y.test.ts
+++ b/components/checkbox/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('checkbox demo a11y', () => {
+  // skip debug demo
+  accessibilityDemoTest('checkbox', { skip: ['custom-line-width.tsx', 'disabled.tsx'] });
+});

--- a/components/checkbox/__tests__/a11y.test.ts
+++ b/components/checkbox/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('checkbox demo a11y', () => {
+accessibilityDemoTest('checkbox', {
   // skip debug demo
-  accessibilityDemoTest('checkbox', { skip: ['custom-line-width.tsx', 'disabled.tsx'] });
+  skip: ['custom-line-width.tsx', 'disabled.tsx'],
 });

--- a/components/collapse/__tests__/a11y.test.ts
+++ b/components/collapse/__tests__/a11y.test.ts
@@ -1,5 +1,5 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('collapse demo a11y', () => {
-  accessibilityDemoTest('collapse', { skip: ['extra.tsx'] });
+accessibilityDemoTest('collapse', {
+  skip: ['extra.tsx'],
 });

--- a/components/color-picker/__tests__/a11y.test.ts
+++ b/components/color-picker/__tests__/a11y.test.ts
@@ -1,4 +1,5 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-// skip _InternalPanelDoNotUseOrYouWillBeFired
-accessibilityDemoTest('color-picker', { skip: ['pure-panel.tsx'] });
+accessibilityDemoTest('color-picker', {
+  skip: ['pure-panel.tsx'],
+});

--- a/components/flex/__tests__/a11y.test.ts
+++ b/components/flex/__tests__/a11y.test.ts
@@ -1,0 +1,9 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('flex demo a11y', () => {
+  accessibilityDemoTest('flex', {
+    disabledRules: ['aria-required-children'],
+    // waiting for segmented fix
+    skip: ['align.tsx'],
+  });
+});

--- a/components/flex/__tests__/a11y.test.ts
+++ b/components/flex/__tests__/a11y.test.ts
@@ -1,9 +1,7 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('flex demo a11y', () => {
-  accessibilityDemoTest('flex', {
-    disabledRules: ['aria-required-children'],
-    // waiting for segmented fix
-    skip: ['align.tsx'],
-  });
+accessibilityDemoTest('flex', {
+  disabledRules: ['aria-required-children'],
+  // waiting for segmented fix
+  skip: ['align.tsx'],
 });

--- a/components/flex/__tests__/a11y.test.ts
+++ b/components/flex/__tests__/a11y.test.ts
@@ -1,3 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('flex');
+accessibilityDemoTest('flex', {
+  // waiting for rc-segmented fix
+  skip: ['align.tsx'],
+});

--- a/components/grid/__tests__/a11y.test.ts
+++ b/components/grid/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('grid demo a11y', () => {
+  accessibilityDemoTest('grid', {
+    // waiting for slider fix
+    skip: ['playground.tsx'],
+  });
+});

--- a/components/grid/__tests__/a11y.test.ts
+++ b/components/grid/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('grid demo a11y', () => {
-  accessibilityDemoTest('grid', {
-    // waiting for slider fix
-    skip: ['playground.tsx'],
-  });
+accessibilityDemoTest('grid', {
+  // waiting for slider fix
+  skip: ['playground.tsx'],
 });

--- a/components/list/__tests__/a11y.test.ts
+++ b/components/list/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('flex');
+accessibilityDemoTest('list');

--- a/components/list/__tests__/a11y.test.ts
+++ b/components/list/__tests__/a11y.test.ts
@@ -1,3 +1,8 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('list');
+accessibilityDemoTest('list', {
+  // waiting for fix
+  skip: ['infinite-load.tsx'],
+  // we can set alt for img in list demo
+  disabledRules: ['image-alt'],
+});

--- a/components/pagination/__tests__/a11y.test.ts
+++ b/components/pagination/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('pagination', {
+  // waiting for rc-pagination fix
+  skip: ['simple.tsx'],
+});

--- a/components/popover/__tests__/a11y.test.ts
+++ b/components/popover/__tests__/a11y.test.ts
@@ -1,3 +1,5 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('breadcrumb');
+accessibilityDemoTest('popover', {
+  skip: ['arrow.tsx'],
+});

--- a/components/progress/__tests__/a11y.test.ts
+++ b/components/progress/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('progress', {
+  // we can set aria attribute to fix it
+  disabledRules: ['aria-progressbar-name'],
+  // we can set aria attribute to fix it
+  skip: ['circle-steps.tsx'],
+});

--- a/components/qr-code/__tests__/a11y.test.ts
+++ b/components/qr-code/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('segmented', {
+accessibilityDemoTest('qr-code', {
   // we can add aria attributes to fix it
-  skip: ['custom.tsx', 'size-consistent.tsx'],
+  disabledRules: ['role-img-alt', 'svg-img-alt'],
 });

--- a/components/qr-code/__tests__/a11y.test.ts
+++ b/components/qr-code/__tests__/a11y.test.ts
@@ -3,4 +3,6 @@ import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 accessibilityDemoTest('qr-code', {
   // we can add aria attributes to fix it
   disabledRules: ['role-img-alt', 'svg-img-alt'],
+  // waiting for rc-segmented fix
+  skip: ['errorlevel.tsx', 'download.tsx'],
 });

--- a/components/rate/__tests__/a11y.test.ts
+++ b/components/rate/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('rate', {
+  // waiting for rc-rate fix
+  disabledRules: ['listitem'],
+});

--- a/components/segmented/__tests__/a11y.test.ts
+++ b/components/segmented/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+describe('segmented demo a11y', () => {
+  accessibilityDemoTest('segmented', {
+    disabledRules: ['aria-allowed-attr'],
+    skip: ['custom.tsx', 'size-consistent.tsx'],
+  });
+});

--- a/components/segmented/__tests__/a11y.test.ts
+++ b/components/segmented/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-describe('segmented demo a11y', () => {
-  accessibilityDemoTest('segmented', {
-    disabledRules: ['aria-allowed-attr'],
-    skip: ['custom.tsx', 'size-consistent.tsx'],
-  });
+accessibilityDemoTest('segmented', {
+  disabledRules: ['aria-allowed-attr'],
+  skip: ['custom.tsx', 'size-consistent.tsx'],
 });

--- a/components/segmented/__tests__/a11y.test.ts
+++ b/components/segmented/__tests__/a11y.test.ts
@@ -3,4 +3,6 @@ import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 accessibilityDemoTest('segmented', {
   // we can add aria attributes to fix it
   skip: ['custom.tsx', 'size-consistent.tsx'],
+  // waiting for rc-segmented fix
+  disabledRules: ['aria-allowed-attr'],
 });

--- a/components/skeleton/__tests__/a11y.test.ts
+++ b/components/skeleton/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('skeleton', {
+  // waiting for fix
+  disabledRules: ['empty-heading'],
+  // we can set aria attribute to fix it
+  skip: ['list.tsx'],
+});

--- a/components/skeleton/__tests__/a11y.test.ts
+++ b/components/skeleton/__tests__/a11y.test.ts
@@ -4,5 +4,5 @@ accessibilityDemoTest('skeleton', {
   // waiting for fix
   disabledRules: ['empty-heading'],
   // we can set aria attribute to fix it
-  skip: ['list.tsx'],
+  skip: ['list.tsx', 'element.tsx'],
 });

--- a/components/slider/__tests__/a11y.test.ts
+++ b/components/slider/__tests__/a11y.test.ts
@@ -1,3 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('slider');
+accessibilityDemoTest('slider', {
+  // we can set aria attribute to fix it
+  disabledRules: ['aria-input-field-name', 'label', 'button-name'],
+});

--- a/components/slider/__tests__/a11y.test.ts
+++ b/components/slider/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('slider');

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -86,6 +86,13 @@ export interface SliderBaseProps {
   getTooltipPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   /** @deprecated `tooltipPlacement` is deprecated. Please use `tooltip.placement` instead. */
   tooltipPlacement?: TooltipPlacement;
+
+  // Accessibility
+  tabIndex?: SliderProps['tabIndex'];
+  ariaLabelForHandle?: SliderProps['ariaLabelForHandle'];
+  ariaLabelledByForHandle?: SliderProps['ariaLabelledByForHandle'];
+  ariaRequired?: SliderProps['ariaRequired'];
+  ariaValueTextFormatterForHandle?: SliderProps['ariaValueTextFormatterForHandle'];
 }
 
 export interface SliderSingleProps extends SliderBaseProps {

--- a/components/statistic/__tests__/a11y.test.ts
+++ b/components/statistic/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('statistic', {
+  // wait for skeleton fix
+  skip: ['basic.tsx'],
+});

--- a/components/steps/__tests__/a11y.test.ts
+++ b/components/steps/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('steps', {
+  // we can set aria attribute to fix it
+  skip: ['inline.tsx', 'label-placement.tsx', 'progress.tsx'],
+});

--- a/components/switch/__tests__/a11y.test.ts
+++ b/components/switch/__tests__/a11y.test.ts
@@ -1,3 +1,5 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('switch', { disabledRules: ['button-name'] });
+accessibilityDemoTest('switch', {
+  disabledRules: ['button-name'],
+});

--- a/components/tooltip/__tests__/a11y.test.ts
+++ b/components/tooltip/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('tooltip', {
+  skip: ['arrow.tsx', 'disabled-children.tsx'],
+});

--- a/components/tree/__tests__/a11y.test.ts
+++ b/components/tree/__tests__/a11y.test.ts
@@ -1,0 +1,11 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('tree', {
+  skip: [
+    // Skip large data demos to prevent test timeout
+    'virtual-scroll.tsx',
+    'big-data.tsx',
+    // we can set aria attributes to fix it
+    'line.tsx',
+  ],
+});

--- a/components/upload/__tests__/a11y.test.ts
+++ b/components/upload/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('upload', {
+  // Skip due to external dependency issue
+  skip: ['drag-sorting.tsx'],
+});

--- a/components/watermark/__tests__/a11y.test.ts
+++ b/components/watermark/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('segmented', {
+accessibilityDemoTest('watermark', {
   // we can add aria attributes to fix it
-  skip: ['custom.tsx', 'size-consistent.tsx'],
+  skip: ['custom.tsx'],
 });

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -112,7 +112,15 @@ export function accessibilityTest(Component: React.ComponentType, disabledRules?
 }
 
 type Options = {
+  /**
+   * 跳过测试
+   * @default false
+   */
   skip?: boolean | string[];
+  /**
+   * 禁用axe规则检查
+   * @default []
+   */
   disabledRules?: string[];
 };
 

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -113,12 +113,12 @@ export function accessibilityTest(Component: React.ComponentType, disabledRules?
 
 type Options = {
   /**
-   * 跳过测试
+   * skip test
    * @default false
    */
   skip?: boolean | string[];
   /**
-   * 禁用axe规则检查
+   * Disable axe rule checks
    * @default []
    */
   disabledRules?: string[];


### PR DESCRIPTION

### 🤔 This is a ...

- [x] ✅ Test Case

### 🔗 Related Issues
resolve #51348 

### 💡 Background and Solution

1. 为了确保组件库的可访问性符合标准，添加了自动化的可访问性测试工具。
2. 为所有组件的demo添加可访问性测试
3. 优化部分组件的可访问性支持

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | •Added automated accessibility testing tools to ensure the component library meets accessibility standards.<br/>•Added accessibility tests for all component demos to ensure compliance with accessibility guidelines. <br/>•Optimized accessibility support for certain components, improving compatibility with screen readers and keyboard navigation. |
| 🇨🇳 Chinese | •为了确保组件库的可访问性符合标准，添加了自动化的可访问性测试工具。<br/>•为所有组件的示例（demo）添加了可访问性测试，确保符合无障碍标准。<br/>•优化了部分组件的可访问性支持，改进了对屏幕阅读器和键盘操作的兼容性。|