### PR TITLE
fix(Spliter): expand collapse button click area for improved usability

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -136,13 +136,13 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
             `${splitBarPrefixCls}-collapse-bar`,
             `${splitBarPrefixCls}-collapse-bar-start`,
           )}
+          onClick={() => onCollapse(index, 'start')}
         >
           <StartIcon
             className={classNames(
               `${splitBarPrefixCls}-collapse-icon`,
               `${splitBarPrefixCls}-collapse-start`,
             )}
-            onClick={() => onCollapse(index, 'start')}
           />
         </div>
       )}
@@ -154,13 +154,13 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
             `${splitBarPrefixCls}-collapse-bar`,
             `${splitBarPrefixCls}-collapse-bar-end`,
           )}
+          onClick={() => onCollapse(index, 'end')}
         >
           <EndIcon
             className={classNames(
               `${splitBarPrefixCls}-collapse-icon`,
               `${splitBarPrefixCls}-collapse-end`,
             )}
-            onClick={() => onCollapse(index, 'end')}
           />
         </div>
       )}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⭐️ Feature enhancement

### 🔗 Related Issues
- close #51382
- close #51384

### 💡 Background and Solution
**Background**
In the Spliter component, the collapse button previously had a limited clickable area, only allowing clicks on the icon itself to trigger the collapse action. This restricted usability, as users needed to aim precisely at the icon to toggle the state.

**Solution:** 
Expanded the clickable area to encompass the entire button, allowing the collapse action to be triggered from any point within the button boundary. This enhances usability by making it easier for users to interact with the component.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Expanded clickable area for the Spliter collapse button to enhance usability.       |
| 🇨🇳 Chinese |      增大 Spliter 组件折叠按钮的点击热区，以提高可用性。     |
