### PR TITLE
fix: add Input cursor disabled

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -186,6 +186,7 @@ export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): 
       // >>>>> Disabled
       [`&${componentCls}-disabled, &[disabled]`]: {
         color: token.colorTextDisabled,
+        cursor: 'not-allowed',
       },
 
       // >>>>> Status


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ✅] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
related to https://github.com/ant-design/ant-design/issues/51386 #51386 

### 💡 Background and Solution
背景：Input 组件当 variant 设置为 borderless 时，disabled 状态下指针 cursor 没有设置为 not-allowed。
解决方案：调整 Input borderless 状态下的 disabled 指针样式。


### 📝 Change Log
Input 组件当 variant 设置为 borderless 时，disabled 状态下指针 cursor 设置为 not-allowed。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |The Input component has the pointer cursor set to not-allowed in the disabled state when variant is set to borderless.|
| 🇨🇳 Chinese |Input 组件当 variant 设置为 borderless 时，disabled 状态下指针 cursor 设置为 not-allowed。|
