### PR TITLE
feat: add a11y test for components demo

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 
 import Affix from '..';
-import accessibilityTest from '../../../tests/shared/accessibilityTest';
+import { accessibilityTest } from '../../../tests/shared/accessibilityTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render, triggerResize, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';

--- a/components/affix/__tests__/a11y.test.ts
+++ b/components/affix/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('affix demo a11y', () => {
+  accessibilityDemoTest('affix');
+});

--- a/components/affix/__tests__/a11y.test.ts
+++ b/components/affix/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('affix demo a11y', () => {
   accessibilityDemoTest('affix');

--- a/components/alert/__tests__/a11y.test.ts
+++ b/components/alert/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('alert demo a11y', () => {
   accessibilityDemoTest('alert', { disabledRules: ['button-name'] });

--- a/components/alert/__tests__/a11y.test.ts
+++ b/components/alert/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('alert demo a11y', () => {
+  accessibilityDemoTest('alert', { disabledRules: ['button-name'] });
+});

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { resetWarned } from 'rc-util/lib/warning';
 
 import Alert from '..';
-import accessibilityTest from '../../../tests/shared/accessibilityTest';
+import { accessibilityTest } from '../../../tests/shared/accessibilityTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, render, screen, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';

--- a/components/anchor/__tests__/a11y.test.ts
+++ b/components/anchor/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('anchor demo a11y', () => {
+  accessibilityDemoTest('anchor');
+});

--- a/components/anchor/__tests__/a11y.test.ts
+++ b/components/anchor/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('anchor demo a11y', () => {
   accessibilityDemoTest('anchor');

--- a/components/app/__tests__/a11y.test.ts
+++ b/components/app/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('app demo a11y', () => {
+  accessibilityDemoTest('app');
+});

--- a/components/app/__tests__/a11y.test.ts
+++ b/components/app/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('app demo a11y', () => {
   accessibilityDemoTest('app');

--- a/components/avatar/__tests__/a11y.test.ts
+++ b/components/avatar/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('avatar demo a11y', () => {
+  accessibilityDemoTest('avatar', { disabledRules: ['image-alt'] });
+});

--- a/components/avatar/__tests__/a11y.test.ts
+++ b/components/avatar/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('avatar demo a11y', () => {
   accessibilityDemoTest('avatar', { disabledRules: ['image-alt'] });

--- a/components/back-top/__tests__/a11y.test.ts
+++ b/components/back-top/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('back-top demo a11y', () => {
+  accessibilityDemoTest('back-top');
+});

--- a/components/back-top/__tests__/a11y.test.ts
+++ b/components/back-top/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('back-top demo a11y', () => {
   accessibilityDemoTest('back-top');

--- a/components/badge/__tests__/a11y.test.ts
+++ b/components/badge/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('badge demo a11y', () => {
   accessibilityDemoTest('badge', { disabledRules: ['button-name'] });

--- a/components/badge/__tests__/a11y.test.ts
+++ b/components/badge/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('badge demo a11y', () => {
+  accessibilityDemoTest('badge', { disabledRules: ['button-name'] });
+});

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { resetWarned } from '../../_util/warning';
-import accessibilityTest from '../../../tests/shared/accessibilityTest';
+import { accessibilityTest } from '../../../tests/shared/accessibilityTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render } from '../../../tests/utils';

--- a/components/breadcrumb/__tests__/a11y.test.ts
+++ b/components/breadcrumb/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('breadcrumb demo a11y', () => {
+  accessibilityDemoTest('breadcrumb');
+});

--- a/components/breadcrumb/__tests__/a11y.test.ts
+++ b/components/breadcrumb/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('breadcrumb demo a11y', () => {
   accessibilityDemoTest('breadcrumb');

--- a/components/button/__tests__/a11y.test.ts
+++ b/components/button/__tests__/a11y.test.ts
@@ -1,0 +1,5 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+describe('button demo a11y', () => {
+  accessibilityDemoTest('button');
+});

--- a/components/button/__tests__/a11y.test.ts
+++ b/components/button/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 describe('button demo a11y', () => {
   accessibilityDemoTest('button');

--- a/components/color-picker/__tests__/a11y.test.ts
+++ b/components/color-picker/__tests__/a11y.test.ts
@@ -1,0 +1,4 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+// skip _InternalPanelDoNotUseOrYouWillBeFired
+accessibilityDemoTest('color-picker', { skip: ['pure-panel.tsx'] });

--- a/components/color-picker/__tests__/a11y.test.ts
+++ b/components/color-picker/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 // skip _InternalPanelDoNotUseOrYouWillBeFired
 accessibilityDemoTest('color-picker', { skip: ['pure-panel.tsx'] });

--- a/components/descriptions/__tests__/a11y.test.ts
+++ b/components/descriptions/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('descriptions');

--- a/components/descriptions/__tests__/a11y.test.ts
+++ b/components/descriptions/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('descriptions');

--- a/components/divider/__tests__/a11y.test.ts
+++ b/components/divider/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('divider');

--- a/components/divider/__tests__/a11y.test.ts
+++ b/components/divider/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('divider');

--- a/components/drawer/__tests__/a11y.test.ts
+++ b/components/drawer/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('drawer', { disabledRules: ['image-alt'] });

--- a/components/drawer/__tests__/a11y.test.ts
+++ b/components/drawer/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('drawer', { disabledRules: ['image-alt'] });

--- a/components/dropdown/__tests__/a11y.test.ts
+++ b/components/dropdown/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('dropdown');

--- a/components/dropdown/__tests__/a11y.test.ts
+++ b/components/dropdown/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('dropdown');

--- a/components/empty/__tests__/a11y.test.ts
+++ b/components/empty/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('empty', { disabledRules: ['label'] });

--- a/components/empty/__tests__/a11y.test.ts
+++ b/components/empty/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('empty', { disabledRules: ['label'] });

--- a/components/float-button/__tests__/a11y.test.ts
+++ b/components/float-button/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('float-button', { disabledRules: ['button-name'] });

--- a/components/float-button/__tests__/a11y.test.ts
+++ b/components/float-button/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('float-button', { disabledRules: ['button-name'] });

--- a/components/icon/__tests__/a11y.test.ts
+++ b/components/icon/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('icon', { disabledRules: ['role-img-alt'] });

--- a/components/icon/__tests__/a11y.test.ts
+++ b/components/icon/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('icon', { disabledRules: ['role-img-alt'] });

--- a/components/image/__tests__/a11y.test.ts
+++ b/components/image/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('image', { disabledRules: ['image-alt', 'label'] });

--- a/components/image/__tests__/a11y.test.ts
+++ b/components/image/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('image', { disabledRules: ['image-alt', 'label'] });

--- a/components/input-number/__tests__/a11y.test.ts
+++ b/components/input-number/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('input-number', { disabledRules: ['label'] });

--- a/components/input-number/__tests__/a11y.test.ts
+++ b/components/input-number/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('input-number', { disabledRules: ['label'] });

--- a/components/input/__tests__/a11y.test.ts
+++ b/components/input/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('input', { disabledRules: ['label'] });

--- a/components/input/__tests__/a11y.test.ts
+++ b/components/input/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('input', { disabledRules: ['label'] });

--- a/components/mentions/__tests__/a11y.test.ts
+++ b/components/mentions/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('mentions', { disabledRules: ['label'] });

--- a/components/mentions/__tests__/a11y.test.ts
+++ b/components/mentions/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('mentions', { disabledRules: ['label'] });

--- a/components/menu/__tests__/a11y.test.ts
+++ b/components/menu/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('menu', { disabledRules: ['button-name'] });

--- a/components/menu/__tests__/a11y.test.ts
+++ b/components/menu/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('menu', { disabledRules: ['button-name'] });

--- a/components/message/__tests__/a11y.test.ts
+++ b/components/message/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('message');

--- a/components/message/__tests__/a11y.test.ts
+++ b/components/message/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('message');

--- a/components/modal/__tests__/a11y.test.ts
+++ b/components/modal/__tests__/a11y.test.ts
@@ -1,0 +1,4 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+// skip debug components
+accessibilityDemoTest('modal', { skip: ['wireframe.tsx', 'render-panel.tsx'] });

--- a/components/modal/__tests__/a11y.test.ts
+++ b/components/modal/__tests__/a11y.test.ts
@@ -1,4 +1,4 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 // skip debug components
 accessibilityDemoTest('modal', { skip: ['wireframe.tsx', 'render-panel.tsx'] });

--- a/components/notification/__tests__/a11y.test.ts
+++ b/components/notification/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('notification', { disabledRules: ['button-name', 'label'] });

--- a/components/notification/__tests__/a11y.test.ts
+++ b/components/notification/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('notification', { disabledRules: ['button-name', 'label'] });

--- a/components/popconfirm/__tests__/a11y.test.ts
+++ b/components/popconfirm/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('popconfirm', { disabledRules: ['button-name'] });

--- a/components/popconfirm/__tests__/a11y.test.ts
+++ b/components/popconfirm/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('popconfirm', { disabledRules: ['button-name'] });

--- a/components/radio/__tests__/a11y.test.ts
+++ b/components/radio/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('radio');

--- a/components/radio/__tests__/a11y.test.ts
+++ b/components/radio/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('radio');

--- a/components/result/__tests__/a11y.test.ts
+++ b/components/result/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('result');

--- a/components/result/__tests__/a11y.test.ts
+++ b/components/result/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('result');

--- a/components/select/__tests__/a11y.test.ts
+++ b/components/select/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('select', { disabledRules: ['label', 'button-name'] });

--- a/components/select/__tests__/a11y.test.ts
+++ b/components/select/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('select', { disabledRules: ['label', 'button-name'] });

--- a/components/space/__tests__/a11y.test.ts
+++ b/components/space/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('space', { disabledRules: ['label', 'button-name'] });

--- a/components/space/__tests__/a11y.test.ts
+++ b/components/space/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('space', { disabledRules: ['label', 'button-name'] });

--- a/components/spin/__tests__/a11y.test.ts
+++ b/components/spin/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('spin', { disabledRules: ['button-name'] });

--- a/components/spin/__tests__/a11y.test.ts
+++ b/components/spin/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('spin', { disabledRules: ['button-name'] });

--- a/components/splitter/__tests__/a11y.test.ts
+++ b/components/splitter/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('splitter');

--- a/components/splitter/__tests__/a11y.test.ts
+++ b/components/splitter/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('splitter');

--- a/components/switch/__tests__/a11y.test.ts
+++ b/components/switch/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('switch', { disabledRules: ['button-name'] });

--- a/components/switch/__tests__/a11y.test.ts
+++ b/components/switch/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('switch', { disabledRules: ['button-name'] });

--- a/components/tag/__tests__/a11y.test.ts
+++ b/components/tag/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('tag');

--- a/components/tag/__tests__/a11y.test.ts
+++ b/components/tag/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('tag');

--- a/components/timeline/__tests__/a11y.test.ts
+++ b/components/timeline/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
-import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('timeline');

--- a/components/timeline/__tests__/a11y.test.ts
+++ b/components/timeline/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import { accessibilityDemoTest } from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('timeline');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -59,12 +59,3 @@ if (typeof window !== 'undefined') {
 
 global.requestAnimationFrame = global.requestAnimationFrame || global.setTimeout;
 global.cancelAnimationFrame = global.cancelAnimationFrame || global.clearTimeout;
-
-// Mock ResizeObserver
-class ResizeObserverMock {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-
-global.ResizeObserver = ResizeObserverMock;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -59,3 +59,12 @@ if (typeof window !== 'undefined') {
 
 global.requestAnimationFrame = global.requestAnimationFrame || global.setTimeout;
 global.cancelAnimationFrame = global.cancelAnimationFrame || global.clearTimeout;
+
+// Mock ResizeObserver
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock;

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { globSync } from 'glob';
 import { axe } from 'jest-axe';
 
 // eslint-disable-next-line jest/no-export
@@ -10,6 +11,37 @@ export default function accessibilityTest(Component: React.ComponentType) {
       const { container } = render(<Component />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
+    });
+  });
+}
+
+type Options = {
+  skip?: boolean | string[];
+};
+
+// eslint-disable-next-line jest/no-export
+export function accessibilityDemoTest(component: string, options: Options = {}) {
+  // If skip is true, return immediately without executing any tests
+  if (options.skip === true) {
+    describe.skip(`${component} demo a11y`, () => {
+      it('skipped', () => {});
+    });
+    return;
+  }
+
+  describe(`${component} demo a11y`, () => {
+    const files = globSync(`./components/${component}/demo/*.tsx`).filter(
+      (file) => !file.includes('_semantic') && !file.includes('-debug'),
+    );
+
+    files.forEach((file) => {
+      const shouldSkip = Array.isArray(options.skip) && options.skip.some((c) => file.endsWith(c));
+      const testMethod = shouldSkip ? describe.skip : describe;
+
+      testMethod(`Test ${file} accessibility`, () => {
+        const Demo = require(`../../${file}`).default;
+        accessibilityTest(Demo);
+      });
     });
   });
 }

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -3,15 +3,63 @@ import { render } from '@testing-library/react';
 import { globSync } from 'glob';
 import { axe } from 'jest-axe';
 
+class AxeQueueManager {
+  private queue: Promise<any> = Promise.resolve();
+  private isProcessing = false;
+
+  async enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const currentQueue = this.queue;
+
+    const newTask = async () => {
+      try {
+        await currentQueue;
+        this.isProcessing = true;
+        return await task();
+      } finally {
+        this.isProcessing = false;
+      }
+    };
+
+    this.queue = this.queue.then(newTask, newTask);
+
+    return this.queue;
+  }
+
+  isRunning(): boolean {
+    return this.isProcessing;
+  }
+}
+
+const axeQueueManager = new AxeQueueManager();
+
+const runAxe = async (...args: Parameters<typeof axe>): Promise<ReturnType<typeof axe>> => {
+  return axeQueueManager.enqueue(async () => {
+    try {
+      return await axe(...args);
+    } catch (error) {
+      console.error('Axe test failed:', error);
+      throw error;
+    }
+  });
+};
+
 // eslint-disable-next-line jest/no-export
 export default function accessibilityTest(Component: React.ComponentType) {
   describe(`accessibility`, () => {
     it(`component does not have any violations`, async () => {
       jest.useRealTimers();
       const { container } = render(<Component />);
-      const results = await axe(container);
+      const results = await runAxe(container, {
+        rules: {
+          'image-alt': { enabled: false },
+          label: { enabled: false },
+          'button-name': { enabled: false },
+          'role-img-alt': { enabled: false },
+          'link-name': { enabled: false },
+        },
+      });
       expect(results).toHaveNoViolations();
-    });
+    }, 30000);
   });
 }
 

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -60,10 +60,7 @@ const convertRulesToAxeFormat = (rules: string[]): Rules => {
 };
 
 // eslint-disable-next-line jest/no-export
-export default function accessibilityTest(
-  Component: React.ComponentType,
-  disabledRules?: string[],
-) {
+export function accessibilityTest(Component: React.ComponentType, disabledRules?: string[]) {
   beforeAll(() => {
     // Fake ResizeObserver
     global.ResizeObserver = jest.fn(() => {
@@ -120,7 +117,7 @@ type Options = {
 };
 
 // eslint-disable-next-line jest/no-export
-export function accessibilityDemoTest(component: string, options: Options = {}) {
+export default function accessibilityDemoTest(component: string, options: Options = {}) {
   // If skip is true, return immediately without executing any tests
   if (options.skip === true) {
     describe.skip(`${component} demo a11y`, () => {

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -94,7 +94,8 @@ export function accessibilityDemoTest(component: string, options: Options = {}) 
 
   describe(`${component} demo a11y`, () => {
     const files = globSync(`./components/${component}/demo/*.tsx`).filter(
-      (file) => !file.includes('_semantic') && !file.includes('-debug'),
+      (file) =>
+        !file.includes('_semantic') && !file.includes('debug') && !file.includes('component-token'),
     );
 
     files.forEach((file) => {

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -64,6 +64,43 @@ export default function accessibilityTest(
   Component: React.ComponentType,
   disabledRules?: string[],
 ) {
+  beforeAll(() => {
+    // Fake ResizeObserver
+    global.ResizeObserver = jest.fn(() => {
+      return {
+        observe() {},
+        unobserve() {},
+        disconnect() {},
+      };
+    }) as jest.Mock;
+
+    // fake fetch
+    global.fetch = jest.fn(() => {
+      return {
+        then() {
+          return this;
+        },
+        catch() {
+          return this;
+        },
+        finally() {
+          return this;
+        },
+      };
+    }) as jest.Mock;
+  });
+
+  beforeEach(() => {
+    // Reset all mocks
+    if (global.fetch) {
+      (global.fetch as jest.Mock).mockClear();
+    }
+  });
+
+  afterEach(() => {
+    // Clear all mocks
+    jest.clearAllMocks();
+  });
   describe(`accessibility`, () => {
     it(`component does not have any violations`, async () => {
       jest.useRealTimers();


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 📽️ Demo improvement
- [x] ✅ Test Case

### 🔗 Related Issues

> - related to #51348 

### 💡 Background and Solution

> - 为了确保组件库的可访问性符合标准，添加了自动化的可访问性测试工具。
> - 为所有组件的demo添加可访问性测试

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     •Added automated accessibility testing tools to ensure the component library meets accessibility standards. <br/>•Added accessibility tests for all component demos to ensure compliance with accessibility guidelines.      |
| 🇨🇳 Chinese |  •为了确保组件库的可访问性符合标准，添加了自动化的可访问性测试工具。<br/>•为所有组件的示例（demo）添加了可访问性测试，确保符合无障碍标准。         |
