### PR TITLE
fix: TreeSelect dropdown content blocked #51415

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -160,7 +160,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [treeNodeCls]: {
         display: 'flex',
         alignItems: 'flex-start',
-        marginBottom: treeNodePadding,
+        paddingBottom: treeNodePadding,
         lineHeight: unit(titleHeight),
         position: 'relative',
 

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -146,6 +146,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             border: `1px solid ${token.colorPrimary}`,
             opacity: 0,
             animationName: treeNodeFX,
+            bottom: treeNodePadding,
             animationDuration: token.motionDurationSlow,
             animationPlayState: 'running',
             animationFillMode: 'forwards',
@@ -172,7 +173,6 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           insetInlineStart: 0,
           width: '100%',
           top: '100%',
-          height: treeNodePadding,
         },
 
         // Disabled


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51415
fix #51465

### 💡 Background and Solution

背景：TreeSelect 组件的下拉渲染框中最下面的一个选项有遮挡。#51210
解决方案：查看样式发现是设置了 marginBottom ，改为 paddingBottom

### 📝 Change Log
修复 TreeSelect 组件的下拉渲染框中最下面的一个选项有遮挡的问题。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fixed the issue where the bottom option in the drop-down rendering box of the TreeSelect component was blocked.|
| 🇨🇳 Chinese |修复 TreeSelect 组件的下拉渲染框中最下面的一个选项有遮挡的问题。|
