### PR TITLE
fix: rename dropdownAlign to popupAlign, remove redundant prop

### DIFF
--- a/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
@@ -41,6 +41,10 @@ const useStyle = createStyles(({ token, css }) => ({
   `,
   copyTip: css`
     color: ${token.colorTextTertiary};
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
   `,
   copiedTip: css`
     .anticon {

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -23,7 +23,7 @@ import { useLocale } from '../../locale';
 import { useCompactItemContext } from '../../space/Compact';
 import enUS from '../locale/en_US';
 import useStyle from '../style';
-import { getRangePlaceholder, transPlacement2DropdownAlign, useIcons } from '../util';
+import { getRangePlaceholder, useIcons } from '../util';
 import { TIME } from './constant';
 import type { RangePickerProps } from './interface';
 import useComponents from './useComponents';
@@ -117,7 +117,6 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
           }
           disabled={mergedDisabled}
           ref={innerRef as any} // Need to modify PickerRef
-          popupAlign={transPlacement2DropdownAlign(direction, placement)}
           placement={placement}
           placeholder={getRangePlaceholder(locale, picker, placeholder)}
           suffixIcon={suffixNode}

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -23,7 +23,7 @@ import { useLocale } from '../../locale';
 import { useCompactItemContext } from '../../space/Compact';
 import enUS from '../locale/en_US';
 import useStyle from '../style';
-import { getPlaceholder, transPlacement2DropdownAlign, useIcons } from '../util';
+import { getPlaceholder, useIcons } from '../util';
 import {
   MONTH,
   MONTHPICKER,
@@ -160,7 +160,6 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
             ref={innerRef}
             placeholder={getPlaceholder(locale, mergedPicker, placeholder)}
             suffixIcon={suffixNode}
-            dropdownAlign={transPlacement2DropdownAlign(direction, placement)}
             placement={placement}
             prevIcon={<span className={`${prefixCls}-prev-icon`} />}
             nextIcon={<span className={`${prefixCls}-next-icon`} />}

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -31,14 +31,14 @@ export type DatePickerType = typeof DatePicker & {
 };
 
 function postPureProps(props: DatePickerProps) {
-  const dropdownAlign = transPlacement2DropdownAlign(props.direction, props.placement);
+  const popupAlign = transPlacement2DropdownAlign(props.direction, props.placement);
 
-  dropdownAlign.overflow!.adjustY = false;
-  dropdownAlign.overflow!.adjustX = false;
+  popupAlign.overflow!.adjustY = false;
+  popupAlign.overflow!.adjustX = false;
 
   return {
     ...props,
-    dropdownAlign,
+    popupAlign,
   };
 }
 

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -31,14 +31,14 @@ export type DatePickerType = typeof DatePicker & {
 };
 
 function postPureProps(props: DatePickerProps) {
-  const popupAlign = transPlacement2DropdownAlign(props.direction, props.placement);
+  const dropdownAlign = transPlacement2DropdownAlign(props.direction, props.placement);
 
-  popupAlign.overflow!.adjustY = false;
-  popupAlign.overflow!.adjustX = false;
+  dropdownAlign.overflow!.adjustY = false;
+  dropdownAlign.overflow!.adjustX = false;
 
   return {
     ...props,
-    popupAlign,
+    dropdownAlign,
   };
 }
 

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -8,7 +8,6 @@ import type {
   PickerProps,
   PickerPropsWithMultiple,
 } from './generatePicker/interface';
-import { transPlacement2DropdownAlign } from './util';
 
 export type DatePickerProps<ValueType = Dayjs | Dayjs> = PickerPropsWithMultiple<
   Dayjs,
@@ -30,23 +29,12 @@ export type DatePickerType = typeof DatePicker & {
   generatePicker: typeof generatePicker;
 };
 
-function postPureProps(props: DatePickerProps) {
-  const dropdownAlign = transPlacement2DropdownAlign(props.direction, props.placement);
-
-  dropdownAlign.overflow!.adjustY = false;
-  dropdownAlign.overflow!.adjustX = false;
-
-  return {
-    ...props,
-    dropdownAlign,
-  };
-}
 
 // We don't care debug panel
 /* istanbul ignore next */
-const PurePanel = genPurePanel(DatePicker, 'picker', null, postPureProps);
+const PurePanel = genPurePanel(DatePicker, 'picker', null);
 (DatePicker as DatePickerType)._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
-const PureRangePanel = genPurePanel(DatePicker.RangePicker, 'picker', null, postPureProps);
+const PureRangePanel = genPurePanel(DatePicker.RangePicker, 'picker', null);
 (DatePicker as DatePickerType)._InternalRangePanelDoNotUseOrYouWillBeFired = PureRangePanel;
 (DatePicker as DatePickerType).generatePicker = generatePicker;
 

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -570,7 +570,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
 
           '&::after': {
             display: 'block',
-            height: token.calc('100%').sub(timeCellHeight).equal(),
+            height: `calc(100% - ${unit(timeCellHeight)})`,
             content: '""',
           },
 

--- a/components/locale/uz_UZ.ts
+++ b/components/locale/uz_UZ.ts
@@ -24,7 +24,7 @@ const localeValues: Locale = {
   Table: {
     filterTitle: 'Filtr',
     filterConfirm: 'OK',
-    filterReset: 'Tshlash',
+    filterReset: 'Bekor qilish',
     filterEmptyText: 'Filtrlarsiz',
     filterCheckall: 'Barcha elementlarni tanlash',
     filterSearchPlaceholder: 'Filtrlarda qidiruv',
@@ -32,7 +32,7 @@ const localeValues: Locale = {
     selectAll: 'Barchasini tanlash',
     selectInvert: 'Tanlovni aylantirish',
     selectNone: "Barcha ma'lumotlarni tozalang",
-    selectionAll: "Barcha ma'lumotlarni tanlash",
+    selectionAll: "Barchasini tanlash",
     sortTitle: 'Tartiblash',
     expand: 'Satirni yozish',
     collapse: "Satirni yig'ish",
@@ -47,7 +47,7 @@ const localeValues: Locale = {
   },
   Modal: {
     okText: 'OK',
-    cancelText: "O'chirish",
+    cancelText: "Yopish",
     justOkText: 'OK',
   },
   Popconfirm: {
@@ -57,8 +57,8 @@ const localeValues: Locale = {
   Transfer: {
     titles: ['', ''],
     searchPlaceholder: 'Qidiruv',
-    itemUnit: 'элем.',
-    itemsUnit: 'элем.',
+    itemUnit: 'elem.',
+    itemsUnit: 'elem.',
     remove: 'Oʻchirish',
     selectAll: "Barch ma'lumotlarni tanlash",
     selectCurrent: 'Joriy sahifani tanlash',
@@ -67,7 +67,7 @@ const localeValues: Locale = {
     removeCurrent: "Joriy sahifani o'chirish",
   },
   Upload: {
-    uploading: 'Yuklanish...',
+    uploading: 'Yuklanmoqda...',
     removeFile: "Faylni o'chirish",
     uploadError: 'Yuklashda xatolik yuz berdi',
     previewFile: "Faylni oldindan ko'rish",

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -3,10 +3,10 @@ import { Keyframes, unit } from '@ant-design/cssinjs';
 
 import { getStyle as getCheckboxStyle } from '../../checkbox/style';
 import { genFocusOutline, resetComponent } from '../../style';
-import { genDirectoryStyle } from './directory';
 import { genCollapseMotion } from '../../style/motion';
 import type { AliasToken, CSSUtil, FullToken, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import { genDirectoryStyle } from './directory';
 
 export interface TreeSharedToken {
   /**
@@ -316,7 +316,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeCls}-node-content-wrapper`]: {
         position: 'relative',
         minHeight: titleHeight,
-        padding: `0 ${token.paddingXS}`,
+        paddingBlock: 0,
+        paddingInline: token.paddingXS,
         background: 'transparent',
         borderRadius: token.borderRadius,
         cursor: 'pointer',

--- a/docs/react/compatible-style.zh-CN.md
+++ b/docs/react/compatible-style.zh-CN.md
@@ -65,7 +65,7 @@ export default () => (
 ## CSS 逻辑属性
 
 - 支持版本：`>=5.0.0`
-- MDN 文档：[:where](https://developer.mozilla.org/en-US/docs/Web/CSS/:where)
+- MDN 文档：[CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties)
 - 浏览器兼容性：[caniuse](https://caniuse.com/css-logical-props)
 - Chrome 最低支持版本：89
 - 默认启用：是


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [X] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/ant-design/issues/50845

### 💡 Background and Solution
移除picker中冗余属性dropdownAlign，将panel中的dropdownAlign属性修改为popupAlign
> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |
