### PR TITLE
style: fix Splitter pseudo element colon notation

### DIFF
--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -112,14 +112,14 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
           zIndex: 1,
 
           // Hover background
-          '&:before': {
+          '&::before': {
             content: '""',
             background: controlItemBgHover,
             ...centerStyle,
           },
 
           // Spinner
-          '&:after': {
+          '&::after': {
             content: '""',
             background: colorFill,
             ...centerStyle,
@@ -127,7 +127,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
 
           // Hover
           [`&:hover:not(${splitBarCls}-dragger-active)`]: {
-            '&:before': {
+            '&::before': {
               background: controlItemBgActive,
             },
           },
@@ -136,7 +136,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
           '&-active': {
             zIndex: 2,
 
-            '&:before': {
+            '&::before': {
               background: controlItemBgActiveHover,
             },
           },
@@ -147,12 +147,12 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
 
             '&, &:hover, &-active': {
               cursor: 'default',
-              '&:before': {
+              '&::before': {
                 background: controlItemBgHover,
               },
             },
 
-            '&:after': {
+            '&::after': {
               display: 'none',
             },
           },
@@ -223,12 +223,12 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             height: '100%',
             width: splitTriggerSize,
 
-            '&:before': {
+            '&::before': {
               height: '100%',
               width: splitBarSize,
             },
 
-            '&:after': {
+            '&::after': {
               height: splitBarDraggableSize,
               width: splitBarSize,
             },
@@ -278,12 +278,12 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
             width: '100%',
             height: splitTriggerSize,
 
-            '&:before': {
+            '&::before': {
               width: '100%',
               height: splitBarSize,
             },
 
-            '&:after': {
+            '&::after': {
               width: splitBarDraggableSize,
               height: splitBarSize,
             },


### PR DESCRIPTION
`:before`, `:after` should be `::before`,`::after`

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [x] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
Pseudo element should have two colons (although browsers also accept single colon)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Fix Splitter pseudo-element colon notation|
| 🇨🇳 Chinese |修复Splitter伪元素符号|
