### PR TITLE
fix(Image): preview.rootClassName

### DIFF
--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -54,7 +54,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
       return preview;
     }
     const _preview = typeof preview === 'object' ? preview : {};
-    const { getContainer, closeIcon, ...restPreviewProps } = _preview;
+    const { getContainer, closeIcon, rootClassName, ...restPreviewProps } = _preview;
     return {
       mask: (
         <div className={`${prefixCls}-mask-info`}>
@@ -64,6 +64,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
       ),
       icons,
       ...restPreviewProps,
+      rootClassName: rootClassName ? classNames(rootClassName, hashId, cssVarCls, rootCls) : mergedRootClassName,
       getContainer: getContainer ?? getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -64,7 +64,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
       ),
       icons,
       ...restPreviewProps,
-      rootClassName: rootClassName ? classNames(rootClassName, hashId, cssVarCls, rootCls) : mergedRootClassName,
+      rootClassName: classNames(mergedRootClassName, rootClassName),
       getContainer: getContainer ?? getContextPopupContainer,
       transitionName: getTransitionName(rootPrefixCls, 'zoom', _preview.transitionName),
       maskTransitionName: getTransitionName(rootPrefixCls, 'fade', _preview.maskTransitionName),


### PR DESCRIPTION
Fix the issue of preview.rootClassName not merging classnames

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix https://github.com/ant-design/ant-design/issues/51510

### 💡 Background and Solution

在未传入`ImageProps.preview.rootClassName`的情况下，`Preview`会默认使用合并了`hashId, cssVarCls, rootCls`的`ImageProps.rootClassName`，而`ImageProps.preview.rootClassName`会覆盖此值且没有做上述合并处理，导致className丢失

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |fix `ImageProps.preview.rootClassName` causes Preview className lost|
| 🇨🇳 Chinese |修复`ImageProps.preview.rootClassName`导致预览图类名丢失|
