### PR TITLE
fix(tabs): prevent content overlap in tabs-nav-list

### DIFF
--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -1003,8 +1003,8 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     [`${componentCls}-centered`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         [`${componentCls}-nav-wrap`]: {
-          [`&:not([class*='${componentCls}-nav-wrap-ping'])`]: {
-            justifyContent: 'center',
+          [`&:not([class*='${componentCls}-nav-wrap-ping']) > ${componentCls}-nav-list`]: {
+            margin: 'auto',
           },
         },
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix: #51565

### 💡 Background and Solution

use `margin: auto` to achieve centering and prevent content overlap in tabs-nav-list.

#### Before
![image](https://github.com/user-attachments/assets/54a3f65a-1095-402a-8b0b-1af8333cf20b)
![image](https://github.com/user-attachments/assets/86a02d33-e6db-4286-a03b-b90a9dfd68df)
[Bug preview](https://codesandbox.io/p/sandbox/antd-reproduction-template-forked-y57vm3?file=%2Findex.tsx%3A1%2C1-84%2C1)

#### After
[PR preview](https://codesandbox.io/p/sandbox/antd-reproduction-template-forked-5xj994?file=%2Findex.tsx%3A15%2C39)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix horizontal scrolling issue caused by centering   |
| 🇨🇳 Chinese |   修复因居中设置导致的横向滚动问题  |
