### PR TITLE
feat: add mousePosition and afterOpenChange prop for confirm dialog

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -173,11 +173,6 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
   const {
     close,
     zIndex,
-    afterClose,
-    open,
-    keyboard,
-    centered,
-    getContainer,
     maskStyle,
     direction,
     prefixCls,
@@ -185,12 +180,8 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     rootPrefixCls,
     bodyStyle,
     closable = false,
-    closeIcon,
-    modalRender,
-    focusTriggerAfterClose,
     onConfirm,
     styles,
-    mousePosition,
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -235,7 +226,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
   // ========================= Render =========================
   return (
     <Modal
-      prefixCls={prefixCls}
+      {...props}
       className={classString}
       wrapClassName={classNames(
         { [`${confirmPrefixCls}-centered`]: !!props.centered },
@@ -245,7 +236,6 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
         close?.({ triggerCancel: true });
         onConfirm?.(false);
       }}
-      open={open}
       title=""
       footer={null}
       transitionName={getTransitionName(rootPrefixCls || '', 'zoom', props.transitionName)}
@@ -256,15 +246,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
       styles={{ body: bodyStyle, mask: maskStyle, ...styles }}
       width={width}
       zIndex={mergedZIndex}
-      afterClose={afterClose}
-      keyboard={keyboard}
-      centered={centered}
-      getContainer={getContainer}
       closable={closable}
-      closeIcon={closeIcon}
-      modalRender={modalRender}
-      focusTriggerAfterClose={focusTriggerAfterClose}
-      mousePosition={mousePosition}
     >
       <ConfirmContent {...props} confirmPrefixCls={confirmPrefixCls} />
     </Modal>

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -190,6 +190,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     focusTriggerAfterClose,
     onConfirm,
     styles,
+    mousePosition,
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -263,6 +264,7 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
       closeIcon={closeIcon}
       modalRender={modalRender}
       focusTriggerAfterClose={focusTriggerAfterClose}
+      mousePosition={mousePosition}
     >
       <ConfirmContent {...props} confirmPrefixCls={confirmPrefixCls} />
     </Modal>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close: #51569

### 💡 Background and Solution

Initially, I added the `mousePosition` prop in the `ConfirmDialog.tsx` file ([commit1](https://github.com/ant-design/ant-design/commit/dd8b5b2e027c3cd824b85805332b7d5712633e2e)), but I noticed that many props were merely being passed through. Therefore, I attempted to simplify the code by passing the entire `props` object, while ensuring that the values of the additional handled props remained consistent with the previous implementation. ([commit2](https://github.com/ant-design/ant-design/commit/5af656667533ca085621b569fd246e24fecabf2b))

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   pass through Modal props  |
| 🇨🇳 Chinese |      透传Modal属性     |
