### PR TITLE
fix(Select): fix prefix text wrap and overlap with placeholder

### DIFF
--- a/BUG_VERSIONS.json
+++ b/BUG_VERSIONS.json
@@ -62,5 +62,6 @@
     "https://github.com/ant-design/ant-design/issues/50960",
     "https://github.com/ant-design/ant-design/issues/50969"
   ],
-  "5.22.0": ["https://github.com/ant-design/ant-design/issues/51601"]
+  "5.22.0": ["https://github.com/ant-design/ant-design/issues/51601"],
+  "5.22.1": ["https://github.com/ant-design/ant-design/issues/51623"]
 }

--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -20,6 +20,7 @@ const genSelectorStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
   return {
     position: 'relative',
     transition: `all ${token.motionDurationMid} ${token.motionEaseInOut}`,
+    paddingInline: token.inputPaddingHorizontalBase,
 
     input: {
       cursor: 'pointer',
@@ -71,6 +72,10 @@ const getSearchInputWithoutBorderStyle: GenerateStyle<SelectToken, CSSObject> = 
 // =============================== Base ===============================
 const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
   const { antCls, componentCls, inputPaddingHorizontalBase, iconCls } = token;
+  const inputPaddingHorizontalSM = token
+    .calc(token.controlPaddingHorizontalSM)
+    .sub(token.lineWidth)
+    .equal();
 
   return {
     [componentCls]: {
@@ -184,6 +189,18 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
       },
     },
 
+    [`${componentCls}${componentCls}-sm`]: {
+      [`&:not(${componentCls}-customize-input) ${componentCls}-selector`]: {
+        paddingInline: inputPaddingHorizontalSM,
+      },
+    },
+
+    [`${componentCls}${componentCls}-lg`]: {
+      [`&:not(${componentCls}-customize-input) ${componentCls}-selector`]: {
+        paddingInline: inputPaddingHorizontalBase,
+      },
+    },
+
     // ========================= Feedback ==========================
     [`${componentCls}-has-feedback`]: {
       [`${componentCls}-clear`]: {
@@ -253,6 +270,7 @@ export default genStyleHooks(
       rootPrefixCls,
       inputPaddingHorizontalBase: token.calc(token.paddingSM).sub(1).equal(),
       multipleSelectItemHeight: token.multipleItemHeight,
+      multipleWrapMarginInlienStart: token.calc(0).sub(token.paddingXS).equal(),
       selectHeight: token.controlHeight,
     });
 

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -12,6 +12,7 @@ type SelectItemToken = Pick<
   | 'multipleSelectorBgDisabled'
   | 'multipleItemColorDisabled'
   | 'multipleItemBorderColorDisabled'
+  | 'multipleWrapMarginInlienStart'
   | 'selectHeight'
   | 'lineWidth'
   | 'calc'
@@ -66,17 +67,6 @@ export const getMultipleSelectorUnit = (
   };
 };
 
-const getSelectItemStyle = (token: SelectItemToken): number | string => {
-  const { multipleSelectItemHeight, selectHeight, lineWidth } = token;
-  const selectItemDist = token
-    .calc(selectHeight)
-    .sub(multipleSelectItemHeight)
-    .div(2)
-    .sub(lineWidth)
-    .equal();
-  return selectItemDist;
-};
-
 /**
  * Get the `rc-overflow` needed style.
  * It's a share style which means not affected by `size`.
@@ -90,6 +80,7 @@ export const genOverflowStyle = (
     | 'borderRadiusSM'
     | 'motionDurationSlow'
     | 'paddingXS'
+    | 'paddingXXS'
     | 'multipleItemColorDisabled'
     | 'multipleItemBorderColorDisabled'
     | 'colorIcon'
@@ -103,6 +94,7 @@ export const genOverflowStyle = (
     borderRadiusSM,
     motionDurationSlow,
     paddingXS,
+    paddingXXS,
     multipleItemColorDisabled,
     multipleItemBorderColorDisabled,
     colorIcon,
@@ -143,7 +135,7 @@ export const genOverflowStyle = (
         borderRadius: borderRadiusSM,
         cursor: 'default',
         transition: `font-size ${motionDurationSlow}, line-height ${motionDurationSlow}, height ${motionDurationSlow}`,
-        marginInlineEnd: token.calc(INTERNAL_FIXED_ITEM_MARGIN).mul(2).equal(),
+        marginInlineEnd: paddingXXS,
         paddingInlineStart: paddingXS,
         paddingInlineEnd: token.calc(paddingXS).div(2).equal(),
 
@@ -195,7 +187,6 @@ const genSelectionStyle = (
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
 
   const selectItemHeight = token.multipleSelectItemHeight;
-  const selectItemDist = getSelectItemStyle(token);
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
@@ -233,8 +224,18 @@ const genSelectionStyle = (
       },
 
       [`${componentCls}-selection-wrap`]: {
-        width: '100%',
+        position: 'relative',
+        flex: '1 1 auto',
         overflow: 'hidden',
+
+        // when there is no prefix
+        '&:first-child': {
+          marginInlineStart: token.multipleWrapMarginInlienStart,
+
+          [`${componentCls}-selection-search, ${componentCls}-selection-placeholder`]: {
+            marginInlineStart: token.paddingXS,
+          },
+        },
       },
 
       // ======================== Selections ========================
@@ -259,7 +260,6 @@ const genSelectionStyle = (
         display: 'inline-flex',
         position: 'relative',
         maxWidth: '100%',
-        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
 
         [`
           &-input,
@@ -291,16 +291,15 @@ const genSelectionStyle = (
       [`${componentCls}-selection-placeholder`]: {
         position: 'absolute',
         top: '50%',
-        insetInlineStart: token.inputPaddingHorizontalBase,
-        insetInlineEnd: token.inputPaddingHorizontalBase,
+        insetInline: 0,
         transform: 'translateY(-50%)',
         transition: `all ${token.motionDurationSlow}`,
       },
 
       [`${componentCls}-prefix`]: {
+        flex: '0 0 auto',
         height: multipleSelectorUnit.itemHeight,
         lineHeight: unit(multipleSelectorUnit.itemLineHeight),
-        marginInlineStart: `calc(${unit(token.inputPaddingHorizontalBase)} - ${unit(multipleSelectorUnit.basePadding)})`,
         marginInlineEnd: token.selectAffixPadding,
       },
     },
@@ -346,6 +345,7 @@ const genMultipleStyle = (token: SelectToken): CSSInterpolation => {
     multipleSelectItemHeight: token.multipleItemHeightSM,
     borderRadius: token.borderRadiusSM,
     borderRadiusSM: token.borderRadiusXS,
+    multipleWrapMarginInlienStart: token.calc(0).sub(token.paddingXXS).equal(),
   });
 
   const largeToken = mergeToken<SelectToken>(token, {
@@ -354,6 +354,7 @@ const genMultipleStyle = (token: SelectToken): CSSInterpolation => {
     multipleSelectItemHeight: token.multipleItemHeightLG,
     borderRadius: token.borderRadiusLG,
     borderRadiusSM: token.borderRadius,
+    multipleWrapMarginInlienStart: token.calc(0).sub(token.paddingXS).equal(),
   });
 
   return [

--- a/components/select/style/single.ts
+++ b/components/select/style/single.ts
@@ -63,6 +63,7 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         },
 
         [`${componentCls}-prefix`]: {
+          flex: '0 0 auto',
           marginInlineEnd: selectAffixPadding,
         },
 
@@ -101,7 +102,6 @@ function genSizeStyle(token: SelectToken, suffix?: string): CSSObject {
         [`${componentCls}-selector`]: {
           width: '100%',
           height: '100%',
-          padding: `0 ${unit(inputPaddingHorizontalBase)}`,
 
           [`${componentCls}-selection-search-input`]: {
             height: selectHeightWithoutBorder,
@@ -165,10 +165,6 @@ export default function genSingleStyle(token: SelectToken): CSSInterpolation {
     {
       [`${componentCls}-single${componentCls}-sm`]: {
         [`&:not(${componentCls}-customize-input)`]: {
-          [`${componentCls}-selector`]: {
-            padding: `0 ${unit(inputPaddingHorizontalSM)}`,
-          },
-
           // With arrow should provides `padding-right` to show the arrow
           [`&${componentCls}-show-arrow ${componentCls}-selection-search`]: {
             insetInlineEnd: token

--- a/components/select/style/token.ts
+++ b/components/select/style/token.ts
@@ -135,6 +135,7 @@ export interface SelectorToken {
   inputPaddingHorizontalBase: number | string;
   multipleSelectItemHeight: number;
   selectHeight: number;
+  multipleWrapMarginInlienStart: number | string;
 }
 
 export interface SelectToken extends FullToken<'Select'>, SelectorToken {
@@ -190,7 +191,7 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
   );
 
   // FIXED_ITEM_MARGIN is a hardcode calculation since calc not support rounding
-  const INTERNAL_FIXED_ITEM_MARGIN = Math.floor(paddingXXS / 2);
+  const INTERNAL_FIXED_ITEM_MARGIN = Math.floor(paddingXXS / 2) + 1;
 
   return {
     INTERNAL_FIXED_ITEM_MARGIN,
@@ -220,5 +221,6 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     activeBorderColor: colorPrimary,
     activeOutlineColor: controlOutline,
     selectAffixPadding: paddingXXS,
+    multipleWrapMarginInlienStart: -token.paddingXS,
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fix #51623

### 💡 Background and Solution

当 prefix 为中文或者英文带空格，默认的 Flex 布局压缩会导致 prefix 文字换行。之前由于 prefix demo 用的是单个英文单词，所以没有发现。

另外多选模式下 prefix 和 placeholder 和重叠是因为 -selection-wrap 没有 position: relative 所致。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Select): fix prefix text wrap and overlap with placeholder |
| 🇨🇳 Chinese | fix(Select): 修复 prefix 文字换行和与 placeholder 重叠的问题 |
