### PR TITLE
docs(timeline): add missing version column and correct version placement

### DIFF
--- a/components/timeline/index.en-US.md
+++ b/components/timeline/index.en-US.md
@@ -52,13 +52,13 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Timeline
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| mode | By sending `alternate` the timeline will distribute the nodes to the left and right | `left` \| `alternate` \| `right` | - |
-| pending | Set the last ghost node's existence or its content | ReactNode | false |
-| pendingDot | Set the dot of the last ghost node when pending is true | ReactNode | &lt;LoadingOutlined /&gt; |
-| reverse | Whether reverse nodes or not | boolean | false |
-| items | Each node of timeline | [Items](#Items)[] | 5.2.0 |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| mode | By sending `alternate` the timeline will distribute the nodes to the left and right | `left` \| `alternate` \| `right` | - |  |
+| pending | Set the last ghost node's existence or its content | ReactNode | false |  |
+| pendingDot | Set the dot of the last ghost node when pending is true | ReactNode | &lt;LoadingOutlined /&gt; |  |
+| reverse | Whether reverse nodes or not | boolean | false |  |
+| items | Each node of timeline | [Items](#Items)[] | - | 5.2.0 |
 
 ### Items
 

--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -53,13 +53,13 @@ return (
 
 ### Timeline
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | - |
-| pending | 指定最后一个幽灵节点是否存在或内容 | ReactNode | false |
-| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | ReactNode | &lt;LoadingOutlined /&gt; |
-| reverse | 节点排序 | boolean | false |
-| items | 选项配置 | [Items](#Items)[] | 5.2.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | - |  |
+| pending | 指定最后一个幽灵节点是否存在或内容 | ReactNode | false |  |
+| pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | ReactNode | &lt;LoadingOutlined /&gt; |  |
+| reverse | 节点排序 | boolean | false |  |
+| items | 选项配置 | [Items](#Items)[] | - | 5.2.0 |
 
 ### Items
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

### 💡 Background and Solution

It was discovered that the `version` column was missing and the version number was incorrectly placed in the `default` value column.

#### Before
![image](https://github.com/user-attachments/assets/974d97ce-28f5-4704-8906-62e449dd4d04)

### After
![image](https://github.com/user-attachments/assets/39e095b5-7cbc-49c9-9663-8cb627f0c7ad)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Added version column to the timeline docs     |
| 🇨🇳 Chinese |    timeline 文档添加版本列       |
