### PR TITLE
fix(Select): clear icon position

### DIFF
--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -3,6 +3,7 @@ import { CloseOutlined } from '@ant-design/icons';
 
 import type { SelectProps } from '..';
 import Select from '..';
+import Form from '../../form';
 import { resetWarned } from '../../_util/warning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -123,6 +124,43 @@ describe('Select', () => {
         jest.runAllTimers();
       });
       expect(asFragment().firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('clear icon position', () => {
+    it('normal', () => {
+      const { container } = render(
+        <Select allowClear options={[{ value: '1', label: '1' }]} value="1" />,
+      );
+      expect(
+        getComputedStyle(container.querySelector('.ant-select-clear')!).insetInlineEnd,
+      ).toEqual('11px');
+    });
+
+    it('hasFeedback, has validateStatus', () => {
+      const { container } = render(
+        <Form>
+          <Form.Item hasFeedback validateStatus="error">
+            <Select allowClear options={[{ value: '1', label: '1' }]} value="1" />,
+          </Form.Item>
+        </Form>,
+      );
+      expect(
+        getComputedStyle(container.querySelector('.ant-select-clear')!).insetInlineEnd,
+      ).toEqual('33px');
+    });
+
+    it('hasFeedback, no validateStatus', () => {
+      const { container } = render(
+        <Form>
+          <Form.Item hasFeedback validateStatus="">
+            <Select allowClear options={[{ value: '1', label: '1' }]} value="1" />,
+          </Form.Item>
+        </Form>,
+      );
+      expect(
+        getComputedStyle(container.querySelector('.ant-select-clear')!).insetInlineEnd,
+      ).toEqual('11px');
     });
   });
 

--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -186,7 +186,7 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
 
     // ========================= Feedback ==========================
     [`${componentCls}-status`]: {
-      [`&-error, &-warning, &-success, &-validating`]: {
+      '&-error, &-warning, &-success, &-validating': {
         [`&${componentCls}-has-feedback`]: {
           [`${componentCls}-clear`]: {
             insetInlineEnd: token

--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -185,13 +185,17 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
     },
 
     // ========================= Feedback ==========================
-    [`${componentCls}-has-feedback`]: {
-      [`${componentCls}-clear`]: {
-        insetInlineEnd: token
-          .calc(inputPaddingHorizontalBase)
-          .add(token.fontSize)
-          .add(token.paddingXS)
-          .equal(),
+    [`${componentCls}-status`]: {
+      [`&-error, &-warning, &-success, &-validating`]: {
+        [`&${componentCls}-has-feedback`]: {
+          [`${componentCls}-clear`]: {
+            insetInlineEnd: token
+              .calc(inputPaddingHorizontalBase)
+              .add(token.fontSize)
+              .add(token.paddingXS)
+              .equal(),
+          },
+        },
       },
     },
   };


### PR DESCRIPTION
Fix `.ant-select-has-feedback .ant-select-clear` position when `validateStatus` is empty

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/51577

### 💡 Background and Solution
antd@4中，清除按钮会在`.ant-select-status-${validateStatus}.ant-select-has-feedback`下左移  
antd@5遗漏了`.ant-select-status-${validateStatus}`条件

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the problem that the clear icon position of `Select` is incorrect when setting `hasFeedback` but no `validateStatus` in `Form.Item` |
| 🇨🇳 Chinese | 修复在有`hasFeedback`但没有`validateStatus`的`Form.Item`中的`Select`组件清除按钮位置错误 |
