### PR TITLE
fix: prevent OTP input focus from advancing when previous input is empty

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -208,7 +208,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     const nextCells = patchValue(index, txt);
 
     const nextIndex = Math.min(index + txt.length, length - 1);
-    if (nextIndex !== index) {
+    if (nextIndex !== index  && nextCells[index] !== undefined) {
       refs.current[nextIndex]?.focus();
     }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

###  💡 Background and Solution

**Issue:** OTP Input component moves focus to next input despite invalid input when using a formatter.

**Demo link:**  [codesanbox](https://codesandbox.io/p/sandbox/t493c3)

**Steps to Reproduce**:

   1.  Use a formatter on the input field. example```formatter: (str: string) => str.replace(/\D/g, "")``` regex for only  numbers
   2. Enter an invalid input(e.g letters) in the OTP input field.
   3. Watch the focus move to the next input.

**Actual Result:** The focus moves to the next input field despite the invalid input.
**Expected Result:** The focus should not move to the next input field until a valid input is entered.

**Solution:** Added check ```&& nextCells[index]  !==  undefined```  to prevent OTP focus from moving to next input if it's undefined.


### 🔗 Related Issues


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fixed OTP Input focus |
| 🇨🇳 Chinese |  -- |
