### PR TITLE
docs(list): remove unexpected message on initial data load

### DIFF
--- a/components/list/demo/virtual-list.tsx
+++ b/components/list/demo/virtual-list.tsx
@@ -25,17 +25,17 @@ const ContainerHeight = 400;
 const App: React.FC = () => {
   const [data, setData] = useState<UserItem[]>([]);
 
-  const appendData = () => {
+  const appendData = (showMessage = true) => {
     fetch(fakeDataUrl)
       .then((res) => res.json())
       .then((body) => {
         setData(data.concat(body.results));
-        message.success(`${body.results.length} more items loaded!`);
+        showMessage && message.success(`${body.results.length} more items loaded!`);
       });
   };
 
   useEffect(() => {
-    appendData();
+    appendData(false);
   }, []);
 
   const onScroll = (e: React.UIEvent<HTMLElement, UIEvent>) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

### 💡 Background and Solution

![image](https://github.com/user-attachments/assets/5e7d83e8-c262-4322-a64d-5578f72836e0)

Every time I access the `List` component documentation, an unexpected message appears, even when I haven't done anything. 

This message comes from the `virtual list` demo, and I believe it shouldn't display `20 more items loaded!` during data initialization.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Removed unexpected message prompt in List docs      |
| 🇨🇳 Chinese |     去除List文档意外的消息提示      |
