### PR TITLE
type(TextArea): combine TextAreaRef and TextAreaProps imports

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { forwardRef } from 'react';
 import classNames from 'classnames';
-import type { TextAreaRef as RcTextAreaRef } from 'rc-textarea';
+import type { TextAreaRef as RcTextAreaRef, TextAreaProps as RcTextAreaProps } from 'rc-textarea';
 import RcTextArea from 'rc-textarea';
-import type { TextAreaProps as RcTextAreaProps } from 'rc-textarea/lib/interface';
-
 import getAllowClear from '../_util/getAllowClear';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🤖 TypeScript definition improvement

### 💡 Background and Solution
rc-textarea都导出了这俩类型，感觉没必要拆两行。
![image](https://github.com/user-attachments/assets/7add4987-90d6-47db-900b-9686eeb570e9)


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       type(TextArea): combine TextAreaRef and TextAreaProps imports    |
| 🇨🇳 Chinese |     type(TextArea): 合并TextAreaRef 和TextAreaProps 的导入|
