### PR TITLE
chore: do not downgrade syntaxes when compiling

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ESNext",
     "jsx": "react",
     "jsxFactory": "React.createElement",
     "jsxFragmentFactory": "React.Fragment",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📦 Bundle size optimization

### 🔗 Related Issues

- https://github.com/ant-design/ant-design/issues/39900#issuecomment-2482080737

### 💡 Background and Solution

Transforming syntax has many drawbacks:

- Much longer bundle size
- Impossible to analyze for Minifiers and Tree-shakers

And in (at least ESM) builds, users should be able to decide whether downgrade the syntax or not.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | No longer downgrade syntaxes, for smaller bundle size and better optimization |
| 🇨🇳 Chinese | 不再降级语法，以减小包体积并便于优化 |