### PR TITLE
fix: Vertical alignment of clear icon in Input

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -421,6 +421,7 @@ const genAllowClearStyle = (token: InputToken): CSSObject => {
     // ========================= Input =========================
     [`${componentCls}-clear-icon`]: {
       margin: 0,
+      lineHeight: 0,
       color: token.colorTextQuaternary,
       fontSize: token.fontSizeIcon,
       verticalAlign: -1,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

<br />

### 💡 Background and Solution

The Input component's clear icon is slightly off-center vertically because its container uses `display: inline-flex`. Browsers reserve bottom space for inline elements for text layout purposes.

To fix this, either set the icon's container to a block element (e.g. `display: flex`) or apply `line-height: 0` to its parent container.

<p align="center"><samp>/ / /</samp></p>

Input 组件的清除 Icon 未能在垂直方向上居中，尽管该偏移很微小。之所以如此，是因为 Icon 的容器元素采用了 `display: inline-flex`，而浏览器会为 inline 元素预留底部空间以用于排版。

将 Icon 的容器元素设置为 block 元素（如 `display: flex`），或为容器元素的容器元素设置 `line-height: 0` 均可解决该问题。

<br />

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix vertical alignment of clear icon in Input component.     |
| 🇨🇳 Chinese |     修复 Input 组件的清除按钮未能垂直居中的问题。      |
