### PR TITLE
component/select dropdown selection bgcolor

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,12 @@ tag: vVERSION
 
 ---
 
+## 5.22.3
+
+`2024-11-20`
+
+- 🐞 Fix select component's selected options background color. [#51718](https://github.com/ant-design/ant-design/pull/51718) [@ChristopherJamesL](https://github.com/ChristopherJamesL)
+
 ## 5.22.2
 
 `2024-11-19`

--- a/components/select/style/index.ts
+++ b/components/select/style/index.ts
@@ -92,6 +92,10 @@ const genBaseStyle: GenerateStyle<SelectToken> = (token) => {
         userSelect: 'none',
         ...textEllipsis,
 
+        [`${componentCls}-selection-item:hover`]: {
+          backgroundColor: '#b0e8a0', // Lighter color on hover
+        },
+
         // https://github.com/ant-design/ant-design/issues/40421
         [`> ${antCls}-typography`]: {
           display: 'inline',

--- a/components/select/style/token.ts
+++ b/components/select/style/token.ts
@@ -160,7 +160,7 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     zIndexPopupBase,
     colorText,
     fontWeightStrong,
-    controlItemBgActive,
+    // controlItemBgActive,
     controlItemBgHover,
     colorBgContainer,
     colorFillSecondary,
@@ -172,6 +172,9 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     colorPrimary,
     controlOutline,
   } = token;
+
+  // Define a new constant for the selected option background color
+  const dropdownOptionSelectedBg = '#1668dc';
 
   // Item height default use `controlHeight - 2 * paddingXXS`,
   // but some case `paddingXXS=0`.
@@ -198,7 +201,7 @@ export const prepareComponentToken: GetDefaultToken<'Select'> = (token) => {
     zIndexPopup: zIndexPopupBase + 50,
     optionSelectedColor: colorText,
     optionSelectedFontWeight: fontWeightStrong,
-    optionSelectedBg: controlItemBgActive,
+    optionSelectedBg: dropdownOptionSelectedBg /* controlItemBgActive */,
     optionActiveBg: controlItemBgHover,
     optionPadding: `${(controlHeight - fontSize * lineHeight) / 2}px ${controlPaddingHorizontal}px`,
     optionFontSize: fontSize,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

    Edited the component/select dropdown selected options background color to the desired blue.  Wasn't sure how to edit the color variable 'controlItemBgActive' in file components/select/style/token.ts, so I made a new variable /dropdownOptionSelectedBg'.  This was to fix issue #30524.

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
