### PR TITLE
fix(transfer): transfer operation button should be disabled when all the checked items are disabled

### DIFF
--- a/components/transfer/ListItem.tsx
+++ b/components/transfer/ListItem.tsx
@@ -34,7 +34,7 @@ const ListItem = <RecordType extends KeyWiseTransferItem>(props: ListItemProps<R
 
   const className = classNames(`${prefixCls}-content-item`, {
     [`${prefixCls}-content-item-disabled`]: disabled || item.disabled,
-    [`${prefixCls}-content-item-checked`]: checked,
+    [`${prefixCls}-content-item-checked`]: checked && !item.disabled,
   });
 
   let title: string | undefined;

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -663,6 +663,17 @@ describe('Transfer', () => {
     expect(getByText('1 of 2')).toBeTruthy();
   });
 
+  it('should disable transfer operation button when some items are set to selected but also disabled', () => {
+    const dataSource = listDisabledProps.dataSource.map((d) => ({
+      ...d,
+      disabled: true,
+    }));
+    const { container } = render(<Transfer {...listDisabledProps} dataSource={dataSource} />);
+    expect(
+      container.querySelectorAll<HTMLDivElement>('.ant-transfer-operation button').item(0),
+    ).toBeDisabled();
+  });
+
   describe('pagination', () => {
     it('boolean', async () => {
       const { getByTitle } = render(<Transfer {...listDisabledProps} pagination />);

--- a/components/transfer/__tests__/list.test.tsx
+++ b/components/transfer/__tests__/list.test.tsx
@@ -66,6 +66,23 @@ describe('Transfer.List', () => {
     );
   });
 
+  it('should disabled all select checkbox when each item of dataSource is disabled', () => {
+    const allDisabledListProps: TransferListProps<KeyWiseTransferItem> = {
+      ...listCommonProps,
+      dataSource: listCommonProps.dataSource.map((d) => ({
+        ...d,
+        disabled: true,
+      })),
+    };
+    const { container } = render(<List {...allDisabledListProps} />);
+    expect(container.querySelector<HTMLLabelElement>('label.ant-checkbox-wrapper')).toHaveClass(
+      'ant-checkbox-wrapper-disabled',
+    );
+    expect(container.querySelector<HTMLSpanElement>('span.ant-checkbox')).toHaveClass(
+      'ant-checkbox-disabled',
+    );
+  });
+
   it('support custom dropdown Icon', () => {
     const { container } = render(
       <List

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -404,8 +404,12 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const mergedStatus = getMergedStatus(status, customStatus);
   const mergedPagination = !children && pagination;
 
-  const leftActive = targetSelectedKeys.length > 0;
-  const rightActive = sourceSelectedKeys.length > 0;
+  const leftActive =
+    rightDataSource.filter((d) => targetSelectedKeys.includes(d.key as TransferKey) && !d.disabled)
+      .length > 0;
+  const rightActive =
+    leftDataSource.filter((d) => sourceSelectedKeys.includes(d.key as TransferKey) && !d.disabled)
+      .length > 0;
 
   const cls = classNames(
     prefixCls,

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -187,8 +187,12 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     return [filterItems, filterRenderItems] as const;
   }, [dataSource, filterValue]);
 
+  const checkedActiveItems = useMemo<RecordType[]>(() => {
+    return filteredItems.filter((item) => checkedKeys.includes(item.key) && !item.disabled);
+  }, [checkedKeys, filteredItems]);
+
   const checkStatus = useMemo<string>(() => {
-    if (checkedKeys.length === 0) {
+    if (checkedActiveItems.length === 0) {
       return 'none';
     }
     const checkedKeysMap = groupKeysMap(checkedKeys);
@@ -196,7 +200,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
       return 'all';
     }
     return 'part';
-  }, [checkedKeys, filteredItems]);
+  }, [checkedKeys, checkedActiveItems]);
 
   const listBody = useMemo<React.ReactNode>(() => {
     const search = showSearch ? (
@@ -254,7 +258,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
 
   const checkBox = (
     <Checkbox
-      disabled={dataSource.length === 0 || disabled}
+      disabled={dataSource.filter((d) => !d.disabled).length === 0 || disabled}
       checked={checkStatus === 'all'}
       indeterminate={checkStatus === 'part'}
       className={`${prefixCls}-checkbox`}
@@ -380,7 +384,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
           </>
         ) : null}
         <span className={`${prefixCls}-header-selected`}>
-          {getSelectAllLabel(checkedKeys.length, filteredItems.length)}
+          {getSelectAllLabel(checkedActiveItems.length, filteredItems.length)}
         </span>
         <span className={`${prefixCls}-header-title`}>{titleText}</span>
       </div>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51627 

### 💡 Background and Solution

Transfer operation button not disabled when all the checked items are disabled, issue #51627 .

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       1.  **improvment**: disable the all select checkbox when all items are disabled. <br>2. **bugfix**: disable the operation button and uncheck the all select checkbox when all items are disabled but some of them are checked    |
| 🇨🇳 Chinese |      1、优化：当所有 item 为 disabled 时，禁用全选checkbox。<br>2、修复：当所有 item 均为 disabled，而其中某些 item 为 checked 时，operation 按钮应为禁用状态， 全选 checkbox 状态应为 unchecked。     |
