### PR TITLE
feat: support preset color as param of color attribute

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -312,6 +312,59 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx extend context
 
 exports[`renders components/button/demo/chinese-chars-loading.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/button/demo/color-preset.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-flex ant-flex-wrap-wrap ant-flex-gap-middle"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-blue ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Blue
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-purple ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Purple
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-cyan ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Cyan
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-green ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Green
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-magenta ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Magenta
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`renders components/button/demo/color-preset.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/button/demo/color-variant.tsx extend context correctly 1`] = `
 <div
   class="ant-flex ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -301,6 +301,57 @@ exports[`renders components/button/demo/chinese-chars-loading.tsx correctly 1`] 
 </div>
 `;
 
+exports[`renders components/button/demo/color-preset.tsx correctly 1`] = `
+<div
+  class="ant-flex ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-flex ant-flex-wrap-wrap ant-flex-gap-middle"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-blue ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Blue
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-purple ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Purple
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-cyan ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Cyan
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-green ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Green
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-magenta ant-btn-variant-solid ant-btn-sm"
+      type="button"
+    >
+      <span>
+        Magenta
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`renders components/button/demo/color-variant.tsx correctly 1`] = `
 <div
   class="ant-flex ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -483,16 +483,12 @@ describe('Button', () => {
 
   it('should support preset colors as parammeter of color attribute', () => {
     const { container: defaultContainer } = render(
-      <ConfigProvider theme={{ algorithm: [theme.defaultAlgorithm], cssVar: true }}>
-        <Button color="purple" variant="solid">
-          purple btn
+      <ConfigProvider theme={{ algorithm: [theme.darkAlgorithm], cssVar: true }}>
+        <Button color="yellow" variant="solid">
+          yellow btn
         </Button>
       </ConfigProvider>,
     );
-
-    expect(defaultContainer.firstChild).toHaveClass('ant-btn-color-purple');
-    expect(defaultContainer.firstChild).toHaveStyle({
-      background: '#531dab',
-    });
+    expect(defaultContainer.querySelector('button')).toHaveClass('ant-btn-color-yellow');
   });
 });

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -480,4 +480,19 @@ describe('Button', () => {
 
     expect(container.querySelector('button')).toBe(document.activeElement);
   });
+
+  it('should support preset colors as parammeter of color attribute', () => {
+    const { container: defaultContainer } = render(
+      <ConfigProvider theme={{ algorithm: [theme.defaultAlgorithm], cssVar: true }}>
+        <Button color="purple" variant="solid">
+          purple btn
+        </Button>
+      </ConfigProvider>,
+    );
+
+    expect(defaultContainer.firstChild).toHaveClass('ant-btn-color-purple');
+    expect(defaultContainer.firstChild).toHaveStyle({
+      background: '#531dab',
+    });
+  });
 });

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -10,6 +10,7 @@ import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { useCompactItemContext } from '../space/Compact';
+import { PresetColorKey } from '../theme/interface/presetColors';
 import Group, { GroupSizeContext } from './button-group';
 import type {
   ButtonColorType,
@@ -28,7 +29,7 @@ export type LegacyButtonType = ButtonType | 'danger';
 
 export interface BaseButtonProps {
   type?: ButtonType;
-  color?: ButtonColorType;
+  color?: ButtonColorType | Exclude<PresetColorKey, 'pink'>;
   variant?: ButtonVariantType;
   icon?: React.ReactNode;
   iconPosition?: 'start' | 'end';
@@ -82,7 +83,10 @@ function getLoadingConfig(loading: BaseButtonProps['loading']): LoadingConfigTyp
   };
 }
 
-type ColorVariantPairType = [color?: ButtonColorType, variant?: ButtonVariantType];
+type ColorVariantPairType = [
+  color?: ButtonColorType | Exclude<PresetColorKey, 'pink'>,
+  variant?: ButtonVariantType,
+];
 
 const ButtonTypeMap: Partial<Record<ButtonType, ColorVariantPairType>> = {
   default: ['default', 'outlined'],

--- a/components/button/demo/color-preset.md
+++ b/components/button/demo/color-preset.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+`color` 属性，可以传入预设颜色 (`'blue', 'purple'`)
+
+## en-US
+
+You can pass preset colors(`'blue', 'purple'`) to `color` attribute

--- a/components/button/demo/color-preset.tsx
+++ b/components/button/demo/color-preset.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Button, ConfigProvider, Flex } from 'antd';
+import { useResponsive } from 'antd-style';
+
+const App: React.FC = () => {
+  const { xxl } = useResponsive();
+
+  return (
+    <ConfigProvider componentSize={xxl ? 'middle' : 'small'}>
+      <Flex vertical gap="middle">
+        <Flex gap="middle" wrap>
+          <Button color="blue" variant="solid">
+            Blue
+          </Button>
+          <Button color="purple" variant="solid">
+            Purple
+          </Button>
+          <Button color="cyan" variant="solid">
+            Cyan
+          </Button>
+          <Button color="green" variant="solid">
+            Green
+          </Button>
+          <Button color="magenta" variant="solid">
+            Magenta
+          </Button>
+        </Flex>
+      </Flex>
+    </ConfigProvider>
+  );
+};
+
+export default App;

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -35,6 +35,7 @@ And 4 other properties additionally.
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Syntactic sugar</code>
 <code src="./demo/color-variant.tsx" version="5.21.0">Color & Variant</code>
+<code src="./demo/color-preset.tsx" version="5.21.0">Using Preset Colors</code>
 <code src="./demo/debug-color-variant" debug>Debug Color & Variant</code>
 <code src="./demo/icon.tsx">Icon</code>
 <code src="./demo/icon-position.tsx" version="5.17.0">Icon Position</code>

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -38,6 +38,7 @@ group:
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">语法糖</code>
 <code src="./demo/color-variant.tsx" version="5.21.0">颜色与变体</code>
+<code src="./demo/color-preset.tsx" version="5.21.0">使用预设颜色</code>
 <code src="./demo/debug-color-variant" debug>调试颜色与变体</code>
 <code src="./demo/icon.tsx">按钮图标</code>
 <code src="./demo/icon-position.tsx" version="5.17.0">按钮图标位置</code>

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -1,8 +1,25 @@
+import {
+  blue,
+  cyan,
+  geekblue,
+  gold,
+  green,
+  lime,
+  magenta,
+  orange,
+  purple,
+  red,
+  volcano,
+  yellow,
+} from '@ant-design/colors';
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
+import { GenerateStyleWithPresetColors } from 'antd/es/theme/interface';
 
+import { AggregationColor } from '../../color-picker/color';
+import { isBright } from '../../color-picker/components/ColorPresets';
 import { genFocusStyle } from '../../style';
-import type { GenerateStyle } from '../../theme/internal';
+import type { GenerateStyle, PresetColorKey } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 import type { ButtonVariantType } from '../buttonHelpers';
 import genGroupStyle from './group';
@@ -65,6 +82,21 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
       },
     },
   };
+};
+
+const presetColors = {
+  blue,
+  purple,
+  cyan,
+  green,
+  magenta,
+  red,
+  orange,
+  yellow,
+  volcano,
+  geekblue,
+  lime,
+  gold,
 };
 
 const genHoverActiveButtonStyle = (
@@ -440,6 +472,96 @@ const genDangerousStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ),
 });
 
+const genPresetColorStyle: GenerateStyleWithPresetColors<ButtonToken, CSSObject> = (
+  token,
+  color,
+) => ({
+  color: presetColors[color][5],
+  boxShadow: `0 ${token.controlOutlineWidth} 0 ${presetColors[color][0]}`,
+
+  ...genSolidButtonStyle(
+    token,
+    isBright(new AggregationColor(presetColors[color][5]), '#fff') ? '#000' : '#fff',
+    presetColors[color][5],
+    {
+      background: presetColors[color][4],
+    },
+    {
+      background: presetColors[color][6],
+    },
+  ),
+
+  ...genOutlinedDashedButtonStyle(
+    token,
+    presetColors[color][5],
+    token.colorBgContainer,
+    {
+      color: presetColors[color][4],
+      borderColor: presetColors[color][4],
+    },
+    {
+      color: presetColors[color][6],
+      borderColor: presetColors[color][6],
+    },
+  ),
+
+  ...genDashedButtonStyle(token),
+
+  ...genFilledButtonStyle(
+    token,
+    presetColors[color][1],
+    {
+      background: presetColors[color][2],
+    },
+    {
+      background: presetColors[color][3],
+    },
+  ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    presetColors[color][5],
+    'link',
+    {
+      color: presetColors[color][4],
+    },
+    {
+      color: presetColors[color][6],
+    },
+  ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    presetColors[color][5],
+    'text',
+    {
+      color: presetColors[color][4],
+      background: presetColors[color][1],
+    },
+    {
+      color: presetColors[color][4],
+      background: presetColors[color][2],
+    },
+  ),
+
+  ...genGhostButtonStyle(
+    token.componentCls,
+    token.ghostBg,
+    presetColors[color][5],
+    presetColors[color][5],
+    token.colorTextDisabled,
+    presetColors[color][5],
+    {
+      color: presetColors[color][4],
+      borderColor: presetColors[color][4],
+    },
+    {
+      color: presetColors[color][6],
+      borderColor: presetColors[color][6],
+    },
+  ),
+});
+
 const genColorButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const { componentCls } = token;
 
@@ -447,6 +569,14 @@ const genColorButtonStyle: GenerateStyle<ButtonToken> = (token) => {
     [`${componentCls}-color-default`]: genDefaultButtonStyle(token),
     [`${componentCls}-color-primary`]: genPrimaryButtonStyle(token),
     [`${componentCls}-color-dangerous`]: genDangerousStyle(token),
+
+    ...Object.keys(presetColors).reduce<Record<string, CSSObject>>((pre, key) => {
+      pre[`${componentCls}-color-${key}`] = genPresetColorStyle(
+        token,
+        key as Exclude<PresetColorKey, 'pink'>,
+      );
+      return pre;
+    }, {}),
   };
 };
 

--- a/components/theme/interface/index.ts
+++ b/components/theme/interface/index.ts
@@ -3,6 +3,7 @@ import type { CSSInterpolation, DerivativeFunc } from '@ant-design/cssinjs';
 import type { AnyObject } from '../../_util/type';
 import type { AliasToken } from './alias';
 import type { MapToken } from './maps';
+import { PresetColorKey } from './presetColors';
 import type { SeedToken } from './seeds';
 
 export type MappingAlgorithm = DerivativeFunc<SeedToken, MapToken>;
@@ -43,3 +44,8 @@ export type GenerateStyle<
   ComponentToken extends AnyObject = AliasToken,
   ReturnType = CSSInterpolation,
 > = (token: ComponentToken) => ReturnType;
+
+export type GenerateStyleWithPresetColors<
+  ComponentToken extends AnyObject = AliasToken,
+  ReturnType = CSSInterpolation,
+> = (token: ComponentToken, color: Exclude<PresetColorKey, 'pink'>) => ReturnType;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

https://github.com/ant-design/ant-design/issues/50978

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

`color` prop now supports preset color keys including 'blue', 'purple', 'cyan', 'green', 'magenta', 'red', 'orange', 'yellow', 'volcano', 'geekblue', 'lime', 'gold'

![image](https://github.com/user-attachments/assets/67765992-11b7-47ec-86af-3cdc8d86b94b)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    support preset color as param of color attribute     |
| 🇨🇳 Chinese |      color 参数支持预设颜色     |
