### PR TITLE
fix: menu collapsed props work in layout

### DIFF
--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -6,7 +6,6 @@ import Layout from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
-import Button from '../../button';
 import Menu from '../../menu';
 
 const { Sider, Content, Footer, Header } = Layout;
@@ -286,9 +285,9 @@ describe('Sider', () => {
       return (
         <Layout style={{ minHeight: '100vh' }}>
           <Layout.Sider collapsed={collapsed}>
-            <Button type="primary" onClick={toggleCollapsed}>
+            <button type="button" onClick={toggleCollapsed}>
               "trigger"
-            </Button>
+            </button>
             <Menu
               theme="dark"
               inlineCollapsed={collapsed}

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import Layout from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
+import Button from '../../button';
 import Menu from '../../menu';
 
 const { Sider, Content, Footer, Header } = Layout;
@@ -274,15 +275,54 @@ describe('Sider', () => {
     expect(onBreakpoint).toHaveBeenCalledWith(true);
   });
 
-  it('should warning if use `inlineCollapsed` with menu', () => {
-    render(
-      <Sider collapsible>
-        <Menu mode="inline" inlineCollapsed />
-      </Sider>,
-    );
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Menu] `inlineCollapsed` not control Menu under Sider. Should set `collapsed` on Sider instead.',
-    );
+  it('should controlled collapse work when using with Layout.Sider', () => {
+    const Demo = () => {
+      const [collapsed, setCollapsed] = useState(false);
+
+      const toggleCollapsed = () => {
+        setCollapsed(!collapsed);
+      };
+
+      return (
+        <Layout style={{ minHeight: '100vh' }}>
+          <Layout.Sider collapsed={collapsed}>
+            <Button type="primary" onClick={toggleCollapsed}>
+              "trigger"
+            </Button>
+            <Menu
+              theme="dark"
+              inlineCollapsed={collapsed}
+              defaultSelectedKeys={['1']}
+              mode="inline"
+            >
+              <Menu.SubMenu key="sub1" icon={<UserOutlined />} title="User">
+                <Menu.Item key="3">Tom</Menu.Item>
+                <Menu.Item key="4">Bill</Menu.Item>
+                <Menu.Item key="5">Alex</Menu.Item>
+              </Menu.SubMenu>
+            </Menu>
+          </Layout.Sider>
+        </Layout>
+      );
+    };
+
+    const { getByRole, queryByRole } = render(<Demo />);
+
+    const menu = queryByRole('menu');
+    expect(menu).toHaveClass('ant-menu-inline');
+
+    const button = getByRole('button');
+    fireEvent.click(button);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(menu).toHaveClass('ant-menu-inline-collapsed');
+
+    fireEvent.click(button);
+
+    expect(menu).not.toHaveClass('ant-menu-inline-collapsed');
   });
 
   it('zeroWidthTriggerStyle should work', () => {

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -108,9 +108,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
 
   // ======================== Collapsed ========================
   // Inline Collapsed
-  const mergedInlineCollapsed = React.useMemo(() => {
-    return inlineCollapsed ?? siderCollapsed;
-  }, [inlineCollapsed, siderCollapsed]);
+  const mergedInlineCollapsed = inlineCollapsed ?? siderCollapsed;
 
   const defaultMotions: MenuProps['defaultMotions'] = {
     horizontal: { motionName: `${rootPrefixCls}-slide-up` },

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -88,13 +88,6 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
       'usage',
       '`inlineCollapsed` should only be used when `mode` is inline.',
     );
-
-    warning(
-      !(props.siderCollapsed !== undefined && 'inlineCollapsed' in props),
-      'usage',
-      '`inlineCollapsed` not control Menu under Sider. Should set `collapsed` on Sider instead.',
-    );
-
     warning.deprecated('items' in props && !props.children, 'children', 'items');
   }
 
@@ -116,10 +109,10 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   // ======================== Collapsed ========================
   // Inline Collapsed
   const mergedInlineCollapsed = React.useMemo(() => {
-    if (siderCollapsed !== undefined) {
-      return siderCollapsed;
+    if (inlineCollapsed !== undefined) {
+      return inlineCollapsed;
     }
-    return inlineCollapsed;
+    return siderCollapsed;
   }, [inlineCollapsed, siderCollapsed]);
 
   const defaultMotions: MenuProps['defaultMotions'] = {

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -109,10 +109,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   // ======================== Collapsed ========================
   // Inline Collapsed
   const mergedInlineCollapsed = React.useMemo(() => {
-    if (inlineCollapsed !== undefined) {
-      return inlineCollapsed;
-    }
-    return siderCollapsed;
+    return inlineCollapsed ?? siderCollapsed;
   }, [inlineCollapsed, siderCollapsed]);
 
   const defaultMotions: MenuProps['defaultMotions'] = {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
close https://github.com/ant-design/ant-design/issues/51768
### 💡 需求背景和解决方案
The inlineCollapsed prop in the Menu component should override the collapsed prop in Layout.Sider.

### 📝 更新日志
| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  The inlineCollapsed prop in the Menu component should override the collapsed prop in Layout.Sider.         |
| 🇨🇳 中文 |  inlineCollapsed 属性在 Menu 组件中应当覆盖 Layout.Sider 中的 collapsed 属性        |