### PR TITLE
fix(menu): use collapsedIconSize to calculate paddingInline for collapsed menu

### DIFF
--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -182,7 +182,7 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
           > ${componentCls}-item-group > ${componentCls}-item-group-list > ${componentCls}-submenu > ${componentCls}-submenu-title,
           > ${componentCls}-submenu > ${componentCls}-submenu-title`]: {
           insetInlineStart: 0,
-          paddingInline: `calc(50% - ${unit(token.calc(fontSizeLG).div(2).equal())} - ${unit(
+          paddingInline: `calc(50% - ${unit(token.calc(collapsedIconSize).div(2).equal())} - ${unit(
             itemMarginInline,
           )})`,
           textOverflow: 'clip',


### PR DESCRIPTION
### 🤔 This is a ...
- [X] 💄 Component style improvement

### 🔗 Related Issues

- When using customized `collapsedIconSize`(size greater than `fontSizeLG`), menu icon will not aligned to center properly.

### 💡 Background and Solution
<img width="333" alt="Screenshot 2024-12-03 at 00 43 43" src="https://github.com/user-attachments/assets/5e4a64ca-bcd3-4609-a697-0c01d7797a19">

Hi team, I have set `collapsedIconSize` to `24` in theme but seems it doesn't work properly since the `padding-inline` uses `fontSizeLG` to do calculation, see above screenshot.

```typescript
<ConfigProvider
  theme={{
    components: {
      Menu: {
        collapsedIconSize: 24,
        iconSize: 16,
      },
    }
  }}
>
```

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix menu icon doesn't aligned to center when collapsed and use customized collapsed icon size.|
