### PR TITLE
ci: fix website deploy fail

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -33,6 +33,12 @@ jobs:
           ANALYZER: 1
           NODE_OPTIONS: --max_old_space_size=4096
 
+      - name: move report.html to _site
+        run: |
+          if [ -f report.html ]; then
+            mv report.html _site && echo "report.html moved to _site"
+          fi
+
       - name: upload site artifact
         uses: actions/upload-artifact@v4
         with:
@@ -59,6 +65,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          exclude_files: ./_site/report.html # 👈 这个功能是 beta, 但即便不排除，也不 care
           force_orphan: true
 
       # Since force_orphan will not trigger Sync to Gitee, we need to force run it here
@@ -73,7 +80,6 @@ jobs:
       - name: Deploy to Surge (with TAG)
         run: |
           export DEPLOY_DOMAIN=ant-design-${{ steps.publish-version.outputs.VERSION }}.surge.sh
-          cp report.html ./_site
           bunx surge --project ./_site --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Create Commit Comment


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] ⏩ Workflow


部署文档到 Surge 时，需要将打包报告一并上传，但是 #51433 将构建报告移动到了另外一个 job，导致文件不存在，cp 的时候报错了。

改 PR 将 报告文件一并丢到 `.site` 目录。 上传到 gh-pages 的时候忽略这个文件。 但是忽略操作是一个 beta。 但是报告文件即便没忽略影响也不大。

<img width="876" alt="image" src="https://github.com/user-attachments/assets/ea97fc7a-98ed-4979-aa15-78e32ef49d30">

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |      修复 ci copy 文件的时候，文件不存在保持     |
