### PR TITLE
fix(transfer): background overflow when last item on current page is selected

### DIFF
--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -147,7 +147,6 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     height: listHeight,
     border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
     borderRadius: token.borderRadiusLG,
-    overflow: 'hidden',
 
     '&-with-pagination': {
       width: listWidthLG,
@@ -222,6 +221,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       padding: 0,
       overflow: 'auto',
       listStyle: 'none',
+      borderRadius: `0 0 ${unit(borderRadiusLG)} ${unit(borderRadiusLG)}`,
 
       '&-item': {
         display: 'flex',

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -221,7 +221,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       padding: 0,
       overflow: 'auto',
       listStyle: 'none',
-      borderRadius: `0 0 ${unit(borderRadiusLG)} ${unit(borderRadiusLG)}`,
+      borderRadius: `0 0 ${unit(token.calc(borderRadiusLG).sub(lineWidth).equal())} ${unit(token.calc(borderRadiusLG).sub(lineWidth).equal())}`,
 
       '&-item': {
         display: 'flex',

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -139,6 +139,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     colorText,
     controlItemBgActiveHover,
   } = token;
+  const contentBorderRadius = unit(token.calc(borderRadiusLG).sub(lineWidth).equal());
 
   return {
     display: 'flex',
@@ -221,7 +222,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
       padding: 0,
       overflow: 'auto',
       listStyle: 'none',
-      borderRadius: `0 0 ${unit(token.calc(borderRadiusLG).sub(lineWidth).equal())} ${unit(token.calc(borderRadiusLG).sub(lineWidth).equal())}`,
+      borderRadius: `0 0 ${contentBorderRadius} ${contentBorderRadius}`,
 
       '&-item': {
         display: 'flex',

--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -1,7 +1,7 @@
 import { unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
-import { resetComponent, resetIcon, textEllipsis, operationUnit } from '../../style';
+import { operationUnit, resetComponent, resetIcon, textEllipsis } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 
@@ -147,6 +147,7 @@ const genTransferListStyle: GenerateStyle<TransferToken> = (token: TransferToken
     height: listHeight,
     border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
     borderRadius: token.borderRadiusLG,
+    overflow: 'hidden',
 
     '&-with-pagination': {
       width: listWidthLG,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51883 

### 💡 Background and Solution

fix #51883 

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Transfer's background overflow when the last item on the current page is selected      |
| 🇨🇳 Chinese |     修复 Transfer 选中当前页最后一项时背景溢出的问题      |
