### PR TITLE
fix: Tooltip min width to resolve arrow pos

### DIFF
--- a/components/tooltip/demo/debug.tsx
+++ b/components/tooltip/demo/debug.tsx
@@ -15,6 +15,9 @@ const App: React.FC = () => (
     <Tooltip open title="." placement="topLeft">
       <Button>Min Width</Button>
     </Tooltip>
+    <Tooltip open title="." placement="top">
+      <Button>Min Width</Button>
+    </Tooltip>
   </Flex>
 );
 

--- a/components/tooltip/demo/debug.tsx
+++ b/components/tooltip/demo/debug.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Flex, Tooltip } from 'antd';
 
+const zeroWidthEle = <div />;
+
 const App: React.FC = () => (
   <Flex vertical gap={72} align="flex-start">
     <span />
@@ -12,10 +14,10 @@ const App: React.FC = () => (
     >
       <Button>Point at center</Button>
     </Tooltip>
-    <Tooltip open title="." placement="topLeft">
+    <Tooltip open title={zeroWidthEle} placement="topLeft">
       <Button>Min Width</Button>
     </Tooltip>
-    <Tooltip open title="." placement="top">
+    <Tooltip open title={zeroWidthEle} placement="top">
       <Button>Min Width</Button>
     </Tooltip>
   </Flex>

--- a/components/tooltip/demo/debug.tsx
+++ b/components/tooltip/demo/debug.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button, Flex, Tooltip } from 'antd';
 
 const App: React.FC = () => (
-  <Tooltip
-    open
-    title="Thanks for using antd. Have a nice day !"
-    arrow={{ pointAtCenter: true }}
-    placement="topLeft"
-  >
-    <Button>Point at center</Button>
-  </Tooltip>
+  <Flex vertical gap={72} align="flex-start">
+    <span />
+    <Tooltip
+      open
+      title="Thanks for using antd. Have a nice day !"
+      arrow={{ pointAtCenter: true }}
+      placement="topLeft"
+    >
+      <Button>Point at center</Button>
+    </Tooltip>
+    <Tooltip open title="." placement="topLeft">
+      <Button>Min Width</Button>
+    </Tooltip>
+  </Flex>
 );
 
 export default App;

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -42,13 +42,17 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     paddingSM,
     paddingXS,
     arrowOffsetHorizontal,
+    sizePopupArrow,
   } = token;
 
-  // minWidth = arrowOffsetHorizontal + arrowWidth + borderRadius
-  const innerMinWidth = calc(tooltipBorderRadius)
-    .add(token.sizePopupArrow)
+  // arrowOffsetHorizontal + arrowWidth + borderRadius
+  const edgeAlignMinWidth = calc(tooltipBorderRadius)
+    .add(sizePopupArrow)
     .add(arrowOffsetHorizontal)
     .equal();
+
+  // borderRadius * 2 + arrowWidth
+  const centerAlignMinWidth = calc(tooltipBorderRadius).mul(2).add(sizePopupArrow).equal();
 
   return [
     {
@@ -73,7 +77,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
 
         // Wrapper for the tooltip content
         [`${componentCls}-inner`]: {
-          minWidth: innerMinWidth,
+          minWidth: centerAlignMinWidth,
           minHeight: controlHeight,
           padding: `${unit(token.calc(paddingSM).div(2).equal())} ${unit(paddingXS)}`,
           color: tooltipColor,
@@ -84,6 +88,16 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
           borderRadius: tooltipBorderRadius,
           boxShadow: boxShadowSecondary,
           boxSizing: 'border-box',
+        },
+
+        // Align placement should have another min width
+        [[
+          `&-placement-topLeft`,
+          `&-placement-topRight`,
+          `&-placement-bottomLeft`,
+          `&-placement-bottomRight`,
+        ].join(',')]: {
+          minWidth: edgeAlignMinWidth,
         },
 
         // Limit left and right placement radius

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -30,6 +30,7 @@ interface TooltipToken extends FullToken<'Tooltip'> {
 
 const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
   const {
+    calc,
     componentCls, // ant-tooltip
     tooltipMaxWidth,
     tooltipColor,
@@ -40,7 +41,14 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     boxShadowSecondary,
     paddingSM,
     paddingXS,
+    arrowOffsetHorizontal,
   } = token;
+
+  // minWidth = arrowOffsetHorizontal + arrowWidth + borderRadius
+  const innerMinWidth = calc(tooltipBorderRadius)
+    .add(token.sizePopupArrow)
+    .add(arrowOffsetHorizontal)
+    .equal();
 
   return [
     {
@@ -65,7 +73,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
 
         // Wrapper for the tooltip content
         [`${componentCls}-inner`]: {
-          minWidth: '1em',
+          minWidth: innerMinWidth,
           minHeight: controlHeight,
           padding: `${unit(token.calc(paddingSM).div(2).equal())} ${unit(paddingXS)}`,
           color: tooltipColor,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #51373

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Tooltip with narrow content will cause arrow out of box.       |
| 🇨🇳 Chinese |    修复 Tooltip 内容过少时，箭头会在容器外的问题。          |
