### PR TITLE
Docs: Optimize Documentation Reading Experience by Opening External Links in New Tabs 

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1117,6 +1117,7 @@ Array [
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
         href="https://www.google.com"
         tabindex="0"
+        target="_blank"
       >
         <span
           class="ant-btn-icon"
@@ -1843,6 +1844,7 @@ exports[`renders components/button/demo/icon.tsx extend context correctly 1`] = 
       class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
       href="https://www.google.com"
       tabindex="0"
+      target="_blank"
     >
       <span
         class="ant-btn-icon"
@@ -2271,6 +2273,7 @@ Array [
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-icon-end"
         href="https://www.google.com"
         tabindex="0"
+        target="_blank"
       >
         <span
           class="ant-btn-icon"

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -1022,6 +1022,7 @@ Array [
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
         href="https://www.google.com"
         tabindex="0"
+        target="_blank"
       >
         <span
           class="ant-btn-icon"
@@ -1666,6 +1667,7 @@ exports[`renders components/button/demo/icon.tsx correctly 1`] = `
       class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
       href="https://www.google.com"
       tabindex="0"
+      target="_blank"
     >
       <span
         class="ant-btn-icon"
@@ -2016,6 +2018,7 @@ Array [
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-icon-end"
         href="https://www.google.com"
         tabindex="0"
+        target="_blank"
       >
         <span
           class="ant-btn-icon"

--- a/components/button/demo/debug-icon.tsx
+++ b/components/button/demo/debug-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SearchOutlined, MinusSquareOutlined } from '@ant-design/icons';
+import { MinusSquareOutlined, SearchOutlined } from '@ant-design/icons';
 import { Button, ConfigProvider, Divider, Flex, Radio, Tooltip } from 'antd';
 import type { ConfigProviderProps } from 'antd';
 
@@ -52,7 +52,7 @@ const App: React.FC = () => {
             <Button type="dashed" icon={<SearchOutlined />}>
               Search
             </Button>
-            <Button icon={<SearchOutlined />} href="https://www.google.com" />
+            <Button icon={<SearchOutlined />} href="https://www.google.com" target="_blank" />
             <Button>
               <SearchOutlined />
               Search

--- a/components/button/demo/icon-position.tsx
+++ b/components/button/demo/icon-position.tsx
@@ -47,7 +47,12 @@ const App: React.FC = () => {
           <Button type="dashed" icon={<SearchOutlined />} iconPosition={position}>
             Search
           </Button>
-          <Button icon={<SearchOutlined />} href="https://www.google.com" iconPosition={position} />
+          <Button
+            icon={<SearchOutlined />}
+            href="https://www.google.com"
+            target="_blank"
+            iconPosition={position}
+          />
           <Button type="primary" loading iconPosition={position}>
             Loading
           </Button>

--- a/components/button/demo/icon.tsx
+++ b/components/button/demo/icon.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => (
       <Button type="dashed" icon={<SearchOutlined />}>
         Search
       </Button>
-      <Button icon={<SearchOutlined />} href="https://www.google.com" />
+      <Button icon={<SearchOutlined />} href="https://www.google.com" target="_blank" />
     </Flex>
   </Flex>
 );

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -406,7 +406,10 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               <Rate defaultValue={2.5} />
               <br />
               <strong>* Note:</strong> Half star not implemented in RTL direction, it will be
-              supported after <a href="https://github.com/react-component/rate">rc-rate</a>{' '}
+              supported after{' '}
+              <a href="https://github.com/react-component/rate" target="_blank" rel="noreferrer">
+                rc-rate
+              </a>{' '}
               implement rtl support.
             </Col>
             <Col span={12}>

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -4343,6 +4343,8 @@ Array [
                 </p>
                 <a
                   href="http://github.com/ant-design/ant-design/"
+                  rel="noreferrer"
+                  target="_blank"
                 >
                   github.com/ant-design/ant-design/
                 </a>

--- a/components/drawer/demo/user-profile.tsx
+++ b/components/drawer/demo/user-profile.tsx
@@ -135,7 +135,7 @@ const App: React.FC = () => {
             <DescriptionItem
               title="Github"
               content={
-                <a href="http://github.com/ant-design/ant-design/">
+                <a href="http://github.com/ant-design/ant-design/" target="_blank" rel="noreferrer">
                   github.com/ant-design/ant-design/
                 </a>
               }

--- a/components/dropdown/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7263,6 +7263,8 @@ Array [
         >
           <a
             href="https://www.antgroup.com"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             1st menu item
           </a>
@@ -7296,6 +7298,8 @@ Array [
         >
           <a
             href="https://www.aliyun.com"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             2nd menu item
           </a>

--- a/components/dropdown/demo/trigger.tsx
+++ b/components/dropdown/demo/trigger.tsx
@@ -5,11 +5,19 @@ import { Dropdown, Space } from 'antd';
 
 const items: MenuProps['items'] = [
   {
-    label: <a href="https://www.antgroup.com">1st menu item</a>,
+    label: (
+      <a href="https://www.antgroup.com" target="_blank" rel="noopener noreferrer">
+        1st menu item
+      </a>
+    ),
     key: '0',
   },
   {
-    label: <a href="https://www.aliyun.com">2nd menu item</a>,
+    label: (
+      <a href="https://www.aliyun.com" target="_blank" rel="noopener noreferrer">
+        2nd menu item
+      </a>
+    ),
     key: '1',
   },
   {

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -942,6 +942,8 @@ Array [
           >
             <a
               href="https://github.com/ant-design/ant-design/issues/36459"
+              rel="noreferrer"
+              target="_blank"
             >
               #36459
             </a>
@@ -1376,6 +1378,8 @@ Array [
           >
             <a
               href="https://github.com/ant-design/ant-design/issues/36459"
+              rel="noreferrer"
+              target="_blank"
             >
               #36459
             </a>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -778,6 +778,8 @@ Array [
           >
             <a
               href="https://github.com/ant-design/ant-design/issues/36459"
+              rel="noreferrer"
+              target="_blank"
             >
               #36459
             </a>
@@ -1107,6 +1109,8 @@ Array [
           >
             <a
               href="https://github.com/ant-design/ant-design/issues/36459"
+              rel="noreferrer"
+              target="_blank"
             >
               #36459
             </a>

--- a/components/form/demo/col-24-debug.tsx
+++ b/components/form/demo/col-24-debug.tsx
@@ -3,7 +3,15 @@ import { Button, Divider, Form, Input, Select } from 'antd';
 
 const sharedItem = (
   <Form.Item
-    label={<a href="https://github.com/ant-design/ant-design/issues/36459">#36459</a>}
+    label={
+      <a
+        href="https://github.com/ant-design/ant-design/issues/36459"
+        target="_blank"
+        rel="noreferrer"
+      >
+        #36459
+      </a>
+    }
     initialValue={['bamboo']}
     name="select"
     style={{ boxShadow: '0 0 3px red' }}

--- a/components/modal/demo/footer.tsx
+++ b/components/modal/demo/footer.tsx
@@ -41,6 +41,7 @@ const App: React.FC = () => {
           <Button
             key="link"
             href="https://google.com"
+            target="_blank"
             type="primary"
             loading={loading}
             onClick={handleOk}

--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -143,6 +143,8 @@ Array [
   >
     <a
       href="https://github.com/ant-design/ant-design/issues/1862"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       Link
     </a>

--- a/components/tag/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.ts.snap
@@ -141,6 +141,8 @@ Array [
   >
     <a
       href="https://github.com/ant-design/ant-design/issues/1862"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       Link
     </a>

--- a/components/tag/demo/basic.tsx
+++ b/components/tag/demo/basic.tsx
@@ -11,7 +11,13 @@ const App: React.FC = () => (
   <>
     <Tag>Tag 1</Tag>
     <Tag>
-      <a href="https://github.com/ant-design/ant-design/issues/1862">Link</a>
+      <a
+        href="https://github.com/ant-design/ant-design/issues/1862"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Link
+      </a>
     </Tag>
     <Tag closeIcon onClose={preventDefault}>
       Prevent Default

--- a/components/tag/demo/component-token.tsx
+++ b/components/tag/demo/component-token.tsx
@@ -8,10 +8,22 @@ const App: React.FC = () => (
   >
     <Flex gap="4px 0" wrap>
       <Tag>
-        <a href="https://github.com/ant-design/ant-design/issues/1862">Link</a>
+        <a
+          href="https://github.com/ant-design/ant-design/issues/1862"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Link
+        </a>
       </Tag>
       <Tag bordered={false}>
-        <a href="https://github.com/ant-design/ant-design/issues/1862">Link</a>
+        <a
+          href="https://github.com/ant-design/ant-design/issues/1862"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Link
+        </a>
       </Tag>
       <Tag closable color="magenta">
         Tag 2


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
- Null

### 💡 Background and Solution

📚 The current documentation includes numerous **external links** that point to domains outside of the current doc site,  and they may replace the current page when clicked. 

⚠️ This behavior is unpredictable and can lead to developers losing their place in the document they are reading, which significantly degrades the user experience. The issue is exacerbated by slow internet connections, where users are forced to wait for the new page to load, blocking them from continuing to read the documentation.

💡 To improve this situation, we propose setting the most of **external** links to open in a new tab (`target="_blank"`). This change ensures a consistent interaction experience for users and allows them to continue reading the documentation while waiting for external pages to load. It also prevents accidental loss of the current page, enhancing overall usability.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Improve document and enhance user's experience     |
| 🇨🇳 Chinese |      改进文档，优化体验     |
