### PR TITLE
fix(layout): enhance Sider zero-width-trigger selector specificity

### DIFF
--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -69,7 +69,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
         transition: `all ${motionDurationMid}`,
       },
 
-      '&-zero-width': {
+      [`${antCls}-layout &-zero-width`]: {
         '> *': {
           overflow: 'hidden',
         },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue
ref https://github.com/ant-design/ant-design/issues/51224#issuecomment-2523525627

修复 Sider 组件在 zero-width 模式下触发器样式优先级不足的问题。

### 💡 需求背景和解决方案

1. **问题**：Sider 组件在 zero-width 模式下，trigger 的样式无法正确应用，因为选择器优先级不够。

2. **解决方案**：
   - 为 zero-width-trigger 相关样式添加 `.ant-layout` 父级选择器，提升选择器优先级
   - 保持其他 Sider 样式不变，只针对性解决 trigger 样式问题

3. **技术实现**：
```typescript
[`${antCls}-layout &-zero-width-trigger`]: {
  // trigger styles
}
```

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 English | Fix Sider zero-width trigger styles not being applied correctly due to insufficient selector specificity. |
| 🇨🇳 Chinese | 修复 Sider 组件在 zero-width 模式下触发器样式优先级不足的问题。 |
