### PR TITLE
fix(affix): use ref to get the latest and correct value

### DIFF
--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -74,6 +74,7 @@ const Affix = React.forwardRef<AffixRef, AffixProps>((props, ref) => {
   const affixPrefixCls = getPrefixCls('affix', prefixCls);
 
   const [lastAffix, setLastAffix] = React.useState(false);
+  const lastAffixRef = React.useRef(lastAffix);
   const [affixStyle, setAffixStyle] = React.useState<React.CSSProperties>();
   const [placeholderStyle, setPlaceholderStyle] = React.useState<React.CSSProperties>();
 
@@ -147,7 +148,7 @@ const Affix = React.forwardRef<AffixRef, AffixProps>((props, ref) => {
 
       newState.lastAffix = !!newState.affixStyle;
 
-      if (lastAffix !== newState.lastAffix) {
+      if (lastAffixRef.current !== newState.lastAffix) {
         onChange?.(newState.lastAffix);
       }
 
@@ -241,6 +242,10 @@ const Affix = React.forwardRef<AffixRef, AffixProps>((props, ref) => {
   React.useEffect(() => {
     updatePosition();
   }, [target, offsetTop, offsetBottom]);
+
+  React.useEffect(() => {
+    lastAffixRef.current = lastAffix;
+  }, [lastAffix]);
 
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(affixPrefixCls);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

解决在特殊情况下，affix 的 `onChange` 事件在连续触发 2 次且入参都是 `true` 后，后续触发的 `onChange` 事件传递出来的
参数值都是 `false`的错误行为。

因为 useRef 可以用来保存组件的最新状态，而不会触发重渲染。这样，即使 lastAffix 在渲染过程中更新，useRef 也可以保持最新值。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the error in the state passing of the onChange event under special circumstances          |
| 🇨🇳 Chinese | 修复特殊情况下 onChange 事件传递的错误固定状态          |
