### PR TITLE
ci: auto unassign

### DIFF
--- a/.github/workflows/auto-unassign.yml
+++ b/.github/workflows/auto-unassign.yml
@@ -2,10 +2,10 @@ name: Auto Unassign
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Run at 00:00 every day
+    - cron: "0 0 * * *" # Run at 00:00 every day
 
 permissions:
-  issues: write  # Need write permission to modify issue assignees
+  issues: write # Need write permission to modify issue assignees
 
 jobs:
   unassign_job:
@@ -15,15 +15,12 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const daysBeforeUnassign = 1; // Threshold for days without updates
-            const { Octokit } = require("@octokit/action");
-            const octokit = new Octokit();
-
+            const daysBeforeUnassign = 14; 
             let page = 1;
             const perPage = 100;
 
             while (true) {
-              const { data: issues } = await octokit.rest.issues.listForRepo({
+              const { data: issues } = await github.rest.issues.listForRepo({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
@@ -44,37 +41,36 @@ jobs:
                 const updatedAt = new Date(issue.updated_at);
                 const daysInactive = (now - updatedAt) / (1000 * 60 * 60 * 24);
 
-                // Check for comments
-                const { data: comments } = await octokit.rest.issues.listComments({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  per_page: 1,
-                });
-
-                // Check for linked Pull Requests
-                const { data: events } = await octokit.rest.issues.listEvents({
+                const { data: timeline } = await github.rest.issues.listEventsForTimeline({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
                 });
 
-                const hasLinkedPR = events.some(event => event.event === 'referenced' && event.commit_id);
+                const hasLinkedPR = timeline.some(event => 
+                  event.event === 'cross-referenced' && event.source?.issue?.pull_request || // PR referenced this issue
+                  event.event === 'connected' || // PR connected via keywords
+                  event.event === 'referenced' && event.commit_id // Connected via commit
+                );
 
-                if (daysInactive >= daysBeforeUnassign && comments.length === 0 && !hasLinkedPR) {
+                if (daysInactive >= daysBeforeUnassign && !hasLinkedPR) {
+                  const assigneesMentions = issue.assignees
+                    .map(user => `@${user.login}`)
+                    .join(' ');
+                    
                   // Remove assignees
-                  await octokit.rest.issues.removeAssignees({
+                  await github.rest.issues.removeAssignees({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
                     assignees: issue.assignees.map(user => user.login),
                   });
 
-                  await octokit.rest.issues.createComment({
+                  await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    body: 'Due to inactivity, assignees have been automatically removed. Please reassign and update progress if needed.',
+                    body: `${assigneesMentions} Assignees have been automatically removed since no PR was linked to this issue within 14 days. Please contact maintainers for reassignment if you wish to continue working on this issue.`,
                   });
                 }
               }

--- a/.github/workflows/auto-unassign.yml
+++ b/.github/workflows/auto-unassign.yml
@@ -1,0 +1,83 @@
+name: Auto Unassign
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run at 00:00 every day
+
+permissions:
+  issues: write  # Need write permission to modify issue assignees
+
+jobs:
+  unassign_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unassign inactive issues
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const daysBeforeUnassign = 1; // Threshold for days without updates
+            const { Octokit } = require("@octokit/action");
+            const octokit = new Octokit();
+
+            let page = 1;
+            const perPage = 100;
+
+            while (true) {
+              const { data: issues } = await octokit.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                assignee: '*', // Filter assigned issues
+                per_page: perPage,
+                page: page,
+              });
+
+              if (issues.length === 0) {
+                break;
+              }
+
+              const now = new Date();
+
+              for (const issue of issues) {
+                if (issue.pull_request) continue;
+
+                const updatedAt = new Date(issue.updated_at);
+                const daysInactive = (now - updatedAt) / (1000 * 60 * 60 * 24);
+
+                // Check for comments
+                const { data: comments } = await octokit.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 1,
+                });
+
+                // Check for linked Pull Requests
+                const { data: events } = await octokit.rest.issues.listEvents({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                });
+
+                const hasLinkedPR = events.some(event => event.event === 'referenced' && event.commit_id);
+
+                if (daysInactive >= daysBeforeUnassign && comments.length === 0 && !hasLinkedPR) {
+                  // Remove assignees
+                  await octokit.rest.issues.removeAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    assignees: issue.assignees.map(user => user.login),
+                  });
+
+                  await octokit.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: 'Due to inactivity, assignees have been automatically removed. Please reassign and update progress if needed.',
+                  });
+                }
+              }
+
+              page += 1;
+            }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案

1. 问题：当前项目中的一些issue被分配后可能长期处于无人处理的状态，影响项目进度跟踪和管理效率。

2. 解决方案：
   - 添加自动取消分配（Auto Unassign）GitHub Action
   - 每天自动检查所有已分配的开放性issue
   - 如果某个issue在14天内没有更新且没有关联的PR，则自动取消其分配状态
   - 取消分配后，会自动在issue下发送通知评论，提醒相关人员

3. 实现细节：
   - 使用GitHub Actions scheduled workflow，每天00:00触发
   - 使用github-script操作检查issue状态
   - 检查issue的更新时间和PR关联状态
   - 自动移除不活跃issue的受让人并添加提醒评论

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 English | Add auto unassign workflow to remove assignees from inactive issues after 14 days |
| 🇨🇳 Chinese | 添加自动取消分配工作流，对超过14天未活动的issue自动取消受让人 |