### PR TITLE
fix(button): ensure solid default button text remains visible on hover in dark mode

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -244,9 +244,11 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     token.solidTextColor,
     token.colorBgSolid,
     {
+      color: token.solidTextColor,
       background: token.colorBgSolidHover,
     },
     {
+      color: token.solidTextColor,
       background: token.colorBgSolidActive,
     },
   ),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #52022

### 💡 Background and Solution

This PR fixes the issue where the solid default button text disappears when hovered in dark mode. The problem was that the button text color would turn white on hover, blending into the white background and losing visibility.

#### Changes
Updated the `genSolidButtonStyle` function to ensure the button text color remains visible when hovered and active.
### 📝 Change Log

#### Before
![image](https://github.com/user-attachments/assets/0eb33579-a726-4e15-a7f2-dc08dee437df)

#### After
![GzJRX2iL1H](https://github.com/user-attachments/assets/f88f6996-f322-47c5-b317-911d4be30647)

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix issue where solid default button text disappears on hover in dark mode.      |
| 🇨🇳 Chinese |    修复暗色模式下默认填充按钮文本在悬停时消失的问题。       |
