### PR TITLE
chore: Improve visual regression screenshot warning

### DIFF
--- a/components/affix/__tests__/image.test.ts
+++ b/components/affix/__tests__/image.test.ts
@@ -1,5 +1,7 @@
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Affix image', () => {
-  imageDemoTest('affix');
+  imageDemoTest('affix', {
+    onlyViewport: ['debug.tsx'],
+  });
 });

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -144,9 +144,9 @@ export default function imageTest(
       // Do inject open trigger
       if (openTriggerClassName) {
         element = (
-          <TriggerMockContext value={{ popupVisible: true }}>
+          <TriggerMockContext.Provider value={{ popupVisible: true }}>
             {element}
-          </TriggerMockContext>
+          </TriggerMockContext.Provider>
         );
       }
 

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -144,9 +144,9 @@ export default function imageTest(
       // Do inject open trigger
       if (openTriggerClassName) {
         element = (
-          <TriggerMockContext.Provider value={{ popupVisible: true }}>
+          <TriggerMockContext value={{ popupVisible: true }}>
             {element}
-          </TriggerMockContext.Provider>
+          </TriggerMockContext>
         );
       }
 
@@ -206,9 +206,9 @@ export default function imageTest(
 
         // loooooong image
         rcWarning(
-          bodyHeight < 2048, // Expected height
+          bodyHeight < 4096, // Expected height
           `[IMAGE TEST] [${identifier}] may cause screenshots to be very long and unacceptable.
-            Please consider using \`onlyViewport: ["filename.tsx"]\`, read more: https://github.com/ant-design/ant-design/pull/2333`,
+            Please consider using \`onlyViewport: ["filename.tsx"]\`, read more: https://github.com/ant-design/ant-design/pull/52053`,
         );
 
         await page.setViewport({ width: 800, height: bodyHeight });

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -8,6 +8,7 @@ import fse from 'fs-extra';
 import { globSync } from 'glob';
 import { JSDOM } from 'jsdom';
 import MockDate from 'mockdate';
+import rcWarning from 'rc-util/lib/warning';
 import type { HTTPRequest } from 'puppeteer';
 import ReactDOMServer from 'react-dom/server';
 
@@ -202,6 +203,14 @@ export default function imageTest(
       if (!options.onlyViewport) {
         // Get scroll height of the rendered page and set viewport
         const bodyHeight = await page.evaluate(() => document.body.scrollHeight);
+
+        // loooooong image
+        rcWarning(
+          bodyHeight < 2048, // Expected height
+          `[IMAGE TEST] [${identifier}] may cause screenshots to be very long and unacceptable.
+            Please consider using \`onlyViewport: ["filename.tsx"]\`, read more: https://github.com/ant-design/ant-design/pull/2333`,
+        );
+
         await page.setViewport({ width: 800, height: bodyHeight });
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

在这个 https://antd-visual-diff.oss-accelerate.aliyuncs.com/pr-52047/visualRegressionReport/report.html 里可以看到截图高度非常高，原因是这个 demo 写了一个内联样式 `<div style={{ height: 10000 }}>` 导致的。

这里可以将视觉测试添加为仅视图 `onlyViewport` 模式:

```diff
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Affix image', () => {
-  imageDemoTest('affix');
+  imageDemoTest('affix', {
+    onlyViewport: ["debug.tsx"]
+  });
 });

```

但是以上并不全部适用，请斟酌后添加...


这个 PR 在测试中添加了一个判断，如果截图超过 `4096px` 高度则给出一个提示。 

<img width="1376" alt="image" src="https://github.com/user-attachments/assets/5acd4d1c-1ab3-46da-8264-4a8af8f5fa5d" />



> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Improve visual regression screenshot warning     |
| 🇨🇳 Chinese |    改进视觉回归截图高度提示       |
