### PR TITLE
INTERNAL: add shortcuts to pro-components

### DIFF
--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -162,10 +162,10 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
 
   // It is just for `pro-components`
   if (formItemRender?.mark === 'pro_table_render') {
-    if (typeof formItemRender?.prepare === 'function') {
+    if (typeof formItemRender.prepare === 'function') {
       const _clonedInnerRender = innerRender;
       innerRender = (...args) => _clonedInnerRender(args[0], formItemRender.prepare(...args));
-    } else if (typeof formItemRender?.render === 'function') {
+    } else if (typeof formItemRender.render === 'function') {
       innerRender = formItemRender.render;
     }
   }

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -11,6 +11,21 @@ import ErrorList from './ErrorList';
 import type { ValidateStatus } from './FormItem';
 import FallbackCmp from './style/fallbackCmp';
 
+
+/** @internal */
+type InternalItemRender = {
+  mark: string;
+  render: (
+    props: FormItemInputProps & FormItemInputMiscProps,
+    domList: {
+      input: JSX.Element;
+      errorList: JSX.Element | null;
+      extra: JSX.Element | null;
+    },
+  ) => React.ReactNode
+  prepare: <T = Parameters<InternalItemRender['render']>[1]>(params: T) => T
+}
+
 interface FormItemInputMiscProps {
   prefixCls: string;
   children: React.ReactNode;
@@ -19,18 +34,8 @@ interface FormItemInputMiscProps {
   marginBottom?: number | null;
   onErrorVisibleChanged?: (visible: boolean) => void;
   /** @internal do not use in any of your production. */
-  _internalItemRender?: {
-    mark: string;
-    render: (
-      props: FormItemInputProps & FormItemInputMiscProps,
-      domList: {
-        input: JSX.Element;
-        errorList: JSX.Element | null;
-        extra: JSX.Element | null;
-      },
-    ) => React.ReactNode;
-  };
-}
+  _internalItemRender?: InternalItemRender;
+};
 
 export interface FormItemInputProps {
   labelCol?: ColProps;
@@ -139,30 +144,42 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
     </div>
   ) : null;
 
-  const additionalDom: React.ReactNode =
-    errorListDom || extraDom ? (
-      <div
-        className={`${baseClassName}-additional`}
-        style={marginBottom ? { minHeight: marginBottom + extraHeight } : {}}
-      >
-        {errorListDom}
-        {extraDom}
-      </div>
-    ) : null;
+  let innerRender: InternalItemRender['render'] = (_, { input, errorList, extra }) => (
+    <>
+      {input}
+      {
+        errorList || extra ? (
+          <div
+            className={`${baseClassName}-additional`}
+            style={marginBottom ? { minHeight: marginBottom + extraHeight } : {}}
+          >
+            {errorList}
+            {extra}
+          </div>
+        ) : null
+      }
+    </>
+  )
 
-  const dom: React.ReactNode =
-    formItemRender && formItemRender.mark === 'pro_table_render' && formItemRender.render ? (
-      formItemRender.render(props, { input: inputDom, errorList: errorListDom, extra: extraDom })
-    ) : (
-      <>
-        {inputDom}
-        {additionalDom}
-      </>
-    );
+  // It is just for `pro-components`
+  if (formItemRender?.mark === 'pro_table_render') {
+    if (typeof formItemRender?.prepare === 'function') {
+      innerRender = (_, ...args) => innerRender(_, formItemRender.prepare(...args))
+    } else if (typeof formItemRender?.render === 'function') {
+      innerRender = formItemRender.render;
+    }
+  }
+
   return (
     <FormContext.Provider value={subFormContext}>
       <Col {...mergedWrapperCol} className={className}>
-        {dom}
+        {
+          innerRender(props, {
+            input: inputDom,
+            errorList: errorListDom,
+            extra: extraDom
+          })
+        }
       </Col>
       <FallbackCmp prefixCls={prefixCls} />
     </FormContext.Provider>

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -163,7 +163,8 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
   // It is just for `pro-components`
   if (formItemRender?.mark === 'pro_table_render') {
     if (typeof formItemRender?.prepare === 'function') {
-      innerRender = (...args) => innerRender(args[0], formItemRender.prepare(...args));
+      const _clonedInnerRender = innerRender;
+      innerRender = (...args) => _clonedInnerRender(args[0], formItemRender.prepare(...args));
     } else if (typeof formItemRender?.render === 'function') {
       innerRender = formItemRender.render;
     }

--- a/components/form/FormItemInput.tsx
+++ b/components/form/FormItemInput.tsx
@@ -11,7 +11,6 @@ import ErrorList from './ErrorList';
 import type { ValidateStatus } from './FormItem';
 import FallbackCmp from './style/fallbackCmp';
 
-
 /** @internal */
 type InternalItemRender = {
   mark: string;
@@ -22,9 +21,11 @@ type InternalItemRender = {
       errorList: JSX.Element | null;
       extra: JSX.Element | null;
     },
-  ) => React.ReactNode
-  prepare: <T = Parameters<InternalItemRender['render']>[1]>(params: T) => T
-}
+  ) => React.ReactNode;
+  prepare: (
+    ...params: Parameters<InternalItemRender['render']>
+  ) => Parameters<InternalItemRender['render']>[1];
+};
 
 interface FormItemInputMiscProps {
   prefixCls: string;
@@ -35,7 +36,7 @@ interface FormItemInputMiscProps {
   onErrorVisibleChanged?: (visible: boolean) => void;
   /** @internal do not use in any of your production. */
   _internalItemRender?: InternalItemRender;
-};
+}
 
 export interface FormItemInputProps {
   labelCol?: ColProps;
@@ -147,24 +148,22 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
   let innerRender: InternalItemRender['render'] = (_, { input, errorList, extra }) => (
     <>
       {input}
-      {
-        errorList || extra ? (
-          <div
-            className={`${baseClassName}-additional`}
-            style={marginBottom ? { minHeight: marginBottom + extraHeight } : {}}
-          >
-            {errorList}
-            {extra}
-          </div>
-        ) : null
-      }
+      {errorList || extra ? (
+        <div
+          className={`${baseClassName}-additional`}
+          style={marginBottom ? { minHeight: marginBottom + extraHeight } : {}}
+        >
+          {errorList}
+          {extra}
+        </div>
+      ) : null}
     </>
-  )
+  );
 
   // It is just for `pro-components`
   if (formItemRender?.mark === 'pro_table_render') {
     if (typeof formItemRender?.prepare === 'function') {
-      innerRender = (_, ...args) => innerRender(_, formItemRender.prepare(...args))
+      innerRender = (...args) => innerRender(args[0], formItemRender.prepare(...args));
     } else if (typeof formItemRender?.render === 'function') {
       innerRender = formItemRender.render;
     }
@@ -173,13 +172,11 @@ const FormItemInput: React.FC<FormItemInputProps & FormItemInputMiscProps> = (pr
   return (
     <FormContext.Provider value={subFormContext}>
       <Col {...mergedWrapperCol} className={className}>
-        {
-          innerRender(props, {
-            input: inputDom,
-            errorList: errorListDom,
-            extra: extraDom
-          })
-        }
+        {innerRender(props, {
+          input: inputDom,
+          errorList: errorListDom,
+          extra: extraDom,
+        })}
       </Col>
       <FallbackCmp prefixCls={prefixCls} />
     </FormContext.Provider>

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1467,30 +1467,82 @@ describe('Form', () => {
     });
   });
 
-  it('_internalItemRender api test', () => {
-    const { container } = render(
-      <Form>
-        <Form.Item
-          name="light"
-          // @ts-ignore
-          _internalItemRender={{
-            mark: 'pro_table_render',
-            render: (_: any, doms: any) => (
-              <div>
-                <div className="bamboo">warning title</div>
-                {doms.input}
-                {doms.errorList}
-                {doms.extra}
-              </div>
-            ),
-          }}
-        >
-          <input defaultValue="should warning" />
-        </Form.Item>
-      </Form>,
-    );
+  describe('_internalItemRender props', () => {
+    it('should work (legacy)', () => {
+      const { container } = render(
+        <Form>
+          <Form.Item
+            name="light"
+            // @ts-ignore
+            _internalItemRender={{
+              mark: 'pro_table_render',
+              render: (_: any, doms: any) => (
+                <div>
+                  <div className="bamboo">warning title</div>
+                  {doms.input}
+                  {doms.errorList}
+                  {doms.extra}
+                </div>
+              ),
+            }}
+          >
+            <input defaultValue="should warning" />
+          </Form.Item>
+        </Form>,
+      );
 
-    expect(container.querySelector('.bamboo')!).toHaveTextContent(/warning title/i);
+      expect(container.querySelector('.bamboo')!).toHaveTextContent(/warning title/i);
+    });
+
+    it('`prepare` should work', () => {
+      const mockPrepare = jest.fn().mockImplementation((props, doms) => {
+        return {
+          ...doms,
+          extra: (
+            <div>
+              <div className="bamboo">hello</div>
+              {doms.extra}
+            </div>
+          ),
+        };
+      });
+
+      const mockRender = jest.fn();
+
+      const { container } = render(
+        <Form>
+          <Form.Item
+            name="light"
+            // @ts-ignore
+            _internalItemRender={{
+              mark: 'pro_table_render',
+              prepare: mockPrepare,
+              render: mockRender,
+            }}
+          >
+            <input defaultValue="should warning" />
+          </Form.Item>
+        </Form>,
+      );
+
+      expect(mockPrepare).toHaveBeenCalled();
+      expect(mockRender).not.toHaveBeenCalled();
+
+      expect(mockPrepare).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: expect.any(Array),
+          warnings: expect.any(Array),
+        }),
+        // https://zirkelc.dev/posts/use-expectobjectcontaining-with-null-and-undefined
+        expect.objectContaining({
+          input: expect.anything(),
+          errorList: expect.toBeOneOf([expect.anything(), null]),
+          extra: expect.toBeOneOf([expect.anything(), null]),
+        }),
+      );
+
+      expect(container.querySelector('.bamboo')!).toHaveTextContent(/hello/i);
+    });
   });
 
   it('Form Item element id will auto add form_item prefix if form name is empty and item name is in the black list', async () => {

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1495,7 +1495,7 @@ describe('Form', () => {
     });
 
     it('`prepare` should work', () => {
-      const mockPrepare = jest.fn().mockImplementation((props, doms) => {
+      const mockPrepare = jest.fn().mockImplementation((_, doms) => {
         return {
           ...doms,
           extra: (

--- a/package.json
+++ b/package.json
@@ -255,6 +255,7 @@
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "jest-environment-node": "^29.7.0",
+    "jest-extended": "^4.0.2",
     "jest-image-snapshot": "^6.4.0",
     "jest-puppeteer": "^10.1.2",
     "jquery": "^3.7.1",

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { toHaveNoViolations } from 'jest-axe';
 import jsdom from 'jsdom';
 import format, { plugins } from 'pretty-format';
+import { toBeOneOf } from 'jest-extended';
 
 import { defaultConfig } from '../components/theme/internal';
 
@@ -113,3 +114,6 @@ expect.addSnapshotSerializer({
 });
 
 expect.extend(toHaveNoViolations);
+
+// https://jest-extended.jestcommunity.dev/docs/getting-started/setup
+expect.extend({ toBeOneOf });

--- a/typings/jest.d.ts
+++ b/typings/jest.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest-extended" />
+
 declare namespace jest {
   interface Matchers<R> {
     toHaveNoViolations(): R;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

backgroubd: https://github.com/ant-design/ant-design/issues/51829#issuecomment-2521895129

给 pro-components 使用的内部口子，加一个 `_internalItemRender.prepare` 允许 pro 那边重新处理 item 几个参数，然后再由 antd 组装一遍使用。

原来的 `_internalItemRender.render` 则继续保留，防止 pro 那边的开发者没有升级前置依赖 antd 导致 break change。

注意：后面 pro-components 升级 major 或者 antd 升级 major 可以考虑移除这部分兼容代码

```tsx
// It is just for `pro-components`
  if (formItemRender?.mark === 'pro_table_render') {
    if (typeof formItemRender?.prepare === 'function') {
      const _clonedInnerRender = innerRender;
      innerRender = (...args) => _clonedInnerRender(args[0], formItemRender.prepare(...args));
    } else if (typeof formItemRender?.render === 'function') {
      innerRender = formItemRender.render;
    }
  }
```

这个 PR 合并了。pro 那边还要写一部分兼容性代码...  PR: https://github.com/ant-design/pro-components/pull/8935

---

因为要写测试用例断言 prepare 的执行入参数，jest 的断言 `expect.anything()` 无法断言 `null` 和 `undefined` 。[根据这篇文章](https://zirkelc.dev/posts/use-expectobjectcontaining-with-null-and-undefined) 添加 `jest-extended` 依赖作为拓展，支持如下断言

```tsx
      expect(mockPrepare).toHaveBeenCalledWith(
        expect.objectContaining({
          errors: expect.any(Array),
          warnings: expect.any(Array),
        }),
        // https://zirkelc.dev/posts/use-expectobjectcontaining-with-null-and-undefined
        expect.objectContaining({
          input: expect.anything(),
          errorList: expect.toBeOneOf([expect.anything(), null]),
          extra: expect.toBeOneOf([expect.anything(), null]),
        }),
      );
```

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --     |
| 🇨🇳 Chinese |    给 pro-comonents  内部 API 用       |
