### PR TITLE
feat: update input.search type and role (#52077)

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -16125,7 +16125,8 @@ exports[`ConfigProvider components Input configProvider 1`] = `
       >
         <input
           class="config-input config-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16225,7 +16226,8 @@ exports[`ConfigProvider components Input configProvider componentDisabled 1`] = 
         <input
           class="config-input config-input-disabled config-input-outlined"
           disabled=""
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16326,7 +16328,8 @@ exports[`ConfigProvider components Input configProvider componentSize large 1`] 
       >
         <input
           class="config-input config-input-lg config-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16424,7 +16427,8 @@ exports[`ConfigProvider components Input configProvider componentSize middle 1`]
       >
         <input
           class="config-input config-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16522,7 +16526,8 @@ exports[`ConfigProvider components Input configProvider componentSize small 1`] 
       >
         <input
           class="config-input config-input-sm config-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16620,7 +16625,8 @@ exports[`ConfigProvider components Input normal 1`] = `
       >
         <input
           class="ant-input ant-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -16718,7 +16724,8 @@ exports[`ConfigProvider components Input prefixCls 1`] = `
       >
         <input
           class="ant-input ant-input-outlined"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -150,6 +150,13 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     className,
   );
 
+  const newProps: InputProps = {
+    className: cls,
+    type: 'search',
+    role: 'searchbox',
+    ...restProps,
+  };
+
   const handleOnCompositionStart: React.CompositionEventHandler<HTMLInputElement> = (e) => {
     composedRef.current = true;
     onCompositionStart?.(e);
@@ -164,7 +171,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     <Input
       ref={composeRef<InputRef>(inputRef, ref)}
       onPressEnter={onPressEnter}
-      {...restProps}
+      {...newProps}
       size={size}
       onCompositionStart={handleOnCompositionStart}
       onCompositionEnd={handleOnCompositionEnd}
@@ -172,7 +179,6 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
       addonAfter={button}
       suffix={suffix}
       onChange={onChange}
-      className={cls}
       disabled={disabled}
     />
   );

--- a/components/input/__tests__/__snapshots__/Search.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/Search.test.tsx.snap
@@ -9,7 +9,8 @@ exports[`Input.Search rtl render component should be rendered correctly in RTL d
   >
     <input
       class="ant-input ant-input-rtl ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -60,7 +61,8 @@ exports[`Input.Search should support ReactNode suffix without error 1`] = `
     >
       <input
         class="ant-input"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -116,7 +118,8 @@ exports[`Input.Search should support addonAfter 1`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -167,7 +170,8 @@ exports[`Input.Search should support addonAfter 2`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -221,7 +225,8 @@ exports[`Input.Search should support addonAfter and suffix for loading 1`] = `
     >
       <input
         class="ant-input"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -279,7 +284,8 @@ exports[`Input.Search should support addonAfter and suffix for loading 2`] = `
     >
       <input
         class="ant-input"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -334,7 +340,8 @@ exports[`Input.Search should support custom Button 1`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -362,7 +369,8 @@ exports[`Input.Search should support custom button 1`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -387,7 +395,8 @@ exports[`Input.Search should support invalid addonAfter 1`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -438,7 +447,8 @@ exports[`Input.Search should support invalid suffix 1`] = `
     >
       <input
         class="ant-input"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -490,7 +500,8 @@ exports[`Input.Search should support loading 1`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span
@@ -538,7 +549,8 @@ exports[`Input.Search should support loading 2`] = `
   >
     <input
       class="ant-input ant-input-outlined"
-      type="text"
+      role="searchbox"
+      type="search"
       value=""
     />
     <span

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5801,7 +5801,8 @@ exports[`renders components/input/demo/compact-style.tsx extend context correctl
             <input
               class="ant-input"
               placeholder="input search text"
-              type="text"
+              role="searchbox"
+              type="search"
               value=""
             />
             <span
@@ -7021,7 +7022,8 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
         >
           <input
             class="ant-input"
-            type="text"
+            role="searchbox"
+            type="search"
             value="0571"
           />
           <span
@@ -7101,7 +7103,8 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
         >
           <input
             class="ant-input"
-            type="text"
+            role="searchbox"
+            type="search"
             value="26888888"
           />
           <span
@@ -10869,7 +10872,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
         <input
           class="ant-input ant-input-outlined"
           placeholder="input search text"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -10923,7 +10927,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           <input
             class="ant-input"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -11013,7 +11018,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           <input
             class="ant-input"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -11094,7 +11100,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
         <input
           class="ant-input ant-input-outlined"
           placeholder="input search text"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -11147,7 +11154,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           <input
             class="ant-input ant-input-lg"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -11211,7 +11219,8 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           <input
             class="ant-input ant-input-lg"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -11270,7 +11279,8 @@ Array [
       <input
         class="ant-input ant-input-outlined"
         placeholder="input search loading default"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -11318,7 +11328,8 @@ Array [
       <input
         class="ant-input ant-input-outlined"
         placeholder="input search loading with enterButton"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -11366,7 +11377,8 @@ Array [
       <input
         class="ant-input ant-input-lg ant-input-outlined"
         placeholder="input search text"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1683,7 +1683,8 @@ exports[`renders components/input/demo/compact-style.tsx correctly 1`] = `
             <input
               class="ant-input"
               placeholder="input search text"
-              type="text"
+              role="searchbox"
+              type="search"
               value=""
             />
             <span
@@ -2714,7 +2715,8 @@ exports[`renders components/input/demo/group.tsx correctly 1`] = `
         >
           <input
             class="ant-input"
-            type="text"
+            role="searchbox"
+            type="search"
             value="0571"
           />
           <span
@@ -2794,7 +2796,8 @@ exports[`renders components/input/demo/group.tsx correctly 1`] = `
         >
           <input
             class="ant-input"
-            type="text"
+            role="searchbox"
+            type="search"
             value="26888888"
           />
           <span
@@ -4192,7 +4195,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
         <input
           class="ant-input ant-input-outlined"
           placeholder="input search text"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -4246,7 +4250,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           <input
             class="ant-input"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -4336,7 +4341,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           <input
             class="ant-input"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -4417,7 +4423,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
         <input
           class="ant-input ant-input-outlined"
           placeholder="input search text"
-          type="text"
+          role="searchbox"
+          type="search"
           value=""
         />
         <span
@@ -4470,7 +4477,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           <input
             class="ant-input ant-input-lg"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -4534,7 +4542,8 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           <input
             class="ant-input ant-input-lg"
             placeholder="input search text"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -4591,7 +4600,8 @@ Array [
       <input
         class="ant-input ant-input-outlined"
         placeholder="input search loading default"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -4639,7 +4649,8 @@ Array [
       <input
         class="ant-input ant-input-outlined"
         placeholder="input search loading with enterButton"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span
@@ -4687,7 +4698,8 @@ Array [
       <input
         class="ant-input ant-input-lg ant-input-outlined"
         placeholder="input search text"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -901,7 +901,8 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value="0571"
           />
           <span
@@ -950,7 +951,8 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
           >
             <input
               class="ant-input"
-              type="text"
+              role="searchbox"
+              type="search"
               value="26888888"
             />
             <span
@@ -1027,7 +1029,8 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value="+1"
           />
           <span
@@ -10918,7 +10921,8 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -10963,7 +10967,8 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -14524,7 +14529,8 @@ Array [
             <input
               class="ant-input ant-input-outlined"
               placeholder="Search"
-              type="text"
+              role="searchbox"
+              type="search"
               value=""
             />
             <span

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -620,7 +620,8 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value="0571"
           />
           <span
@@ -669,7 +670,8 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
           >
             <input
               class="ant-input"
-              type="text"
+              role="searchbox"
+              type="search"
               value="26888888"
             />
             <span
@@ -746,7 +748,8 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value="+1"
           />
           <span
@@ -2910,7 +2913,8 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -2955,7 +2959,8 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
         >
           <input
             class="ant-input ant-input-outlined"
-            type="text"
+            role="searchbox"
+            type="search"
             value=""
           />
           <span
@@ -4145,7 +4150,8 @@ Array [
             <input
               class="ant-input ant-input-outlined"
               placeholder="Search"
-              type="text"
+              role="searchbox"
+              type="search"
               value=""
             />
             <span

--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4362,7 +4362,8 @@ exports[`renders components/tree/demo/search.tsx extend context correctly 1`] = 
       <input
         class="ant-input ant-input-outlined"
         placeholder="Search"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -4245,7 +4245,8 @@ exports[`renders components/tree/demo/search.tsx correctly 1`] = `
       <input
         class="ant-input ant-input-outlined"
         placeholder="Search"
-        type="text"
+        role="searchbox"
+        type="search"
         value=""
       />
       <span


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

[issues/52077](https://github.com/ant-design/ant-design/issues/52077)
The rendered HTML <input> element has its type attribute set to "text", which gives the input an implicit role of "textbox".

### 💡 Background and Solution

add "search" type and "searchbox" role

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add "search" type and role "searchbox" for Input.Search   |
| 🇨🇳 Chinese |  为input.search元素补充"search" type和"searchbox" role  |
