### PR TITLE
fix(collapse): enhance focus styles and border radius for collapse items

### DIFF
--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import { unit } from '@ant-design/cssinjs';
 
-import { resetComponent, resetIcon } from '../../style';
+import { genFocusStyle, resetComponent, resetIcon } from '../../style';
 import { genCollapseMotion } from '../../style/motion';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
@@ -95,6 +95,14 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
 
       [`& > ${componentCls}-item`]: {
         borderBottom: borderBase,
+        '&:first-child': {
+          [`
+            &,
+            & > ${componentCls}-header`]: {
+            borderRadius: `${unit(collapsePanelBorderRadius)} ${unit(collapsePanelBorderRadius)} 0 0`,
+          },
+        },
+
         '&:last-child': {
           [`
             &,
@@ -115,6 +123,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken> = (token) => {
           lineHeight,
           cursor: 'pointer',
           transition: `all ${motionDurationSlow}, visibility 0s`,
+          ...genFocusStyle(token),
 
           [`> ${componentCls}-header-text`]: {
             flex: 'auto',


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 💄 Component style improvement

### 🔗 Related Issues

none

### 💡 Background and Solution
统一一下聚焦的样式

**Before:**
![Clipboard-20241222-083143-571](https://github.com/user-attachments/assets/004fa156-fdd5-48e3-bd32-db99f7670f28)

**After**
![Clipboard-20241222-083303-329](https://github.com/user-attachments/assets/3c543356-c404-415c-89f5-1e141dcd8041)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     enhance focus styles and border radius for collapse items      |
| 🇨🇳 Chinese |    优化聚焦样式以及折叠项圆角       |
