### PR TITLE
Slight wording fix to match correct HN name ("Hacker News")

### DIFF
--- a/docs/spec/introduce.en-US.md
+++ b/docs/spec/introduce.en-US.md
@@ -56,7 +56,7 @@ We provide comprehensive design guidelines, best practices, resources, and tools
 
 ## Words From Community
 
-- Hacknews: [Show HN: Antd – A set of high-quality React components](https://news.ycombinator.com/item?id=13053137)
+- Hacker News: [Show HN: Antd – A set of high-quality React components](https://news.ycombinator.com/item?id=13053137)
 - Alligator: [Crafting Beautiful UIs in React Using Ant Design](https://alligator.io/react/beautiful-uis-ant-design/)
 - [Introduction to Ant Design](https://blog.logrocket.com/introduction-to-ant-design/)
 - [Build a React App with Ant Design Principles](https://developer.okta.com/blog/2020/09/16/ant-design-react-app)


### PR DESCRIPTION
[news.ycombinator.com](https://news.ycombinator.com) has title formatted as "Hacker News" rather than Hacknews. There are a few other sites with the latter name, so having this might help to make this clearer.


### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 📝 Change Log

> - Minimal development impact, this is just cleaning up the docs.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Changes link name from Hacknews to Hacker News to match official title format given by Y Combinator.          |
