### PR TITLE
fix: reactRender is not a function in React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "rc-tree": "~5.10.1",
     "rc-tree-select": "~5.24.5",
     "rc-upload": "~4.8.1",
-    "rc-util": "^5.44.2",
+    "rc-util": "^5.44.3",
     "scroll-into-view-if-needed": "^3.1.0",
     "throttle-debounce": "^5.0.2"
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

- fix https://github.com/ant-design/ant-design/issues/52080
- fix https://github.com/ant-design/ant-design/issues/52091
- fix https://github.com/ant-design/ant-design/issues/52079
- fix https://github.com/ant-design/ant-design/issues/52078

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

- 先加个判空逻辑，至少先保证不报错：https://github.com/react-component/util/pull/609

React 19 下的 antd 兼容性表现：

- Wave 水波效果将会失效：https://codesandbox.io/p/sandbox/ndsdws
- message/notifiction/Modal.confirm 等静态方法将会失效，但 useApp、useMessage、useModal、useNotification 可以使用：https://codesandbox.io/p/sandbox/ndsdws

---

Add a null check logic first to ensure that it does not throw an error: https://github.com/react-component/util/pull/609

Compatibility behavior of antd under React 19:
- The Wave ripple effect will be disabled: https://codesandbox.io/p/sandbox/ndsdws
- Static methods such as message, notification, and Modal.confirm will fail, but useApp, useMessage, useModal, and useNotification hooks can still be used: https://codesandbox.io/p/sandbox/ndsdws


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Button throws `reactRender is not a function` under React 19. |
| 🇨🇳 Chinese |  修复在 React 19 下点击 Button 时抛出 `reactRender is not a function` 错误的问题。        |