### PR TITLE
feat:transfer开启showSearch漏出input相关配置

### DIFF
--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -859,7 +859,7 @@ describe('Transfer', () => {
     expect(searchInputs).toHaveLength(2);
     searchInputs.forEach((input) => {
       expect(input.getAttribute('placeholder')).toBe('Search placeholder');
-      expect(input.value).toBe('values');
+      expect(input).toHaveValue('values');
     });
   });
 });

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -365,7 +365,7 @@ describe('Transfer', () => {
   });
 
   it('should display the correct locale and ignore old API', () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { notFoundContent: 'old1', searchPlaceholder: 'old2' };
@@ -745,7 +745,7 @@ describe('Transfer', () => {
   });
 
   it('control mode select all should not throw warning', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
 
     const App: React.FC = () => {
       const [selectedKeys, setSelectedKeys] = useState<TransferProps['selectedKeys']>([]);
@@ -842,6 +842,37 @@ describe('Transfer', () => {
           ?.querySelector('input[type="checkbox"]')!,
       ).toBeChecked();
     });
+  });
+
+  it('showSearch with single object', () => {
+    const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
+    const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
+    const { getAllByPlaceholderText, getAllByDisplayValue } = render(
+      <Transfer {...listCommonProps} {...emptyProps} showSearch={{ placeholder: "Search placeholder", defaultValue: "values" }} locale={locale} />,
+    );
+    expect(getAllByPlaceholderText('Search placeholder')).toHaveLength(2);
+    expect(getAllByDisplayValue('values')).toHaveLength(2);
+  });
+
+  it('showSearch with array of objects', () => {
+    const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
+    const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
+    const { getByPlaceholderText, getByDisplayValue } = render(
+      <Transfer {...listCommonProps} {...emptyProps}
+        showSearch={[
+          { placeholder: "Search placeholder", defaultValue: "values" },
+          { placeholder: "Search placeholder right", defaultValue: "values right" }
+        ]}
+        locale={locale}
+      />,
+    );
+    // 检查左侧搜索框的占位符和默认值
+    expect(getByPlaceholderText('Search placeholder')).toBeInTheDocument();
+    expect(getByDisplayValue('values')).toBeInTheDocument();
+
+    // 检查右侧搜索框的占位符和默认值
+    expect(getByPlaceholderText('Search placeholder right')).toBeInTheDocument();
+    expect(getByDisplayValue('values right')).toBeInTheDocument();
   });
 });
 

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -847,7 +847,7 @@ describe('Transfer', () => {
   it('showSearch with single object', () => {
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
-    const { getAllByPlaceholderText, getAllByDisplayValue } = render(
+    const { container } = render(
       <Transfer
         {...listCommonProps}
         {...emptyProps}
@@ -855,8 +855,12 @@ describe('Transfer', () => {
         locale={locale}
       />,
     );
-    expect(getAllByPlaceholderText('Search placeholder')).toHaveLength(2);
-    expect(getAllByDisplayValue('values')).toHaveLength(2);
+    const searchInputs = container.querySelectorAll('.ant-transfer-list-search input');
+    expect(searchInputs).toHaveLength(2);
+    searchInputs.forEach((input) => {
+      expect(input.getAttribute('placeholder')).toBe('Search placeholder');
+      expect(input.value).toBe('values');
+    });
   });
 });
 

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -6,8 +6,8 @@ import type { SelectAllLabel, TransferProps } from '..';
 import Transfer from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import Button from '../../button';
 import { waitFakeTimer } from '../../../tests/utils';
+import Button from '../../button';
 
 const listCommonProps: {
   dataSource: { key: string; title: string; disabled?: boolean }[];
@@ -365,7 +365,7 @@ describe('Transfer', () => {
   });
 
   it('should display the correct locale and ignore old API', () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { notFoundContent: 'old1', searchPlaceholder: 'old2' };
@@ -745,7 +745,7 @@ describe('Transfer', () => {
   });
 
   it('control mode select all should not throw warning', () => {
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const App: React.FC = () => {
       const [selectedKeys, setSelectedKeys] = useState<TransferProps['selectedKeys']>([]);
@@ -848,7 +848,12 @@ describe('Transfer', () => {
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
     const { getAllByPlaceholderText, getAllByDisplayValue } = render(
-      <Transfer {...listCommonProps} {...emptyProps} showSearch={{ placeholder: "Search placeholder", defaultValue: "values" }} locale={locale} />,
+      <Transfer
+        {...listCommonProps}
+        {...emptyProps}
+        showSearch={{ placeholder: 'Search placeholder', defaultValue: 'values' }}
+        locale={locale}
+      />,
     );
     expect(getAllByPlaceholderText('Search placeholder')).toHaveLength(2);
     expect(getAllByDisplayValue('values')).toHaveLength(2);
@@ -858,10 +863,12 @@ describe('Transfer', () => {
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
     const { getByPlaceholderText, getByDisplayValue } = render(
-      <Transfer {...listCommonProps} {...emptyProps}
+      <Transfer
+        {...listCommonProps}
+        {...emptyProps}
         showSearch={[
-          { placeholder: "Search placeholder", defaultValue: "values" },
-          { placeholder: "Search placeholder right", defaultValue: "values right" }
+          { placeholder: 'Search placeholder', defaultValue: 'values' },
+          { placeholder: 'Search placeholder right', defaultValue: 'values right' },
         ]}
         locale={locale}
       />,

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -858,29 +858,6 @@ describe('Transfer', () => {
     expect(getAllByPlaceholderText('Search placeholder')).toHaveLength(2);
     expect(getAllByDisplayValue('values')).toHaveLength(2);
   });
-
-  it('showSearch with array of objects', () => {
-    const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
-    const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };
-    const { getByPlaceholderText, getByDisplayValue } = render(
-      <Transfer
-        {...listCommonProps}
-        {...emptyProps}
-        showSearch={[
-          { placeholder: 'Search placeholder', defaultValue: 'values' },
-          { placeholder: 'Search placeholder right', defaultValue: 'values right' },
-        ]}
-        locale={locale}
-      />,
-    );
-    // 检查左侧搜索框的占位符和默认值
-    expect(getByPlaceholderText('Search placeholder')).toBeInTheDocument();
-    expect(getByDisplayValue('values')).toBeInTheDocument();
-
-    // 检查右侧搜索框的占位符和默认值
-    expect(getByPlaceholderText('Search placeholder right')).toBeInTheDocument();
-    expect(getByDisplayValue('values right')).toBeInTheDocument();
-  });
 });
 
 describe('immutable data', () => {

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -53,8 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode | - |  |
 | selectAllLabels | A set of customized labels for select all checkboxes on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] \| number\[] | \[] |  |
-| showSearch | If included, a search box is shown on each column | boolean | false |  |
-| searchOptions | Search box configuration item, which can configure the search boxes on both sides | { placeholder:string,defaultValue:string }\|{ placeholder:string,defaultValue:string }[] | {} |  |
+| showSearch | If included, a search box is shown on each column | boolean \| { placeholder:string,defaultValue:string } \| { placeholder:string,defaultValue:string }[] | false |  |
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | A set of keys of elements that are listed on the right column | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -54,7 +54,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | selectAllLabels | A set of customized labels for select all checkboxes on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] \| number\[] | \[] |  |
 | showSearch | If included, a search box is shown on each column | boolean | false |  |
-| searchOptions | Search box configuration item, which can configure the search boxes on both sides | { placeholder:string,defaultValue:string,... }\|{ placeholder:string,defaultValue:string,... }[] | {} |  |
+| searchOptions | Search box configuration item, which can configure the search boxes on both sides | { placeholder:string,defaultValue:string }\|{ placeholder:string,defaultValue:string }[] | {} |  |
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | A set of keys of elements that are listed on the right column | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -54,6 +54,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | selectAllLabels | A set of customized labels for select all checkboxes on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] \| number\[] | \[] |  |
 | showSearch | If included, a search box is shown on each column | boolean | false |  |
+| searchOptions | Search box configuration item, which can configure the search boxes on both sides | { placeholder:string,defaultValue:string,... }\|{ placeholder:string,defaultValue:string,... }[] | {} |  |
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | A set of keys of elements that are listed on the right column | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode | - |  |
 | selectAllLabels | A set of customized labels for select all checkboxes on the header | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | A set of keys of selected items | string\[] \| number\[] | \[] |  |
-| showSearch | If included, a search box is shown on each column | boolean \| { placeholder:string,defaultValue:string } \| { placeholder:string,defaultValue:string }[] | false |  |
+| showSearch | If included, a search box is shown on each column | boolean \| { placeholder:string,defaultValue:string } | false |  |
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | A set of keys of elements that are listed on the right column | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -72,7 +72,7 @@ export interface TransferLocale {
   selectInvert?: string;
   removeAll?: string;
   removeCurrent?: string;
-};
+}
 
 export interface TransferSearchOption {
   placeholder: string;
@@ -441,11 +441,11 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   const searchOption = React.useMemo(() => {
     if (Array.isArray(showSearch)) {
-      return [showSearch[0], showSearch[1]]
+      return [showSearch[0], showSearch[1]];
     } else {
-      return [showSearch, showSearch]
+      return [showSearch, showSearch];
     }
-  }, [showSearch])
+  }, [showSearch]);
 
   return wrapCSSVar(
     <div className={cls} style={{ ...transfer?.style, ...style }}>

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -75,8 +75,8 @@ export interface TransferLocale {
 }
 
 export interface TransferSearchOption {
-  placeholder: string;
-  defaultValue: string;
+  placeholder?: string;
+  defaultValue?: string;
 }
 
 export interface TransferProps<RecordType = any> {
@@ -99,7 +99,7 @@ export interface TransferProps<RecordType = any> {
   operationStyle?: CSSProperties;
   titles?: React.ReactNode[];
   operations?: string[];
-  showSearch?: boolean | boolean[] | TransferSearchOption | TransferSearchOption[];
+  showSearch?: boolean | TransferSearchOption;
   filterOption?: (inputValue: string, item: RecordType, direction: TransferDirection) => boolean;
   locale?: Partial<TransferLocale>;
   footer?: (
@@ -439,14 +439,6 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   const mergedSelectionsIcon = selectionsIcon ?? transfer?.selectionsIcon;
 
-  const searchOption = React.useMemo(() => {
-    if (Array.isArray(showSearch)) {
-      return [showSearch[0], showSearch[1]];
-    } else {
-      return [showSearch, showSearch];
-    }
-  }, [showSearch]);
-
   return wrapCSSVar(
     <div className={cls} style={{ ...transfer?.style, ...style }}>
       <List<KeyWise<RecordType>>
@@ -461,7 +453,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         onItemSelect={onLeftItemSelect}
         onItemSelectAll={onLeftItemSelectAll as any}
         render={render}
-        showSearch={searchOption[0]}
+        showSearch={showSearch}
         renderList={children as any}
         footer={footer as any}
         onScroll={handleLeftScroll}
@@ -499,7 +491,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         onItemSelectAll={onRightItemSelectAll as any}
         onItemRemove={onRightItemRemove}
         render={render}
-        showSearch={searchOption[1]}
+        showSearch={showSearch}
         renderList={children as any}
         footer={footer as any}
         onScroll={handleRightScroll}

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -99,7 +99,7 @@ export interface TransferProps<RecordType = any> {
   operationStyle?: CSSProperties;
   titles?: React.ReactNode[];
   operations?: string[];
-  showSearch?: boolean;
+  showSearch?: boolean | boolean[] | TransferSearchOption | TransferSearchOption[];
   filterOption?: (inputValue: string, item: RecordType, direction: TransferDirection) => boolean;
   locale?: Partial<TransferLocale>;
   footer?: (
@@ -116,7 +116,6 @@ export interface TransferProps<RecordType = any> {
   pagination?: PaginationType;
   status?: InputStatus;
   selectionsIcon?: React.ReactNode;
-  searchOptions?: TransferSearchOption | TransferSearchOption[];
 }
 
 const Transfer = <RecordType extends TransferItem = TransferItem>(
@@ -152,7 +151,6 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     onChange,
     onSearch,
     onSelectChange,
-    searchOptions={},
   } = props;
 
   const {
@@ -441,6 +439,14 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   const mergedSelectionsIcon = selectionsIcon ?? transfer?.selectionsIcon;
 
+  const searchOption = React.useMemo(() => {
+    if (Array.isArray(showSearch)) {
+      return [showSearch[0], showSearch[1]]
+    } else {
+      return [showSearch, showSearch]
+    }
+  }, [showSearch])
+
   return wrapCSSVar(
     <div className={cls} style={{ ...transfer?.style, ...style }}>
       <List<KeyWise<RecordType>>
@@ -455,7 +461,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         onItemSelect={onLeftItemSelect}
         onItemSelectAll={onLeftItemSelectAll as any}
         render={render}
-        showSearch={showSearch}
+        showSearch={searchOption[0]}
         renderList={children as any}
         footer={footer as any}
         onScroll={handleLeftScroll}
@@ -466,7 +472,6 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         pagination={mergedPagination}
         selectionsIcon={mergedSelectionsIcon}
         {...listLocale}
-        searchOptions={Array.isArray(searchOptions) ? searchOptions[0] : searchOptions}
       />
       <Operation
         className={`${prefixCls}-operation`}
@@ -494,7 +499,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         onItemSelectAll={onRightItemSelectAll as any}
         onItemRemove={onRightItemRemove}
         render={render}
-        showSearch={showSearch}
+        showSearch={searchOption[1]}
         renderList={children as any}
         footer={footer as any}
         onScroll={handleRightScroll}
@@ -506,7 +511,6 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         pagination={mergedPagination}
         selectionsIcon={mergedSelectionsIcon}
         {...listLocale}
-        searchOptions={Array.isArray(searchOptions) ? searchOptions[1] : searchOptions}
       />
     </div>,
   );

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -72,6 +72,11 @@ export interface TransferLocale {
   selectInvert?: string;
   removeAll?: string;
   removeCurrent?: string;
+};
+
+export interface TransferSearchOption {
+  placeholder: string;
+  defaultValue: string;
 }
 
 export interface TransferProps<RecordType = any> {
@@ -111,6 +116,7 @@ export interface TransferProps<RecordType = any> {
   pagination?: PaginationType;
   status?: InputStatus;
   selectionsIcon?: React.ReactNode;
+  searchOptions?: TransferSearchOption | TransferSearchOption[];
 }
 
 const Transfer = <RecordType extends TransferItem = TransferItem>(
@@ -146,6 +152,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     onChange,
     onSearch,
     onSelectChange,
+    searchOptions={},
   } = props;
 
   const {
@@ -459,6 +466,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         pagination={mergedPagination}
         selectionsIcon={mergedSelectionsIcon}
         {...listLocale}
+        searchOptions={Array.isArray(searchOptions) ? searchOptions[0] : searchOptions}
       />
       <Operation
         className={`${prefixCls}-operation`}
@@ -498,6 +506,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
         pagination={mergedPagination}
         selectionsIcon={mergedSelectionsIcon}
         {...listLocale}
+        searchOptions={Array.isArray(searchOptions) ? searchOptions[1] : searchOptions}
       />
     </div>,
   );

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -56,8 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] \| number\[] | \[] |  |
-| showSearch | 是否显示搜索框 | boolean | false |  |
-| searchOptions | 搜索框配置项,可对两侧搜索框进行配置 | { placeholder:string,defaultValue:string }\|{ placeholder:string,defaultValue:string }[] | {} |  |
+| showSearch | 是否显示搜索框，或可对两侧搜索框进行配置 | boolean \| { placeholder:string,defaultValue:string } \| { placeholder:string,defaultValue:string }[] | false |  |
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -56,7 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] \| number\[] | \[] |  |
-| showSearch | 是否显示 | boolean | false |  |
+| showSearch | 是否显示搜索框 | boolean | false |  |
 | searchOptions | 搜索框配置项,可对两侧搜索框进行配置 | { placeholder:string,defaultValue:string }\|{ placeholder:string,defaultValue:string }[] | {} |  |
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -57,7 +57,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] \| number\[] | \[] |  |
 | showSearch | 是否显示 | boolean | false |  |
-| searchOptions | 搜索框配置项,可对两侧搜索框进行配置 | { placeholder:string,defaultValue:string,... }\|{ placeholder:string,defaultValue:string,... }[] | {} |  |
+| searchOptions | 搜索框配置项,可对两侧搜索框进行配置 | { placeholder:string,defaultValue:string }\|{ placeholder:string,defaultValue:string }[] | {} |  |
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -56,7 +56,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] \| number\[] | \[] |  |
-| showSearch | 是否显示搜索框 | boolean | false |  |
+| showSearch | 是否显示 | boolean | false |  |
+| searchOptions | 搜索框配置项,可对两侧搜索框进行配置 | { placeholder:string,defaultValue:string,... }\|{ placeholder:string,defaultValue:string,... }[] | {} |  |
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] \| number\[] | \[] |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -56,7 +56,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |
 | selectAllLabels | 自定义顶部多选框标题的集合 | (ReactNode \| (info: { selectedCount: number, totalCount: number }) => ReactNode)\[] | - |  |
 | selectedKeys | 设置哪些项应该被选中 | string\[] \| number\[] | \[] |  |
-| showSearch | 是否显示搜索框，或可对两侧搜索框进行配置 | boolean \| { placeholder:string,defaultValue:string } \| { placeholder:string,defaultValue:string }[] | false |  |
+| showSearch | 是否显示搜索框，或可对两侧搜索框进行配置 | boolean \| { placeholder:string,defaultValue:string } | false |  |
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
 | targetKeys | 显示在右侧框数据的 key 集合 | string\[] \| number\[] | \[] |  |

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -14,6 +14,7 @@ import type {
   SelectAllLabel,
   TransferDirection,
   TransferLocale,
+  TransferSearchOption,
 } from './index';
 import type { PaginationType, TransferKey } from './interface';
 import type { ListBodyRef, TransferListBodyProps } from './ListBody';
@@ -79,9 +80,10 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   showRemove?: boolean;
   pagination?: PaginationType;
   selectionsIcon?: React.ReactNode;
+  searchOptions?: TransferSearchOption;
 }
 
-export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> {}
+export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> { }
 
 const TransferList = <RecordType extends KeyWiseTransferItem>(
   props: TransferListProps<RecordType>,
@@ -118,9 +120,10 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     handleClear,
     filterOption,
     render = defaultRender,
+    searchOptions
   } = props;
 
-  const [filterValue, setFilterValue] = useState<string>('');
+  const [filterValue, setFilterValue] = useState<string>(searchOptions?.defaultValue || '');
   const listBodyRef = useRef<ListBodyRef<RecordType>>({});
 
   const internalHandleFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -143,9 +146,9 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
   const renderListBody = (listProps: TransferListBodyProps<RecordType>) => {
     let bodyContent: React.ReactNode = renderList
       ? renderList({
-          ...listProps,
-          onItemSelect: (key, check) => listProps.onItemSelect(key, check),
-        })
+        ...listProps,
+        onItemSelect: (key, check) => listProps.onItemSelect(key, check),
+      })
       : null;
     const customize: boolean = !!bodyContent;
     if (!customize) {
@@ -206,10 +209,11 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     const search = showSearch ? (
       <div className={`${prefixCls}-body-search-wrapper`}>
         <Search
+          searchOptions={searchOptions}
           prefixCls={`${prefixCls}-search`}
           onChange={internalHandleFilter}
           handleClear={internalHandleClear}
-          placeholder={searchPlaceholder}
+          placeholder={searchOptions?.placeholder || searchPlaceholder}
           value={filterValue}
           disabled={disabled}
         />
@@ -307,15 +311,15 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
       /* Remove Current Page */
       pagination
         ? {
-            key: 'removeCurrent',
-            label: removeCurrent,
-            onClick() {
-              const pageKeys = getEnabledItemKeys(
-                (listBodyRef.current?.items || []).map((entity) => entity.item),
-              );
-              onItemRemove?.(pageKeys);
-            },
-          }
+          key: 'removeCurrent',
+          label: removeCurrent,
+          onClick() {
+            const pageKeys = getEnabledItemKeys(
+              (listBodyRef.current?.items || []).map((entity) => entity.item),
+            );
+            onItemRemove?.(pageKeys);
+          },
+        }
         : null,
       /* Remove All */
       {
@@ -338,13 +342,13 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
       },
       pagination
         ? {
-            key: 'selectCurrent',
-            label: selectCurrent,
-            onClick() {
-              const pageItems = listBodyRef.current?.items || [];
-              onItemSelectAll?.(getEnabledItemKeys(pageItems.map((entity) => entity.item)), true);
-            },
-          }
+          key: 'selectCurrent',
+          label: selectCurrent,
+          onClick() {
+            const pageItems = listBodyRef.current?.items || [];
+            onItemSelectAll?.(getEnabledItemKeys(pageItems.map((entity) => entity.item)), true);
+          },
+        }
         : null,
       {
         key: 'selectInvert',

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -84,6 +84,19 @@ export interface TransferListProps<RecordType> extends TransferLocale {
 
 export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> {}
 
+const useShowSearchOption = (showSearch: boolean | TransferSearchOption) => {
+  if (showSearch instanceof Object) {
+    return {
+      ...showSearch,
+      defaultValue: showSearch.defaultValue || '',
+    };
+  }
+  return {
+    defaultValue: '',
+    placeholder: '',
+  };
+};
+
 const TransferList = <RecordType extends KeyWiseTransferItem>(
   props: TransferListProps<RecordType>,
 ) => {
@@ -120,8 +133,8 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     filterOption,
     render = defaultRender,
   } = props;
-  const searchDefaultValue = showSearch instanceof Object ? showSearch?.defaultValue : '';
-  const [filterValue, setFilterValue] = useState<string>(searchDefaultValue);
+  const searchOptions = useShowSearchOption(showSearch);
+  const [filterValue, setFilterValue] = useState<string>(searchOptions.defaultValue);
   const listBodyRef = useRef<ListBodyRef<RecordType>>({});
 
   const internalHandleFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -203,12 +216,6 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     return 'part';
   }, [checkedKeys, checkedActiveItems]);
 
-  const searchOptions = useMemo<TransferSearchOption>(() => {
-    if (typeof showSearch === 'boolean') {
-      return {};
-    }
-    return showSearch;
-  }, [showSearch]);
   const listBody = useMemo<React.ReactNode>(() => {
     const search = showSearch ? (
       <div className={`${prefixCls}-body-search-wrapper`}>
@@ -217,7 +224,7 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
           prefixCls={`${prefixCls}-search`}
           onChange={internalHandleFilter}
           handleClear={internalHandleClear}
-          placeholder={searchOptions?.placeholder || searchPlaceholder}
+          placeholder={searchOptions.placeholder || searchPlaceholder}
           value={filterValue}
           disabled={disabled}
         />

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -82,7 +82,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   selectionsIcon?: React.ReactNode;
 }
 
-export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> { }
+export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> {}
 
 const TransferList = <RecordType extends KeyWiseTransferItem>(
   props: TransferListProps<RecordType>,
@@ -144,9 +144,9 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
   const renderListBody = (listProps: TransferListBodyProps<RecordType>) => {
     let bodyContent: React.ReactNode = renderList
       ? renderList({
-        ...listProps,
-        onItemSelect: (key, check) => listProps.onItemSelect(key, check),
-      })
+          ...listProps,
+          onItemSelect: (key, check) => listProps.onItemSelect(key, check),
+        })
       : null;
     const customize: boolean = !!bodyContent;
     if (!customize) {
@@ -205,10 +205,10 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
 
   const searchOptions = useMemo<TransferSearchOption>(() => {
     if (typeof showSearch === 'boolean') {
-      return {}
-    };
-    return showSearch
-  }, [showSearch])
+      return {};
+    }
+    return showSearch;
+  }, [showSearch]);
   const listBody = useMemo<React.ReactNode>(() => {
     const search = showSearch ? (
       <div className={`${prefixCls}-body-search-wrapper`}>
@@ -315,15 +315,15 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
       /* Remove Current Page */
       pagination
         ? {
-          key: 'removeCurrent',
-          label: removeCurrent,
-          onClick() {
-            const pageKeys = getEnabledItemKeys(
-              (listBodyRef.current?.items || []).map((entity) => entity.item),
-            );
-            onItemRemove?.(pageKeys);
-          },
-        }
+            key: 'removeCurrent',
+            label: removeCurrent,
+            onClick() {
+              const pageKeys = getEnabledItemKeys(
+                (listBodyRef.current?.items || []).map((entity) => entity.item),
+              );
+              onItemRemove?.(pageKeys);
+            },
+          }
         : null,
       /* Remove All */
       {
@@ -346,13 +346,13 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
       },
       pagination
         ? {
-          key: 'selectCurrent',
-          label: selectCurrent,
-          onClick() {
-            const pageItems = listBodyRef.current?.items || [];
-            onItemSelectAll?.(getEnabledItemKeys(pageItems.map((entity) => entity.item)), true);
-          },
-        }
+            key: 'selectCurrent',
+            label: selectCurrent,
+            onClick() {
+              const pageItems = listBodyRef.current?.items || [];
+              onItemSelectAll?.(getEnabledItemKeys(pageItems.map((entity) => entity.item)), true);
+            },
+          }
         : null,
       {
         key: 'selectInvert',

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -63,7 +63,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   handleClear: () => void;
   /** Render item */
   render?: (item: RecordType) => RenderResult;
-  showSearch?: boolean;
+  showSearch?: boolean | TransferSearchOption;
   searchPlaceholder: string;
   itemUnit: string;
   itemsUnit: string;
@@ -80,7 +80,6 @@ export interface TransferListProps<RecordType> extends TransferLocale {
   showRemove?: boolean;
   pagination?: PaginationType;
   selectionsIcon?: React.ReactNode;
-  searchOptions?: TransferSearchOption;
 }
 
 export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> { }
@@ -120,10 +119,9 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     handleClear,
     filterOption,
     render = defaultRender,
-    searchOptions
   } = props;
-
-  const [filterValue, setFilterValue] = useState<string>(searchOptions?.defaultValue || '');
+  const searchDefaultValue = showSearch instanceof Object ? showSearch?.defaultValue : '';
+  const [filterValue, setFilterValue] = useState<string>(searchDefaultValue);
   const listBodyRef = useRef<ListBodyRef<RecordType>>({});
 
   const internalHandleFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -205,6 +203,12 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     return 'part';
   }, [checkedKeys, checkedActiveItems]);
 
+  const searchOptions = useMemo<TransferSearchOption>(() => {
+    if (typeof showSearch === 'boolean') {
+      return {}
+    };
+    return showSearch
+  }, [showSearch])
   const listBody = useMemo<React.ReactNode>(() => {
     const search = showSearch ? (
       <div className={`${prefixCls}-body-search-wrapper`}>

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -220,7 +220,6 @@ const TransferList = <RecordType extends KeyWiseTransferItem>(
     const search = showSearch ? (
       <div className={`${prefixCls}-body-search-wrapper`}>
         <Search
-          searchOptions={searchOptions}
           prefixCls={`${prefixCls}-search`}
           onChange={internalHandleFilter}
           handleClear={internalHandleClear}

--- a/components/transfer/list.tsx
+++ b/components/transfer/list.tsx
@@ -85,7 +85,7 @@ export interface TransferListProps<RecordType> extends TransferLocale {
 export interface TransferCustomListBodyProps<T> extends TransferListBodyProps<T> {}
 
 const useShowSearchOption = (showSearch: boolean | TransferSearchOption) => {
-  if (showSearch instanceof Object) {
+  if (showSearch && typeof showSearch === 'object') {
     return {
       ...showSearch,
       defaultValue: showSearch.defaultValue || '',

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
 
-import Input from '../input';
 import type { TransferSearchOption } from '.';
+import Input from '../input';
 
 export interface TransferSearchProps {
   prefixCls?: string;
@@ -15,7 +15,15 @@ export interface TransferSearchProps {
 }
 
 const Search: React.FC<TransferSearchProps> = (props) => {
-  const { placeholder = '', value, prefixCls, disabled, onChange, handleClear, searchOptions } = props;
+  const {
+    placeholder = '',
+    value,
+    prefixCls,
+    disabled,
+    onChange,
+    handleClear,
+    searchOptions,
+  } = props;
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
-
-import type { TransferSearchOption } from '.';
 import Input from '../input';
 
 export interface TransferSearchProps {
@@ -11,7 +9,6 @@ export interface TransferSearchProps {
   handleClear?: () => void;
   value?: string;
   disabled?: boolean;
-  searchOptions?: TransferSearchOption;
 }
 
 const Search: React.FC<TransferSearchProps> = (props) => {
@@ -22,7 +19,6 @@ const Search: React.FC<TransferSearchProps> = (props) => {
     disabled,
     onChange,
     handleClear,
-    searchOptions,
   } = props;
 
   const handleChange = React.useCallback(
@@ -37,7 +33,6 @@ const Search: React.FC<TransferSearchProps> = (props) => {
 
   return (
     <Input
-      {...searchOptions}
       placeholder={placeholder}
       className={prefixCls}
       value={value}

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
 
 import Input from '../input';
+import type { TransferSearchOption } from '.';
 
 export interface TransferSearchProps {
   prefixCls?: string;
@@ -10,10 +11,11 @@ export interface TransferSearchProps {
   handleClear?: () => void;
   value?: string;
   disabled?: boolean;
+  searchOptions?: TransferSearchOption;
 }
 
 const Search: React.FC<TransferSearchProps> = (props) => {
-  const { placeholder = '', value, prefixCls, disabled, onChange, handleClear } = props;
+  const { placeholder = '', value, prefixCls, disabled, onChange, handleClear, searchOptions } = props;
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -27,6 +29,7 @@ const Search: React.FC<TransferSearchProps> = (props) => {
 
   return (
     <Input
+      {...searchOptions}
       placeholder={placeholder}
       className={prefixCls}
       value={value}


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
- [x] ⭐️ Feature enhancement

### 🔗 Related Issues
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
fix #17240

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Transfer opens showSearch, revealing Input related configurations, defaultValue and placeholder      |
| 🇨🇳 Chinese |     Transfer 开启 showSearch漏出 input相关配置,defaultValue和placeholder      |
