### PR TITLE
fix(FormItem): fix formItem.useStatus() update when error message upd…

### DIFF
--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -98,7 +98,14 @@ export default function StatusProvider({
     }
 
     return context;
-  }, [mergedValidateStatus, hasFeedback, noStyle, parentIsFormItemInput, parentStatus, errors]);
+  }, [
+    mergedValidateStatus,
+    hasFeedback,
+    noStyle,
+    parentIsFormItemInput,
+    parentStatus,
+    errors.join(),
+  ]);
 
   // ======================= Render =======================
   return (

--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -98,7 +98,7 @@ export default function StatusProvider({
     }
 
     return context;
-  }, [mergedValidateStatus, hasFeedback, noStyle, parentIsFormItemInput, parentStatus]);
+  }, [mergedValidateStatus, hasFeedback, noStyle, parentIsFormItemInput, parentStatus, errors]);
 
   // ======================= Render =======================
   return (

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1943,6 +1943,73 @@ describe('Form', () => {
     );
   });
 
+  it('Form.Item.useStatus should update error message when returns of validator change', async () => {
+    const ErrorItem: React.FC = () => {
+      const { errors } = Form.Item.useStatus();
+      return <div className="test-error">{errors[0]}</div>;
+    };
+
+    const errorMessages = ['first error message', 'second error message'];
+    let errorMessagesIndex = 0;
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+
+      const error = Form.useWatch('error', form);
+
+      useEffect(() => {
+        form.validateFields();
+      }, [error]);
+
+      return (
+        <Form form={form} name="test-form" initialValues={{ error: '' }}>
+          <Form.Item
+            name="error"
+            rules={[
+              {
+                validator(_, value) {
+                  if (value === errorMessages[0]) {
+                    return Promise.reject(errorMessages[0]);
+                  }
+                  if (value === errorMessages[1]) {
+                    return Promise.reject(errorMessages[1]);
+                  }
+                  return Promise.resolve();
+                },
+              },
+            ]}
+          >
+            <ErrorItem />
+          </Form.Item>
+          <Button
+            className="change-message-button"
+            onClick={() => {
+              form.setFieldValue('error', errorMessages[errorMessagesIndex++] ?? '');
+            }}
+          >
+            Change message
+          </Button>
+        </Form>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    expect(container.querySelector('.test-error')).toHaveTextContent('');
+    await waitFakeTimer();
+
+    fireEvent.click(container.querySelector('.change-message-button')!);
+    await waitFakeTimer();
+    expect(container.querySelector('.test-error')).toHaveTextContent(errorMessages[0]);
+
+    fireEvent.click(container.querySelector('.change-message-button')!);
+    await waitFakeTimer();
+    expect(container.querySelector('.test-error')).toHaveTextContent(errorMessages[1]);
+
+    fireEvent.click(container.querySelector('.change-message-button')!);
+    await waitFakeTimer();
+    expect(container.querySelector('.test-error')).toHaveTextContent('');
+  });
+
   it('item customize margin', async () => {
     const computeSpy = jest
       .spyOn(window, 'getComputedStyle')


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues


### 💡 Background and Solution



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fixed an issue where when using FomItem.useStatus() in a custom component, FomItem.useStatus() would not update the latest error message when the error message was updated  |
| 🇨🇳 Chinese |  修复在自定义组件中使用 `FomItem.useStatus()` 时，当错误信息更新时 `FomItem.useStatus()` 不更新最新的错误信息的问题  |
