### PR TITLE
feat(Result): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -22,6 +22,7 @@ import type { MenuProps } from '../menu';
 import type { ModalProps } from '../modal';
 import type { ArgsProps } from '../notification/interface';
 import type { PaginationProps } from '../pagination';
+import type { ResultProps } from '../result';
 import type { SelectProps } from '../select';
 import type { SpaceProps } from '../space';
 import type { SpinProps } from '../spin';
@@ -178,6 +179,8 @@ export type SpaceConfig = ComponentStyleConfig & Pick<SpaceProps, 'size' | 'clas
 
 export type SpinConfig = ComponentStyleConfig & Pick<SpinProps, 'indicator'>;
 
+export type ResultConfig = ComponentStyleConfig & Pick<ResultProps, 'classNames' | 'styles'>;
+
 export type InputNumberConfig = ComponentStyleConfig & Pick<InputNumberProps, 'variant'>;
 
 export type CascaderConfig = ComponentStyleConfig & Pick<CascaderProps, 'variant'>;
@@ -268,7 +271,7 @@ export interface ConfigConsumerProps {
   mentions?: MentionsConfig;
   modal?: ModalConfig;
   progress?: ComponentStyleConfig;
-  result?: ComponentStyleConfig;
+  result?: ResultConfig;
   slider?: ComponentStyleConfig;
   breadcrumb?: ComponentStyleConfig;
   menu?: MenuConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -145,7 +145,7 @@ const {
 | progress | Set Progress common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | Set Rate common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| result | Set Result common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| result | Set Result common props | { className?: string, style?: React.CSSProperties , classNames?: [ResultProps\["classNames"\]](/components/result#api), styles?: [ResultProps\["styles"\]](/components/result#api)} | - | 5.7.0, `classNames` and `styles`: 5.23.0 |
 | skeleton | Set Skeleton common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | Set Segmented common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | Set Select common props | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -145,7 +145,7 @@ const {
 | progress | Set Progress common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | Set Rate common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| result | Set Result common props | { className?: string, style?: React.CSSProperties , classNames?: [ResultProps\["classNames"\]](/components/result#api), styles?: [ResultProps\["styles"\]](/components/result#api)} | - | 5.7.0, `classNames` and `styles`: 5.23.0 |
+| result | Set Result common props | { className?: string, style?: React.CSSProperties , classNames?: [ResultProps\["classNames"\]](/components/result#api), styles?: [ResultProps\["styles"\]](/components/result#api)} | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | skeleton | Set Skeleton common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | Set Segmented common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | Set Select common props | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -147,7 +147,7 @@ const {
 | progress | 设置 Progress 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | 设置 Rate 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [ResultProps\["classNames"\]](/components/result-cn#api), styles?: [ResultProps\["styles"\]](/components/result-cn#api) } | - | 5.7.0, `classNames` 和 `styles`: 5.23.0 |
 | skeleton | 设置 Skeleton 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | 设置 Segmented 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | 设置 Select 组件的通用属性 | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -147,7 +147,7 @@ const {
 | progress | 设置 Progress 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | rate | 设置 Rate 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [ResultProps\["classNames"\]](/components/result-cn#api), styles?: [ResultProps\["styles"\]](/components/result-cn#api) } | - | 5.7.0, `classNames` 和 `styles`: 5.23.0 |
+| result | 设置 Result 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [ResultProps\["classNames"\]](/components/result-cn#api), styles?: [ResultProps\["styles"\]](/components/result-cn#api) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | skeleton | 设置 Skeleton 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | segmented | 设置 Segmented 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | select | 设置 Select 组件的通用属性 | { className?: string, showSearch?: boolean, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/result/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/result/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1207,7 +1207,7 @@ exports[`renders components/result/demo/error.tsx extend context correctly 1`] =
     </button>
   </div>
   <div
-    class="ant-result-content"
+    class="ant-result-body"
   >
     <div
       class="desc"

--- a/components/result/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/result/__tests__/__snapshots__/demo.test.ts.snap
@@ -1197,7 +1197,7 @@ exports[`renders components/result/demo/error.tsx correctly 1`] = `
     </button>
   </div>
   <div
-    class="ant-result-content"
+    class="ant-result-body"
   >
     <div
       class="desc"

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -110,7 +110,7 @@ describe('Result', () => {
     const resultElement = container.querySelector('.ant-result') as HTMLElement;
     const resultTitleElement = container.querySelector('.ant-result-title') as HTMLElement;
     const resultSubTitleElement = container.querySelector('.ant-result-subtitle') as HTMLElement;
-    const resultBodyElement = container.querySelector('.ant-result-content') as HTMLElement;
+    const resultBodyElement = container.querySelector('.ant-result-body') as HTMLElement;
     const resultExtraElement = container.querySelector('.ant-result-extra') as HTMLElement;
     const resultIconElement = container.querySelector('.ant-result-icon') as HTMLElement;
 

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -75,4 +75,59 @@ describe('Result', () => {
     const { container: container2 } = render(<Result title="404" icon={false} />);
     expect(container2.querySelectorAll('.ant-result-icon')).toHaveLength(0);
   });
+
+  it('should apply custom styles to Result', () => {
+    const customClassNames = {
+      root: 'custom-root',
+      title: 'custom-title',
+      subTitle: 'custom-subTitle',
+      body: 'custom-body',
+      extra: 'custom-extra',
+      icon: 'custom-icon',
+    };
+
+    const customStyles = {
+      root: { color: 'red' },
+      title: { color: 'green' },
+      subTitle: { color: 'yellow' },
+      body: { color: 'blue' },
+      extra: { backgroundColor: 'blue' },
+      icon: { backgroundColor: 'black' },
+    };
+
+    const { container } = render(
+      <Result
+        title="title"
+        subTitle="subTitle"
+        extra={'extra'}
+        classNames={customClassNames}
+        styles={customStyles}
+      >
+        <div>The Content of Result</div>
+      </Result>,
+    );
+
+    const resultElement = container.querySelector('.ant-result') as HTMLElement;
+    const resultTitleElement = container.querySelector('.ant-result-title') as HTMLElement;
+    const resultSubTitleElement = container.querySelector('.ant-result-subtitle') as HTMLElement;
+    const resultBodyElement = container.querySelector('.ant-result-content') as HTMLElement;
+    const resultExtraElement = container.querySelector('.ant-result-extra') as HTMLElement;
+    const resultIconElement = container.querySelector('.ant-result-icon') as HTMLElement;
+
+    // check classNames
+    expect(resultElement.classList).toContain('custom-root');
+    expect(resultTitleElement.classList).toContain('custom-title');
+    expect(resultSubTitleElement.classList).toContain('custom-subTitle');
+    expect(resultBodyElement.classList).toContain('custom-body');
+    expect(resultExtraElement.classList).toContain('custom-extra');
+    expect(resultIconElement.classList).toContain('custom-icon');
+
+    // check styles
+    expect(resultElement.style.color).toBe('red');
+    expect(resultTitleElement.style.color).toBe('green');
+    expect(resultSubTitleElement.style.color).toBe('yellow');
+    expect(resultBodyElement.style.color).toBe('blue');
+    expect(resultExtraElement.style.backgroundColor).toBe('blue');
+    expect(resultIconElement.style.backgroundColor).toBe('black');
+  });
 });

--- a/components/result/demo/_semantic.tsx
+++ b/components/result/demo/_semantic.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Button, Result } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素',
+    title: '标题元素',
+    subTitle: '副标题元素',
+    body: '内容元素',
+    extra: '额外元素',
+    icon: '图标元素',
+  },
+  en: {
+    root: 'Root Element',
+    title: 'Title Element',
+    subTitle: 'Subtitle Element',
+    body: 'Content Element',
+    extra: 'Extra Element',
+    icon: 'Icon Element',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      semantics={[
+        { name: 'root', desc: locale.root, version: '5.23.0' },
+        { name: 'icon', desc: locale.icon, version: '5.23.0' },
+        { name: 'title', desc: locale.title, version: '5.23.0' },
+        { name: 'subTitle', desc: locale.subTitle, version: '5.23.0' },
+        { name: 'extra', desc: locale.extra, version: '5.23.0' },
+        { name: 'body', desc: locale.body, version: '5.23.0' },
+      ]}
+    >
+      <Result
+        title="title"
+        subTitle="subTitle"
+        extra={
+          <Button type="primary" key="console">
+            extra
+          </Button>
+        }
+      >
+        <div style={{ textAlign: 'center' }}>The Content of Result</div>
+      </Result>
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/result/demo/_semantic.tsx
+++ b/components/result/demo/_semantic.tsx
@@ -28,12 +28,12 @@ const App: React.FC = () => {
   return (
     <SemanticPreview
       semantics={[
-        { name: 'root', desc: locale.root, version: '5.23.0' },
-        { name: 'icon', desc: locale.icon, version: '5.23.0' },
-        { name: 'title', desc: locale.title, version: '5.23.0' },
-        { name: 'subTitle', desc: locale.subTitle, version: '5.23.0' },
-        { name: 'extra', desc: locale.extra, version: '5.23.0' },
-        { name: 'body', desc: locale.body, version: '5.23.0' },
+        { name: 'root', desc: locale.root, version: '6.0.0' },
+        { name: 'icon', desc: locale.icon, version: '6.0.0' },
+        { name: 'title', desc: locale.title, version: '6.0.0' },
+        { name: 'subTitle', desc: locale.subTitle, version: '6.0.0' },
+        { name: 'extra', desc: locale.extra, version: '6.0.0' },
+        { name: 'body', desc: locale.body, version: '6.0.0' },
       ]}
     >
       <Result

--- a/components/result/index.en-US.md
+++ b/components/result/index.en-US.md
@@ -36,6 +36,10 @@ Common props ref：[Common props](/docs/react/common-props)
 | subTitle | The subTitle | ReactNode | - |
 | title | The title | ReactNode | - |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="Result"></ComponentTokenTable>

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -39,6 +39,22 @@ export interface ResultProps {
   rootClassName?: string;
   style?: React.CSSProperties;
   children?: React.ReactNode;
+  classNames?: {
+    root?: string;
+    title?: string;
+    subTitle?: string;
+    body?: string;
+    extra?: string;
+    icon?: string;
+  };
+  styles?: {
+    root?: React.CSSProperties;
+    title?: React.CSSProperties;
+    subTitle?: React.CSSProperties;
+    body?: React.CSSProperties;
+    extra?: React.CSSProperties;
+    icon?: React.CSSProperties;
+  };
 }
 
 // ExceptionImageMap keys
@@ -52,14 +68,13 @@ const ExceptionStatus = Object.keys(ExceptionMap);
  */
 
 interface IconProps {
-  prefixCls: string;
+  className: string;
   icon: React.ReactNode;
   status: ResultStatusType;
+  style?: React.CSSProperties;
 }
 
-const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
-  const className = classNames(`${prefixCls}-icon`);
-
+const Icon: React.FC<IconProps> = ({ icon, status, className, style }) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Result');
 
@@ -73,7 +88,7 @@ const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
   if (ExceptionStatus.includes(`${status}`)) {
     const SVGComponent = ExceptionMap[status as ExceptionStatusType];
     return (
-      <div className={`${className} ${prefixCls}-image`}>
+      <div className={className} style={style}>
         <SVGComponent />
       </div>
     );
@@ -87,19 +102,28 @@ const Icon: React.FC<IconProps> = ({ prefixCls, icon, status }) => {
     return null;
   }
 
-  return <div className={className}>{icon || iconNode}</div>;
+  return (
+    <div className={className} style={style}>
+      {icon || iconNode}
+    </div>
+  );
 };
 
 interface ExtraProps {
-  prefixCls: string;
   extra: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
-const Extra: React.FC<ExtraProps> = ({ prefixCls, extra }) => {
+const Extra: React.FC<ExtraProps> = ({ className, extra, style }) => {
   if (!extra) {
     return null;
   }
-  return <div className={`${prefixCls}-extra`}>{extra}</div>;
+  return (
+    <div className={className} style={style}>
+      {extra}
+    </div>
+  );
 };
 
 export interface ResultType extends React.FC<ResultProps> {
@@ -119,6 +143,8 @@ const Result: ResultType = ({
   status = 'info',
   icon,
   extra,
+  styles,
+  classNames: resultClassNames,
 }) => {
   const { getPrefixCls, direction, result } = React.useContext(ConfigContext);
 
@@ -127,7 +153,7 @@ const Result: ResultType = ({
   // Style
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
 
-  const className = classNames(
+  const rootClassNames = classNames(
     prefixCls,
     `${prefixCls}-${status}`,
     customizeClassName,
@@ -136,17 +162,77 @@ const Result: ResultType = ({
     { [`${prefixCls}-rtl`]: direction === 'rtl' },
     hashId,
     cssVarCls,
+    result?.classNames?.root,
+    resultClassNames?.root,
   );
 
-  const mergedStyle: React.CSSProperties = { ...result?.style, ...style };
+  const titleClassNames = classNames(
+    `${prefixCls}-title`,
+    result?.classNames?.title,
+    resultClassNames?.title,
+  );
+
+  const subTitleClassNames = classNames(
+    `${prefixCls}-subtitle`,
+    result?.classNames?.subTitle,
+    resultClassNames?.subTitle,
+  );
+
+  const extraClassNames = classNames(
+    `${prefixCls}-extra`,
+    result?.classNames?.extra,
+    resultClassNames?.extra,
+  );
+
+  const bodyClassNames = classNames(
+    `${prefixCls}-content`,
+    result?.classNames?.body,
+    resultClassNames?.body,
+  );
+
+  const iconClassNames = classNames(
+    `${prefixCls}-icon`,
+    { [`${prefixCls}-image`]: ExceptionStatus.includes(`${status}`) },
+    result?.classNames?.icon,
+    resultClassNames?.icon,
+  );
+
+  const rootStyles: React.CSSProperties = {
+    ...result?.styles?.root,
+    ...styles?.root,
+    ...result?.style,
+    ...style,
+  };
 
   return wrapCSSVar(
-    <div className={className} style={mergedStyle}>
-      <Icon prefixCls={prefixCls} status={status} icon={icon} />
-      <div className={`${prefixCls}-title`}>{title}</div>
-      {subTitle && <div className={`${prefixCls}-subtitle`}>{subTitle}</div>}
-      <Extra prefixCls={prefixCls} extra={extra} />
-      {children && <div className={`${prefixCls}-content`}>{children}</div>}
+    <div className={rootClassNames} style={rootStyles}>
+      <Icon
+        className={iconClassNames}
+        style={{ ...result?.styles?.icon, ...styles?.icon }}
+        status={status}
+        icon={icon}
+      />
+      <div className={titleClassNames} style={{ ...result?.styles?.title, ...styles?.title }}>
+        {title}
+      </div>
+      {subTitle && (
+        <div
+          className={subTitleClassNames}
+          style={{ ...result?.styles?.subTitle, ...styles?.subTitle }}
+        >
+          {subTitle}
+        </div>
+      )}
+      <Extra
+        className={extraClassNames}
+        extra={extra}
+        style={{ ...result?.styles?.extra, ...styles?.extra }}
+      />
+      {children && (
+        <div className={bodyClassNames} style={{ ...result?.styles?.body, ...styles?.body }}>
+          {children}
+        </div>
+      )}
     </div>,
   );
 };

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -185,7 +185,7 @@ const Result: ResultType = ({
   );
 
   const bodyClassNames = classNames(
-    `${prefixCls}-content`,
+    `${prefixCls}-body`,
     result?.classNames?.body,
     resultClassNames?.body,
   );

--- a/components/result/index.zh-CN.md
+++ b/components/result/index.zh-CN.md
@@ -37,6 +37,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-0kxQrbHx2kAAA
 | subTitle | subTitle 文字 | ReactNode | - |
 | title | title 文字 | ReactNode | - |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Result"></ComponentTokenTable>

--- a/components/result/style/index.ts
+++ b/components/result/style/index.ts
@@ -93,7 +93,7 @@ const genBaseStyle: GenerateStyle<ResultToken> = (token): CSSObject => {
       textAlign: 'center',
     },
 
-    [`${componentCls} ${componentCls}-content`]: {
+    [`${componentCls} ${componentCls}-body`]: {
       marginTop: paddingLG,
       padding: `${unit(paddingLG)} ${unit(token.calc(padding).mul(2.5).equal())}`,
       backgroundColor: token.colorFillAlter,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    feat: ConfigProvider support classNames and styles for Result       |
| 🇨🇳 Chinese |        feat: ConfigProvider 支持 Result   组件的classNames 和styles 配置|
