### PR TITLE
feat:[Tree] selected background color is gray when the node is disabled

### DIFF
--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -90,7 +90,7 @@ exports[`renders components/tree/demo/basic.tsx extend context correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked"
             draggable="false"
           >
             <span
@@ -218,7 +218,7 @@ exports[`renders components/tree/demo/basic.tsx extend context correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected ant-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -260,7 +260,7 @@ exports[`renders components/tree/demo/basic.tsx extend context correctly 1`] = `
               />
             </span>
             <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open ant-tree-node-selected"
               title="parent 1-1"
             >
               <span
@@ -4120,7 +4120,7 @@ exports[`renders components/tree/demo/multiple-line.tsx extend context correctly
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked"
             draggable="false"
           >
             <span
@@ -4248,7 +4248,7 @@ exports[`renders components/tree/demo/multiple-line.tsx extend context correctly
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected ant-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -4290,7 +4290,7 @@ exports[`renders components/tree/demo/multiple-line.tsx extend context correctly
               />
             </span>
             <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open ant-tree-node-selected"
               title="parent 1-1"
             >
               <span

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -90,7 +90,7 @@ exports[`renders components/tree/demo/basic.tsx correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked"
             draggable="false"
           >
             <span
@@ -218,7 +218,7 @@ exports[`renders components/tree/demo/basic.tsx correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected ant-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -260,7 +260,7 @@ exports[`renders components/tree/demo/basic.tsx correctly 1`] = `
               />
             </span>
             <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open ant-tree-node-selected"
               title="parent 1-1"
             >
               <span
@@ -4005,7 +4005,7 @@ exports[`renders components/tree/demo/multiple-line.tsx correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected"
+            class="ant-tree-treenode ant-tree-treenode-disabled ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked"
             draggable="false"
           >
             <span
@@ -4133,7 +4133,7 @@ exports[`renders components/tree/demo/multiple-line.tsx correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-leaf-last"
+            class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-checkbox-checked ant-tree-treenode-selected ant-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -4175,7 +4175,7 @@ exports[`renders components/tree/demo/multiple-line.tsx correctly 1`] = `
               />
             </span>
             <span
-              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+              class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open ant-tree-node-selected"
               title="parent 1-1"
             >
               <span

--- a/components/tree/demo/basic.tsx
+++ b/components/tree/demo/basic.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
     <Tree
       checkable
       defaultExpandedKeys={['0-0-0', '0-0-1']}
-      defaultSelectedKeys={['0-0-0', '0-0-1']}
+      defaultSelectedKeys={['0-0-1']}
       defaultCheckedKeys={['0-0-0', '0-0-1']}
       onSelect={onSelect}
       onCheck={onCheck}

--- a/components/tree/demo/basic.tsx
+++ b/components/tree/demo/basic.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Tree } from 'antd';
 import type { TreeDataNode, TreeProps } from 'antd';
 
@@ -33,7 +33,9 @@ const treeData: TreeDataNode[] = [
 ];
 
 const App: React.FC = () => {
+ const [keys,setKeys] =useState(['0-0-0'])
   const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
+    setKeys(selectedKeys)
     console.log('selected', selectedKeys, info);
   };
 
@@ -45,10 +47,11 @@ const App: React.FC = () => {
     <Tree
       checkable
       defaultExpandedKeys={['0-0-0', '0-0-1']}
-      defaultSelectedKeys={['0-0-0', '0-0-1']}
+      // defaultSelectedKeys={['0-0-0', '0-0-1']}
       defaultCheckedKeys={['0-0-0', '0-0-1']}
       onSelect={onSelect}
       onCheck={onCheck}
+      selectedKeys={keys}
       treeData={treeData}
     />
   );

--- a/components/tree/demo/basic.tsx
+++ b/components/tree/demo/basic.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Tree } from 'antd';
 import type { TreeDataNode, TreeProps } from 'antd';
 
@@ -33,9 +33,7 @@ const treeData: TreeDataNode[] = [
 ];
 
 const App: React.FC = () => {
- const [keys,setKeys] =useState(['0-0-0'])
   const onSelect: TreeProps['onSelect'] = (selectedKeys, info) => {
-    setKeys(selectedKeys)
     console.log('selected', selectedKeys, info);
   };
 
@@ -47,11 +45,10 @@ const App: React.FC = () => {
     <Tree
       checkable
       defaultExpandedKeys={['0-0-0', '0-0-1']}
-      // defaultSelectedKeys={['0-0-0', '0-0-1']}
+      defaultSelectedKeys={['0-0-0', '0-0-1']}
       defaultCheckedKeys={['0-0-0', '0-0-1']}
       onSelect={onSelect}
       onCheck={onCheck}
-      selectedKeys={keys}
       treeData={treeData}
     />
   );

--- a/components/tree/demo/component-token.tsx
+++ b/components/tree/demo/component-token.tsx
@@ -58,7 +58,7 @@ const App: React.FC = () => {
       <Tree
         checkable
         defaultExpandedKeys={['0-0-0', '0-0-1']}
-        defaultSelectedKeys={['0-0-0', '0-0-1']}
+        defaultSelectedKeys={['0-0-1']}
         defaultCheckedKeys={['0-0-0', '0-0-1']}
         onSelect={onSelect}
         onCheck={onCheck}

--- a/components/tree/demo/directory-debug.md
+++ b/components/tree/demo/directory-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试 [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)[#28018](https://github.com/ant-design/ant-design/issues/28018)
+调试 [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)
 
 ## en-US
 
-Debugging [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)[#28018](https://github.com/ant-design/ant-design/issues/28018)
+Debugging [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)

--- a/components/tree/demo/directory-debug.md
+++ b/components/tree/demo/directory-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试 [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)
+调试 [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)[#28018](https://github.com/ant-design/ant-design/issues/28018)
 
 ## en-US
 
-Debugging [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)
+Debugging [#51210](https://github.com/ant-design/ant-design/pull/51210), [#51448](https://github.com/ant-design/ant-design/pull/51448#issuecomment-2449144872)[#28018](https://github.com/ant-design/ant-design/issues/28018)

--- a/components/tree/demo/directory-debug.tsx
+++ b/components/tree/demo/directory-debug.tsx
@@ -9,8 +9,8 @@ const treeData: TreeDataNode[] = [
     title: 'parent 0',
     key: '0-0',
     children: [
-      { title: 'leaf 0-0', key: '0-0-0', isLeaf: true },
-      { title: 'leaf 0-1', key: '0-0-1', isLeaf: true },
+      { title: 'leaf 0-0', key: '0-0-0', isLeaf: true, disabled: true },
+      { title: 'leaf 0-1', key: '0-0-1', isLeaf: true, disableCheckbox: true },
     ],
   },
   {
@@ -46,7 +46,7 @@ const BasicDemo = () => <DirectoryTree {...sharedProps} multiple treeData={treeD
 
 const NormalDemo = () => <Tree {...sharedProps} defaultSelectedKeys={['0-1']} />;
 
-const NormalCheckDemo = () => <Tree {...sharedProps} checkable defaultSelectedKeys={['0-1']} />;
+const NormalCheckDemo = () => <Tree {...sharedProps} checkable defaultSelectedKeys={['0-1','0-0-0', '0-0-1','0-1-1']} />;
 
 const NormalDragDemo = () => <Tree {...sharedProps} draggable defaultSelectedKeys={['0-1-0']} />;
 

--- a/components/tree/demo/multiple-line.tsx
+++ b/components/tree/demo/multiple-line.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
     <Tree
       checkable
       defaultExpandedKeys={['0-0-0', '0-0-1']}
-      defaultSelectedKeys={['0-0-0', '0-0-1']}
+      defaultSelectedKeys={['0-0-1']}
       defaultCheckedKeys={['0-0-0', '0-0-1']}
       onSelect={onSelect}
       onCheck={onCheck}

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -136,6 +136,10 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         transform: 'rotate(90deg)',
       },
 
+      [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected`]: {
+        backgroundColor: `${nodeHoverBg} !important`,
+      },
+
       [`&-focused:not(:hover):not(${treeCls}-active-focused)`]: {
         ...genFocusOutline(token),
       },

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -119,7 +119,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
     nodeSelectedBg,
     nodeHoverBg,
     colorTextQuaternary,
-    controlItemBgActiveDisabled
+    controlItemBgActiveDisabled,
   } = token;
   return {
     [treeCls]: {
@@ -136,9 +136,10 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         transform: 'rotate(90deg)',
       },
 
-      [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected`]: {
-        backgroundColor: `${controlItemBgActiveDisabled} !important`,
-      },
+      // [`${treeNodeCls}-disabled${treeCls}-node-selected ${treeCls}-node-content-wrapper`]: {
+      //   backgroundColor: `red`,
+
+      // },
 
       [`&-focused:not(:hover):not(${treeCls}-active-focused)`]: {
         ...genFocusOutline(token),
@@ -203,6 +204,14 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           },
         },
 
+        [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected`]: {
+          backgroundColor: `${controlItemBgActiveDisabled} `,
+        },
+        [`&${treeNodeCls}-disabled${treeNodeCls}-selected`]: {
+          [`${treeCls}-node-content-wrapper`]:{
+            backgroundColor: `${controlItemBgActiveDisabled} `,
+          }
+        },
         // not disable
         [`&:not(${treeNodeCls}-disabled)`]: {
           // >>> Title

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -119,8 +119,8 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
     nodeSelectedBg,
     nodeHoverBg,
     colorTextQuaternary,
+    controlItemBgActiveDisabled
   } = token;
-
   return {
     [treeCls]: {
       ...resetComponent(token),
@@ -137,7 +137,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       },
 
       [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected`]: {
-        backgroundColor: `${nodeHoverBg} !important`,
+        backgroundColor: `${controlItemBgActiveDisabled} !important`,
       },
 
       [`&-focused:not(:hover):not(${treeCls}-active-focused)`]: {

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -199,14 +199,11 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           },
         },
 
-        [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected`]: {
-          backgroundColor: `${controlItemBgActiveDisabled} `,
-        },
-        [`&${treeNodeCls}-disabled${treeNodeCls}-selected`]: {
-          [`${treeCls}-node-content-wrapper`]:{
-            backgroundColor: `${controlItemBgActiveDisabled} `,
-          }
-        },
+        [`${treeCls}-checkbox-disabled + ${treeCls}-node-selected,&${treeNodeCls}-disabled${treeNodeCls}-selected ${treeCls}-node-content-wrapper`]:
+          {
+            backgroundColor: controlItemBgActiveDisabled,
+          },
+
         // not disable
         [`&:not(${treeNodeCls}-disabled)`]: {
           // >>> Title

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -136,11 +136,6 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         transform: 'rotate(90deg)',
       },
 
-      // [`${treeNodeCls}-disabled${treeCls}-node-selected ${treeCls}-node-content-wrapper`]: {
-      //   backgroundColor: `red`,
-
-      // },
-
       [`&-focused:not(:hover):not(${treeCls}-active-focused)`]: {
         ...genFocusOutline(token),
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 💄 Component style improvement

### 🔗 Related Issues

fix #28018

### 💡 Background and Solution

#28018 
### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjust the background color of the text select status for the disableCheckbox item in the Tree component to gray      |
| 🇨🇳 Chinese |      对Tree组件中，disableCheckbox项目的select状态背景色调整为灰色     |
