### PR TITLE
fix(Menu): extra fontSize and vertical align

### DIFF
--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -652,7 +652,6 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           [`${componentCls}-item-extra`]: {
             marginInlineStart: 'auto',
             paddingInlineStart: token.padding,
-            fontSize: token.fontSizeSM,
           },
         },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fix #52215 

### 💡 Background and Solution

extra 字体比正文小，导致垂直不居中

![image](https://github.com/user-attachments/assets/c497ee27-1b89-45a2-b036-bcb821cadabe)

且某些情况下，比如放置帮助或外链图标，尺寸偏小，不协调

![image](https://github.com/user-attachments/assets/16719d5a-8fdf-4a1d-9bec-0e057cf72061)

将 extra 字体调整为何主体一致，则可以同时解决以上两个问题

![image](https://github.com/user-attachments/assets/ee2c639f-dcbc-4c68-8a54-cadb531f8d1d)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Menu): extra fontSize and vertical align |
| 🇨🇳 Chinese | fix(Menu): extra 字体大小和垂直居中对齐 |
