### PR TITLE
chore: fix website deploy action

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -117,7 +117,7 @@ jobs:
           cd ..
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           fail_on_unmatched_files: true
           files: website.tar.gz

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -117,7 +117,7 @@ jobs:
           cd ..
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@v2
         with:
           fail_on_unmatched_files: true
           files: website.tar.gz


### PR DESCRIPTION
去掉 GitHub actions 的锁，最近几次发版 ci 都遇到问题，https://github.com/softprops/action-gh-release/issues/556

错误日志：https://github.com/ant-design/ant-design/actions/runs/12629487217/job/35187742612

对比发现自己之前测试的时候没有锁版本： https://github.com/Wxh16144/test-ci/actions/runs/12260062550/workflow#L65 ，这个 PR 继续向下锁版本看看， 参考了 https://github.com/slsa-framework/slsa-github-generator/pull/4036 这个人的提交