### PR TITLE
feat: memoize DisabledContext value using useMemo in DisabledContextProvider

### DIFF
--- a/components/config-provider/DisabledContext.tsx
+++ b/components/config-provider/DisabledContext.tsx
@@ -9,11 +9,8 @@ export interface DisabledContextProps {
 
 export const DisabledContextProvider: React.FC<DisabledContextProps> = ({ children, disabled }) => {
   const originDisabled = React.useContext(DisabledContext);
-  return (
-    <DisabledContext.Provider value={disabled ?? originDisabled}>
-      {children}
-    </DisabledContext.Provider>
-  );
+  const value = React.useMemo(() => disabled ?? originDisabled, [disabled, originDisabled]);
+  return <DisabledContext.Provider value={value}>{children}</DisabledContext.Provider>;
 };
 
 export default DisabledContext;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

### 💡 Background and Solution

![image](https://github.com/user-attachments/assets/79f711be-4b15-4217-9b91-c6d6cbe68264)

This PR refactors the `DisabledContextProvider` component to use `useMemo` for memoizing the context value. This change resolves the ESLint warning `react/no-unstable-context-value` by ensuring that the context value only updates when its dependencies (`disabled`, `originDisabled`) change, preventing unnecessary re-renders.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Memoized `DisabledContext` value using `useMemo`.     |
| 🇨🇳 Chinese |    使用 `useMemo` memoize `DisabledContext` 的值       |
