### PR TITLE
fix: 修复响应式关于断点说明使用屏幕宽度的错误

### DIFF
--- a/components/grid/index.zh-CN.md
+++ b/components/grid/index.zh-CN.md
@@ -76,12 +76,12 @@ Ant Design 的布局组件若不能满足你的需求，你也可以直接使用
 | pull | 栅格向左移动格数 | number | 0 |  |
 | push | 栅格向右移动格数 | number | 0 |  |
 | span | 栅格占位格数，为 0 时相当于 `display: none` | number | - |  |
-| xs | `屏幕 < 576px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
-| sm | `屏幕 ≥ 576px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
-| md | `屏幕 ≥ 768px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
-| lg | `屏幕 ≥ 992px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
-| xl | `屏幕 ≥ 1200px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
-| xxl | `屏幕 ≥ 1600px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| xs | `窗口宽度 < 576px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| sm | `窗口宽度 ≥ 576px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| md | `窗口宽度 ≥ 768px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| lg | `窗口宽度 ≥ 992px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| xl | `窗口宽度 ≥ 1200px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
+| xxl | `窗口宽度 ≥ 1600px` 响应式栅格，可为栅格数或一个包含其他属性的对象 | number \| object | - |  |
 
 您可以使用 [主题定制](/docs/react/customize-theme-cn) 修改 `screen[XS|SM|MD|LG|XL|XXL]` 来修改断点值（自 5.1.0 起，[codesandbox demo](https://codesandbox.io/s/antd-reproduction-template-forked-dlq3r9?file=/index.js)）。
 


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

> 1. 描述相关需求的来源，如相关的 issue 讨论链接。
> 2. 例如 close #xxxx、 fix #xxxx

### 💡 需求背景和解决方案

> 1. 关于栅格响应式断点的描述使用“屏幕”有误，实际上是窗口宽度。
> 2. 实际上应该是窗口宽度影响了响应式，可根据该demo测试 https://codesandbox.io/s/antd-reproduction-template-forked-dlq3r9?file=/index.js 拉伸窗口时，窗口尺寸导致断点变化，而此时屏幕分辨率并未变化，此前说屏幕影响响应式容易造成误解。

### 📝 更新日志

> - 修改响应式断点使用“屏幕”作为影响因子的描述，改为“窗口宽度”

| 语言    | 更新描述 |
| ------- | -------- |
| 🇨🇳 中文 |   修改响应式断点使用“屏幕”作为影响因子的描述，改为“窗口宽度”   |