### PR TITLE
fix: when tree data table work with pagination and checkStrictly false, some disabled rows are incorrectly check (#52319)

### DIFF
--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -197,7 +197,16 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
   }, [flattedData, getRowKey, getCheckboxProps]);
 
   const isCheckboxDisabled: GetCheckDisabled<RecordType> = useCallback(
-    (r: RecordType) => !!checkboxPropsMap.get(getRowKey(r))?.disabled,
+    (r: RecordType) => {
+      const rowKey = getRowKey(r);
+      let checkboxProps: Partial<CheckboxProps> | undefined;
+      if (checkboxPropsMap.has(rowKey)) {
+        checkboxProps = checkboxPropsMap.get(getRowKey(r));
+      } else {
+        checkboxProps = getCheckboxProps ? getCheckboxProps(r) : undefined;
+      }
+      return !!checkboxProps?.disabled;
+    },
     [checkboxPropsMap, getRowKey],
   );
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue
fix #52319 

### 💡 需求背景和解决方案
问题：
在使用树形数据表格时，开启分页，`checkStrictly`设置为`false`，选中带有`disabled`的`children`的行，切换到下一页，选中所有行，再切换回上一页，`disabled`的行变为了选中状态

原因：
切换到下一页时，`checkboxPropsMap`里的数据会更新为新页的数据，而原页面的数据不在`checkboxPropsMap`中，于是`isCheckboxDisabled`返回了默认值`{disabled: false}`

解决方案：
修改`isCheckboxDisabled`，如果数据不在`checkboxPropsMap`中，则尝试调用`rowSelection.getCheckboxProps()`，若无`rowSelection.getCheckboxProps`，再返回默认值`{disabled: false}`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |fix: when tree data table work with pagination and `checkStrictly false`, some disabled rows are incorrectly check. #52319|
| 🇨🇳 中文 |修复树形表格开启分页并设置 `checkStrictly false`时, 某些禁用的行会被错误地选中。 #52319|