### PR TITLE
feat(ConfigProvider): support Modal centered global config

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -145,7 +145,7 @@ export type DescriptionsConfig = ComponentStyleConfig &
 export type EmptyConfig = ComponentStyleConfig & Pick<EmptyProps, 'classNames' | 'styles'>;
 
 export type ModalConfig = ComponentStyleConfig &
-  Pick<ModalProps, 'classNames' | 'styles' | 'closeIcon' | 'closable'>;
+  Pick<ModalProps, 'classNames' | 'styles' | 'closeIcon' | 'closable' | 'centered'>;
 
 export type TabsConfig = ComponentStyleConfig &
   Pick<TabsProps, 'indicator' | 'indicatorSize' | 'more' | 'moreIcon' | 'addIcon' | 'removeIcon'>;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -99,7 +99,7 @@ const Modal: React.FC<ModalProps> = (props) => {
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
   const wrapClassNameExtended = classNames(wrapClassName, {
-    [`${prefixCls}-centered`]: !!centered,
+    [`${prefixCls}-centered`]: centered ?? modalContext?.centered,
     [`${prefixCls}-wrap-rtl`]: direction === 'rtl',
   });
 

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -6,6 +6,7 @@ import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { createEvent, fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 jest.mock('rc-util/lib/Portal');
 
@@ -207,5 +208,28 @@ describe('Modal', () => {
       '--ant-modal-xl-width': '50%',
       '--ant-modal-xxl-width': '40%',
     });
+  });
+
+  it('Should support centered prop', () => {
+    render(<Modal open centered />);
+    expect(document.querySelector('.ant-modal-centered')).toBeTruthy();
+  });
+
+  it('Should support centered global config', () => {
+    render(
+      <ConfigProvider modal={{ centered: true }}>
+        <Modal open />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-centered')).toBeTruthy();
+  });
+
+  it('Should prefer centered prop over centered global config', () => {
+    render(
+      <ConfigProvider modal={{ centered: true }}>
+        <Modal open centered={false} />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-centered')).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

定制主题和应用为了追求视觉统一，可能要求 Modal 全部居中（centered），增加此全局配置可以很方便实现这一点。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(ConfigProvider): support Modal centered global config|
| 🇨🇳 Chinese | feat(ConfigProvider): 支持 Modal centered 全局配置|
