### PR TITLE
Fix : Clear Icon Button Padding With Input

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -420,6 +420,7 @@ const genAllowClearStyle = (token: InputToken): CSSObject => {
   return {
     // ========================= Input =========================
     [`${componentCls}-clear-icon`]: {
+      padding: 0,
       margin: 0,
       lineHeight: 0,
       color: token.colorTextQuaternary,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [https://github.com/ant-design/ant-design/issues/52345 ] 🐞 Bug fix

### 🔗 Related Issues

> - This pr addresses the issue described in # 52345, where the clear icon button had 6px padding in version 5.2.3. This 
       time, the pr has cleared the clear button padding.

### 💡 Background and Solution

> - The clear icon button returned by the user will have some additional padding in version 5.2.3.
> - Add padding 0  width clear icon button.

### 📝 Change Log

> - Add Padding 0  Width Clear Icon Button

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Add  clear icon button  padding 0  with input    |
| 🇨🇳 Chinese |     增加输入框清除图标按钮padding为0      |
