### PR TITLE
feat: ConfigProvider support arrow for tooltip/popover/popconfirm

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -191,13 +191,19 @@ export type SelectConfig = ComponentStyleConfig & Pick<SelectProps, 'showSearch'
 
 export type SpaceConfig = ComponentStyleConfig & Pick<SpaceProps, 'size' | 'classNames' | 'styles'>;
 
-export type TooltipConfig = Pick<TooltipProps, 'className' | 'style' | 'styles' | 'classNames'>;
+export type TooltipConfig = Pick<
+  TooltipProps,
+  'className' | 'style' | 'styles' | 'classNames' | 'arrow'
+>;
 
-export type PopoverConfig = Pick<PopoverProps, 'className' | 'style' | 'styles' | 'classNames'>;
+export type PopoverConfig = Pick<
+  PopoverProps,
+  'className' | 'style' | 'styles' | 'classNames' | 'arrow'
+>;
 
 export type PopconfirmConfig = Pick<
   PopconfirmProps,
-  'className' | 'style' | 'styles' | 'classNames'
+  'className' | 'style' | 'styles' | 'classNames' | 'arrow'
 >;
 
 export type SliderConfig = ComponentStyleConfig & Pick<SliderProps, 'styles' | 'classNames'>;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -163,9 +163,9 @@ const {
 | timeline | Set Timeline common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | timePicker | Set TimePicker common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tour | Set Tour common props | { closeIcon?: React.ReactNode } | - | 5.14.0 |
-| tooltip | Set Tooltip common props | { className?: string, style?: React.CSSProperties, classNames?:[Tooltip\["classNames"\]](/components/tooltip#api), styles?: [Tooltip\["styles"\]](/components/tooltip#api) } | - | 5.23.0 |
-| popover | Set Popover common props | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover#api), styles?: [Popover\["styles"\]](/components/popover#api) } | - | 5.23.0 |
-| popconfirm | Set Popconfirm common props | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm#api) } | - | 5.23.0 |
+| tooltip | Set Tooltip common props | { className?: string, style?: React.CSSProperties, classNames?:[Tooltip\["classNames"\]](/components/tooltip#api), styles?: [Tooltip\["styles"\]](/components/tooltip#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
+| popover | Set Popover common props | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover#api), styles?: [Popover\["styles"\]](/components/popover#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
+| popconfirm | Set Popconfirm common props | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
 | transfer | Set Transfer common props | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, selectionsIcon: 5.14.0 |
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -165,9 +165,9 @@ const {
 | timeline | 设置 Timeline 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | timePicker | 设置 TimePicker 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | tour | 设置 Tour 组件的通用属性 | { closeIcon?: React.ReactNode } | - | 5.14.0 |
-| tooltip | 设置 Tooltip 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Tooltip\["classNames"\]](/components/tooltip-cn#api), styles?: [Tooltip\["styles"\]](/components/tooltip-cn#api) } | - | 5.23.0 |
-| popover | 设置 Popover 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover-cn#api), styles?: [Popover\["styles"\]](/components/popover-cn#api) } | - | 5.23.0 |
-| popconfirm | 设置 Popconfirm 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm-cn#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm-cn#api) } | - | 5.23.0 |
+| tooltip | 设置 Tooltip 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Tooltip\["classNames"\]](/components/tooltip-cn#api), styles?: [Tooltip\["styles"\]](/components/tooltip-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
+| popover | 设置 Popover 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover-cn#api), styles?: [Popover\["styles"\]](/components/popover-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
+| popconfirm | 设置 Popconfirm 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm-cn#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, arrow: 6.0.0 |
 | transfer | 设置 Transfer 组件的通用属性 | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, selectionsIcon: 5.14.0 |
 | tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
+import ConfigProvider from '../../config-provider';
 
 // TODO: Remove this. Mock for React 19
 jest.mock('react-dom', () => {
@@ -352,5 +353,68 @@ describe('Popconfirm', () => {
     // 验证 styles
     expect(popconfirmElement.style.backgroundColor).toBe('blue');
     expect(popconfirmBodyElement.style.color).toBe('red');
+  });
+  it('ConfigProvider support arrow props', () => {
+    const TooltipTestComponent = () => {
+      const [configArrow, setConfigArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          popconfirm={{
+            arrow: configArrow,
+          }}
+        >
+          <button onClick={() => setConfigArrow(false)} className="configArrow" type="button">
+            showconfigArrow
+          </button>
+          <Popconfirm open title>
+            <div className="target">target</div>
+          </Popconfirm>
+        </ConfigProvider>
+      );
+    };
+    const { container } = render(<TooltipTestComponent />);
+    const getTooltipArrow = () => container.querySelector('.ant-popover-arrow');
+    const configbtn = container.querySelector('.configArrow');
+
+    expect(getTooltipArrow()).not.toBeNull();
+    fireEvent.click(configbtn!);
+    expect(getTooltipArrow()).toBeNull();
+  });
+  it('ConfigProvider with arrow set to false, Tooltip arrow controlled by prop', () => {
+    const TooltipTestComponent = () => {
+      const [arrow, setArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          popover={{
+            arrow: false,
+          }}
+        >
+          <button onClick={() => setArrow(!arrow)} className="toggleArrow" type="button">
+            toggleArrow
+          </button>
+          <Popconfirm open arrow={arrow} title>
+            <div className="target">target</div>
+          </Popconfirm>
+        </ConfigProvider>
+      );
+    };
+
+    const { container } = render(<TooltipTestComponent />);
+
+    const getTooltipArrow = () => container.querySelector('.ant-popover-arrow');
+    const toggleArrowBtn = container.querySelector('.toggleArrow');
+
+    // Initial render, arrow should be visible because Tooltip's arrow prop is true
+    expect(getTooltipArrow()).not.toBeNull();
+
+    // Click the toggleArrow button to hide the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).toBeNull();
+
+    // Click the toggleArrow button again to show the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).not.toBeNull();
   });
 });

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -10,6 +10,7 @@ import { ConfigContext } from '../config-provider';
 import type { PopoverProps } from '../popover';
 import Popover from '../popover';
 import type { AbstractTooltipProps, TooltipRef } from '../tooltip';
+import useMergedArrow from '../tooltip/hook/useMergedArrow';
 import PurePanel, { Overlay } from './PurePanel';
 import useStyle from './style';
 
@@ -49,6 +50,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     onOpenChange,
     overlayStyle,
     styles,
+    arrow: popconfirmArrow,
     classNames: popconfirmClassNames,
     ...restProps
   } = props;
@@ -58,6 +60,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     value: props.open,
     defaultValue: props.defaultOpen,
   });
+  const mergedArrow = useMergedArrow(popconfirmArrow, popconfirm?.arrow);
 
   const settingOpen: PopoverProps['onOpenChange'] = (value, e) => {
     setOpen(value, true);
@@ -96,6 +99,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
 
   return wrapCSSVar(
     <Popover
+      arrow={mergedArrow}
       {...omit(restProps, ['title'])}
       trigger={trigger}
       placement={placement}

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -166,4 +166,67 @@ describe('Popover', () => {
     expect(popoverElement.style.backgroundColor).toBe('blue');
     expect(popoverBodyElement.style.color).toBe('red');
   });
+  it('ConfigProvider support arrow props', () => {
+    const TooltipTestComponent = () => {
+      const [configArrow, setConfigArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          popover={{
+            arrow: configArrow,
+          }}
+        >
+          <button onClick={() => setConfigArrow(false)} className="configArrow" type="button">
+            showconfigArrow
+          </button>
+          <Popover open>
+            <div className="target">target</div>
+          </Popover>
+        </ConfigProvider>
+      );
+    };
+    const { container } = render(<TooltipTestComponent />);
+    const getTooltipArrow = () => container.querySelector('.ant-popover-arrow');
+    const configbtn = container.querySelector('.configArrow');
+
+    expect(getTooltipArrow()).not.toBeNull();
+    fireEvent.click(configbtn!);
+    expect(getTooltipArrow()).toBeNull();
+  });
+  it('ConfigProvider with arrow set to false, Tooltip arrow controlled by prop', () => {
+    const TooltipTestComponent = () => {
+      const [arrow, setArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          popover={{
+            arrow: false,
+          }}
+        >
+          <button onClick={() => setArrow(!arrow)} className="toggleArrow" type="button">
+            toggleArrow
+          </button>
+          <Popover open arrow={arrow}>
+            <div className="target">target</div>
+          </Popover>
+        </ConfigProvider>
+      );
+    };
+
+    const { container } = render(<TooltipTestComponent />);
+
+    const getTooltipArrow = () => container.querySelector('.ant-popover-arrow');
+    const toggleArrowBtn = container.querySelector('.toggleArrow');
+
+    // Initial render, arrow should be visible because Tooltip's arrow prop is true
+    expect(getTooltipArrow()).not.toBeNull();
+
+    // Click the toggleArrow button to hide the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).toBeNull();
+
+    // Click the toggleArrow button again to show the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).not.toBeNull();
+  });
 });

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -10,6 +10,7 @@ import { cloneElement } from '../_util/reactNode';
 import { ConfigContext } from '../config-provider';
 import type { AbstractTooltipProps, TooltipRef } from '../tooltip';
 import Tooltip from '../tooltip';
+import useMergedArrow from '../tooltip/hook/useMergedArrow';
 import PurePanel, { Overlay } from './PurePanel';
 // CSSINJS
 import useStyle from './style';
@@ -39,6 +40,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
     styles,
     classNames: popoverClassNames,
     motion,
+    arrow: popoverArrow,
     ...otherProps
   } = props;
   const { popover, getPrefixCls } = React.useContext(ConfigContext);
@@ -46,6 +48,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
   const prefixCls = getPrefixCls('popover', customizePrefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   const rootPrefixCls = getPrefixCls();
+  const mergedArrow = useMergedArrow(popoverArrow, popover?.arrow);
 
   const rootClassNames = classNames(
     overlayClassName,
@@ -84,6 +87,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
 
   return wrapCSSVar(
     <Tooltip
+      arrow={mergedArrow}
       placement={placement}
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -41,7 +41,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
     classNames: popoverClassNames,
     motion,
     arrow: popoverArrow,
-    ...otherProps
+    ...restProps
   } = props;
   const { popover, getPrefixCls } = React.useContext(ConfigContext);
 
@@ -92,7 +92,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
       trigger={trigger}
       mouseEnterDelay={mouseEnterDelay}
       mouseLeaveDelay={mouseLeaveDelay}
-      {...otherProps}
+      {...restProps}
       prefixCls={prefixCls}
       classNames={{ root: rootClassNames, body: bodyClassNames }}
       styles={{

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -8,6 +8,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
+import ConfigProvider from '../../config-provider';
 import DatePicker from '../../date-picker';
 import Input from '../../input';
 import Group from '../../input/Group';
@@ -498,5 +499,68 @@ describe('Tooltip', () => {
     // 验证 styles
     expect(tooltipElement.style.backgroundColor).toBe('blue');
     expect(tooltipBodyElement.style.color).toBe('red');
+  });
+
+  it('ConfigProvider support arrow props', () => {
+    const TooltipTestComponent = () => {
+      const [configArrow, setConfigArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          tooltip={{
+            arrow: configArrow,
+          }}
+        >
+          <button onClick={() => setConfigArrow(false)} className="configArrow" type="button">
+            showconfigArrow
+          </button>
+          <Tooltip open>
+            <div className="target">target</div>
+          </Tooltip>
+        </ConfigProvider>
+      );
+    };
+    const { container } = render(<TooltipTestComponent />);
+    const getTooltipArrow = () => container.querySelector('.ant-tooltip-arrow');
+    const configbtn = container.querySelector('.configArrow');
+
+    expect(getTooltipArrow()).not.toBeNull();
+    fireEvent.click(configbtn!);
+    expect(getTooltipArrow()).toBeNull();
+  });
+  it('ConfigProvider with arrow set to false, Tooltip arrow controlled by prop', () => {
+    const TooltipTestComponent = () => {
+      const [arrow, setArrow] = React.useState(true);
+
+      return (
+        <ConfigProvider
+          tooltip={{
+            arrow: false,
+          }}
+        >
+          <button onClick={() => setArrow(!arrow)} className="toggleArrow" type="button">
+            toggleArrow
+          </button>
+          <Tooltip open arrow={arrow}>
+            <div className="target">target</div>
+          </Tooltip>
+        </ConfigProvider>
+      );
+    };
+
+    const { container } = render(<TooltipTestComponent />);
+    const getTooltipArrow = () => container.querySelector('.ant-tooltip-arrow');
+    const toggleArrowBtn = container.querySelector('.toggleArrow');
+
+    // Initial render, arrow should be visible because Tooltip's arrow prop is true
+    expect(getTooltipArrow()).not.toBeNull();
+
+    // Click the toggleArrow button to hide the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).toBeNull();
+
+    // Click the toggleArrow button again to show the arrow
+    fireEvent.click(toggleArrowBtn!);
+    expect(getTooltipArrow()).not.toBeNull();
   });
 });

--- a/components/tooltip/hook/useMergedArrow.ts
+++ b/components/tooltip/hook/useMergedArrow.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { AbstractTooltipProps } from '..';
+import { TooltipConfig } from '../../config-provider/context';
+
+const useMergedArrow = (
+  providedArrow?: AbstractTooltipProps['arrow'],
+  providedContextArrow?: TooltipConfig['arrow'],
+) => {
+  return React.useMemo(() => {
+    if (typeof providedArrow === 'object') {
+      return {
+        ...providedArrow,
+        pointAtCenter:
+          providedArrow.pointAtCenter ??
+          (providedContextArrow as { pointAtCenter: boolean })?.pointAtCenter,
+      };
+    }
+
+    return providedArrow ?? providedContextArrow ?? true;
+  }, [providedArrow, providedContextArrow]);
+};
+
+export default useMergedArrow;

--- a/components/tooltip/hook/useMergedArrow.ts
+++ b/components/tooltip/hook/useMergedArrow.ts
@@ -4,19 +4,19 @@ import { AbstractTooltipProps } from '..';
 import { TooltipConfig } from '../../config-provider/context';
 
 interface MergedArrow {
-  show?: boolean;
+  show: boolean;
   pointAtCenter?: boolean;
 }
 const useMergedArrow = (
   providedArrow?: AbstractTooltipProps['arrow'],
   providedContextArrow?: TooltipConfig['arrow'],
 ): MergedArrow => {
-  const toConfig = (arrow?: boolean | AbstractTooltipProps['arrow']) =>
+  const toConfig = (arrow?: boolean | AbstractTooltipProps['arrow']): Partial<MergedArrow> =>
     typeof arrow === 'boolean' ? { show: arrow } : arrow || {};
 
   return React.useMemo(() => {
-    const arrowConfig: MergedArrow = toConfig(providedArrow);
-    const contextArrowConfig: MergedArrow = toConfig(providedContextArrow);
+    const arrowConfig = toConfig(providedArrow);
+    const contextArrowConfig = toConfig(providedContextArrow);
 
     return {
       ...contextArrowConfig,

--- a/components/tooltip/hook/useMergedArrow.ts
+++ b/components/tooltip/hook/useMergedArrow.ts
@@ -15,11 +15,14 @@ const useMergedArrow = (
     typeof arrow === 'boolean' ? { show: arrow } : arrow || {};
 
   return React.useMemo(() => {
-    const arrowConfig = toConfig(providedArrow);
-    const contextArrowConfig = toConfig(providedContextArrow);
+    const arrowConfig: MergedArrow = toConfig(providedArrow);
+    const contextArrowConfig: MergedArrow = toConfig(providedContextArrow);
 
-    return { ...contextArrowConfig, ...arrowConfig };
+    return {
+      ...contextArrowConfig,
+      ...arrowConfig,
+      show: arrowConfig.show ?? contextArrowConfig.show ?? true,
+    };
   }, [providedArrow, providedContextArrow]);
 };
-
 export default useMergedArrow;

--- a/components/tooltip/hook/useMergedArrow.ts
+++ b/components/tooltip/hook/useMergedArrow.ts
@@ -3,21 +3,22 @@ import React from 'react';
 import { AbstractTooltipProps } from '..';
 import { TooltipConfig } from '../../config-provider/context';
 
+interface MergedArrow {
+  show?: boolean;
+  pointAtCenter?: boolean;
+}
 const useMergedArrow = (
   providedArrow?: AbstractTooltipProps['arrow'],
   providedContextArrow?: TooltipConfig['arrow'],
-) => {
-  return React.useMemo(() => {
-    if (typeof providedArrow === 'object') {
-      return {
-        ...providedArrow,
-        pointAtCenter:
-          providedArrow.pointAtCenter ??
-          (providedContextArrow as { pointAtCenter: boolean })?.pointAtCenter,
-      };
-    }
+): MergedArrow => {
+  const toConfig = (arrow?: boolean | AbstractTooltipProps['arrow']) =>
+    typeof arrow === 'boolean' ? { show: arrow } : arrow || {};
 
-    return providedArrow ?? providedContextArrow ?? true;
+  return React.useMemo(() => {
+    const arrowConfig = toConfig(providedArrow);
+    const contextArrowConfig = toConfig(providedContextArrow);
+
+    return { ...contextArrowConfig, ...arrowConfig };
   }, [providedArrow, providedContextArrow]);
 };
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -22,6 +22,7 @@ import { devUseWarning } from '../_util/warning';
 import zIndexContext from '../_util/zindexContext';
 import { ConfigContext } from '../config-provider';
 import { useToken } from '../theme/internal';
+import useMergedArrow from './hook/useMergedArrow';
 import PurePanel from './PurePanel';
 import useStyle from './style';
 import { parseColor } from './util';
@@ -127,15 +128,13 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     children,
     afterOpenChange,
     destroyTooltipOnHide,
-    arrow = true,
+    arrow: tooltipArrow,
     title,
     overlay,
     builtinPlacements,
     autoAdjustOverflow = true,
     motion,
   } = props;
-
-  const mergedShowArrow = !!arrow;
 
   const [, token] = useToken();
 
@@ -145,6 +144,8 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     direction,
     tooltip,
   } = React.useContext(ConfigContext);
+  const mergedArrow = useMergedArrow(tooltipArrow, tooltip?.arrow);
+  const mergedShowArrow = !!mergedArrow;
 
   // ============================== Ref ===============================
   const warning = devUseWarning('Tooltip');
@@ -196,7 +197,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     return (
       builtinPlacements ||
       getPlacements({
-        arrowPointAtCenter: typeof arrow === 'object' ? arrow?.pointAtCenter : false,
+        arrowPointAtCenter: typeof mergedArrow === 'object' ? mergedArrow?.pointAtCenter : false,
         autoAdjustOverflow,
         arrowWidth: mergedShowArrow ? token.sizePopupArrow : 0,
         borderRadius: token.borderRadius,
@@ -204,7 +205,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
         visibleFirst: true,
       })
     );
-  }, [arrow, builtinPlacements, token]);
+  }, [mergedArrow, builtinPlacements, token]);
 
   const memoOverlay = React.useMemo<TooltipProps['overlay']>(() => {
     if (title === 0) {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -155,7 +155,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     tooltip,
   } = React.useContext(ConfigContext);
   const mergedArrow = useMergedArrow(tooltipArrow, tooltip?.arrow);
-  const mergedShowArrow = mergedArrow?.show;
+  const mergedShowArrow = mergedArrow.show;
 
   // ============================== Ref ===============================
   const warning = devUseWarning('Tooltip');

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -128,12 +128,25 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     children,
     afterOpenChange,
     destroyTooltipOnHide,
-    arrow: tooltipArrow,
     title,
     overlay,
     builtinPlacements,
     autoAdjustOverflow = true,
     motion,
+  } = props;
+
+  const {
+    getPopupContainer,
+    placement = 'top',
+    mouseEnterDelay = 0.1,
+    mouseLeaveDelay = 0.1,
+    overlayStyle,
+    rootClassName,
+    overlayClassName,
+    styles,
+    classNames: tooltipClassNames,
+    arrow: tooltipArrow,
+    ...restProps
   } = props;
 
   const [, token] = useToken();
@@ -220,19 +233,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     </ContextIsolator>
   );
 
-  const {
-    getPopupContainer,
-    placement = 'top',
-    mouseEnterDelay = 0.1,
-    mouseLeaveDelay = 0.1,
-    overlayStyle,
-    rootClassName,
-    overlayClassName,
-    styles,
-    classNames: tooltipClassNames,
-    ...otherProps
-  } = props;
-
   const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
 
@@ -277,11 +277,11 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
   const bodyClassNames = classNames(tooltip?.classNames?.body, tooltipClassNames?.body);
 
   // ============================ zIndex ============================
-  const [zIndex, contextZIndex] = useZIndex('Tooltip', otherProps.zIndex);
+  const [zIndex, contextZIndex] = useZIndex('Tooltip', restProps.zIndex);
 
   const content = (
     <RcTooltip
-      {...otherProps}
+      {...restProps}
       zIndex={zIndex}
       showArrow={mergedShowArrow}
       placement={placement}

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -128,14 +128,12 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     children,
     afterOpenChange,
     destroyTooltipOnHide,
+    arrow: tooltipArrow,
     title,
     overlay,
     builtinPlacements,
     autoAdjustOverflow = true,
     motion,
-  } = props;
-
-  const {
     getPopupContainer,
     placement = 'top',
     mouseEnterDelay = 0.1,
@@ -145,7 +143,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     overlayClassName,
     styles,
     classNames: tooltipClassNames,
-    arrow: tooltipArrow,
     ...restProps
   } = props;
 
@@ -158,7 +155,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     tooltip,
   } = React.useContext(ConfigContext);
   const mergedArrow = useMergedArrow(tooltipArrow, tooltip?.arrow);
-  const mergedShowArrow = mergedArrow?.show ?? true;
+  const mergedShowArrow = mergedArrow?.show;
 
   // ============================== Ref ===============================
   const warning = devUseWarning('Tooltip');

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -145,7 +145,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     tooltip,
   } = React.useContext(ConfigContext);
   const mergedArrow = useMergedArrow(tooltipArrow, tooltip?.arrow);
-  const mergedShowArrow = !!mergedArrow;
+  const mergedShowArrow = mergedArrow?.show ?? true;
 
   // ============================== Ref ===============================
   const warning = devUseWarning('Tooltip');
@@ -197,7 +197,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     return (
       builtinPlacements ||
       getPlacements({
-        arrowPointAtCenter: typeof mergedArrow === 'object' ? mergedArrow?.pointAtCenter : false,
+        arrowPointAtCenter: mergedArrow?.pointAtCenter ?? false,
         autoAdjustOverflow,
         arrowWidth: mergedShowArrow ? token.sizePopupArrow : 0,
         borderRadius: token.borderRadius,


### PR DESCRIPTION

### 🤔 This is a ...
- [x] 🆕 New feature


### 💡 Background and Solution
全局配置箭头挺有用的，next ui 就无箭头
![image](https://github.com/user-attachments/assets/562317e9-4bae-4fa9-abb7-2e3f14c90d11)




| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       feat: ConfigProvider support arrow for tooltip/popover/popconfirm    |
| 🇨🇳 Chinese |      feat: ConfigProvider 支持tooltip/popover/popconfirm组件的箭头配置     |
