### PR TITLE
Fix focus outline issue in tabs component

### DIFF
--- a/components/tabs/__tests__/index.test.tsx
+++ b/components/tabs/__tests__/index.test.tsx
@@ -150,4 +150,24 @@ describe('Tabs', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('should remove focus outline when switching browser pages', () => {
+    const { container } = render(
+      <Tabs>
+        <TabPane tab="Tab 1" key="1">
+          Content 1
+        </TabPane>
+        <TabPane tab="Tab 2" key="2">
+          Content 2
+        </TabPane>
+      </Tabs>,
+    );
+
+    const tabElement = container.querySelector('.ant-tabs-tab')!;
+    fireEvent.focus(tabElement);
+    expect(tabElement).toHaveClass('ant-tabs-tab-active');
+
+    fireEvent.blur(tabElement, { relatedTarget: document.createElement('iframe') });
+    expect(tabElement).not.toHaveClass('ant-tabs-tab-active');
+  });
 });

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -110,6 +110,13 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
     size: indicator?.size ?? indicatorSize ?? tabs?.indicator?.size ?? tabs?.indicatorSize,
   };
 
+  const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    const activeElement = document.activeElement;
+    if (activeElement && activeElement.tagName === 'IFRAME') {
+      e.currentTarget.blur();
+    }
+  };
+
   return wrapCSSVar(
     <RcTabs
       direction={direction}
@@ -141,6 +148,7 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
       prefixCls={prefixCls}
       animated={mergedAnimated}
       indicator={mergedIndicator}
+      onBlur={handleBlur}
     />,
   );
 };


### PR DESCRIPTION
Add `onBlur` event handler to `Tabs` component to remove focus outline when switching browser pages.

* Add `handleBlur` function in `components/tabs/index.tsx` to handle the blur event and remove focus outline when switching to an iframe.
* Add `onBlur` event handler to `RcTabs` component in `components/tabs/index.tsx`.
* Add test case in `components/tabs/__tests__/index.test.tsx` to check if focus outline is removed when switching browser pages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ant-design/ant-design/pull/52437?shareId=79d7e13b-3aad-4cfd-a6ba-a6e9e6208a0e).