### PR TITLE
fix: collapse first row of virtual table, scrollTop should be 0

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -557,18 +557,18 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const virtualProps: { listItemHeight?: number } = {};
 
   const listItemHeight = React.useMemo(() => {
-    const { fontSize, lineHeight, padding, paddingXS, paddingSM } = token;
+    const { fontSize, lineHeight, lineWidth, padding, paddingXS, paddingSM } = token;
     const fontHeight = Math.floor(fontSize * lineHeight);
 
     switch (mergedSize) {
-      case 'large':
-        return padding * 2 + fontHeight;
+      case 'middle':
+        return paddingSM * 2 + fontHeight + lineWidth;
 
       case 'small':
-        return paddingXS * 2 + fontHeight;
+        return paddingXS * 2 + fontHeight + lineWidth;
 
       default:
-        return paddingSM * 2 + fontHeight;
+        return padding * 2 + fontHeight + lineWidth;
     }
   }, [token, mergedSize]);
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 💡 Background and Solution
#### Probrem
When a virtual table work with expandable, expand the first row, and then collapse it, the scroll bar position is not 0.
#### Reproduced
https://codesandbox.io/p/sandbox/antdxu-ni-biao-ge-zhan-kai-di-yi-xing-xiang-shang-gun-dong-forked-2thdfd?file=%2Findex.tsx%3A17%2C21


https://github.com/user-attachments/assets/843cad27-99f6-47f7-9e8c-84c424051dc0

#### Reason
The default component size of table is `large`, however, when calculating `listItemHeight` in the code, `middle` is used as the default value, resulting in incorrect calculation result of lineItemHeight.

#### Solution
Use `large` as the default value and add the border width to the calculation.
### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |fix: collapse first row of virtual table, scrollTop should be 0|
| 🇨🇳 Chinese |fix: 收起虚拟滚动表格的第一行时，滚动条高度应该为0|
