### PR TITLE
feat: [V6] Retire deprecated api for tooltip/popover/popconfirm

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -141,38 +141,6 @@ describe('Popconfirm', () => {
     jest.useRealTimers();
   });
 
-  it('should be controlled by visible', () => {
-    jest.useFakeTimers();
-    const popconfirm = render(
-      <Popconfirm title="code">
-        <span>show me your code</span>
-      </Popconfirm>,
-    );
-
-    expect(popconfirm.container.querySelector('.ant-popover')).toBe(null);
-    popconfirm.rerender(
-      <Popconfirm title="code" visible>
-        <span>show me your code</span>
-      </Popconfirm>,
-    );
-
-    expect(popconfirm.container.querySelector('.ant-popover')).not.toBe(null);
-    expect(popconfirm.container.querySelector('.ant-popover')?.className).not.toContain(
-      'ant-popover-hidden',
-    );
-
-    popconfirm.rerender(
-      <Popconfirm title="code" visible={false}>
-        <span>show me your code</span>
-      </Popconfirm>,
-    );
-    act(() => {
-      jest.runAllTimers();
-    });
-    expect(popconfirm.container.querySelector('.ant-popover')).not.toBe(null);
-    jest.useRealTimers();
-  });
-
   it('should trigger onConfirm and onCancel', async () => {
     const confirm = jest.fn();
     const cancel = jest.fn();
@@ -344,28 +312,6 @@ describe('Popconfirm', () => {
     await waitFakeTimer();
     fireEvent.click(popconfirm.container.querySelector('.ant-popover-inner-content')!);
     expect(onPopupClick).toHaveBeenCalled();
-  });
-
-  // https://github.com/ant-design/ant-design/issues/42314
-  it('legacy onVisibleChange should only trigger once', async () => {
-    const onOpenChange = jest.fn();
-    const onVisibleChange = jest.fn();
-
-    const { container } = render(
-      <Popconfirm
-        title="will unmount"
-        onOpenChange={onOpenChange}
-        onVisibleChange={onVisibleChange}
-      >
-        <span className="target" />
-      </Popconfirm>,
-    );
-
-    fireEvent.click(container.querySelector('.target')!);
-    await waitFakeTimer();
-
-    expect(onOpenChange).toHaveBeenCalledTimes(1);
-    expect(onVisibleChange).toHaveBeenCalledTimes(1);
   });
 
   it('okText & cancelText could be empty', () => {

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -47,7 +47,6 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     children,
     overlayClassName,
     onOpenChange,
-    onVisibleChange,
     overlayStyle,
     styles,
     classNames: popconfirmClassNames,
@@ -56,13 +55,12 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
 
   const { getPrefixCls, popconfirm } = React.useContext(ConfigContext);
   const [open, setOpen] = useMergedState(false, {
-    value: props.open ?? props.visible,
-    defaultValue: props.defaultOpen ?? props.defaultVisible,
+    value: props.open,
+    defaultValue: props.defaultOpen,
   });
 
   const settingOpen: PopoverProps['onOpenChange'] = (value, e) => {
     setOpen(value, true);
-    onVisibleChange?.(value);
     onOpenChange?.(value, e);
   };
 

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -57,8 +57,8 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
   const bodyClassNames = classNames(popover?.classNames?.body, popoverClassNames?.body);
 
   const [open, setOpen] = useMergedState(false, {
-    value: props.open ?? props.visible,
-    defaultValue: props.defaultOpen ?? props.defaultVisible,
+    value: props.open,
+    defaultValue: props.defaultOpen,
   });
 
   const settingOpen = (

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -4,10 +4,9 @@ import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
 import type { TooltipPlacement } from '..';
 import Tooltip from '..';
 import getPlacements from '../../_util/placements';
-import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import DatePicker from '../../date-picker';
 import Input from '../../input';
@@ -202,44 +201,6 @@ describe('Tooltip', () => {
     );
     expect(getComputedStyle(containerInline.querySelector('button')!)?.display).toBe('inline-flex');
     expect(getComputedStyle(containerBlock.querySelector('button')!)?.display).toBe('block');
-  });
-
-  it('should warn for arrowPointAtCenter', async () => {
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    render(
-      <Tooltip
-        title="xxxxx"
-        trigger="click"
-        mouseEnterDelay={0}
-        mouseLeaveDelay={0}
-        placement="bottomLeft"
-        arrowPointAtCenter
-        classNames={{ root: 'point-center-element' }}
-      >
-        <button type="button">Hello world!</button>
-      </Tooltip>,
-    );
-    expect(warnSpy).toHaveBeenLastCalledWith(
-      expect.stringContaining('`arrowPointAtCenter` is deprecated'),
-    );
-
-    render(
-      <Tooltip
-        title="xxxxx"
-        trigger="click"
-        mouseEnterDelay={0}
-        mouseLeaveDelay={0}
-        placement="bottomLeft"
-        arrow={{ arrowPointAtCenter: true }}
-        classNames={{ root: 'point-center-element' }}
-      >
-        <button type="button">Hello world!</button>
-      </Tooltip>,
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('`arrowPointAtCenter` in `arrow` is deprecated'),
-    );
   });
 
   it('should works for date picker', async () => {
@@ -480,86 +441,6 @@ describe('Tooltip', () => {
     expect(container.querySelector('.ant-tooltip-open')).toBeNull();
   });
 
-  it('deprecated warning', async () => {
-    resetWarned();
-    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    // defaultVisible
-    const { container, rerender } = render(
-      <Tooltip defaultVisible title="bamboo">
-        <a />
-      </Tooltip>,
-    );
-    await waitFakeTimer();
-
-    expect(errSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Tooltip] `defaultVisible` is deprecated. Please use `defaultOpen` instead.',
-    );
-    expect(isTooltipOpen()).toBeTruthy();
-
-    // visible
-    rerender(
-      <Tooltip visible title="bamboo">
-        <a />
-      </Tooltip>,
-    );
-    expect(errSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Tooltip] `visible` is deprecated. Please use `open` instead.',
-    );
-
-    rerender(
-      <Tooltip visible={false} title="bamboo">
-        <a />
-      </Tooltip>,
-    );
-    await waitFakeTimer();
-    if (container.querySelector('.ant-zoom-big-fast-leave-active')) {
-      fireEvent.animationEnd(container.querySelector('.ant-zoom-big-fast-leave-active')!);
-    }
-    expect(isTooltipOpen()).toBeFalsy();
-
-    // onVisibleChange
-    rerender(
-      <Tooltip onVisibleChange={() => {}} title="bamboo">
-        <a />
-      </Tooltip>,
-    );
-    expect(errSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Tooltip] `onVisibleChange` is deprecated. Please use `onOpenChange` instead.',
-    );
-
-    // afterVisibleChange
-    rerender(
-      <Tooltip afterVisibleChange={() => {}} title="bamboo">
-        <a />
-      </Tooltip>,
-    );
-    expect(errSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Tooltip] `afterVisibleChange` is deprecated. Please use `afterOpenChange` instead.',
-    );
-
-    // Event Trigger
-    const onVisibleChange = jest.fn();
-    const afterVisibleChange = jest.fn();
-    rerender(
-      <Tooltip
-        visible
-        onVisibleChange={onVisibleChange}
-        afterVisibleChange={afterVisibleChange}
-        title="bamboo"
-      >
-        <a />
-      </Tooltip>,
-    );
-
-    fireEvent.mouseLeave(container.querySelector('a')!);
-    await waitFakeTimer();
-    expect(onVisibleChange).toHaveBeenCalled();
-    expect(afterVisibleChange).toHaveBeenCalled();
-
-    errSpy.mockRestore();
-  });
-
   it('not inject className when children className is not string type', () => {
     const HOC = ({ className }: { className: () => string }) => <span className={className()} />;
     const { container } = render(
@@ -590,18 +471,6 @@ describe('Tooltip', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('use ref.current.forcePopupAlign', async () => {
-    const ref = React.createRef<any>();
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-    render(<Tooltip open ref={ref} />);
-    act(() => {
-      ref.current.forcePopupAlign();
-      jest.runAllTimers();
-    });
-    expect(error).toHaveBeenCalled();
-    error.mockRestore();
-  });
-
   it('should apply custom styles to Tooltip', () => {
     const customClassNames = {
       body: 'custom-body',
@@ -614,7 +483,7 @@ describe('Tooltip', () => {
     };
 
     const { container } = render(
-      <Tooltip classNames={customClassNames} overlay={<div />} styles={customStyles} visible>
+      <Tooltip classNames={customClassNames} overlay={<div />} styles={customStyles} open>
         <button type="button">button</button>
       </Tooltip>,
     );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature


### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Retire deprecated api for  tooltip/popover/popconfirm|
| 🇨🇳 Chinese |  tooltip/popover/popconfirm废弃 api 退休         |
