### PR TITLE
docs: fix color

### DIFF
--- a/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { FastColor } from '@ant-design/fast-color';
-import type { ColorInput } from '@ant-design/fast-color';
+// @ts-ignore
+import { TinyColor } from 'dumi-plugin-color-chunk/component';
 import { createStyles } from 'antd-style';
 
 const useStyle = createStyles(({ token, css }) => ({
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ token, css }) => ({
 }));
 
 interface ColorChunkProps {
-  value: ColorInput;
+  value: any;
 }
 
 const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) => {
@@ -30,7 +30,7 @@ const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) =
   const { value, children } = props;
 
   const dotColor = React.useMemo(() => {
-    const _color = new FastColor(value).toHexString();
+    const _color = new TinyColor(value).toHex8String();
     return _color.endsWith('ff') ? _color.slice(0, -2) : _color;
   }, [value]);
 


### PR DESCRIPTION

Reason: https://github.com/ant-design/ant-design/pull/52157/files#r1919837262

close #52451

先这样修复，后面 antd 如果支持 color name ，我的 dumi 插件也同步一下实现。目前这个只会增加网站构建体积。可以忽略不计先

很早之前我在插件中写了一个 alias，https://github.com/Wxh16144/dumi-plugin-color-chunk/blob/d092bbb0/src/index.ts#L12


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      --     |
| 🇨🇳 Chinese |    修复文档颜色块儿显示错误       |
