### PR TITLE
refactor: remove cssinjs warning in Space.Compact

### DIFF
--- a/components/button/style/compact.ts
+++ b/components/button/style/compact.ts
@@ -11,21 +11,20 @@ import { prepareComponentToken, prepareToken } from './token';
 const genButtonCompactStyle: GenerateStyle<ButtonToken> = (token) => {
   const { componentCls, colorPrimaryHover, lineWidth, calc } = token;
   const insetOffset = calc(lineWidth).mul(-1).equal();
-  const getCompactBorderStyle = (vertical?: boolean) =>
-    ({
-      [`${componentCls}-compact${vertical ? '-vertical' : ''}-item${componentCls}-primary:not([disabled])`]:
-        {
-          '& + &::before': {
-            position: 'absolute',
-            top: vertical ? insetOffset : 0,
-            insetInlineStart: vertical ? 0 : insetOffset,
-            backgroundColor: colorPrimaryHover,
-            content: '""',
-            width: vertical ? '100%' : lineWidth,
-            height: vertical ? lineWidth : '100%',
-          },
-        },
-    }) as CSSObject;
+  const getCompactBorderStyle = (vertical?: boolean) => {
+    const selector = `${componentCls}-compact${vertical ? '-vertical' : ''}-item${componentCls}-primary:not([disabled])`;
+    return {
+      [`${selector} + ${selector}::before`]: {
+        position: 'absolute',
+        top: vertical ? insetOffset : 0,
+        insetInlineStart: vertical ? 0 : insetOffset,
+        backgroundColor: colorPrimaryHover,
+        content: '""',
+        width: vertical ? '100%' : lineWidth,
+        height: vertical ? lineWidth : '100%',
+      } as CSSObject,
+    };
+  };
   // Special styles for Primary Button
   return {
     ...getCompactBorderStyle(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

<img width="1489" alt="图片" src="https://github.com/user-attachments/assets/bff22904-d993-444e-8da1-5b99a6b69ad1" />

```
Warning: [Ant Design CSS-in-JS] Error in Button-compact-ant-btn-anticon: Should not use more than one `&` in a selector. Selector: .ant-btn-compact-item.ant-btn-primary:not([disabled]) | & + &::before Component Stack: 
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Space.Compact `Should not use more than one & in a selector` warning.           |
| 🇨🇳 Chinese | 修复 Space.Compact 抛出 `Should not use more than one & in a selector` 警告信息的问题。          |
