### PR TITLE
fix(splitter): correct collapse behavior in RTL mode

### DIFF
--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -95,6 +95,7 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     itemPtgSizes,
     containerSize,
     updateSizes,
+    isRTL,
   );
 
   // ======================== Events ========================
@@ -180,8 +181,12 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
                 ariaNow={stackSizes[idx] * 100}
                 ariaMin={Math.max(ariaMinStart, ariaMinEnd) * 100}
                 ariaMax={Math.min(ariaMaxStart, ariaMaxEnd) * 100}
-                startCollapsible={resizableInfo.startCollapsible}
-                endCollapsible={resizableInfo.endCollapsible}
+                startCollapsible={
+                  isRTL ? resizableInfo.endCollapsible : resizableInfo.startCollapsible
+                }
+                endCollapsible={
+                  isRTL ? resizableInfo.startCollapsible : resizableInfo.endCollapsible
+                }
                 onOffsetStart={onInternalResizeStart}
                 onOffsetUpdate={(index, offsetX, offsetY) => {
                   let offset = isVertical ? offsetY : offsetX;

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -87,7 +87,7 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     useSizes(items, containerSize);
 
   // ====================== Resizable =======================
-  const resizableInfos = useResizable(items, itemPxSizes);
+  const resizableInfos = useResizable(items, itemPxSizes, isRTL);
 
   const [onOffsetStart, onOffsetUpdate, onOffsetEnd, onCollapse, movingIndex] = useResize(
     items,
@@ -181,12 +181,8 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
                 ariaNow={stackSizes[idx] * 100}
                 ariaMin={Math.max(ariaMinStart, ariaMinEnd) * 100}
                 ariaMax={Math.min(ariaMaxStart, ariaMaxEnd) * 100}
-                startCollapsible={
-                  isRTL ? resizableInfo.endCollapsible : resizableInfo.startCollapsible
-                }
-                endCollapsible={
-                  isRTL ? resizableInfo.startCollapsible : resizableInfo.endCollapsible
-                }
+                startCollapsible={resizableInfo.startCollapsible}
+                endCollapsible={resizableInfo.endCollapsible}
                 onOffsetStart={onInternalResizeStart}
                 onOffsetUpdate={(index, offsetX, offsetY) => {
                   let offset = isVertical ? offsetY : offsetX;

--- a/components/splitter/hooks/useResizable.ts
+++ b/components/splitter/hooks/useResizable.ts
@@ -52,8 +52,8 @@ export default function useResizable(items: ItemType[], pxSizes: number[], isRTL
 
       resizeInfos[i] = {
         resizable: mergedResizable,
-        startCollapsible: isRTL ? !!endCollapsible : !!startCollapsible,
-        endCollapsible: isRTL ? !!startCollapsible : !!endCollapsible,
+        startCollapsible: !!(isRTL ? endCollapsible : startCollapsible),
+        endCollapsible: !!(isRTL ? startCollapsible : endCollapsible),
       };
     }
 

--- a/components/splitter/hooks/useResizable.ts
+++ b/components/splitter/hooks/useResizable.ts
@@ -8,7 +8,7 @@ export type ResizableInfo = {
   endCollapsible: boolean;
 };
 
-export default function useResizable(items: ItemType[], pxSizes: number[]) {
+export default function useResizable(items: ItemType[], pxSizes: number[], isRTL: boolean) {
   return React.useMemo(() => {
     const resizeInfos: ResizableInfo[] = [];
 
@@ -52,8 +52,8 @@ export default function useResizable(items: ItemType[], pxSizes: number[]) {
 
       resizeInfos[i] = {
         resizable: mergedResizable,
-        startCollapsible: !!startCollapsible,
-        endCollapsible: !!endCollapsible,
+        startCollapsible: isRTL ? !!endCollapsible : !!startCollapsible,
+        endCollapsible: isRTL ? !!startCollapsible : !!endCollapsible,
       };
     }
 

--- a/components/splitter/hooks/useResize.ts
+++ b/components/splitter/hooks/useResize.ts
@@ -13,6 +13,7 @@ export default function useResize(
   percentSizes: number[],
   containerSize: number | undefined,
   updateSizes: (sizes: number[]) => void,
+  isRTL?: boolean,
 ) {
   const limitSizes = items.map((item) => [item.min, item.max]);
 
@@ -119,9 +120,10 @@ export default function useResize(
   // ======================= Collapse =======================
   const onCollapse = (index: number, type: 'start' | 'end') => {
     const currentSizes = getPxSizes();
+    const adjustedType = isRTL ? (type === 'start' ? 'end' : 'start') : type;
 
-    const currentIndex = type === 'start' ? index : index + 1;
-    const targetIndex = type === 'start' ? index + 1 : index;
+    const currentIndex = adjustedType === 'start' ? index : index + 1;
+    const targetIndex = adjustedType === 'start' ? index + 1 : index;
 
     const currentSize = currentSizes[currentIndex];
     const targetSize = currentSizes[targetIndex];
@@ -146,7 +148,7 @@ export default function useResize(
       const targetCacheCollapsedSize = cacheCollapsedSize.current[index];
       const currentCacheCollapsedSize = totalSize - targetCacheCollapsedSize;
 
-      const shouldUseCache = 
+      const shouldUseCache =
         targetCacheCollapsedSize &&
         targetCacheCollapsedSize <= targetSizeMax &&
         targetCacheCollapsedSize >= targetSizeMin &&

--- a/components/splitter/hooks/useResize.ts
+++ b/components/splitter/hooks/useResize.ts
@@ -13,7 +13,7 @@ export default function useResize(
   percentSizes: number[],
   containerSize: number | undefined,
   updateSizes: (sizes: number[]) => void,
-  isRTL?: boolean,
+  isRTL: boolean,
 ) {
   const limitSizes = items.map((item) => [item.min, item.max]);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

none

### 💡 Background and Solution

目前Splitter在RTL模式下，折叠箭头方向错位；且折叠尺寸计算也不对

#### **Before**

![Clipboard-20250120-133509-466](https://github.com/user-attachments/assets/ff452230-ef59-4038-8e44-4739cceac550)

#### **After**

![Clipboard-20250120-133924-777](https://github.com/user-attachments/assets/5b2d5530-0ade-4201-9ea4-3aa74d101d8e)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     🐞 Fix incorrect collapse behavior in RTL mode. Collapse icons and panel expansion/collapse direction now properly respond to RTL layout.      |
| 🇨🇳 Chinese |     🐞 修复 RTL 模式下折叠行为异常的问题。现在折叠图标方向和面板收缩方向将正确响应 RTL 布局。      |
