### PR TITLE
Revert "fix: default cssvarkey only picked when component themeconfig && parent th…"

### DIFF
--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -64,9 +64,7 @@ export default function useTheme(
         prefix: config?.prefixCls, // Same as prefixCls by default
         ...(typeof parentThemeConfig.cssVar === 'object' ? parentThemeConfig.cssVar : {}),
         ...(typeof themeConfig.cssVar === 'object' ? themeConfig.cssVar : {}),
-        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key)
-          || (typeof parentThemeConfig.cssVar === 'object' && parentThemeConfig.cssVar?.key)
-          || cssVarKey,
+        key: (typeof themeConfig.cssVar === 'object' && themeConfig.cssVar?.key) || cssVarKey,
       };
 
       // Base token


### PR DESCRIPTION
Reverts ant-design/ant-design#50377