### PR TITLE
fix: make closeIcon in useNotification work (#52494)

### DIFF
--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { render as testLibRender } from '@testing-library/react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import notification from '..';
@@ -234,5 +235,40 @@ describe('notification.hooks', () => {
       jest.advanceTimersByTime(1000);
     });
     expect(getNoticeCount()).toBe(0);
+  });
+
+  it('should hide close btn when closeIcon setting to null or false', () => {
+    const Demo = () => {
+      const Holder = (className: string, closeIcon?: React.ReactNode) => {
+        const [api, holder] = notification.useNotification({ closeIcon });
+
+        React.useEffect(() => {
+          api.info({
+            className,
+            message: 'Notification Title',
+            duration: 0,
+          });
+        }, []);
+
+        return holder;
+      };
+
+      return (
+        <>
+          {Holder('normal')}
+          {Holder('custom', <span className="custom-close-icon">Close</span>)}
+          {Holder('with-null', null)}
+          {Holder('with-false', false)}
+        </>
+      );
+    };
+
+    // We use origin testing lib here since StrictMode will render multiple times
+    testLibRender(<Demo />);
+
+    expect(document.querySelectorAll('.normal .ant-notification-notice-close').length).toBe(1);
+    expect(document.querySelectorAll('.custom .custom-close-icon').length).toBe(1);
+    expect(document.querySelectorAll('.with-null .ant-notification-notice-close').length).toBe(0);
+    expect(document.querySelectorAll('.with-false .ant-notification-notice-close').length).toBe(0);
   });
 });

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -78,4 +78,5 @@ export interface NotificationConfig {
   duration?: number;
   showProgress?: boolean;
   pauseOnHover?: boolean;
+  closeIcon?: React.ReactNode;
 }

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -158,7 +158,11 @@ export function useInternalNotification(
 
       const realCloseIcon = getCloseIcon(
         noticePrefixCls,
-        typeof closeIcon !== 'undefined' ? closeIcon : notification?.closeIcon,
+        typeof closeIcon !== 'undefined'
+          ? closeIcon
+          : typeof notificationConfig?.closeIcon !== 'undefined'
+            ? notificationConfig?.closeIcon
+            : notification?.closeIcon,
       );
 
       return originOpen({

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -17,7 +17,7 @@ import type {
 } from './interface';
 import { getCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
-import { getMotion, getPlacementStyle } from './util';
+import { getMotion, getPlacementStyle, getCloseIconConfig } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -158,11 +158,7 @@ export function useInternalNotification(
 
       const realCloseIcon = getCloseIcon(
         noticePrefixCls,
-        typeof closeIcon !== 'undefined'
-          ? closeIcon
-          : typeof notificationConfig?.closeIcon !== 'undefined'
-            ? notificationConfig?.closeIcon
-            : notification?.closeIcon,
+        getCloseIconConfig(closeIcon, notificationConfig, notification),
       );
 
       return originOpen({

--- a/components/notification/util.ts
+++ b/components/notification/util.ts
@@ -1,7 +1,8 @@
 import type * as React from 'react';
 import type { CSSMotionProps } from 'rc-motion';
 
-import type { NotificationPlacement } from './interface';
+import type { NotificationConfig, NotificationPlacement } from './interface';
+import type { NotificationConfig as CPNotificationConfig } from '../config-provider/context';
 
 export function getPlacementStyle(placement: NotificationPlacement, top: number, bottom: number) {
   let style: React.CSSProperties;
@@ -66,4 +67,18 @@ export function getMotion(prefixCls: string): CSSMotionProps {
   return {
     motionName: `${prefixCls}-fade`,
   };
+}
+
+export function getCloseIconConfig(
+  closeIcon: React.ReactNode,
+  notificationConfig?: NotificationConfig,
+  notification?: CPNotificationConfig,
+) {
+  if (typeof closeIcon !== 'undefined') {
+    return closeIcon;
+  }
+  if (typeof notificationConfig?.closeIcon !== 'undefined') {
+    return notificationConfig.closeIcon;
+  }
+  return notification?.closeIcon;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix #52494

### 💡 Background and Solution

- `closeIcon` is configured by `notification.success(config)`
- `notificationConfig.closeIcon` is configured by `notification.useNotification(config)`
- `notification.closeIcon` is configured by `ConfigProvider`
When compute `realCloseIcon`, take `closeIcon` as the first choice, `notificationConfig.closeIcon` as the second choice, and `notification.closeIcon` as the third choice.


This is a work ground, and I think it'd be better to refactor logic of notification configuration. 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix closeIcon config not work in useNotification |
| 🇨🇳 Chinese |   修复useNotification中closeIcon配置无效的问题 |
