### PR TITLE
fix(tree): allow pointer events for disabled checkboxes in tree

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -204,6 +204,12 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             backgroundColor: controlItemBgActiveDisabled,
           },
 
+        // we can not set pointer-events to none for checkbox in tree
+        // ref: https://github.com/ant-design/ant-design/issues/39822#issuecomment-2605234058
+        [`${treeCls}-checkbox-disabled`]: {
+          pointerEvents: 'unset',
+        },
+
         // not disable
         [`&:not(${treeNodeCls}-disabled)`]: {
           // >>> Title


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- ref https://github.com/ant-design/ant-design/issues/39822#issuecomment-2605234058

### 💡 Background and Solution

同时使用 `cursor: 'not-allowed'`和 `pointer-events: 'none'` 时，鼠标指针并不会变成 not-allowed 的样式，原因在于 pointer-events: none 会禁用所有鼠标事件，包括鼠标指针的样式变化。

![Clipboard-20250121-165634-357](https://github.com/user-attachments/assets/c2d5afbc-c3c9-41a6-928b-01ff11fa28e5)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  🐛 Fix cursor style for disabled Tree checkboxes. |
| 🇨🇳 Chinese |  🐛  修复 Tree 组件禁用状态下复选框的鼠标指针样式问题。         |
