### PR TITLE
fix(cascader): allow pointer events for disabled checkboxes

### DIFF
--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -25,6 +25,7 @@ const getColumnsStyle: GenerateStyle<CascaderToken> = (token: CascaderToken): CS
         '&-checkbox': {
           top: 0,
           marginInlineEnd: token.paddingXS,
+          pointerEvents: 'unset',
         },
 
         // ==================== Menu ====================


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- same as https://github.com/ant-design/ant-design/issues/39822#issuecomment-2605234058

### 💡 Background and Solution

**before**
![Clipboard-20250122-085806-005](https://github.com/user-attachments/assets/1e90a34a-3f20-4fa7-91e8-dfb261c97228)

**after**
![Clipboard-20250122-085623-768](https://github.com/user-attachments/assets/4535c44b-73f3-47ad-b584-b2cc0ba42825)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       🐛 Fix cursor style for disabled Cascader checkboxes.    |
| 🇨🇳 Chinese |    🐛 修复 Cascader 组件禁用状态下复选框的鼠标指针样式问题。       |
