### PR TITLE
fix[table]: resolve border color transition issues for the last row

### DIFF
--- a/components/table/style/index.ts
+++ b/components/table/style/index.ts
@@ -359,7 +359,7 @@ const genTableStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
                 )}
                 ${unit(calc(tablePaddingHorizontal).mul(-1).equal())}`,
                 [`${componentCls}-tbody > tr:last-child > td`]: {
-                  borderBottom: 0,
+                  borderBottomWidth: 0,
                   '&:first-child, &:last-child': {
                     borderRadius: 0,
                   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #52545

### 💡 Background and Solution

Modified the last row td `borderBottom: 0` to `borderBottomWidth: 0` to avoid triggering border color transition when resetting `borderBottom`. This fix ensures that the original last row does not have its border color transition when it becomes another row during table sorting.

#### Before
![image](https://github.com/user-attachments/assets/865fb2cc-d487-4891-b6fc-24bb0a5fe3c6)

#### After
![Td01FgNwkC](https://github.com/user-attachments/assets/590764e4-5e27-4bad-96ae-7382fe46ed7b)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix the border color transition issue of the last row in the table      |
| 🇨🇳 Chinese |      修复表格最后一行边框颜色过渡问题     |
