### PR TITLE
区分 Group 和 GroupProps

### DIFF
--- a/components/avatar/group.tsx
+++ b/components/avatar/group.tsx
@@ -28,7 +28,7 @@ const AvatarContextProvider: React.FC<AvatarContextType & ContextProps> = (props
   );
 };
 
-export interface GroupProps {
+export interface AvatarGroupProps {
   className?: string;
   rootClassName?: string;
   children?: React.ReactNode;
@@ -55,7 +55,7 @@ export interface GroupProps {
   shape?: 'circle' | 'square';
 }
 
-const Group: React.FC<GroupProps> = (props) => {
+const AvatarGroup: React.FC<AvatarGroupProps> = (props) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const {
     prefixCls: customizePrefixCls,
@@ -150,4 +150,4 @@ const Group: React.FC<GroupProps> = (props) => {
   );
 };
 
-export default Group;
+export default AvatarGroup;

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -1,16 +1,20 @@
 import InternalAvatar from './avatar';
-import Group from './group';
+import AvatarGroup from './group';
 
 export type { AvatarProps } from './avatar';
-export type { GroupProps } from './group';
-export { Group };
+export type {
+  AvatarGroupProps,
+  /** @deprecated Please use `AvatarGroupProps` */
+  AvatarGroupProps as GroupProps,
+} from './group';
+export { AvatarGroup as Group };
 
 type CompoundedComponent = typeof InternalAvatar & {
-  Group: typeof Group;
+  Group: typeof AvatarGroup;
 };
 
 const Avatar = InternalAvatar as CompoundedComponent;
 
-Avatar.Group = Group;
+Avatar.Group = AvatarGroup;
 
 export default Avatar;

--- a/components/input/Group.tsx
+++ b/components/input/Group.tsx
@@ -8,7 +8,7 @@ import type { FormItemStatusContextProps } from '../form/context';
 import { FormItemInputContext } from '../form/context';
 import useStyle from './style';
 
-export interface GroupProps {
+export interface InputGroupProps {
   className?: string;
   size?: 'large' | 'small' | 'default';
   children?: React.ReactNode;
@@ -21,7 +21,7 @@ export interface GroupProps {
   compact?: boolean;
 }
 
-const Group: React.FC<GroupProps> = (props) => {
+const InputGroup: React.FC<InputGroupProps> = (props) => {
   const { getPrefixCls, direction } = useContext(ConfigContext);
   const { prefixCls: customizePrefixCls, className } = props;
   const prefixCls = getPrefixCls('input-group', customizePrefixCls);
@@ -71,4 +71,4 @@ const Group: React.FC<GroupProps> = (props) => {
   );
 };
 
-export default Group;
+export default InputGroup;

--- a/components/input/index.tsx
+++ b/components/input/index.tsx
@@ -1,18 +1,22 @@
-import Group from './Group';
+import InputGroup from './Group';
 import InternalInput from './Input';
 import OTP from './OTP';
 import Password from './Password';
 import Search from './Search';
 import TextArea from './TextArea';
 
-export type { GroupProps } from './Group';
+export type {
+  InputGroupProps,
+  /** @deprecated Please use `InputGroupProps` */
+  InputGroupProps as GroupProps,
+} from './Group';
 export type { InputProps, InputRef } from './Input';
 export type { PasswordProps } from './Password';
 export type { SearchProps } from './Search';
 export type { TextAreaProps } from './TextArea';
 
 type CompoundedComponent = typeof InternalInput & {
-  Group: typeof Group;
+  Group: typeof InputGroup;
   Search: typeof Search;
   TextArea: typeof TextArea;
   Password: typeof Password;
@@ -21,7 +25,7 @@ type CompoundedComponent = typeof InternalInput & {
 
 const Input = InternalInput as CompoundedComponent;
 
-Input.Group = Group;
+Input.Group = InputGroup;
 Input.Search = Search;
 Input.TextArea = TextArea;
 Input.Password = Password;

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -11,7 +11,7 @@ import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import DatePicker from '../../date-picker';
 import Input from '../../input';
-import Group from '../../input/Group';
+import InputGroup from '../../input/Group';
 import Radio from '../../radio';
 import Switch from '../../switch';
 import { isTooltipOpen } from './util';
@@ -273,10 +273,10 @@ describe('Tooltip', () => {
     const ref = React.createRef<any>();
     const { container } = render(
       <Tooltip title="hello" onOpenChange={onOpenChange} ref={ref}>
-        <Group>
+        <InputGroup>
           <Input style={{ width: '50%' }} />
           <Input style={{ width: '50%' }} />
-        </Group>
+        </InputGroup>
       </Tooltip>,
     );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

components/avatar 和 components/input 都导出了同名的 GroupProps 接口，容易引起歧义和误用。因此分别重命名为 AvatarGroupProps 和 InputGroupProps，并将 GroupProps 标记为已废弃。

同时也重命名了 Group 组件为 AvatarGroup 和 InputGroup，不过他们是内部命名，不影响任何对外接口。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(Avatar): export AvatarGroupProps and deprecate GroupProps |
| 🇺🇸 English | feat(Input): export InputGroupProps and deprecate GroupProps |
| 🇨🇳 Chinese | feat(Avatar): 导出 AvatarGroupProps 并废弃 GroupProps  |
| 🇨🇳 Chinese | feat(Input): 导出 InputGroupProps 并废弃 GroupProps |
