### PR TITLE
refactor(Input): make TextArea style tree shakeable

### DIFF
--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -1,11 +1,7 @@
 import { unit } from '@ant-design/cssinjs';
 
-import {
-  genBasicInputStyle,
-  genInputGroupStyle,
-  genPlaceholderStyle,
-  initInputToken,
-} from '../../input/style';
+import { genBasicInputStyle, genPlaceholderStyle, initInputToken } from '../../input/style';
+import { genInputGroupStyle } from '../../input/style/group';
 import {
   genBorderlessStyle,
   genFilledGroupStyle,

--- a/components/input/Group.tsx
+++ b/components/input/Group.tsx
@@ -6,7 +6,7 @@ import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import type { FormItemStatusContextProps } from '../form/context';
 import { FormItemInputContext } from '../form/context';
-import useStyle from './style';
+import useStyle from './style/group';
 
 export interface GroupProps {
   className?: string;

--- a/components/input/style/group.ts
+++ b/components/input/style/group.ts
@@ -1,0 +1,394 @@
+import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
+
+import { clearFix, resetComponent } from '../../style';
+import type { GenerateStyle } from '../../theme/internal';
+import { genStyleHooks, mergeToken } from '../../theme/internal';
+import type { InputToken } from './token';
+import { initComponentToken, initInputToken } from './token';
+import { genFilledGroupStyle, genOutlinedGroupStyle } from './variants';
+import { genInputLargeStyle, genInputSmallStyle } from '.';
+
+export const genInputGroupStyle = (token: InputToken): CSSObject => {
+  const { componentCls, antCls } = token;
+
+  return {
+    position: 'relative',
+    display: 'table',
+    width: '100%',
+    borderCollapse: 'separate',
+    borderSpacing: 0,
+
+    // Undo padding and float of grid classes
+    "&[class*='col-']": {
+      paddingInlineEnd: token.paddingXS,
+
+      '&:last-child': {
+        paddingInlineEnd: 0,
+      },
+    },
+
+    // Sizing options
+    [`&-lg ${componentCls}, &-lg > ${componentCls}-group-addon`]: {
+      ...genInputLargeStyle(token),
+    },
+
+    [`&-sm ${componentCls}, &-sm > ${componentCls}-group-addon`]: {
+      ...genInputSmallStyle(token),
+    },
+
+    // Fix https://github.com/ant-design/ant-design/issues/5754
+    [`&-lg ${antCls}-select-single ${antCls}-select-selector`]: {
+      height: token.controlHeightLG,
+    },
+
+    [`&-sm ${antCls}-select-single ${antCls}-select-selector`]: {
+      height: token.controlHeightSM,
+    },
+
+    [`> ${componentCls}`]: {
+      display: 'table-cell',
+
+      '&:not(:first-child):not(:last-child)': {
+        borderRadius: 0,
+      },
+    },
+
+    [`${componentCls}-group`]: {
+      '&-addon, &-wrap': {
+        display: 'table-cell',
+        width: 1,
+        whiteSpace: 'nowrap',
+        verticalAlign: 'middle',
+
+        '&:not(:first-child):not(:last-child)': {
+          borderRadius: 0,
+        },
+      },
+
+      '&-wrap > *': {
+        display: 'block !important',
+      },
+
+      '&-addon': {
+        position: 'relative',
+        padding: `0 ${unit(token.paddingInline)}`,
+        color: token.colorText,
+        fontWeight: 'normal',
+        fontSize: token.inputFontSize,
+        textAlign: 'center',
+        borderRadius: token.borderRadius,
+        transition: `all ${token.motionDurationSlow}`,
+        lineHeight: 1,
+
+        // Reset Select's style in addon
+        [`${antCls}-select`]: {
+          margin: `${unit(token.calc(token.paddingBlock).add(1).mul(-1).equal())} ${unit(
+            token.calc(token.paddingInline).mul(-1).equal(),
+          )}`,
+
+          [`&${antCls}-select-single:not(${antCls}-select-customize-input):not(${antCls}-pagination-size-changer)`]:
+            {
+              [`${antCls}-select-selector`]: {
+                backgroundColor: 'inherit',
+                border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
+                boxShadow: 'none',
+              },
+            },
+        },
+
+        // https://github.com/ant-design/ant-design/issues/31333
+        [`${antCls}-cascader-picker`]: {
+          margin: `-9px ${unit(token.calc(token.paddingInline).mul(-1).equal())}`,
+          backgroundColor: 'transparent',
+          [`${antCls}-cascader-input`]: {
+            textAlign: 'start',
+            border: 0,
+            boxShadow: 'none',
+          },
+        },
+      },
+    },
+
+    [componentCls]: {
+      width: '100%',
+      marginBottom: 0,
+      textAlign: 'inherit',
+
+      '&:focus': {
+        zIndex: 1, // Fix https://gw.alipayobjects.com/zos/rmsportal/DHNpoqfMXSfrSnlZvhsJ.png
+        borderInlineEndWidth: 1,
+      },
+
+      '&:hover': {
+        zIndex: 1,
+        borderInlineEndWidth: 1,
+
+        [`${componentCls}-search-with-button &`]: {
+          zIndex: 0,
+        },
+      },
+    },
+
+    // Reset rounded corners
+    [`> ${componentCls}:first-child, ${componentCls}-group-addon:first-child`]: {
+      borderStartEndRadius: 0,
+      borderEndEndRadius: 0,
+
+      // Reset Select's style in addon
+      [`${antCls}-select ${antCls}-select-selector`]: {
+        borderStartEndRadius: 0,
+        borderEndEndRadius: 0,
+      },
+    },
+
+    [`> ${componentCls}-affix-wrapper`]: {
+      [`&:not(:first-child) ${componentCls}`]: {
+        borderStartStartRadius: 0,
+        borderEndStartRadius: 0,
+      },
+
+      [`&:not(:last-child) ${componentCls}`]: {
+        borderStartEndRadius: 0,
+        borderEndEndRadius: 0,
+      },
+    },
+
+    [`> ${componentCls}:last-child, ${componentCls}-group-addon:last-child`]: {
+      borderStartStartRadius: 0,
+      borderEndStartRadius: 0,
+
+      // Reset Select's style in addon
+      [`${antCls}-select ${antCls}-select-selector`]: {
+        borderStartStartRadius: 0,
+        borderEndStartRadius: 0,
+      },
+    },
+
+    [`${componentCls}-affix-wrapper`]: {
+      '&:not(:last-child)': {
+        borderStartEndRadius: 0,
+        borderEndEndRadius: 0,
+        [`${componentCls}-search &`]: {
+          borderStartStartRadius: token.borderRadius,
+          borderEndStartRadius: token.borderRadius,
+        },
+      },
+
+      [`&:not(:first-child), ${componentCls}-search &:not(:first-child)`]: {
+        borderStartStartRadius: 0,
+        borderEndStartRadius: 0,
+      },
+    },
+
+    [`&${componentCls}-group-compact`]: {
+      display: 'block',
+      ...clearFix(),
+
+      [`${componentCls}-group-addon, ${componentCls}-group-wrap, > ${componentCls}`]: {
+        '&:not(:first-child):not(:last-child)': {
+          borderInlineEndWidth: token.lineWidth,
+
+          '&:hover, &:focus': {
+            zIndex: 1,
+          },
+        },
+      },
+
+      '& > *': {
+        display: 'inline-flex',
+        float: 'none',
+        verticalAlign: 'top', // https://github.com/ant-design/ant-design-pro/issues/139
+        borderRadius: 0,
+      },
+
+      [`
+        & > ${componentCls}-affix-wrapper,
+        & > ${componentCls}-number-affix-wrapper,
+        & > ${antCls}-picker-range
+      `]: {
+        display: 'inline-flex',
+      },
+
+      '& > *:not(:last-child)': {
+        marginInlineEnd: token.calc(token.lineWidth).mul(-1).equal(),
+        borderInlineEndWidth: token.lineWidth,
+      },
+
+      // Undo float for .ant-input-group .ant-input
+      [componentCls]: {
+        float: 'none',
+      },
+
+      // reset border for Select, DatePicker, AutoComplete, Cascader, Mention, TimePicker, Input
+      [`& > ${antCls}-select > ${antCls}-select-selector,
+      & > ${antCls}-select-auto-complete ${componentCls},
+      & > ${antCls}-cascader-picker ${componentCls},
+      & > ${componentCls}-group-wrapper ${componentCls}`]: {
+        borderInlineEndWidth: token.lineWidth,
+        borderRadius: 0,
+
+        '&:hover, &:focus': {
+          zIndex: 1,
+        },
+      },
+
+      [`& > ${antCls}-select-focused`]: {
+        zIndex: 1,
+      },
+
+      // update z-index for arrow icon
+      [`& > ${antCls}-select > ${antCls}-select-arrow`]: {
+        zIndex: 1, // https://github.com/ant-design/ant-design/issues/20371
+      },
+
+      [`& > *:first-child,
+      & > ${antCls}-select:first-child > ${antCls}-select-selector,
+      & > ${antCls}-select-auto-complete:first-child ${componentCls},
+      & > ${antCls}-cascader-picker:first-child ${componentCls}`]: {
+        borderStartStartRadius: token.borderRadius,
+        borderEndStartRadius: token.borderRadius,
+      },
+
+      [`& > *:last-child,
+      & > ${antCls}-select:last-child > ${antCls}-select-selector,
+      & > ${antCls}-cascader-picker:last-child ${componentCls},
+      & > ${antCls}-cascader-picker-focused:last-child ${componentCls}`]: {
+        borderInlineEndWidth: token.lineWidth,
+        borderStartEndRadius: token.borderRadius,
+        borderEndEndRadius: token.borderRadius,
+      },
+
+      // https://github.com/ant-design/ant-design/issues/12493
+      [`& > ${antCls}-select-auto-complete ${componentCls}`]: {
+        verticalAlign: 'top',
+      },
+
+      [`${componentCls}-group-wrapper + ${componentCls}-group-wrapper`]: {
+        marginInlineStart: token.calc(token.lineWidth).mul(-1).equal(),
+        [`${componentCls}-affix-wrapper`]: {
+          borderRadius: 0,
+        },
+      },
+
+      [`${componentCls}-group-wrapper:not(:last-child)`]: {
+        [`&${componentCls}-search > ${componentCls}-group`]: {
+          [`& > ${componentCls}-group-addon > ${componentCls}-search-button`]: {
+            borderRadius: 0,
+          },
+
+          [`& > ${componentCls}`]: {
+            borderStartStartRadius: token.borderRadius,
+            borderStartEndRadius: 0,
+            borderEndEndRadius: 0,
+            borderEndStartRadius: token.borderRadius,
+          },
+        },
+      },
+    },
+  };
+};
+
+const genGroupStyle: GenerateStyle<InputToken> = (token: InputToken) => {
+  const { componentCls, borderRadiusLG, borderRadiusSM } = token;
+
+  return {
+    [`${componentCls}-group`]: {
+      // Style for input-group: input with label, with button or dropdown...
+      ...resetComponent(token),
+      ...genInputGroupStyle(token),
+
+      '&-rtl': {
+        direction: 'rtl',
+      },
+
+      '&-wrapper': {
+        display: 'inline-block',
+        width: '100%',
+        textAlign: 'start',
+        verticalAlign: 'top', // https://github.com/ant-design/ant-design/issues/6403
+
+        '&-rtl': {
+          direction: 'rtl',
+        },
+
+        // Size
+        '&-lg': {
+          [`${componentCls}-group-addon`]: {
+            borderRadius: borderRadiusLG,
+            fontSize: token.inputFontSizeLG,
+          },
+        },
+        '&-sm': {
+          [`${componentCls}-group-addon`]: {
+            borderRadius: borderRadiusSM,
+          },
+        },
+
+        // Variants
+        ...genOutlinedGroupStyle(token),
+        ...genFilledGroupStyle(token),
+
+        // '&-disabled': {
+        //   [`${componentCls}-group-addon`]: {
+        //     ...genDisabledStyle(token),
+        //   },
+        // },
+
+        // Fix the issue of using icons in Space Compact mode
+        // https://github.com/ant-design/ant-design/issues/42122
+        [`&:not(${componentCls}-compact-first-item):not(${componentCls}-compact-last-item)${componentCls}-compact-item`]:
+          {
+            [`${componentCls}, ${componentCls}-group-addon`]: {
+              borderRadius: 0,
+            },
+          },
+
+        [`&:not(${componentCls}-compact-last-item)${componentCls}-compact-first-item`]: {
+          [`${componentCls}, ${componentCls}-group-addon`]: {
+            borderStartEndRadius: 0,
+            borderEndEndRadius: 0,
+          },
+        },
+
+        [`&:not(${componentCls}-compact-first-item)${componentCls}-compact-last-item`]: {
+          [`${componentCls}, ${componentCls}-group-addon`]: {
+            borderStartStartRadius: 0,
+            borderEndStartRadius: 0,
+          },
+        },
+
+        // Fix the issue of input use show-count param in space compact mode
+        // https://github.com/ant-design/ant-design/issues/46872
+        [`&:not(${componentCls}-compact-last-item)${componentCls}-compact-item`]: {
+          [`${componentCls}-affix-wrapper`]: {
+            borderStartEndRadius: 0,
+            borderEndEndRadius: 0,
+          },
+        },
+        // Fix the issue of input use `addonAfter` param in space compact mode
+        // https://github.com/ant-design/ant-design/issues/52483
+        [`&:not(${componentCls}-compact-first-item)${componentCls}-compact-item`]: {
+          [`${componentCls}-affix-wrapper`]: {
+            borderStartStartRadius: 0,
+            borderEndStartRadius: 0,
+          },
+        },
+      },
+    },
+  };
+};
+
+// ============================== Export ==============================
+export default genStyleHooks(
+  'Input',
+  (token) => {
+    const inputToken = mergeToken<InputToken>(token, initInputToken(token));
+
+    return [genGroupStyle(inputToken)];
+  },
+  initComponentToken,
+  {
+    resetFont: false,
+  },
+);

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -1,19 +1,13 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 
-import { clearFix, resetComponent } from '../../style';
+import { resetComponent } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import type { GenerateStyle } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 import type { ComponentToken, InputToken } from './token';
 import { initComponentToken, initInputToken } from './token';
-import {
-  genBorderlessStyle,
-  genFilledGroupStyle,
-  genFilledStyle,
-  genOutlinedGroupStyle,
-  genOutlinedStyle,
-} from './variants';
+import { genBorderlessStyle, genFilledStyle, genOutlinedStyle } from './variants';
 
 export type { ComponentToken };
 export { initComponentToken, initInputToken };
@@ -39,7 +33,7 @@ export const genActiveStyle = (token: InputToken) => ({
   backgroundColor: token.activeBg,
 });
 
-const genInputLargeStyle = (token: InputToken): CSSObject => {
+export const genInputLargeStyle = (token: InputToken): CSSObject => {
   const { paddingBlockLG, lineHeightLG, borderRadiusLG, paddingInlineLG } = token;
 
   return {
@@ -93,286 +87,6 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
     direction: 'rtl',
   },
 });
-
-export const genInputGroupStyle = (token: InputToken): CSSObject => {
-  const { componentCls, antCls } = token;
-
-  return {
-    position: 'relative',
-    display: 'table',
-    width: '100%',
-    borderCollapse: 'separate',
-    borderSpacing: 0,
-
-    // Undo padding and float of grid classes
-    "&[class*='col-']": {
-      paddingInlineEnd: token.paddingXS,
-
-      '&:last-child': {
-        paddingInlineEnd: 0,
-      },
-    },
-
-    // Sizing options
-    [`&-lg ${componentCls}, &-lg > ${componentCls}-group-addon`]: {
-      ...genInputLargeStyle(token),
-    },
-
-    [`&-sm ${componentCls}, &-sm > ${componentCls}-group-addon`]: {
-      ...genInputSmallStyle(token),
-    },
-
-    // Fix https://github.com/ant-design/ant-design/issues/5754
-    [`&-lg ${antCls}-select-single ${antCls}-select-selector`]: {
-      height: token.controlHeightLG,
-    },
-
-    [`&-sm ${antCls}-select-single ${antCls}-select-selector`]: {
-      height: token.controlHeightSM,
-    },
-
-    [`> ${componentCls}`]: {
-      display: 'table-cell',
-
-      '&:not(:first-child):not(:last-child)': {
-        borderRadius: 0,
-      },
-    },
-
-    [`${componentCls}-group`]: {
-      '&-addon, &-wrap': {
-        display: 'table-cell',
-        width: 1,
-        whiteSpace: 'nowrap',
-        verticalAlign: 'middle',
-
-        '&:not(:first-child):not(:last-child)': {
-          borderRadius: 0,
-        },
-      },
-
-      '&-wrap > *': {
-        display: 'block !important',
-      },
-
-      '&-addon': {
-        position: 'relative',
-        padding: `0 ${unit(token.paddingInline)}`,
-        color: token.colorText,
-        fontWeight: 'normal',
-        fontSize: token.inputFontSize,
-        textAlign: 'center',
-        borderRadius: token.borderRadius,
-        transition: `all ${token.motionDurationSlow}`,
-        lineHeight: 1,
-
-        // Reset Select's style in addon
-        [`${antCls}-select`]: {
-          margin: `${unit(token.calc(token.paddingBlock).add(1).mul(-1).equal())} ${unit(
-            token.calc(token.paddingInline).mul(-1).equal(),
-          )}`,
-
-          [`&${antCls}-select-single:not(${antCls}-select-customize-input):not(${antCls}-pagination-size-changer)`]:
-            {
-              [`${antCls}-select-selector`]: {
-                backgroundColor: 'inherit',
-                border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
-                boxShadow: 'none',
-              },
-            },
-        },
-
-        // https://github.com/ant-design/ant-design/issues/31333
-        [`${antCls}-cascader-picker`]: {
-          margin: `-9px ${unit(token.calc(token.paddingInline).mul(-1).equal())}`,
-          backgroundColor: 'transparent',
-          [`${antCls}-cascader-input`]: {
-            textAlign: 'start',
-            border: 0,
-            boxShadow: 'none',
-          },
-        },
-      },
-    },
-
-    [componentCls]: {
-      width: '100%',
-      marginBottom: 0,
-      textAlign: 'inherit',
-
-      '&:focus': {
-        zIndex: 1, // Fix https://gw.alipayobjects.com/zos/rmsportal/DHNpoqfMXSfrSnlZvhsJ.png
-        borderInlineEndWidth: 1,
-      },
-
-      '&:hover': {
-        zIndex: 1,
-        borderInlineEndWidth: 1,
-
-        [`${componentCls}-search-with-button &`]: {
-          zIndex: 0,
-        },
-      },
-    },
-
-    // Reset rounded corners
-    [`> ${componentCls}:first-child, ${componentCls}-group-addon:first-child`]: {
-      borderStartEndRadius: 0,
-      borderEndEndRadius: 0,
-
-      // Reset Select's style in addon
-      [`${antCls}-select ${antCls}-select-selector`]: {
-        borderStartEndRadius: 0,
-        borderEndEndRadius: 0,
-      },
-    },
-
-    [`> ${componentCls}-affix-wrapper`]: {
-      [`&:not(:first-child) ${componentCls}`]: {
-        borderStartStartRadius: 0,
-        borderEndStartRadius: 0,
-      },
-
-      [`&:not(:last-child) ${componentCls}`]: {
-        borderStartEndRadius: 0,
-        borderEndEndRadius: 0,
-      },
-    },
-
-    [`> ${componentCls}:last-child, ${componentCls}-group-addon:last-child`]: {
-      borderStartStartRadius: 0,
-      borderEndStartRadius: 0,
-
-      // Reset Select's style in addon
-      [`${antCls}-select ${antCls}-select-selector`]: {
-        borderStartStartRadius: 0,
-        borderEndStartRadius: 0,
-      },
-    },
-
-    [`${componentCls}-affix-wrapper`]: {
-      '&:not(:last-child)': {
-        borderStartEndRadius: 0,
-        borderEndEndRadius: 0,
-        [`${componentCls}-search &`]: {
-          borderStartStartRadius: token.borderRadius,
-          borderEndStartRadius: token.borderRadius,
-        },
-      },
-
-      [`&:not(:first-child), ${componentCls}-search &:not(:first-child)`]: {
-        borderStartStartRadius: 0,
-        borderEndStartRadius: 0,
-      },
-    },
-
-    [`&${componentCls}-group-compact`]: {
-      display: 'block',
-      ...clearFix(),
-
-      [`${componentCls}-group-addon, ${componentCls}-group-wrap, > ${componentCls}`]: {
-        '&:not(:first-child):not(:last-child)': {
-          borderInlineEndWidth: token.lineWidth,
-
-          '&:hover, &:focus': {
-            zIndex: 1,
-          },
-        },
-      },
-
-      '& > *': {
-        display: 'inline-flex',
-        float: 'none',
-        verticalAlign: 'top', // https://github.com/ant-design/ant-design-pro/issues/139
-        borderRadius: 0,
-      },
-
-      [`
-        & > ${componentCls}-affix-wrapper,
-        & > ${componentCls}-number-affix-wrapper,
-        & > ${antCls}-picker-range
-      `]: {
-        display: 'inline-flex',
-      },
-
-      '& > *:not(:last-child)': {
-        marginInlineEnd: token.calc(token.lineWidth).mul(-1).equal(),
-        borderInlineEndWidth: token.lineWidth,
-      },
-
-      // Undo float for .ant-input-group .ant-input
-      [componentCls]: {
-        float: 'none',
-      },
-
-      // reset border for Select, DatePicker, AutoComplete, Cascader, Mention, TimePicker, Input
-      [`& > ${antCls}-select > ${antCls}-select-selector,
-      & > ${antCls}-select-auto-complete ${componentCls},
-      & > ${antCls}-cascader-picker ${componentCls},
-      & > ${componentCls}-group-wrapper ${componentCls}`]: {
-        borderInlineEndWidth: token.lineWidth,
-        borderRadius: 0,
-
-        '&:hover, &:focus': {
-          zIndex: 1,
-        },
-      },
-
-      [`& > ${antCls}-select-focused`]: {
-        zIndex: 1,
-      },
-
-      // update z-index for arrow icon
-      [`& > ${antCls}-select > ${antCls}-select-arrow`]: {
-        zIndex: 1, // https://github.com/ant-design/ant-design/issues/20371
-      },
-
-      [`& > *:first-child,
-      & > ${antCls}-select:first-child > ${antCls}-select-selector,
-      & > ${antCls}-select-auto-complete:first-child ${componentCls},
-      & > ${antCls}-cascader-picker:first-child ${componentCls}`]: {
-        borderStartStartRadius: token.borderRadius,
-        borderEndStartRadius: token.borderRadius,
-      },
-
-      [`& > *:last-child,
-      & > ${antCls}-select:last-child > ${antCls}-select-selector,
-      & > ${antCls}-cascader-picker:last-child ${componentCls},
-      & > ${antCls}-cascader-picker-focused:last-child ${componentCls}`]: {
-        borderInlineEndWidth: token.lineWidth,
-        borderStartEndRadius: token.borderRadius,
-        borderEndEndRadius: token.borderRadius,
-      },
-
-      // https://github.com/ant-design/ant-design/issues/12493
-      [`& > ${antCls}-select-auto-complete ${componentCls}`]: {
-        verticalAlign: 'top',
-      },
-
-      [`${componentCls}-group-wrapper + ${componentCls}-group-wrapper`]: {
-        marginInlineStart: token.calc(token.lineWidth).mul(-1).equal(),
-        [`${componentCls}-affix-wrapper`]: {
-          borderRadius: 0,
-        },
-      },
-
-      [`${componentCls}-group-wrapper:not(:last-child)`]: {
-        [`&${componentCls}-search > ${componentCls}-group`]: {
-          [`& > ${componentCls}-group-addon > ${componentCls}-search-button`]: {
-            borderRadius: 0,
-          },
-
-          [`& > ${componentCls}`]: {
-            borderStartStartRadius: token.borderRadius,
-            borderStartEndRadius: 0,
-            borderEndEndRadius: 0,
-            borderEndStartRadius: token.borderRadius,
-          },
-        },
-      },
-    },
-  };
-};
 
 const genInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
   const { componentCls, controlHeightSM, lineWidth, calc } = token;
@@ -559,96 +273,6 @@ const genAffixStyle: GenerateStyle<InputToken> = (token: InputToken) => {
 
         '&:hover': {
           color: colorIcon,
-        },
-      },
-    },
-  };
-};
-
-const genGroupStyle: GenerateStyle<InputToken> = (token: InputToken) => {
-  const { componentCls, borderRadiusLG, borderRadiusSM } = token;
-
-  return {
-    [`${componentCls}-group`]: {
-      // Style for input-group: input with label, with button or dropdown...
-      ...resetComponent(token),
-      ...genInputGroupStyle(token),
-
-      '&-rtl': {
-        direction: 'rtl',
-      },
-
-      '&-wrapper': {
-        display: 'inline-block',
-        width: '100%',
-        textAlign: 'start',
-        verticalAlign: 'top', // https://github.com/ant-design/ant-design/issues/6403
-
-        '&-rtl': {
-          direction: 'rtl',
-        },
-
-        // Size
-        '&-lg': {
-          [`${componentCls}-group-addon`]: {
-            borderRadius: borderRadiusLG,
-            fontSize: token.inputFontSizeLG,
-          },
-        },
-        '&-sm': {
-          [`${componentCls}-group-addon`]: {
-            borderRadius: borderRadiusSM,
-          },
-        },
-
-        // Variants
-        ...genOutlinedGroupStyle(token),
-        ...genFilledGroupStyle(token),
-
-        // '&-disabled': {
-        //   [`${componentCls}-group-addon`]: {
-        //     ...genDisabledStyle(token),
-        //   },
-        // },
-
-        // Fix the issue of using icons in Space Compact mode
-        // https://github.com/ant-design/ant-design/issues/42122
-        [`&:not(${componentCls}-compact-first-item):not(${componentCls}-compact-last-item)${componentCls}-compact-item`]:
-          {
-            [`${componentCls}, ${componentCls}-group-addon`]: {
-              borderRadius: 0,
-            },
-          },
-
-        [`&:not(${componentCls}-compact-last-item)${componentCls}-compact-first-item`]: {
-          [`${componentCls}, ${componentCls}-group-addon`]: {
-            borderStartEndRadius: 0,
-            borderEndEndRadius: 0,
-          },
-        },
-
-        [`&:not(${componentCls}-compact-first-item)${componentCls}-compact-last-item`]: {
-          [`${componentCls}, ${componentCls}-group-addon`]: {
-            borderStartStartRadius: 0,
-            borderEndStartRadius: 0,
-          },
-        },
-
-        // Fix the issue of input use show-count param in space compact mode
-        // https://github.com/ant-design/ant-design/issues/46872
-        [`&:not(${componentCls}-compact-last-item)${componentCls}-compact-item`]: {
-          [`${componentCls}-affix-wrapper`]: {
-            borderStartEndRadius: 0,
-            borderEndEndRadius: 0,
-          },
-        },
-        // Fix the issue of input use `addonAfter` param in space compact mode
-        // https://github.com/ant-design/ant-design/issues/52483
-        [`&:not(${componentCls}-compact-first-item)${componentCls}-compact-item`]: {
-          [`${componentCls}-affix-wrapper`]: {
-            borderStartStartRadius: 0,
-            borderEndStartRadius: 0,
-          },
         },
       },
     },
@@ -879,7 +503,6 @@ export default genStyleHooks(
       genInputStyle(inputToken),
       genTextAreaStyle(inputToken),
       genAffixStyle(inputToken),
-      genGroupStyle(inputToken),
       genSearchInputStyle(inputToken),
       genRangeStyle(inputToken),
       // =====================================================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [x] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor(Input): make Group style tree shakeable |
| 🇨🇳 Chinese | refactor(Input): 让 Group 样式支持 tree shaking |
