### PR TITLE
Optimize internal input tree shaking

### DIFF
--- a/components/color-picker/components/ColorHexInput.tsx
+++ b/components/color-picker/components/ColorHexInput.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useEffect, useState } from 'react';
 
-import Input from '../../input';
+import Input from '../../input/Input';
 import type { AggregationColor } from '../color';
 import { toHexFormat } from '../color';
 import { generateColor } from '../util';

--- a/components/table/hooks/useFilter/FilterSearch.tsx
+++ b/components/table/hooks/useFilter/FilterSearch.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
 
 import type { AnyObject } from '../../../_util/type';
-import Input from '../../../input';
+import Input from '../../../input/Input';
 import type { FilterSearchType, TableLocale } from '../../interface';
 
 interface FilterSearchProps<RecordType = AnyObject> {

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
-import Input from '../input';
+import Input from '../input/Input';
 
 export interface TransferSearchProps {
   prefixCls?: string;
@@ -12,14 +12,7 @@ export interface TransferSearchProps {
 }
 
 const Search: React.FC<TransferSearchProps> = (props) => {
-  const {
-    placeholder = '',
-    value,
-    prefixCls,
-    disabled,
-    onChange,
-    handleClear,
-  } = props;
+  const { placeholder = '', value, prefixCls, disabled, onChange, handleClear } = props;
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [x] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

将内部依赖的 `import Input from '../input'` 改为 `import Input from '../input/Input'` 可以避免将不需要的 TextArea, Search, OTP 等组件打包进来，减少最后的打包体积。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | refactor(ColorPicker): optimize bundle size |
| 🇺🇸 English | refactor(Table): optimize bundle size |
| 🇺🇸 English | refactor(Transfer): optimize bundle size |
| 🇨🇳 Chinese | refactor(ColorPicker): 优化打包体积 |
| 🇨🇳 Chinese | refactor(Table): 优化打包体积 |
| 🇨🇳 Chinese | refactor(Transfer): 优化打包体积 |