### PR TITLE
Rate 的 tooltips属性支持全部的Tooltip props

### DIFF
--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tweet
-        uses: nearform-actions/github-action-notify-twitter@v1
+        uses: nearform-actions/github-action-notify-twitter@master
         with:
           message: |
             🤖 Ant Design just released antd@${{ github.event.ref }} ✨🎊✨ Check out the full release note: https://github.com/ant-design/ant-design/releases/tag/${{ github.event.ref }}
           twitter-app-key: ${{ secrets.TWITTER_API_KEY }}
-          twitter-app-secret: ${{ secrets.TWITTER_API_SECRET_KEY }}
+          twitter-app-secret: ${{ secrets.TWITTER_API_SECRET }}
           twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}

--- a/.github/workflows/release-x.yml
+++ b/.github/workflows/release-x.yml
@@ -14,7 +14,7 @@ jobs:
         uses: nearform-actions/github-action-notify-twitter@master
         with:
           message: |
-            🤖 Ant Design just released antd@${{ github.event.ref }} ✨🎊✨ Check out the full release note: https://github.com/ant-design/ant-design/releases/tag/${{ github.event.ref }}
+            🤖 Ant Design just released antd@${{ github.event.release.tag_name }} ✨🎊✨ Check out the full release note: ${{ github.event.release.html_url }}
           twitter-app-key: ${{ secrets.TWITTER_API_KEY }}
           twitter-app-secret: ${{ secrets.TWITTER_API_SECRET }}
           twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/.github/workflows/release-x.yml
+++ b/.github/workflows/release-x.yml
@@ -1,10 +1,9 @@
-name: 🐦 Release to Tweet
+name: 🆇 Release to X
 
 on:
-  create
-
-permissions:
-  contents: read
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   tweet:

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -18,6 +18,7 @@ import useVariant from '../form/hooks/useVariants';
 import type { InputFocusOptions } from './Input';
 import { triggerFocus } from './Input';
 import useStyle from './style';
+import { useCompactItemContext } from '../space/Compact';
 
 export interface TextAreaProps extends Omit<RcTextAreaProps, 'suffix'> {
   /** @deprecated Use `variant` instead */
@@ -62,9 +63,6 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
 
   const { getPrefixCls, direction, textArea } = React.useContext(ConfigContext);
 
-  // ===================== Size =====================
-  const mergedSize = useSize(customizeSize);
-
   // ===================== Disabled =====================
   const disabled = React.useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
@@ -94,6 +92,12 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
+  // ===================== Compact Item =====================
+  const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
+
+  // ===================== Size =====================
+  const mergedSize = useSize((ctx) => customizeSize ?? compactSize ?? ctx);
+
   const [variant, enableVariantCls] = useVariant('textArea', customVariant, bordered);
 
   const mergedAllowClear = getAllowClear(allowClear ?? textArea?.allowClear);
@@ -106,7 +110,14 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
       styles={{ ...textArea?.styles, ...styles }}
       disabled={mergedDisabled}
       allowClear={mergedAllowClear}
-      className={classNames(cssVarCls, rootCls, className, rootClassName, textArea?.className)}
+      className={classNames(
+        cssVarCls,
+        rootCls,
+        className,
+        rootClassName,
+        compactItemClassnames,
+        textArea?.className,
+      )}
       classNames={{
         ...classes,
         ...textArea?.classNames,

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -109,7 +109,7 @@ The rest of the props of `Input.TextArea` are the same as the original [textarea
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| enterButton | Whether to show an enter button after input. This property conflicts with the `addonAfter` property | ReactNode | false |
+| enterButton | false displays the default button color, true uses the primary color, or you can provide a custom button. Conflicts with addonAfter. | ReactNode | false |
 | loading | Search box with loading | boolean | false |
 | onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key | function(value, event, { source: "input" \| "clear" }) | - |
 

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -810,6 +810,10 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
           border: 'none',
           outline: 'none',
           background: 'transparent',
+          minHeight: token
+            .calc(token.controlHeight)
+            .sub(token.calc(token.lineWidth).mul(2))
+            .equal(),
 
           '&:focus': {
             boxShadow: 'none !important',

--- a/components/locale/ar_EG.ts
+++ b/components/locale/ar_EG.ts
@@ -30,6 +30,11 @@ const localeValues: Locale = {
     triggerAsc: 'ترتيب تصاعدي',
     cancelSort: 'إلغاء الترتيب',
   },
+  Tour: {
+    Next: 'التالي',
+    Previous: 'السابق',
+    Finish: 'إنهاء',
+  },
   Modal: {
     okText: 'تأكيد',
     cancelText: 'إلغاء',

--- a/components/locale/he_IL.ts
+++ b/components/locale/he_IL.ts
@@ -30,6 +30,11 @@ const localeValues: Locale = {
     triggerAsc: 'לחץ למיון לפי סדר עולה',
     cancelSort: 'לחץ כדי לבטל את המיון',
   },
+  Tour: {
+    Next: 'הבא',
+    Previous: 'הקודם',
+    Finish: 'סיום',
+  },
   Modal: {
     okText: 'אישור',
     cancelText: 'ביטול',

--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -1020,6 +1020,7 @@ export default (prefixCls: string, rootCls: string = prefixCls, injectStyle = tr
         itemHoverColor: darkItemHoverColor,
         groupTitleColor: darkGroupTitleColor,
         itemSelectedColor: darkItemSelectedColor,
+        subMenuItemSelectedColor: darkItemSelectedColor,
         itemBg: darkItemBg,
         popupBg: darkPopupBg,
         subMenuItemBg: darkSubMenuItemBg,

--- a/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4675,6 +4675,7 @@ Array [
       title="2/5"
     >
       <input
+        aria-label="Go to"
         size="3"
         type="text"
         value="2"
@@ -4841,6 +4842,7 @@ Array [
       title="2/5"
     >
       <input
+        aria-label="Go to"
         disabled=""
         size="3"
         type="text"

--- a/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
@@ -3522,6 +3522,7 @@ Array [
       title="2/5"
     >
       <input
+        aria-label="Go to"
         size="3"
         type="text"
         value="2"
@@ -3688,6 +3689,7 @@ Array [
       title="2/5"
     >
       <input
+        aria-label="Go to"
         disabled=""
         size="3"
         type="text"

--- a/components/pagination/__tests__/a11y.test.ts
+++ b/components/pagination/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('pagination', {
-  // waiting for rc-pagination fix
-  skip: ['simple.tsx'],
-});
+accessibilityDemoTest('pagination');

--- a/components/rate/demo/text.tsx
+++ b/components/rate/demo/text.tsx
@@ -7,7 +7,14 @@ const App: React.FC = () => {
   const [value, setValue] = useState(3);
   return (
     <Flex gap="middle" vertical>
-      <Rate tooltips={desc} onChange={setValue} value={value} />
+      <Rate
+        tooltips={desc}
+        tooltipProps={{
+          placement: 'top',
+        }}
+        onChange={setValue}
+        value={value}
+      />
       {value ? <span>{desc[value - 1]}</span> : null}
     </Flex>
   );

--- a/components/rate/demo/text.tsx
+++ b/components/rate/demo/text.tsx
@@ -1,21 +1,27 @@
 import React, { useState } from 'react';
-import { Flex, Rate } from 'antd';
+import { Flex, Rate, RateProps } from 'antd';
 
-const desc = ['terrible', 'bad', 'normal', 'good', 'wonderful'];
+const desc: RateProps['tooltips'] = [
+  'terrible',
+  { placement: 'top', title: 'bad', trigger: 'hover' },
+  'normal',
+  'good',
+  'wonderful',
+];
+
+function getDescTitle(value: number, desc: RateProps['tooltips']) {
+  const item = desc?.[value - 1];
+  return typeof item === 'object' ? item.title : item;
+}
 
 const App: React.FC = () => {
   const [value, setValue] = useState(3);
+
   return (
     <Flex gap="middle" vertical>
-      <Rate
-        tooltips={desc}
-        tooltipProps={{
-          placement: 'top',
-        }}
-        onChange={setValue}
-        value={value}
-      />
-      {value ? <span>{desc[value - 1]}</span> : null}
+      <Rate tooltips={desc} onChange={setValue} value={value} />
+      {value ? <span>{getDescTitle(value, desc) as React.ReactNode}</span> : null}
+      {value}
     </Flex>
   );
 };

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -43,6 +43,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | keyboard | Support keyboard operation | boolean | true | 5.18.0 |
 | style | The custom style object of rate | CSSProperties | - |  |
 | tooltips | Customize tooltip by each character | string\[] | - |  |
+| tooltipProps | Tooltips property | [TooltipProps](/components/tooltip-cn#api) | - |  |
 | value | The current value | number | - |  |
 | onBlur | Callback when component lose focus | function() | - |  |
 | onChange | Callback when select value | function(value: number) | - |  |

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -42,8 +42,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | disabled | If read only, unable to interact | boolean | false |  |
 | keyboard | Support keyboard operation | boolean | true | 5.18.0 |
 | style | The custom style object of rate | CSSProperties | - |  |
-| tooltips | Customize tooltip by each character | string\[] | - |  |
-| tooltipProps | Tooltips property | [TooltipProps](/components/tooltip-cn#api) | - |  |
+| tooltips | Customize tooltip by each character | [TooltipProps](/components/tooltip-cn#api)[] \| string\[] | - |  |
 | value | The current value | number | - |  |
 | onBlur | Callback when component lose focus | function() | - |  |
 | onChange | Callback when select value | function(value: number) | - |  |

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -6,13 +6,14 @@ import type { RateRef, RateProps as RcRateProps } from 'rc-rate/lib/Rate';
 import type { StarProps as RcStarProps } from 'rc-rate/lib/Star';
 
 import { ConfigContext } from '../config-provider';
-import Tooltip from '../tooltip';
-import useStyle from './style';
 import DisabledContext from '../config-provider/DisabledContext';
+import Tooltip, { TooltipProps } from '../tooltip';
+import useStyle from './style';
 
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
   tooltips?: Array<string>;
+  tooltipProps?: TooltipProps;
 }
 
 const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
@@ -22,6 +23,7 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     rootClassName,
     style,
     tooltips,
+    tooltipProps,
     character = <StarFilled />,
     disabled: customDisabled,
     ...rest
@@ -31,7 +33,11 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     if (!tooltips) {
       return node;
     }
-    return <Tooltip title={tooltips[index as number]}>{node}</Tooltip>;
+    return (
+      <Tooltip title={tooltips[index as number]} {...tooltipProps}>
+        {node}
+      </Tooltip>
+    );
   };
 
   const { getPrefixCls, direction, rate } = React.useContext(ConfigContext);

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -12,8 +12,7 @@ import useStyle from './style';
 
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
-  tooltips?: Array<string>;
-  tooltipProps?: TooltipProps;
+  tooltips?: Array<TooltipProps | string>;
 }
 
 const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
@@ -23,7 +22,6 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     rootClassName,
     style,
     tooltips,
-    tooltipProps,
     character = <StarFilled />,
     disabled: customDisabled,
     ...rest
@@ -33,11 +31,14 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     if (!tooltips) {
       return node;
     }
-    return (
-      <Tooltip title={tooltips[index as number]} {...tooltipProps}>
-        {node}
-      </Tooltip>
-    );
+
+    const tooltipsItem = tooltips[index as number];
+
+    if (typeof tooltips[index as number] === 'object') {
+      return <Tooltip {...(tooltipsItem as object)}>{node}</Tooltip>;
+    }
+
+    return <Tooltip title={tooltipsItem as string}>{node}</Tooltip>;
   };
 
   const { getPrefixCls, direction, rate } = React.useContext(ConfigContext);

--- a/components/rate/index.zh-CN.md
+++ b/components/rate/index.zh-CN.md
@@ -44,6 +44,7 @@ demo:
 | keyboard | 支持使用键盘操作 | boolean | true | 5.18.0 |
 | style | 自定义样式对象 | CSSProperties | - |  |
 | tooltips | 自定义每项的提示信息 | string\[] | - |  |
+| tooltipProps | Tooltips属性 | [TooltipProps](/components/tooltip-cn#api) | - |  |
 | value | 当前数，受控值 | number | - |  |
 | onBlur | 失去焦点时的回调 | function() | - |  |
 | onChange | 选择时的回调 | function(value: number) | - |  |

--- a/components/rate/index.zh-CN.md
+++ b/components/rate/index.zh-CN.md
@@ -43,8 +43,7 @@ demo:
 | disabled | 只读，无法进行交互 | boolean | false |  |
 | keyboard | 支持使用键盘操作 | boolean | true | 5.18.0 |
 | style | 自定义样式对象 | CSSProperties | - |  |
-| tooltips | 自定义每项的提示信息 | string\[] | - |  |
-| tooltipProps | Tooltips属性 | [TooltipProps](/components/tooltip-cn#api) | - |  |
+| tooltips | 自定义每项的提示信息 | [TooltipProps](/components/tooltip-cn#api)[] \| string\[] | - |  |
 | value | 当前数，受控值 | number | - |  |
 | onBlur | 失去焦点时的回调 | function() | - |  |
 | onChange | 选择时的回调 | function(value: number) | - |  |

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7031,6 +7031,7 @@ Array [
             title="1/100"
           >
             <input
+              aria-label="Go to"
               size="3"
               type="text"
               value="1"
@@ -7572,6 +7573,7 @@ Array [
             title="1/100"
           >
             <input
+              aria-label="Go to"
               size="3"
               type="text"
               value="1"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "rc-menu": "~9.16.0",
     "rc-motion": "^2.9.5",
     "rc-notification": "~5.6.2",
-    "rc-pagination": "~5.0.0",
+    "rc-pagination": "~5.1.0",
     "rc-picker": "~4.9.2",
     "rc-progress": "~4.0.0",
     "rc-rate": "~2.13.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - fix #52485

### 💡 Background and Solution

issues中主问题：`tooltips，应该支持全部的Tooltip props`已修改，其他三点优化看代码是要改rc-rate包，是否可以放另外一个issues help。 如何关联修改，请大佬指点。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Rate component tooltips should support all Tooltip props      |
| 🇨🇳 Chinese |     Rate组件 tooltips，应该支持全部的Tooltip props      |
