### PR TITLE
feat: input.otp add separator api

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -17,6 +17,7 @@ import type { InputRef } from '../Input';
 import useStyle from '../style/otp';
 import OTPInput from './OTPInput';
 import type { OTPInputProps } from './OTPInput';
+import type { ReactNode } from 'react';
 
 export interface OTPRef {
   focus: VoidFunction;
@@ -41,6 +42,7 @@ export interface OTPProps
   value?: string;
   onChange?: (value: string) => void;
   formatter?: (value: string) => string;
+  separator?: ((index: number) => ReactNode | string) | ReactNode | string;
 
   // Status
   disabled?: boolean;
@@ -66,6 +68,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     value,
     onChange,
     formatter,
+    separator,
     variant,
     disabled,
     status: customStatus,
@@ -229,6 +232,22 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     inputMode,
   };
 
+  const renderSeparator = (index: number) => {
+    if (typeof separator === 'function') {
+      const result = separator(index);
+      if (typeof result === 'string') {
+        return <span className={`${prefixCls}-separator`}>{result}</span>;
+      }
+      return result;
+    }
+
+    if (typeof separator === 'string') {
+      return <span className={`${prefixCls}-separator`}>{separator}</span>;
+    }
+
+    return separator;
+  };
+
   return wrapCSSVar(
     <div
       {...domAttrs}
@@ -249,21 +268,23 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
           const key = `otp-${index}`;
           const singleValue = valueCells[index] || '';
           return (
-            <OTPInput
-              ref={(inputEle) => {
-                refs.current[index] = inputEle;
-              }}
-              key={key}
-              index={index}
-              size={mergedSize}
-              htmlSize={1}
-              className={`${prefixCls}-input`}
-              onChange={onInputChange}
-              value={singleValue}
-              onActiveChange={onInputActiveChange}
-              autoFocus={index === 0 && autoFocus}
-              {...inputSharedProps}
-            />
+            <React.Fragment key={key}>
+              <OTPInput
+                ref={(inputEle) => {
+                  refs.current[index] = inputEle;
+                }}
+                index={index}
+                size={mergedSize}
+                htmlSize={1}
+                className={`${prefixCls}-input`}
+                onChange={onInputChange}
+                value={singleValue}
+                onActiveChange={onInputActiveChange}
+                autoFocus={index === 0 && autoFocus}
+                {...inputSharedProps}
+              />
+              {separator && index < length - 1 && renderSeparator(index)}
+            </React.Fragment>
           );
         })}
       </FormItemInputContext.Provider>

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -42,7 +42,7 @@ export interface OTPProps
   value?: string;
   onChange?: (value: string) => void;
   formatter?: (value: string) => string;
-  separator?: ((index: number) => ReactNode | string) | ReactNode | string;
+  separator?: ((index: number) => ReactNode) | ReactNode;
 
   // Status
   disabled?: boolean;
@@ -233,19 +233,8 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
   };
 
   const renderSeparator = (index: number) => {
-    if (typeof separator === 'function') {
-      const result = separator(index);
-      if (typeof result === 'string') {
-        return <span className={`${prefixCls}-separator`}>{result}</span>;
-      }
-      return result;
-    }
-
-    if (typeof separator === 'string') {
-      return <span className={`${prefixCls}-separator`}>{separator}</span>;
-    }
-
-    return separator;
+    const result = typeof separator === 'function' ? separator(index) : separator;
+    return result ? <span className={`${prefixCls}-separator`}>{result}</span> : null;
   };
 
   return wrapCSSVar(

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10590,9 +10590,13 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
       value=""
     />
     <span
-      style="color: red;"
+      class="ant-otp-separator"
     >
-      —
+      <span
+        style="color: red;"
+      >
+        —
+      </span>
     </span>
     <input
       class="ant-input ant-input-outlined ant-otp-input"

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10519,6 +10519,106 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
       value=""
     />
   </div>
+  <h5
+    class="ant-typography"
+  >
+    With custom string separator
+  </h5>
+  <div
+    class="ant-otp"
+  >
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <span
+      class="ant-otp-separator"
+    >
+      -
+    </span>
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </div>
+  <h5
+    class="ant-typography"
+  >
+    With custom JSX separator
+  </h5>
+  <div
+    class="ant-otp"
+  >
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <span
+      style="color: red;"
+    >
+      —
+    </span>
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </div>
 </div>
 `;
 

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3869,6 +3869,106 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
       value=""
     />
   </div>
+  <h5
+    class="ant-typography"
+  >
+    With custom string separator
+  </h5>
+  <div
+    class="ant-otp"
+  >
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <span
+      class="ant-otp-separator"
+    >
+      -
+    </span>
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </div>
+  <h5
+    class="ant-typography"
+  >
+    With custom JSX separator
+  </h5>
+  <div
+    class="ant-otp"
+  >
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <span
+      style="color:red"
+    >
+      —
+    </span>
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+    <input
+      class="ant-input ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </div>
 </div>
 `;
 

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3940,9 +3940,13 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
       value=""
     />
     <span
-      style="color:red"
+      class="ant-otp-separator"
     >
-      —
+      <span
+        style="color:red"
+      >
+        —
+      </span>
     </span>
     <input
       class="ant-input ant-input-outlined ant-otp-input"

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -200,4 +200,22 @@ describe('Input.OTP', () => {
 
     expect(event.defaultPrevented).toBeTruthy();
   });
+
+  it('renders separator between input fields', () => {
+    const { container } = render(
+      <OTP
+        length={4}
+        separator={(index) => (
+          <span key={index} className="custom-separator">
+            |
+          </span>
+        )}
+      />,
+    );
+    const separators = container.querySelectorAll('.custom-separator');
+    expect(separators.length).toBe(3);
+    separators.forEach((separator) => {
+      expect(separator.textContent).toBe('|');
+    });
+  });
 });

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -218,4 +218,23 @@ describe('Input.OTP', () => {
       expect(separator.textContent).toBe('|');
     });
   });
+
+  it('renders separator when separator is a string', () => {
+    const { container } = render(<OTP length={4} separator="-" />);
+    const separators = container.querySelectorAll(`.ant-otp-separator`);
+    expect(separators.length).toBe(3);
+    separators.forEach((separator) => {
+      expect(separator.textContent).toBe('-');
+    });
+  });
+
+  it('renders separator when separator is a element', () => {
+    const customSeparator = <div data-testid="custom-separator">X</div>;
+    const { getAllByTestId } = render(<OTP length={4} separator={customSeparator} />);
+    const separators = getAllByTestId('custom-separator');
+    expect(separators.length).toBe(3);
+    separators.forEach((separator) => {
+      expect(separator.textContent).toBe('X');
+    });
+  });
 });

--- a/components/input/demo/otp.tsx
+++ b/components/input/demo/otp.tsx
@@ -32,6 +32,13 @@ const App: React.FC = () => {
       <Input.OTP variant="filled" {...sharedProps} />
       <Title level={5}>With custom display character</Title>
       <Input.OTP mask="🔒" {...sharedProps} />
+      <Title level={5}>With custom string separator</Title>
+      <Input.OTP separator={(index) => (index === 2 ? '-' : undefined)} {...sharedProps} />
+      <Title level={5}>With custom JSX separator</Title>
+      <Input.OTP
+        separator={(index) => index === 1 && <span style={{ color: 'red' }}>—</span>}
+        {...sharedProps}
+      />
     </Flex>
   );
 };

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -135,6 +135,7 @@ Added in `5.16.0`.
 | defaultValue | Default value | string | - |  |
 | disabled | Whether the input is disabled | boolean | false |  |
 | formatter | Format display, blank fields will be filled with ` ` | (value: string) => string | - |  |
+| separator | render the separator after the input box of the specified index | ((index: number) => ReactNode \| string) \| ReactNode \| string | - |  |
 | mask | Custom display, the original value will not be modified | boolean \| string | `false` | `5.17.0` |
 | length | The number of input elements | number | 6 |  |
 | status | Set validation status | 'error' \| 'warning' | - |  |

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -135,7 +135,7 @@ Added in `5.16.0`.
 | defaultValue | Default value | string | - |  |
 | disabled | Whether the input is disabled | boolean | false |  |
 | formatter | Format display, blank fields will be filled with ` ` | (value: string) => string | - |  |
-| separator | render the separator after the input box of the specified index | ((index: number) => ReactNode \| string) \| ReactNode \| string | - |  |
+| separator | render the separator after the input box of the specified index | ((index: number) => ReactNode) \| ReactNode | - |  |
 | mask | Custom display, the original value will not be modified | boolean \| string | `false` | `5.17.0` |
 | length | The number of input elements | number | 6 |  |
 | status | Set validation status | 'error' \| 'warning' | - |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -136,7 +136,7 @@ interface CountConfig {
 | defaultValue | 默认值 | string | - |  |
 | disabled | 是否禁用 | boolean | false |  |
 | formatter | 格式化展示，留空字段会被 ` ` 填充 | (value: string) => string | - |  |
-| separator | 分隔符，在指定索引的输入框后渲染分隔符 | ((index: number) => ReactNode \| string) \| ReactNode \| string | - |  |
+| separator | 分隔符，在指定索引的输入框后渲染分隔符 | ((index: number) => ReactNode) \| ReactNode | - |  |
 | mask | 自定义展示，和 `formatter` 的区别是不会修改原始值 | boolean \| string | `false` | `5.17.0` |
 | length | 输入元素数量 | number | 6 |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -136,6 +136,7 @@ interface CountConfig {
 | defaultValue | 默认值 | string | - |  |
 | disabled | 是否禁用 | boolean | false |  |
 | formatter | 格式化展示，留空字段会被 ` ` 填充 | (value: string) => string | - |  |
+| separator | 分隔符，在指定索引的输入框后渲染分隔符 | ((index: number) => ReactNode \| string) \| ReactNode \| string | - |  |
 | mask | 自定义展示，和 `formatter` 的区别是不会修改原始值 | boolean \| string | `false` | `5.17.0` |
 | length | 输入元素数量 | number | 6 |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close ant-design/ant-design#50165

### 💡 Background and Solution

> - Add custom separator capabilities to Input.OTP component

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Input.OTP add separator api     |
| 🇨🇳 Chinese |  Input.OTP 添加 separator api        |
