### PR TITLE
fix: fix Tabs a11y issue

### DIFF
--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -213,11 +213,9 @@ Array [
               aria-controls="rc-tabs-test-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="rc-tabs-test-more"
               style="visibility: hidden; order: 1;"
-              tabindex="-1"
               type="button"
             >
               <span
@@ -1181,11 +1179,9 @@ Array [
               aria-controls="rc-tabs-test-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="rc-tabs-test-more"
               style="visibility: hidden; order: 1;"
-              tabindex="-1"
               type="button"
             >
               <span
@@ -1337,11 +1333,9 @@ Array [
               aria-controls="rc-tabs-test-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="rc-tabs-test-more"
               style="visibility: hidden; order: 1;"
-              tabindex="-1"
               type="button"
             >
               <span

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -205,11 +205,9 @@ Array [
               aria-controls="null-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="null-more"
               style="visibility:hidden;order:1"
-              tabindex="-1"
               type="button"
             >
               <span
@@ -1134,11 +1132,9 @@ Array [
               aria-controls="null-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="null-more"
               style="visibility:hidden;order:1"
-              tabindex="-1"
               type="button"
             >
               <span
@@ -1265,11 +1261,9 @@ Array [
               aria-controls="null-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-hidden="true"
               class="ant-tabs-nav-more"
               id="null-more"
               style="visibility:hidden;order:1"
-              tabindex="-1"
               type="button"
             >
               <span

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`Card correct pass tabList props 1`] = `
               <button
                 aria-label="remove"
                 class="ant-tabs-tab-remove"
+                role="tab"
                 tabindex="0"
                 type="button"
               >
@@ -84,6 +85,7 @@ exports[`Card correct pass tabList props 1`] = `
               <button
                 aria-label="remove"
                 class="ant-tabs-tab-remove"
+                role="tab"
                 tabindex="-1"
                 type="button"
               >
@@ -179,11 +181,9 @@ exports[`Card correct pass tabList props 1`] = `
             aria-controls="rc-tabs-test-more-popup"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-hidden="true"
             class="ant-tabs-nav-more"
             id="rc-tabs-test-more"
             style="visibility: hidden; order: 1;"
-            tabindex="-1"
             type="button"
           >
             <span

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -29015,11 +29015,9 @@ exports[`ConfigProvider components Tabs configProvider 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="config-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29106,11 +29104,9 @@ exports[`ConfigProvider components Tabs configProvider componentDisabled 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="config-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29197,11 +29193,9 @@ exports[`ConfigProvider components Tabs configProvider componentSize large 1`] =
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="config-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29288,11 +29282,9 @@ exports[`ConfigProvider components Tabs configProvider componentSize middle 1`] 
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="config-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29379,11 +29371,9 @@ exports[`ConfigProvider components Tabs configProvider componentSize small 1`] =
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="config-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29470,11 +29460,9 @@ exports[`ConfigProvider components Tabs normal 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -29561,11 +29549,9 @@ exports[`ConfigProvider components Tabs prefixCls 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="prefix-Tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -822,11 +822,9 @@ exports[`renders components/splitter/demo/nested-in-tabs.tsx extend context corr
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -832,11 +832,9 @@ exports[`renders components/splitter/demo/nested-in-tabs.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -134,11 +134,9 @@ Array [
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -278,11 +276,9 @@ exports[`renders components/tabs/demo/basic.tsx extend context correctly 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -420,11 +416,9 @@ exports[`renders components/tabs/demo/card.tsx extend context correctly 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -565,11 +559,9 @@ exports[`renders components/tabs/demo/card-top.tsx extend context correctly 1`] 
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -716,11 +708,9 @@ exports[`renders components/tabs/demo/centered.tsx extend context correctly 1`] 
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -860,11 +850,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1010,11 +998,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1160,11 +1146,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1310,11 +1294,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1461,11 +1443,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1600,11 +1580,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1739,11 +1717,9 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1855,6 +1831,7 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context corr
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="0"
               type="button"
             >
@@ -1897,6 +1874,7 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context corr
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -1934,11 +1912,9 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx extend context corr
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2139,11 +2115,9 @@ Array [
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2287,11 +2261,9 @@ exports[`renders components/tabs/demo/custom-tab-bar.tsx extend context correctl
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2606,11 +2578,9 @@ exports[`renders components/tabs/demo/disabled.tsx extend context correctly 1`] 
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -2708,6 +2678,7 @@ exports[`renders components/tabs/demo/editable-card.tsx extend context correctly
           <button
             aria-label="remove"
             class="ant-tabs-tab-remove"
+            role="tab"
             tabindex="0"
             type="button"
           >
@@ -2750,6 +2721,7 @@ exports[`renders components/tabs/demo/editable-card.tsx extend context correctly
           <button
             aria-label="remove"
             class="ant-tabs-tab-remove"
+            role="tab"
             tabindex="-1"
             type="button"
           >
@@ -2830,11 +2802,9 @@ exports[`renders components/tabs/demo/editable-card.tsx extend context correctly
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -3001,11 +2971,9 @@ Array [
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -3218,11 +3186,9 @@ Array [
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -3408,11 +3374,9 @@ exports[`renders components/tabs/demo/icon.tsx extend context correctly 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -4194,11 +4158,9 @@ exports[`renders components/tabs/demo/nest.tsx extend context correctly 1`] = `
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -4582,11 +4544,9 @@ exports[`renders components/tabs/demo/nest.tsx extend context correctly 1`] = `
                   aria-controls="rc-tabs-test-more-popup"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-hidden="true"
                   class="ant-tabs-nav-more"
                   id="rc-tabs-test-more"
                   style="visibility: hidden; order: 1;"
-                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -4829,11 +4789,9 @@ Array [
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -5040,11 +4998,9 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -5178,11 +5134,9 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -5275,6 +5229,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="0"
               type="button"
             >
@@ -5317,6 +5272,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -5359,6 +5315,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -5424,11 +5381,9 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -6077,11 +6032,9 @@ exports[`renders components/tabs/demo/slide.tsx extend context correctly 1`] = `
           aria-controls="rc-tabs-test-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="rc-tabs-test-more"
           style="visibility: hidden; order: 1;"
-          tabindex="-1"
           type="button"
         >
           <span

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -128,11 +128,9 @@ Array [
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -245,11 +243,9 @@ exports[`renders components/tabs/demo/basic.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -360,11 +356,9 @@ exports[`renders components/tabs/demo/card.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -478,11 +472,9 @@ exports[`renders components/tabs/demo/card-top.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -608,11 +600,9 @@ exports[`renders components/tabs/demo/centered.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -725,11 +715,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -850,11 +838,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -975,11 +961,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1100,11 +1084,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1226,11 +1208,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1340,11 +1320,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1454,11 +1432,9 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1547,6 +1523,7 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="0"
               type="button"
             >
@@ -1587,6 +1564,7 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -1624,11 +1602,9 @@ exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1802,11 +1778,9 @@ Array [
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -1923,11 +1897,9 @@ exports[`renders components/tabs/demo/custom-tab-bar.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2058,11 +2030,9 @@ exports[`renders components/tabs/demo/custom-tab-bar-node.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -2173,11 +2143,9 @@ exports[`renders components/tabs/demo/disabled.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -2252,6 +2220,7 @@ exports[`renders components/tabs/demo/editable-card.tsx correctly 1`] = `
           <button
             aria-label="remove"
             class="ant-tabs-tab-remove"
+            role="tab"
             tabindex="0"
             type="button"
           >
@@ -2292,6 +2261,7 @@ exports[`renders components/tabs/demo/editable-card.tsx correctly 1`] = `
           <button
             aria-label="remove"
             class="ant-tabs-tab-remove"
+            role="tab"
             tabindex="-1"
             type="button"
           >
@@ -2370,11 +2340,9 @@ exports[`renders components/tabs/demo/editable-card.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -2514,11 +2482,9 @@ Array [
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2706,11 +2672,9 @@ Array [
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -2871,11 +2835,9 @@ exports[`renders components/tabs/demo/icon.tsx correctly 1`] = `
         aria-controls="null-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="null-more"
         style="visibility:hidden;order:1"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -3218,11 +3180,9 @@ exports[`renders components/tabs/demo/nest.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -3547,11 +3507,9 @@ exports[`renders components/tabs/demo/nest.tsx correctly 1`] = `
                   aria-controls="null-more-popup"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-hidden="true"
                   class="ant-tabs-nav-more"
                   id="null-more"
                   style="visibility:hidden;order:1"
-                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -3767,11 +3725,9 @@ Array [
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -3951,11 +3907,9 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -4064,11 +4018,9 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -4140,6 +4092,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="0"
               type="button"
             >
@@ -4180,6 +4133,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -4220,6 +4174,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
             <button
               aria-label="remove"
               class="ant-tabs-tab-remove"
+              role="tab"
               tabindex="-1"
               type="button"
             >
@@ -4285,11 +4240,9 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span
@@ -4857,11 +4810,9 @@ exports[`renders components/tabs/demo/slide.tsx correctly 1`] = `
           aria-controls="null-more-popup"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-hidden="true"
           class="ant-tabs-nav-more"
           id="null-more"
           style="visibility:hidden;order:1"
-          tabindex="-1"
           type="button"
         >
           <span

--- a/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,11 +71,9 @@ exports[`Tabs rtl render component should be rendered correctly in RTL direction
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -188,11 +186,9 @@ exports[`Tabs tabBarGutter should work 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="margin-left: 0px; visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -321,11 +317,9 @@ exports[`Tabs tabBarGutter should work 2`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="margin-left: 0px; visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span
@@ -428,11 +422,9 @@ exports[`Tabs tabPosition remove card 1`] = `
         aria-controls="rc-tabs-test-more-popup"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-hidden="true"
         class="ant-tabs-nav-more"
         id="rc-tabs-test-more"
         style="visibility: hidden; order: 1;"
-        tabindex="-1"
         type="button"
       >
         <span

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
     "rc-table": "~7.50.2",
-    "rc-tabs": "~15.5.0",
+    "rc-tabs": "~15.5.1",
     "rc-textarea": "~1.9.0",
     "rc-tooltip": "~6.3.2",
     "rc-tree": "~5.13.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

https://github.com/react-component/tabs/pull/775

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve Tabs accessibility by fixing error `Certain ARIA roles must contain particular children`.          |
| 🇨🇳 Chinese | 优化 Tabs 组件的可访问性，修复 `Certain ARIA roles must contain particular children` 的报错。         |
