### PR TITLE
feat: support all Tooltip props in Rate's tooltips

### DIFF
--- a/components/rate/demo/text.tsx
+++ b/components/rate/demo/text.tsx
@@ -16,12 +16,10 @@ function getDescTitle(value: number, desc: RateProps['tooltips']) {
 
 const App: React.FC = () => {
   const [value, setValue] = useState(3);
-
   return (
     <Flex gap="middle" vertical>
       <Rate tooltips={desc} onChange={setValue} value={value} />
       {value ? <span>{getDescTitle(value, desc) as React.ReactNode}</span> : null}
-      {value}
     </Flex>
   );
 };

--- a/components/rate/demo/text.tsx
+++ b/components/rate/demo/text.tsx
@@ -1,14 +1,27 @@
 import React, { useState } from 'react';
-import { Flex, Rate } from 'antd';
+import { Flex, Rate, RateProps } from 'antd';
 
-const desc = ['terrible', 'bad', 'normal', 'good', 'wonderful'];
+const desc: RateProps['tooltips'] = [
+  'terrible',
+  { placement: 'top', title: 'bad', trigger: 'hover' },
+  'normal',
+  'good',
+  'wonderful',
+];
+
+function getDescTitle(value: number, desc: RateProps['tooltips']) {
+  const item = desc?.[value - 1];
+  return typeof item === 'object' ? item.title : item;
+}
 
 const App: React.FC = () => {
   const [value, setValue] = useState(3);
+
   return (
     <Flex gap="middle" vertical>
       <Rate tooltips={desc} onChange={setValue} value={value} />
-      {value ? <span>{desc[value - 1]}</span> : null}
+      {value ? <span>{getDescTitle(value, desc) as React.ReactNode}</span> : null}
+      {value}
     </Flex>
   );
 };

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -42,7 +42,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | disabled | If read only, unable to interact | boolean | false |  |
 | keyboard | Support keyboard operation | boolean | true | 5.18.0 |
 | style | The custom style object of rate | CSSProperties | - |  |
-| tooltips | Customize tooltip by each character | string\[] | - |  |
+| tooltips | Customize tooltip by each character | [TooltipProps](/components/tooltip-cn#api)[] \| string\[] | - |  |
 | value | The current value | number | - |  |
 | onBlur | Callback when component lose focus | function() | - |  |
 | onChange | Callback when select value | function(value: number) | - |  |

--- a/components/rate/index.en-US.md
+++ b/components/rate/index.en-US.md
@@ -42,7 +42,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | disabled | If read only, unable to interact | boolean | false |  |
 | keyboard | Support keyboard operation | boolean | true | 5.18.0 |
 | style | The custom style object of rate | CSSProperties | - |  |
-| tooltips | Customize tooltip by each character | [TooltipProps](/components/tooltip-cn#api)[] \| string\[] | - |  |
+| tooltips | Customize tooltip by each character | [TooltipProps](/components/tooltip#api)[] \| string\[] | - |  |
 | value | The current value | number | - |  |
 | onBlur | Callback when component lose focus | function() | - |  |
 | onChange | Callback when select value | function(value: number) | - |  |

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -16,7 +16,7 @@ const isTooltipProps = (item: TooltipProps | string): item is TooltipProps => {
 
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
-  tooltips?: Array<TooltipProps | string>;
+  tooltips?: (TooltipProps | string)[];
 }
 
 const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -6,13 +6,17 @@ import type { RateRef, RateProps as RcRateProps } from 'rc-rate/lib/Rate';
 import type { StarProps as RcStarProps } from 'rc-rate/lib/Star';
 
 import { ConfigContext } from '../config-provider';
-import Tooltip from '../tooltip';
-import useStyle from './style';
 import DisabledContext from '../config-provider/DisabledContext';
+import Tooltip, { TooltipProps } from '../tooltip';
+import useStyle from './style';
+
+const isTooltipProps = (item: TooltipProps | string): item is TooltipProps => {
+  return typeof item === 'object' && item !== null;
+};
 
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
-  tooltips?: Array<string>;
+  tooltips?: Array<TooltipProps | string>;
 }
 
 const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
@@ -31,7 +35,14 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     if (!tooltips) {
       return node;
     }
-    return <Tooltip title={tooltips[index as number]}>{node}</Tooltip>;
+
+    const tooltipsItem = tooltips[index as number];
+
+    if (isTooltipProps(tooltipsItem)) {
+      return <Tooltip {...tooltipsItem}>{node}</Tooltip>;
+    }
+
+    return <Tooltip title={tooltipsItem as string}>{node}</Tooltip>;
   };
 
   const { getPrefixCls, direction, rate } = React.useContext(ConfigContext);

--- a/components/rate/index.zh-CN.md
+++ b/components/rate/index.zh-CN.md
@@ -43,7 +43,7 @@ demo:
 | disabled | 只读，无法进行交互 | boolean | false |  |
 | keyboard | 支持使用键盘操作 | boolean | true | 5.18.0 |
 | style | 自定义样式对象 | CSSProperties | - |  |
-| tooltips | 自定义每项的提示信息 | string\[] | - |  |
+| tooltips | 自定义每项的提示信息 | [TooltipProps](/components/tooltip-cn#api)[] \| string\[] | - |  |
 | value | 当前数，受控值 | number | - |  |
 | onBlur | 失去焦点时的回调 | function() | - |  |
 | onChange | 选择时的回调 | function(value: number) | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x]  ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - fix #52485

### 💡 Background and Solution

issues中主问题：`tooltips，应该支持全部的Tooltip props`已修改。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Rate component tooltips should support all Tooltip props       |
| 🇨🇳 Chinese |      Rate组件 tooltips，应该支持全部的Tooltip props       |
