### PR TITLE
fix(a11y): fix empty table header for a11y and add localization support

### DIFF
--- a/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -12446,9 +12446,13 @@ Array [
           >
             <thead>
               <tr>
-                <th
-                  aria-label="empty cell"
-                />
+                <th>
+                  <span
+                    style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                  >
+                    Week
+                  </span>
+                </th>
                 <th>
                   Su
                 </th>
@@ -14091,9 +14095,13 @@ Array [
           >
             <thead>
               <tr>
-                <th
-                  aria-label="empty cell"
-                />
+                <th>
+                  <span
+                    style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                  >
+                    Week
+                  </span>
+                </th>
                 <th>
                   Su
                 </th>

--- a/components/calendar/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.ts.snap
@@ -7306,9 +7306,13 @@ Array [
           >
             <thead>
               <tr>
-                <th
-                  aria-label="empty cell"
-                />
+                <th>
+                  <span
+                    style="width:0;height:0;position:absolute;overflow:hidden;opacity:0"
+                  >
+                    Week
+                  </span>
+                </th>
                 <th>
                   Su
                 </th>
@@ -8313,9 +8317,13 @@ Array [
           >
             <thead>
               <tr>
-                <th
-                  aria-label="empty cell"
-                />
+                <th>
+                  <span
+                    style="width:0;height:0;position:absolute;overflow:hidden;opacity:0"
+                  >
+                    Week
+                  </span>
+                </th>
                 <th>
                   Su
                 </th>

--- a/components/calendar/__tests__/a11y.test.ts
+++ b/components/calendar/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('calendar', {
-  // waiting for rc-picker fix
-  skip: ['week.tsx'],
   // fix in another pr
   disabledRules: ['label'],
 });

--- a/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -89,7 +89,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Последна година (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -99,7 +99,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Предишен месец (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -112,7 +112,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Избор на месец"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -120,7 +120,7 @@ Array [
                     јан
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Избор на година"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -129,7 +129,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Следващ месец (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -139,7 +139,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Следваща година (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"

--- a/components/date-picker/__tests__/__snapshots__/RangePicker.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/RangePicker.test.tsx.snap
@@ -194,7 +194,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -204,7 +204,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -217,7 +217,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -225,7 +225,7 @@ Array [
                         Sep
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -234,7 +234,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -245,7 +245,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -736,7 +736,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -747,7 +747,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -761,7 +761,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -769,7 +769,7 @@ Array [
                         Oct
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -778,7 +778,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -788,7 +788,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -119,7 +119,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -129,7 +129,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -142,7 +142,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -150,7 +150,7 @@ Array [
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -159,7 +159,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -170,7 +170,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -661,7 +661,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -672,7 +672,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -686,7 +686,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -694,7 +694,7 @@ Array [
                         Dec
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -703,7 +703,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -713,7 +713,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -1272,7 +1272,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -1282,7 +1282,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -1295,7 +1295,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -1303,7 +1303,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -1312,7 +1312,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -1322,7 +1322,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -1889,7 +1889,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -1899,7 +1899,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -1912,7 +1912,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -1920,7 +1920,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -1929,7 +1929,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -1939,7 +1939,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -1957,9 +1957,13 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -2557,7 +2561,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -2570,7 +2574,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -2579,7 +2583,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -2799,7 +2803,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -2812,7 +2816,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -2821,7 +2825,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -2955,7 +2959,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -2968,7 +2972,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="decade panel"
+                      aria-label="Choose a decade"
                       class="ant-picker-decade-btn"
                       tabindex="-1"
                       type="button"
@@ -2977,7 +2981,7 @@ exports[`renders components/date-picker/demo/basic.tsx extend context correctly 
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -3240,7 +3244,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -3250,7 +3254,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -3263,7 +3267,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -3271,7 +3275,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       Jan
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -3280,7 +3284,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -3290,7 +3294,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -3885,7 +3889,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -3895,7 +3899,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -3908,7 +3912,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -3916,7 +3920,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         Jan
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -3925,7 +3929,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -3935,7 +3939,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -6027,7 +6031,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -6037,7 +6041,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -6050,7 +6054,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -6058,7 +6062,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                           Jan
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -6067,7 +6071,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -6077,7 +6081,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -6672,7 +6676,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -6682,7 +6686,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -6695,7 +6699,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -6703,7 +6707,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                             Jan
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -6712,7 +6716,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           tabindex="-1"
                           type="button"
@@ -6722,7 +6726,7 @@ exports[`renders components/date-picker/demo/buddhist-era.tsx extend context cor
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           tabindex="-1"
                           type="button"
@@ -8786,7 +8790,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -8796,7 +8800,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -8809,7 +8813,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -8817,7 +8821,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -8826,7 +8830,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -8836,7 +8840,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -9460,7 +9464,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -9470,7 +9474,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -9483,7 +9487,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -9491,7 +9495,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -9500,7 +9504,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -9511,7 +9515,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -10004,7 +10008,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -10015,7 +10019,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -10029,7 +10033,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -10037,7 +10041,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -10046,7 +10050,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -10056,7 +10060,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -10775,7 +10779,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn ant-picker-header-super-prev-btn-disabled"
                   disabled=""
                   tabindex="-1"
@@ -10786,7 +10790,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -10799,7 +10803,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -10807,7 +10811,7 @@ Array [
                     Sep
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -10816,7 +10820,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -10826,7 +10830,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -11403,7 +11407,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -11413,7 +11417,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -11426,7 +11430,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -11434,7 +11438,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       Jun
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -11443,7 +11447,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -11453,7 +11457,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -12021,7 +12025,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -12034,7 +12038,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -12043,7 +12047,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -12320,7 +12324,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -12330,7 +12334,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -12343,7 +12347,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -12351,7 +12355,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                           Jun
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -12360,7 +12364,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -12371,7 +12375,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -12862,7 +12866,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -12873,7 +12877,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -12887,7 +12891,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -12895,7 +12899,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                           Jul
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -12904,7 +12908,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -12914,7 +12918,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -13546,7 +13550,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -13556,7 +13560,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -13569,7 +13573,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -13577,7 +13581,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                           Sep
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -13586,7 +13590,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -13597,7 +13601,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -14088,7 +14092,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -14099,7 +14103,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -14113,7 +14117,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -14121,7 +14125,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                           Oct
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -14130,7 +14134,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -14140,7 +14144,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -14716,7 +14720,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn ant-picker-header-super-prev-btn-disabled"
                     disabled=""
                     tabindex="-1"
@@ -14727,7 +14731,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -14740,7 +14744,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -14748,7 +14752,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                       Sep
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -14757,7 +14761,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -14767,7 +14771,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn ant-picker-header-super-next-btn-disabled"
                     disabled=""
                     tabindex="-1"
@@ -15348,7 +15352,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -15358,7 +15362,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -15371,7 +15375,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -15379,7 +15383,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -15388,7 +15392,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -15398,7 +15402,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -17450,7 +17454,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -17463,7 +17467,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -17472,7 +17476,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -17747,7 +17751,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -17757,7 +17761,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -17770,7 +17774,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -17778,7 +17782,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -17787,7 +17791,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -17798,7 +17802,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -18289,7 +18293,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -18300,7 +18304,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -18314,7 +18318,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -18322,7 +18326,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -18331,7 +18335,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -18341,7 +18345,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -18947,7 +18951,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -18957,7 +18961,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -18970,7 +18974,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -18978,7 +18982,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -18987,7 +18991,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -18997,7 +19001,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -20530,7 +20534,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -20540,7 +20544,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -20553,7 +20557,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -20561,7 +20565,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -20570,7 +20574,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -20580,7 +20584,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -21155,7 +21159,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -21165,7 +21169,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -21178,7 +21182,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -21186,7 +21190,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -21195,7 +21199,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -21205,7 +21209,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -23317,7 +23321,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -23327,7 +23331,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -23340,7 +23344,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -23348,7 +23352,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -23357,7 +23361,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -23368,7 +23372,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -23859,7 +23863,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -23870,7 +23874,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -23884,7 +23888,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -23892,7 +23896,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -23901,7 +23905,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -23911,7 +23915,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -24526,7 +24530,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -24536,7 +24540,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -24549,7 +24553,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -24557,7 +24561,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -24566,7 +24570,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -24576,7 +24580,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -26624,7 +26628,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -26637,7 +26641,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -26646,7 +26650,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -26886,7 +26890,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -26896,7 +26900,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -26909,7 +26913,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -26917,7 +26921,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       Jun
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -26926,7 +26930,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -26936,7 +26940,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -27504,7 +27508,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -27517,7 +27521,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -27526,7 +27530,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -27803,7 +27807,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -27813,7 +27817,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -27826,7 +27830,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -27834,7 +27838,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Jun
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -27843,7 +27847,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -27854,7 +27858,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -28345,7 +28349,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -28356,7 +28360,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -28370,7 +28374,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -28378,7 +28382,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Jul
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -28387,7 +28391,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -28397,7 +28401,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -29029,7 +29033,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -29039,7 +29043,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -29052,7 +29056,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -29060,7 +29064,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Sep
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -29069,7 +29073,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -29080,7 +29084,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -29571,7 +29575,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -29582,7 +29586,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -29596,7 +29600,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -29604,7 +29608,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Oct
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -29613,7 +29617,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -29623,7 +29627,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -30200,7 +30204,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -30210,7 +30214,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -30223,7 +30227,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -30231,7 +30235,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       Dec
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -30240,7 +30244,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -30250,7 +30254,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -30818,7 +30822,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -30828,7 +30832,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -30841,7 +30845,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -30849,7 +30853,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -30858,7 +30862,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -30868,7 +30872,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -31491,7 +31495,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -31501,7 +31505,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -31514,7 +31518,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -31522,7 +31526,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -31531,7 +31535,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -31542,7 +31546,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -32033,7 +32037,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -32044,7 +32048,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -32058,7 +32062,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -32066,7 +32070,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -32075,7 +32079,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -32085,7 +32089,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -32692,7 +32696,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -32702,7 +32706,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -32715,7 +32719,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -32723,7 +32727,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -32732,7 +32736,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -32743,7 +32747,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -33234,7 +33238,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -33245,7 +33249,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -33259,7 +33263,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -33267,7 +33271,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -33276,7 +33280,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -33286,7 +33290,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -33872,7 +33876,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -33882,7 +33886,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -33895,7 +33899,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -33903,7 +33907,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       Jan
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -33912,7 +33916,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -33922,7 +33926,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -34514,7 +34518,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -34524,7 +34528,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -34537,7 +34541,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -34545,7 +34549,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       Jan
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -34554,7 +34558,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -34564,7 +34568,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -35156,7 +35160,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -35169,7 +35173,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -35178,7 +35182,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -35424,7 +35428,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -35434,7 +35438,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -35447,7 +35451,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -35455,7 +35459,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -35464,7 +35468,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -35474,7 +35478,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -35492,9 +35496,13 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -36172,7 +36180,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -36182,7 +36190,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -36195,7 +36203,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -36203,7 +36211,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                           Jan
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -36212,7 +36220,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -36223,7 +36231,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -36714,7 +36722,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -36725,7 +36733,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -36739,7 +36747,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -36747,7 +36755,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                           Feb
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -36756,7 +36764,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -36766,7 +36774,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -37343,7 +37351,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -37353,7 +37361,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -37366,7 +37374,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -37374,7 +37382,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                       Jan
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -37383,7 +37391,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -37393,7 +37401,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -37969,7 +37977,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -37979,7 +37987,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -37992,7 +38000,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -38000,7 +38008,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -38009,7 +38017,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -38019,7 +38027,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -38586,7 +38594,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -38596,7 +38604,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -38609,7 +38617,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -38617,7 +38625,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -38626,7 +38634,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -38636,7 +38644,7 @@ exports[`renders components/date-picker/demo/mask.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -40831,7 +40839,7 @@ exports[`renders components/date-picker/demo/mode.tsx extend context correctly 1
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -40844,7 +40852,7 @@ exports[`renders components/date-picker/demo/mode.tsx extend context correctly 1
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -40853,7 +40861,7 @@ exports[`renders components/date-picker/demo/mode.tsx extend context correctly 1
                       </button>
                     </div>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -41123,7 +41131,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -41133,7 +41141,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -41146,7 +41154,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -41154,7 +41162,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -41163,7 +41171,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -41173,7 +41181,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -41761,7 +41769,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -41771,7 +41779,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -41784,7 +41792,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -41792,7 +41800,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -41801,7 +41809,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -41811,7 +41819,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -42399,7 +42407,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -42409,7 +42417,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -42422,7 +42430,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -42430,7 +42438,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -42439,7 +42447,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -42449,7 +42457,7 @@ exports[`renders components/date-picker/demo/multiple.tsx extend context correct
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -43009,7 +43017,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -43019,7 +43027,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -43032,7 +43040,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -43040,7 +43048,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                     Nov
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -43049,7 +43057,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -43059,7 +43067,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -44021,7 +44029,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -44031,7 +44039,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -44044,7 +44052,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -44052,7 +44060,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -44061,7 +44069,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -44071,7 +44079,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -45033,7 +45041,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -45043,7 +45051,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -45056,7 +45064,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -45064,7 +45072,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -45073,7 +45081,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -45083,7 +45091,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -46045,7 +46053,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -46055,7 +46063,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -46068,7 +46076,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -46076,7 +46084,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -46085,7 +46093,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -46095,7 +46103,7 @@ exports[`renders components/date-picker/demo/multiple-debug.tsx extend context c
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -46647,7 +46655,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -46657,7 +46665,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -46670,7 +46678,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -46678,7 +46686,7 @@ Array [
                     Nov
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -46687,7 +46695,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -46697,7 +46705,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -47367,7 +47375,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -47377,7 +47385,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -47390,7 +47398,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -47398,7 +47406,7 @@ Array [
                     Nov
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -47407,7 +47415,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -47417,7 +47425,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -48037,7 +48045,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -48047,7 +48055,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -48060,7 +48068,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -48068,7 +48076,7 @@ Array [
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -48077,7 +48085,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -48088,7 +48096,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -48579,7 +48587,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -48590,7 +48598,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -48604,7 +48612,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -48612,7 +48620,7 @@ Array [
                         Dec
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -48621,7 +48629,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -48631,7 +48639,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -49206,7 +49214,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -49216,7 +49224,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -49229,7 +49237,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -49237,7 +49245,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -49246,7 +49254,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -49256,7 +49264,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -49896,7 +49904,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -49906,7 +49914,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -49919,7 +49927,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -49927,7 +49935,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -49936,7 +49944,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -49947,7 +49955,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -50438,7 +50446,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -50449,7 +50457,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -50463,7 +50471,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -50471,7 +50479,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -50480,7 +50488,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -50490,7 +50498,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -51121,7 +51129,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -51131,7 +51139,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -51144,7 +51152,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -51152,7 +51160,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -51161,7 +51169,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -51171,7 +51179,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -53279,7 +53287,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -53289,7 +53297,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -53302,7 +53310,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -53310,7 +53318,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -53319,7 +53327,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -53330,7 +53338,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -53821,7 +53829,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -53832,7 +53840,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -53846,7 +53854,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -53854,7 +53862,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -53863,7 +53871,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -53873,7 +53881,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -54479,7 +54487,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -54489,7 +54497,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -54502,7 +54510,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -54510,7 +54518,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -54519,7 +54527,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -54529,7 +54537,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -56627,7 +56635,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -56637,7 +56645,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -56650,7 +56658,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -56658,7 +56666,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -56667,7 +56675,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -56678,7 +56686,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -56697,9 +56705,13 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       >
                         <thead>
                           <tr>
-                            <th
-                              aria-label="empty cell"
-                            />
+                            <th>
+                              <span
+                                style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                              >
+                                Week
+                              </span>
+                            </th>
                             <th>
                               Su
                             </th>
@@ -57238,7 +57250,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -57249,7 +57261,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -57263,7 +57275,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -57271,7 +57283,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -57280,7 +57292,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -57290,7 +57302,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -57308,9 +57320,13 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       >
                         <thead>
                           <tr>
-                            <th
-                              aria-label="empty cell"
-                            />
+                            <th>
+                              <span
+                                style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                              >
+                                Week
+                              </span>
+                            </th>
                             <th>
                               Su
                             </th>
@@ -57965,7 +57981,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -57978,7 +57994,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -57987,7 +58003,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58149,7 +58165,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58163,7 +58179,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -58172,7 +58188,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -58449,7 +58465,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -58462,7 +58478,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -58471,7 +58487,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58547,7 +58563,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58561,7 +58577,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -58570,7 +58586,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -58763,7 +58779,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -58776,7 +58792,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="decade panel"
+                          aria-label="Choose a decade"
                           class="ant-picker-decade-btn"
                           tabindex="-1"
                           type="button"
@@ -58785,7 +58801,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58947,7 +58963,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -58961,7 +58977,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="decade panel"
+                          aria-label="Choose a decade"
                           class="ant-picker-decade-btn"
                           tabindex="-1"
                           type="button"
@@ -58970,7 +58986,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -59199,7 +59215,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -59209,7 +59225,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -59222,7 +59238,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -59230,7 +59246,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                     Nov
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -59239,7 +59255,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -59249,7 +59265,7 @@ exports[`renders components/date-picker/demo/render-panel.tsx extend context cor
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -59888,7 +59904,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -59898,7 +59914,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -59911,7 +59927,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -59919,7 +59935,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -59928,7 +59944,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -59939,7 +59955,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -60430,7 +60446,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -60441,7 +60457,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -60455,7 +60471,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -60463,7 +60479,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -60472,7 +60488,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -60482,7 +60498,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -61097,7 +61113,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -61110,7 +61126,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -61119,7 +61135,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -61281,7 +61297,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -61295,7 +61311,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -61304,7 +61320,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
                         </button>
                       </div>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -61605,7 +61621,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -61615,7 +61631,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -61628,7 +61644,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -61636,7 +61652,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -61645,7 +61661,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -61655,7 +61671,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -62222,7 +62238,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -62235,7 +62251,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -62244,7 +62260,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -62519,7 +62535,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -62529,7 +62545,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -62542,7 +62558,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -62550,7 +62566,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -62559,7 +62575,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -62570,7 +62586,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -63061,7 +63077,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -63072,7 +63088,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -63086,7 +63102,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -63094,7 +63110,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -63103,7 +63119,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -63113,7 +63129,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -63664,7 +63680,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -63674,7 +63690,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -63687,7 +63703,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -63695,7 +63711,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -63704,7 +63720,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -63714,7 +63730,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -63732,9 +63748,13 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -64344,7 +64364,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -64354,7 +64374,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -64367,7 +64387,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -64375,7 +64395,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -64384,7 +64404,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -64394,7 +64414,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -66449,7 +66469,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -66459,7 +66479,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -66472,7 +66492,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -66480,7 +66500,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -66489,7 +66509,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -66499,7 +66519,7 @@ exports[`renders components/date-picker/demo/start-end.tsx extend context correc
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -68562,7 +68582,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -68572,7 +68592,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -68585,7 +68605,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -68593,7 +68613,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -68602,7 +68622,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -68612,7 +68632,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -69180,7 +69200,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -69190,7 +69210,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -69203,7 +69223,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -69211,7 +69231,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -69220,7 +69240,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -69230,7 +69250,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -69853,7 +69873,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -69863,7 +69883,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -69876,7 +69896,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -69884,7 +69904,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -69893,7 +69913,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -69904,7 +69924,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -70395,7 +70415,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -70406,7 +70426,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -70420,7 +70440,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -70428,7 +70448,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -70437,7 +70457,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -70447,7 +70467,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -71054,7 +71074,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -71064,7 +71084,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -71077,7 +71097,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -71085,7 +71105,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -71094,7 +71114,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -71105,7 +71125,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -71596,7 +71616,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -71607,7 +71627,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -71621,7 +71641,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -71629,7 +71649,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -71638,7 +71658,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -71648,7 +71668,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -72209,7 +72229,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -72219,7 +72239,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -72232,7 +72252,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -72240,7 +72260,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -72249,7 +72269,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -72259,7 +72279,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -72826,7 +72846,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -72839,7 +72859,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -72848,7 +72868,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -73123,7 +73143,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -73133,7 +73153,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -73146,7 +73166,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -73154,7 +73174,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -73163,7 +73183,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -73174,7 +73194,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -73665,7 +73685,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -73676,7 +73696,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -73690,7 +73710,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -73698,7 +73718,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -73707,7 +73727,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -73717,7 +73737,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -74268,7 +74288,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -74278,7 +74298,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -74291,7 +74311,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -74299,7 +74319,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -74308,7 +74328,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -74318,7 +74338,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -74336,9 +74356,13 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -74918,7 +74942,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -74928,7 +74952,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -74941,7 +74965,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -74949,7 +74973,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -74958,7 +74982,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -74968,7 +74992,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -75517,7 +75541,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -75530,7 +75554,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -75539,7 +75563,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -75796,7 +75820,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -75806,7 +75830,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -75819,7 +75843,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -75827,7 +75851,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -75836,7 +75860,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -75847,7 +75871,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -76338,7 +76362,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -76349,7 +76373,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -76363,7 +76387,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -76371,7 +76395,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -76380,7 +76404,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -76390,7 +76414,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -76923,7 +76947,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -76933,7 +76957,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -76946,7 +76970,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -76954,7 +76978,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -76963,7 +76987,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -76973,7 +76997,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -76991,9 +77015,13 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -77614,7 +77642,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -77624,7 +77652,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -77637,7 +77665,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -77645,7 +77673,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -77654,7 +77682,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -77664,7 +77692,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -77682,9 +77710,13 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                   >
                     <thead>
                       <tr>
-                        <th
-                          aria-label="empty cell"
-                        />
+                        <th>
+                          <span
+                            style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                          >
+                            Week
+                          </span>
+                        </th>
                         <th>
                           Su
                         </th>
@@ -78360,7 +78392,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -78370,7 +78402,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -78383,7 +78415,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -78391,7 +78423,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -78400,7 +78432,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -78411,7 +78443,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -78430,9 +78462,13 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       >
                         <thead>
                           <tr>
-                            <th
-                              aria-label="empty cell"
-                            />
+                            <th>
+                              <span
+                                style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                              >
+                                Week
+                              </span>
+                            </th>
                             <th>
                               Su
                             </th>
@@ -78971,7 +79007,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -78982,7 +79018,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -78996,7 +79032,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -79004,7 +79040,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -79013,7 +79049,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -79023,7 +79059,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -79041,9 +79077,13 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
                       >
                         <thead>
                           <tr>
-                            <th
-                              aria-label="empty cell"
-                            />
+                            <th>
+                              <span
+                                style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                              >
+                                Week
+                              </span>
+                            </th>
                             <th>
                               Su
                             </th>
@@ -81442,7 +81482,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -81452,7 +81492,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -81465,7 +81505,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -81473,7 +81513,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -81482,7 +81522,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -81492,7 +81532,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -83599,7 +83639,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -83609,7 +83649,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -83622,7 +83662,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -83630,7 +83670,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -83639,7 +83679,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -83649,7 +83689,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -85098,7 +85138,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -85108,7 +85148,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -85121,7 +85161,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -85129,7 +85169,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -85138,7 +85178,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -85148,7 +85188,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -85766,7 +85806,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -85776,7 +85816,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -85789,7 +85829,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -85797,7 +85837,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -85806,7 +85846,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -85817,7 +85857,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -86308,7 +86348,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -86319,7 +86359,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -86333,7 +86373,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -86341,7 +86381,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -86350,7 +86390,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -86360,7 +86400,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -86912,7 +86952,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -86922,7 +86962,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -86935,7 +86975,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -86943,7 +86983,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -86952,7 +86992,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -86962,7 +87002,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -87580,7 +87620,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -87590,7 +87630,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -87603,7 +87643,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -87611,7 +87651,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -87620,7 +87660,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -87631,7 +87671,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -88122,7 +88162,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -88133,7 +88173,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -88147,7 +88187,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -88155,7 +88195,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -88164,7 +88204,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -88174,7 +88214,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"
@@ -88726,7 +88766,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -88736,7 +88776,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -88749,7 +88789,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -88757,7 +88797,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -88766,7 +88806,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -88776,7 +88816,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -89394,7 +89434,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -89404,7 +89444,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -89417,7 +89457,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -89425,7 +89465,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -89434,7 +89474,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -89445,7 +89485,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -89936,7 +89976,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -89947,7 +89987,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -89961,7 +90001,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -89969,7 +90009,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -89978,7 +90018,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -89988,7 +90028,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"

--- a/components/date-picker/__tests__/__snapshots__/other.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/other.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`MonthPicker and WeekPicker render MonthPicker 1`] = `
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -102,7 +102,7 @@ exports[`MonthPicker and WeekPicker render MonthPicker 1`] = `
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -111,7 +111,7 @@ exports[`MonthPicker and WeekPicker render MonthPicker 1`] = `
                   </button>
                 </div>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -357,7 +357,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -367,7 +367,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -380,7 +380,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -388,7 +388,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                     Jan
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -397,7 +397,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -407,7 +407,7 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -425,9 +425,13 @@ exports[`MonthPicker and WeekPicker render WeekPicker 1`] = `
                 >
                   <thead>
                     <tr>
-                      <th
-                        aria-label="empty cell"
-                      />
+                      <th>
+                        <span
+                          style="width: 0px; height: 0px; position: absolute; overflow: hidden; opacity: 0;"
+                        >
+                          Week
+                        </span>
+                      </th>
                       <th>
                         Su
                       </th>

--- a/components/date-picker/locale/sl_SI.ts
+++ b/components/date-picker/locale/sl_SI.ts
@@ -12,6 +12,7 @@ const locale: PickerLocale = {
     backToToday: 'Nazaj na trenutni datum',
     ok: 'OK',
     clear: 'Počisti',
+    week: 'Teden',
     month: 'Mesec',
     year: 'Leto',
     timeSelect: 'Izberi čas',

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -1659,7 +1659,7 @@ Array [
                                             class="ant-picker-header"
                                           >
                                             <button
-                                              aria-label="super-prev-year"
+                                              aria-label="Last year (Control + left)"
                                               class="ant-picker-header-super-prev-btn"
                                               tabindex="-1"
                                               type="button"
@@ -1669,7 +1669,7 @@ Array [
                                               />
                                             </button>
                                             <button
-                                              aria-label="prev-year"
+                                              aria-label="Previous month (PageUp)"
                                               class="ant-picker-header-prev-btn"
                                               tabindex="-1"
                                               type="button"
@@ -1682,7 +1682,7 @@ Array [
                                               class="ant-picker-header-view"
                                             >
                                               <button
-                                                aria-label="month panel"
+                                                aria-label="Choose a month"
                                                 class="ant-picker-month-btn"
                                                 tabindex="-1"
                                                 type="button"
@@ -1690,7 +1690,7 @@ Array [
                                                 Nov
                                               </button>
                                               <button
-                                                aria-label="year panel"
+                                                aria-label="Choose a year"
                                                 class="ant-picker-year-btn"
                                                 tabindex="-1"
                                                 type="button"
@@ -1699,7 +1699,7 @@ Array [
                                               </button>
                                             </div>
                                             <button
-                                              aria-label="next-year"
+                                              aria-label="Next month (PageDown)"
                                               class="ant-picker-header-next-btn"
                                               style="visibility: hidden;"
                                               tabindex="-1"
@@ -1710,7 +1710,7 @@ Array [
                                               />
                                             </button>
                                             <button
-                                              aria-label="super-next-year"
+                                              aria-label="Next year (Control + right)"
                                               class="ant-picker-header-super-next-btn"
                                               style="visibility: hidden;"
                                               tabindex="-1"
@@ -2201,7 +2201,7 @@ Array [
                                             class="ant-picker-header"
                                           >
                                             <button
-                                              aria-label="super-prev-year"
+                                              aria-label="Last year (Control + left)"
                                               class="ant-picker-header-super-prev-btn"
                                               style="visibility: hidden;"
                                               tabindex="-1"
@@ -2212,7 +2212,7 @@ Array [
                                               />
                                             </button>
                                             <button
-                                              aria-label="prev-year"
+                                              aria-label="Previous month (PageUp)"
                                               class="ant-picker-header-prev-btn"
                                               style="visibility: hidden;"
                                               tabindex="-1"
@@ -2226,7 +2226,7 @@ Array [
                                               class="ant-picker-header-view"
                                             >
                                               <button
-                                                aria-label="month panel"
+                                                aria-label="Choose a month"
                                                 class="ant-picker-month-btn"
                                                 tabindex="-1"
                                                 type="button"
@@ -2234,7 +2234,7 @@ Array [
                                                 Dec
                                               </button>
                                               <button
-                                                aria-label="year panel"
+                                                aria-label="Choose a year"
                                                 class="ant-picker-year-btn"
                                                 tabindex="-1"
                                                 type="button"
@@ -2243,7 +2243,7 @@ Array [
                                               </button>
                                             </div>
                                             <button
-                                              aria-label="next-year"
+                                              aria-label="Next month (PageDown)"
                                               class="ant-picker-header-next-btn"
                                               tabindex="-1"
                                               type="button"
@@ -2253,7 +2253,7 @@ Array [
                                               />
                                             </button>
                                             <button
-                                              aria-label="super-next-year"
+                                              aria-label="Next year (Control + right)"
                                               class="ant-picker-header-super-next-btn"
                                               tabindex="-1"
                                               type="button"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3111,7 +3111,7 @@ Array [
                             class="ant-picker-header"
                           >
                             <button
-                              aria-label="super-prev-year"
+                              aria-label="Last year (Control + left)"
                               class="ant-picker-header-super-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -3121,7 +3121,7 @@ Array [
                               />
                             </button>
                             <button
-                              aria-label="prev-year"
+                              aria-label="Previous month (PageUp)"
                               class="ant-picker-header-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -3134,7 +3134,7 @@ Array [
                               class="ant-picker-header-view"
                             >
                               <button
-                                aria-label="month panel"
+                                aria-label="Choose a month"
                                 class="ant-picker-month-btn"
                                 tabindex="-1"
                                 type="button"
@@ -3142,7 +3142,7 @@ Array [
                                 Nov
                               </button>
                               <button
-                                aria-label="year panel"
+                                aria-label="Choose a year"
                                 class="ant-picker-year-btn"
                                 tabindex="-1"
                                 type="button"
@@ -3151,7 +3151,7 @@ Array [
                               </button>
                             </div>
                             <button
-                              aria-label="next-year"
+                              aria-label="Next month (PageDown)"
                               class="ant-picker-header-next-btn"
                               tabindex="-1"
                               type="button"
@@ -3161,7 +3161,7 @@ Array [
                               />
                             </button>
                             <button
-                              aria-label="super-next-year"
+                              aria-label="Next year (Control + right)"
                               class="ant-picker-header-super-next-btn"
                               tabindex="-1"
                               type="button"
@@ -3811,7 +3811,7 @@ Array [
                                 class="ant-picker-header"
                               >
                                 <button
-                                  aria-label="super-prev-year"
+                                  aria-label="Last year (Control + left)"
                                   class="ant-picker-header-super-prev-btn"
                                   tabindex="-1"
                                   type="button"
@@ -3821,7 +3821,7 @@ Array [
                                   />
                                 </button>
                                 <button
-                                  aria-label="prev-year"
+                                  aria-label="Previous month (PageUp)"
                                   class="ant-picker-header-prev-btn"
                                   tabindex="-1"
                                   type="button"
@@ -3834,7 +3834,7 @@ Array [
                                   class="ant-picker-header-view"
                                 >
                                   <button
-                                    aria-label="month panel"
+                                    aria-label="Choose a month"
                                     class="ant-picker-month-btn"
                                     tabindex="-1"
                                     type="button"
@@ -3842,7 +3842,7 @@ Array [
                                     Nov
                                   </button>
                                   <button
-                                    aria-label="year panel"
+                                    aria-label="Choose a year"
                                     class="ant-picker-year-btn"
                                     tabindex="-1"
                                     type="button"
@@ -3851,7 +3851,7 @@ Array [
                                   </button>
                                 </div>
                                 <button
-                                  aria-label="next-year"
+                                  aria-label="Next month (PageDown)"
                                   class="ant-picker-header-next-btn"
                                   style="visibility: hidden;"
                                   tabindex="-1"
@@ -3862,7 +3862,7 @@ Array [
                                   />
                                 </button>
                                 <button
-                                  aria-label="super-next-year"
+                                  aria-label="Next year (Control + right)"
                                   class="ant-picker-header-super-next-btn"
                                   style="visibility: hidden;"
                                   tabindex="-1"
@@ -4353,7 +4353,7 @@ Array [
                                 class="ant-picker-header"
                               >
                                 <button
-                                  aria-label="super-prev-year"
+                                  aria-label="Last year (Control + left)"
                                   class="ant-picker-header-super-prev-btn"
                                   style="visibility: hidden;"
                                   tabindex="-1"
@@ -4364,7 +4364,7 @@ Array [
                                   />
                                 </button>
                                 <button
-                                  aria-label="prev-year"
+                                  aria-label="Previous month (PageUp)"
                                   class="ant-picker-header-prev-btn"
                                   style="visibility: hidden;"
                                   tabindex="-1"
@@ -4378,7 +4378,7 @@ Array [
                                   class="ant-picker-header-view"
                                 >
                                   <button
-                                    aria-label="month panel"
+                                    aria-label="Choose a month"
                                     class="ant-picker-month-btn"
                                     tabindex="-1"
                                     type="button"
@@ -4386,7 +4386,7 @@ Array [
                                     Dec
                                   </button>
                                   <button
-                                    aria-label="year panel"
+                                    aria-label="Choose a year"
                                     class="ant-picker-year-btn"
                                     tabindex="-1"
                                     type="button"
@@ -4395,7 +4395,7 @@ Array [
                                   </button>
                                 </div>
                                 <button
-                                  aria-label="next-year"
+                                  aria-label="Next month (PageDown)"
                                   class="ant-picker-header-next-btn"
                                   tabindex="-1"
                                   type="button"
@@ -4405,7 +4405,7 @@ Array [
                                   />
                                 </button>
                                 <button
-                                  aria-label="super-next-year"
+                                  aria-label="Next year (Control + right)"
                                   class="ant-picker-header-super-next-btn"
                                   tabindex="-1"
                                   type="button"
@@ -7907,7 +7907,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -7917,7 +7917,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                             />
                           </button>
                           <button
-                            aria-label="prev-year"
+                            aria-label="Previous month (PageUp)"
                             class="ant-picker-header-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -7930,7 +7930,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="month panel"
+                              aria-label="Choose a month"
                               class="ant-picker-month-btn"
                               tabindex="-1"
                               type="button"
@@ -7938,7 +7938,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                               Jan
                             </button>
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -7947,7 +7947,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                             </button>
                           </div>
                           <button
-                            aria-label="next-year"
+                            aria-label="Next month (PageDown)"
                             class="ant-picker-header-next-btn"
                             tabindex="-1"
                             type="button"
@@ -7957,7 +7957,7 @@ exports[`renders components/form/demo/getValueProps-normalize.tsx extend context
                             />
                           </button>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -12347,7 +12347,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -12357,7 +12357,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                             />
                           </button>
                           <button
-                            aria-label="prev-year"
+                            aria-label="Previous month (PageUp)"
                             class="ant-picker-header-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -12370,7 +12370,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="month panel"
+                              aria-label="Choose a month"
                               class="ant-picker-month-btn"
                               tabindex="-1"
                               type="button"
@@ -12378,7 +12378,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                               Nov
                             </button>
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -12387,7 +12387,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                             </button>
                           </div>
                           <button
-                            aria-label="next-year"
+                            aria-label="Next month (PageDown)"
                             class="ant-picker-header-next-btn"
                             tabindex="-1"
                             type="button"
@@ -12397,7 +12397,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                             />
                           </button>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -13195,7 +13195,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -13205,7 +13205,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             />
                           </button>
                           <button
-                            aria-label="prev-year"
+                            aria-label="Previous month (PageUp)"
                             class="ant-picker-header-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -13218,7 +13218,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="month panel"
+                              aria-label="Choose a month"
                               class="ant-picker-month-btn"
                               tabindex="-1"
                               type="button"
@@ -13226,7 +13226,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               Nov
                             </button>
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -13235,7 +13235,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             </button>
                           </div>
                           <button
-                            aria-label="next-year"
+                            aria-label="Next month (PageDown)"
                             class="ant-picker-header-next-btn"
                             tabindex="-1"
                             type="button"
@@ -13245,7 +13245,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             />
                           </button>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -13844,7 +13844,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             class="ant-picker-header"
                           >
                             <button
-                              aria-label="super-prev-year"
+                              aria-label="Last year (Control + left)"
                               class="ant-picker-header-super-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -13854,7 +13854,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               />
                             </button>
                             <button
-                              aria-label="prev-year"
+                              aria-label="Previous month (PageUp)"
                               class="ant-picker-header-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -13867,7 +13867,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               class="ant-picker-header-view"
                             >
                               <button
-                                aria-label="month panel"
+                                aria-label="Choose a month"
                                 class="ant-picker-month-btn"
                                 tabindex="-1"
                                 type="button"
@@ -13875,7 +13875,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 Nov
                               </button>
                               <button
-                                aria-label="year panel"
+                                aria-label="Choose a year"
                                 class="ant-picker-year-btn"
                                 tabindex="-1"
                                 type="button"
@@ -13884,7 +13884,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               </button>
                             </div>
                             <button
-                              aria-label="next-year"
+                              aria-label="Next month (PageDown)"
                               class="ant-picker-header-next-btn"
                               tabindex="-1"
                               type="button"
@@ -13894,7 +13894,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               />
                             </button>
                             <button
-                              aria-label="super-next-year"
+                              aria-label="Next year (Control + right)"
                               class="ant-picker-header-super-next-btn"
                               tabindex="-1"
                               type="button"
@@ -15975,7 +15975,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -15988,7 +15988,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -15997,7 +15997,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                             </button>
                           </div>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -16302,7 +16302,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -16312,7 +16312,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -16325,7 +16325,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -16333,7 +16333,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                   Nov
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -16342,7 +16342,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -16353,7 +16353,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -16844,7 +16844,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -16855,7 +16855,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -16869,7 +16869,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -16877,7 +16877,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                   Dec
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -16886,7 +16886,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -16896,7 +16896,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -17532,7 +17532,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -17542,7 +17542,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -17555,7 +17555,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -17563,7 +17563,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                   Nov
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -17572,7 +17572,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -17582,7 +17582,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -24487,7 +24487,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -24497,7 +24497,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                             />
                           </button>
                           <button
-                            aria-label="prev-year"
+                            aria-label="Previous month (PageUp)"
                             class="ant-picker-header-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -24510,7 +24510,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="month panel"
+                              aria-label="Choose a month"
                               class="ant-picker-month-btn"
                               tabindex="-1"
                               type="button"
@@ -24518,7 +24518,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                               Nov
                             </button>
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -24527,7 +24527,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                             </button>
                           </div>
                           <button
-                            aria-label="next-year"
+                            aria-label="Next month (PageDown)"
                             class="ant-picker-header-next-btn"
                             tabindex="-1"
                             type="button"
@@ -24537,7 +24537,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                             />
                           </button>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -26821,7 +26821,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -26831,7 +26831,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -26844,7 +26844,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -26852,7 +26852,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                   Nov
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -26861,7 +26861,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -26872,7 +26872,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -27363,7 +27363,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -27374,7 +27374,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -27388,7 +27388,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -27396,7 +27396,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                   Dec
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -27405,7 +27405,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -27415,7 +27415,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -28601,7 +28601,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                     class="ant-picker-header"
                                   >
                                     <button
-                                      aria-label="super-prev-year"
+                                      aria-label="Last year (Control + left)"
                                       class="ant-picker-header-super-prev-btn"
                                       tabindex="-1"
                                       type="button"
@@ -28611,7 +28611,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       />
                                     </button>
                                     <button
-                                      aria-label="prev-year"
+                                      aria-label="Previous month (PageUp)"
                                       class="ant-picker-header-prev-btn"
                                       tabindex="-1"
                                       type="button"
@@ -28624,7 +28624,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       class="ant-picker-header-view"
                                     >
                                       <button
-                                        aria-label="month panel"
+                                        aria-label="Choose a month"
                                         class="ant-picker-month-btn"
                                         tabindex="-1"
                                         type="button"
@@ -28632,7 +28632,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                         Nov
                                       </button>
                                       <button
-                                        aria-label="year panel"
+                                        aria-label="Choose a year"
                                         class="ant-picker-year-btn"
                                         tabindex="-1"
                                         type="button"
@@ -28641,7 +28641,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       </button>
                                     </div>
                                     <button
-                                      aria-label="next-year"
+                                      aria-label="Next month (PageDown)"
                                       class="ant-picker-header-next-btn"
                                       tabindex="-1"
                                       type="button"
@@ -28651,7 +28651,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       />
                                     </button>
                                     <button
-                                      aria-label="super-next-year"
+                                      aria-label="Next year (Control + right)"
                                       class="ant-picker-header-super-next-btn"
                                       tabindex="-1"
                                       type="button"
@@ -29260,7 +29260,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                     class="ant-picker-header"
                                   >
                                     <button
-                                      aria-label="super-prev-year"
+                                      aria-label="Last year (Control + left)"
                                       class="ant-picker-header-super-prev-btn"
                                       tabindex="-1"
                                       type="button"
@@ -29270,7 +29270,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       />
                                     </button>
                                     <button
-                                      aria-label="prev-year"
+                                      aria-label="Previous month (PageUp)"
                                       class="ant-picker-header-prev-btn"
                                       tabindex="-1"
                                       type="button"
@@ -29283,7 +29283,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       class="ant-picker-header-view"
                                     >
                                       <button
-                                        aria-label="month panel"
+                                        aria-label="Choose a month"
                                         class="ant-picker-month-btn"
                                         tabindex="-1"
                                         type="button"
@@ -29291,7 +29291,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                         Nov
                                       </button>
                                       <button
-                                        aria-label="year panel"
+                                        aria-label="Choose a year"
                                         class="ant-picker-year-btn"
                                         tabindex="-1"
                                         type="button"
@@ -29300,7 +29300,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       </button>
                                     </div>
                                     <button
-                                      aria-label="next-year"
+                                      aria-label="Next month (PageDown)"
                                       class="ant-picker-header-next-btn"
                                       tabindex="-1"
                                       type="button"
@@ -29310,7 +29310,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                                       />
                                     </button>
                                     <button
-                                      aria-label="super-next-year"
+                                      aria-label="Next year (Control + right)"
                                       class="ant-picker-header-super-next-btn"
                                       tabindex="-1"
                                       type="button"
@@ -31708,7 +31708,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                           class="ant-picker-header"
                         >
                           <button
-                            aria-label="super-prev-year"
+                            aria-label="Last year (Control + left)"
                             class="ant-picker-header-super-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -31718,7 +31718,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                             />
                           </button>
                           <button
-                            aria-label="prev-year"
+                            aria-label="Previous month (PageUp)"
                             class="ant-picker-header-prev-btn"
                             tabindex="-1"
                             type="button"
@@ -31731,7 +31731,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                             class="ant-picker-header-view"
                           >
                             <button
-                              aria-label="month panel"
+                              aria-label="Choose a month"
                               class="ant-picker-month-btn"
                               tabindex="-1"
                               type="button"
@@ -31739,7 +31739,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                               Nov
                             </button>
                             <button
-                              aria-label="year panel"
+                              aria-label="Choose a year"
                               class="ant-picker-year-btn"
                               tabindex="-1"
                               type="button"
@@ -31748,7 +31748,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                             </button>
                           </div>
                           <button
-                            aria-label="next-year"
+                            aria-label="Next month (PageDown)"
                             class="ant-picker-header-next-btn"
                             tabindex="-1"
                             type="button"
@@ -31758,7 +31758,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                             />
                           </button>
                           <button
-                            aria-label="super-next-year"
+                            aria-label="Next year (Control + right)"
                             class="ant-picker-header-super-next-btn"
                             tabindex="-1"
                             type="button"
@@ -32410,7 +32410,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -32420,7 +32420,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 tabindex="-1"
                                 type="button"
@@ -32433,7 +32433,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -32441,7 +32441,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                   Nov
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -32450,7 +32450,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -32461,7 +32461,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -32952,7 +32952,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                               class="ant-picker-header"
                             >
                               <button
-                                aria-label="super-prev-year"
+                                aria-label="Last year (Control + left)"
                                 class="ant-picker-header-super-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -32963,7 +32963,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 />
                               </button>
                               <button
-                                aria-label="prev-year"
+                                aria-label="Previous month (PageUp)"
                                 class="ant-picker-header-prev-btn"
                                 style="visibility: hidden;"
                                 tabindex="-1"
@@ -32977,7 +32977,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 class="ant-picker-header-view"
                               >
                                 <button
-                                  aria-label="month panel"
+                                  aria-label="Choose a month"
                                   class="ant-picker-month-btn"
                                   tabindex="-1"
                                   type="button"
@@ -32985,7 +32985,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                   Dec
                                 </button>
                                 <button
-                                  aria-label="year panel"
+                                  aria-label="Choose a year"
                                   class="ant-picker-year-btn"
                                   tabindex="-1"
                                   type="button"
@@ -32994,7 +32994,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 </button>
                               </div>
                               <button
-                                aria-label="next-year"
+                                aria-label="Next month (PageDown)"
                                 class="ant-picker-header-next-btn"
                                 tabindex="-1"
                                 type="button"
@@ -33004,7 +33004,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                                 />
                               </button>
                               <button
-                                aria-label="super-next-year"
+                                aria-label="Next year (Control + right)"
                                 class="ant-picker-header-super-next-btn"
                                 tabindex="-1"
                                 type="button"

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -959,7 +959,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -969,7 +969,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="prev-year"
+                  aria-label="Previous month (PageUp)"
                   class="ant-picker-header-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -982,7 +982,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="month panel"
+                    aria-label="Choose a month"
                     class="ant-picker-month-btn"
                     tabindex="-1"
                     type="button"
@@ -990,7 +990,7 @@ Array [
                     Nov
                   </button>
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -999,7 +999,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="next-year"
+                  aria-label="Next month (PageDown)"
                   class="ant-picker-header-next-btn"
                   tabindex="-1"
                   type="button"
@@ -1009,7 +1009,7 @@ Array [
                   />
                 </button>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -3916,7 +3916,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -3926,7 +3926,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -3939,7 +3939,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -3947,7 +3947,7 @@ Array [
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -3956,7 +3956,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -3967,7 +3967,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -4458,7 +4458,7 @@ Array [
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -4469,7 +4469,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       style="visibility: hidden;"
                       tabindex="-1"
@@ -4483,7 +4483,7 @@ Array [
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -4491,7 +4491,7 @@ Array [
                         Dec
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -4500,7 +4500,7 @@ Array [
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -4510,7 +4510,7 @@ Array [
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -5057,7 +5057,7 @@ Array [
                 class="ant-picker-header"
               >
                 <button
-                  aria-label="super-prev-year"
+                  aria-label="Last year (Control + left)"
                   class="ant-picker-header-super-prev-btn"
                   tabindex="-1"
                   type="button"
@@ -5070,7 +5070,7 @@ Array [
                   class="ant-picker-header-view"
                 >
                   <button
-                    aria-label="year panel"
+                    aria-label="Choose a year"
                     class="ant-picker-year-btn"
                     tabindex="-1"
                     type="button"
@@ -5079,7 +5079,7 @@ Array [
                   </button>
                 </div>
                 <button
-                  aria-label="super-next-year"
+                  aria-label="Next year (Control + right)"
                   class="ant-picker-header-super-next-btn"
                   tabindex="-1"
                   type="button"
@@ -7473,7 +7473,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                   class="ant-picker-header"
                 >
                   <button
-                    aria-label="super-prev-year"
+                    aria-label="Last year (Control + left)"
                     class="ant-picker-header-super-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -7483,7 +7483,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                     />
                   </button>
                   <button
-                    aria-label="prev-year"
+                    aria-label="Previous month (PageUp)"
                     class="ant-picker-header-prev-btn"
                     tabindex="-1"
                     type="button"
@@ -7496,7 +7496,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                     class="ant-picker-header-view"
                   >
                     <button
-                      aria-label="month panel"
+                      aria-label="Choose a month"
                       class="ant-picker-month-btn"
                       tabindex="-1"
                       type="button"
@@ -7504,7 +7504,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                       Nov
                     </button>
                     <button
-                      aria-label="year panel"
+                      aria-label="Choose a year"
                       class="ant-picker-year-btn"
                       tabindex="-1"
                       type="button"
@@ -7513,7 +7513,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                     </button>
                   </div>
                   <button
-                    aria-label="next-year"
+                    aria-label="Next month (PageDown)"
                     class="ant-picker-header-next-btn"
                     tabindex="-1"
                     type="button"
@@ -7523,7 +7523,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                     />
                   </button>
                   <button
-                    aria-label="super-next-year"
+                    aria-label="Next year (Control + right)"
                     class="ant-picker-header-super-next-btn"
                     tabindex="-1"
                     type="button"
@@ -8153,7 +8153,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -8163,7 +8163,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         tabindex="-1"
                         type="button"
@@ -8176,7 +8176,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -8184,7 +8184,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                           Nov
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -8193,7 +8193,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -8204,7 +8204,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -8695,7 +8695,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                       class="ant-picker-header"
                     >
                       <button
-                        aria-label="super-prev-year"
+                        aria-label="Last year (Control + left)"
                         class="ant-picker-header-super-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -8706,7 +8706,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         />
                       </button>
                       <button
-                        aria-label="prev-year"
+                        aria-label="Previous month (PageUp)"
                         class="ant-picker-header-prev-btn"
                         style="visibility: hidden;"
                         tabindex="-1"
@@ -8720,7 +8720,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         class="ant-picker-header-view"
                       >
                         <button
-                          aria-label="month panel"
+                          aria-label="Choose a month"
                           class="ant-picker-month-btn"
                           tabindex="-1"
                           type="button"
@@ -8728,7 +8728,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                           Dec
                         </button>
                         <button
-                          aria-label="year panel"
+                          aria-label="Choose a year"
                           class="ant-picker-year-btn"
                           tabindex="-1"
                           type="button"
@@ -8737,7 +8737,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         </button>
                       </div>
                       <button
-                        aria-label="next-year"
+                        aria-label="Next month (PageDown)"
                         class="ant-picker-header-next-btn"
                         tabindex="-1"
                         type="button"
@@ -8747,7 +8747,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
                         />
                       </button>
                       <button
-                        aria-label="super-next-year"
+                        aria-label="Next year (Control + right)"
                         class="ant-picker-header-super-next-btn"
                         tabindex="-1"
                         type="button"

--- a/components/locale/hy_AM.ts
+++ b/components/locale/hy_AM.ts
@@ -11,6 +11,7 @@ const datePickerLocale: PickerLocale = {
     backToToday: 'Վերադառնալ այսօր',
     ok: 'Օկ',
     clear: 'Մաքրել',
+    week: 'Շաբաթ',
     month: 'Ամիս',
     year: 'Տարի',
     timeSelect: 'ընտրեք ժամը',

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1372,7 +1372,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                     class="ant-picker-header"
                   >
                     <button
-                      aria-label="super-prev-year"
+                      aria-label="Last year (Control + left)"
                       class="ant-picker-header-super-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -1382,7 +1382,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                       />
                     </button>
                     <button
-                      aria-label="prev-year"
+                      aria-label="Previous month (PageUp)"
                       class="ant-picker-header-prev-btn"
                       tabindex="-1"
                       type="button"
@@ -1395,7 +1395,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                       class="ant-picker-header-view"
                     >
                       <button
-                        aria-label="month panel"
+                        aria-label="Choose a month"
                         class="ant-picker-month-btn"
                         tabindex="-1"
                         type="button"
@@ -1403,7 +1403,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                         Nov
                       </button>
                       <button
-                        aria-label="year panel"
+                        aria-label="Choose a year"
                         class="ant-picker-year-btn"
                         tabindex="-1"
                         type="button"
@@ -1412,7 +1412,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                       </button>
                     </div>
                     <button
-                      aria-label="next-year"
+                      aria-label="Next month (PageDown)"
                       class="ant-picker-header-next-btn"
                       tabindex="-1"
                       type="button"
@@ -1422,7 +1422,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                       />
                     </button>
                     <button
-                      aria-label="super-next-year"
+                      aria-label="Next year (Control + right)"
                       class="ant-picker-header-super-next-btn"
                       tabindex="-1"
                       type="button"
@@ -2049,7 +2049,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -2059,7 +2059,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -2072,7 +2072,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -2080,7 +2080,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                             Nov
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -2089,7 +2089,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -2100,7 +2100,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -2591,7 +2591,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -2602,7 +2602,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -2616,7 +2616,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -2624,7 +2624,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                             Dec
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -2633,7 +2633,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           tabindex="-1"
                           type="button"
@@ -2643,7 +2643,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           tabindex="-1"
                           type="button"
@@ -3274,7 +3274,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -3284,7 +3284,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -3297,7 +3297,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -3305,7 +3305,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                             Nov
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -3314,7 +3314,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -3325,7 +3325,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -3816,7 +3816,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -3827,7 +3827,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -3841,7 +3841,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -3849,7 +3849,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                             Dec
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -3858,7 +3858,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           tabindex="-1"
                           type="button"
@@ -3868,7 +3868,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           tabindex="-1"
                           type="button"
@@ -11790,7 +11790,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                             class="ant-picker-header"
                           >
                             <button
-                              aria-label="super-prev-year"
+                              aria-label="Last year (Control + left)"
                               class="ant-picker-header-super-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -11800,7 +11800,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                               />
                             </button>
                             <button
-                              aria-label="prev-year"
+                              aria-label="Previous month (PageUp)"
                               class="ant-picker-header-prev-btn"
                               tabindex="-1"
                               type="button"
@@ -11813,7 +11813,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                               class="ant-picker-header-view"
                             >
                               <button
-                                aria-label="month panel"
+                                aria-label="Choose a month"
                                 class="ant-picker-month-btn"
                                 tabindex="-1"
                                 type="button"
@@ -11821,7 +11821,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                                 Nov
                               </button>
                               <button
-                                aria-label="year panel"
+                                aria-label="Choose a year"
                                 class="ant-picker-year-btn"
                                 tabindex="-1"
                                 type="button"
@@ -11830,7 +11830,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                               </button>
                             </div>
                             <button
-                              aria-label="next-year"
+                              aria-label="Next month (PageDown)"
                               class="ant-picker-header-next-btn"
                               tabindex="-1"
                               type="button"
@@ -11840,7 +11840,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                               />
                             </button>
                             <button
-                              aria-label="super-next-year"
+                              aria-label="Next year (Control + right)"
                               class="ant-picker-header-super-next-btn"
                               tabindex="-1"
                               type="button"
@@ -12926,7 +12926,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -12936,7 +12936,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           tabindex="-1"
                           type="button"
@@ -12949,7 +12949,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -12957,7 +12957,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                             Nov
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -12966,7 +12966,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -12977,7 +12977,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -13468,7 +13468,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                         class="ant-picker-header"
                       >
                         <button
-                          aria-label="super-prev-year"
+                          aria-label="Last year (Control + left)"
                           class="ant-picker-header-super-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -13479,7 +13479,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           />
                         </button>
                         <button
-                          aria-label="prev-year"
+                          aria-label="Previous month (PageUp)"
                           class="ant-picker-header-prev-btn"
                           style="visibility: hidden;"
                           tabindex="-1"
@@ -13493,7 +13493,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           class="ant-picker-header-view"
                         >
                           <button
-                            aria-label="month panel"
+                            aria-label="Choose a month"
                             class="ant-picker-month-btn"
                             tabindex="-1"
                             type="button"
@@ -13501,7 +13501,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                             Dec
                           </button>
                           <button
-                            aria-label="year panel"
+                            aria-label="Choose a year"
                             class="ant-picker-year-btn"
                             tabindex="-1"
                             type="button"
@@ -13510,7 +13510,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           </button>
                         </div>
                         <button
-                          aria-label="next-year"
+                          aria-label="Next month (PageDown)"
                           class="ant-picker-header-next-btn"
                           tabindex="-1"
                           type="button"
@@ -13520,7 +13520,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           />
                         </button>
                         <button
-                          aria-label="super-next-year"
+                          aria-label="Next year (Control + right)"
                           class="ant-picker-header-super-next-btn"
                           tabindex="-1"
                           type="button"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "rc-motion": "^2.9.5",
     "rc-notification": "~5.6.2",
     "rc-pagination": "~5.1.0",
-    "rc-picker": "~4.9.2",
+    "rc-picker": "~4.10.0",
     "rc-progress": "~4.0.0",
     "rc-rate": "~2.13.0",
     "rc-resize-observer": "^1.4.3",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ⭐️ Feature enhancement
- [x] 🌐 Internationalization

### 🔗 Related Issues

- ref https://github.com/react-component/picker/pull/904
- ref https://github.com/react-component/picker/pull/905

### 💡 Background and Solution

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Improve accessibility by adding localized labels for empty table header and panel buttons    |
| 🇨🇳 Chinese |    优化无障碍体验，为空表头和面板按钮添加本地化标签       |
