### PR TITLE
fix: Button shadow color should be transparent

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -309,13 +309,11 @@ const genPresetColorStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
     const lightHoverColor = token[`${colorKey}2`];
     const lightBorderColor = token[`${colorKey}3`];
     const activeColor = token[`${colorKey}7`];
-    const boxShadow = `0 ${unit(token.controlOutlineWidth)} 0 ${token[`${colorKey}1`]}`;
-
     return {
       ...prev,
       [`&${componentCls}-color-${colorKey}`]: {
         color: darkColor,
-        boxShadow,
+        boxShadow: token[`${colorKey}ShadowColor`],
 
         ...genSolidButtonStyle(
           token,

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -1,9 +1,13 @@
 import type { CSSProperties } from 'react';
+import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 
 import { AggregationColor } from '../../color-picker/color';
 import { isBright } from '../../color-picker/components/ColorPresets';
-import type { FullToken, GenStyleFn, GetDefaultToken } from '../../theme/internal';
+import type { FullToken, GenStyleFn, GetDefaultToken, PresetColorKey } from '../../theme/internal';
 import { getLineHeight, mergeToken } from '../../theme/internal';
+import { PresetColors } from '../../theme/interface';
+import getAlphaColor from '../../theme/util/getAlphaColor';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -218,7 +222,15 @@ export interface ComponentToken {
   contentLineHeightSM: number;
 }
 
-export interface ButtonToken extends FullToken<'Button'> {
+type ShadowColorMap = {
+  /**
+   * @desc 预设按钮的阴影色
+   * @descEN Shadow colors of preset button
+   */
+  [Key in `${PresetColorKey}ShadowColor`]: string;
+};
+
+export interface ButtonToken extends FullToken<'Button'>, ShadowColorMap {
   /**
    * @desc 按钮横向内边距
    * @descEN Horizontal padding of button
@@ -261,7 +273,16 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     ? '#000'
     : '#fff';
 
+  const shadowColorTokens = PresetColors.reduce<CSSObject>(
+    (prev: CSSObject, colorKey: PresetColorKey) => ({
+      ...prev,
+      [`${colorKey}ShadowColor`]: `0 ${unit(token.controlOutlineWidth)} 0 ${getAlphaColor(token[`${colorKey}1`], token.colorBgContainer)}`,
+    }),
+    {},
+  );
+
   return {
+    ...shadowColorTokens,
     fontWeight: 400,
     defaultShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlTmpOutline}`,
     primaryShadow: `0 ${token.controlOutlineWidth}px 0 ${token.controlOutline}`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/52699

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

修复后的效果：

<img width="594" alt="图片" src="https://github.com/user-attachments/assets/293336d0-8602-412d-8d8f-b30c52ee26c2" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Button shadow color appearing awkward on dark backgrounds.         |
| 🇨🇳 Chinese | 修复 Button 预设值按钮的阴影色在暗色背景下显示突兀的问题。          |
