### PR TITLE
fix: the animation transition effect of Segmented in dark mode

### DIFF
--- a/components/segmented/style/index.ts
+++ b/components/segmented/style/index.ts
@@ -170,7 +170,8 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
           top: 0,
           insetInlineStart: 0,
           borderRadius: 'inherit',
-          transition: `background-color ${token.motionDurationMid}`,
+          opacity: 0,
+          transition: `opacity ${token.motionDurationMid}`,
           // This is mandatory to make it not clickable or hoverable
           // Ref: https://github.com/ant-design/ant-design/issues/40888
           pointerEvents: 'none',
@@ -179,12 +180,14 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
         [`&:hover:not(${componentCls}-item-selected):not(${componentCls}-item-disabled)`]: {
           color: token.itemHoverColor,
           '&::after': {
+            opacity: 1,
             backgroundColor: token.itemHoverBg,
           },
         },
         [`&:active:not(${componentCls}-item-selected):not(${componentCls}-item-disabled)`]: {
           color: token.itemHoverColor,
           '&::after': {
+            opacity: 1,
             backgroundColor: token.itemActiveBg,
           },
         },


### PR DESCRIPTION
…mode is unnatural

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix #52398

### 💡 Background and Solution
> - Background : 暗黑模式下，由较暗色到较浅色的动画过渡过程中，会在两个label间出现短暂的`白色线条`
> - Solution : 改为`opacity`显色的形式，可以避免由于背景颜色切换而出现的`白色线条`


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fixed the unnatural animation transition effect of Segmented component in dark mode      |
| 🇨🇳 Chinese |   修复Segmented 组件在暗黑模式下的动画过渡效果不自然        |
