### PR TITLE
docs: fix btn description for notification

### DIFF
--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -49,7 +49,7 @@ The properties of config are as follows:
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| btn | Customized close button | ReactNode | - | - |
+| btn | Customized button group | ReactNode | - | - |
 | className | Customized CSS class | string | - | - |
 | closeIcon | Custom close icon | ReactNode | true | 5.7.0: close button will be hidden when setting to null or false |
 | description | The content of notification box (required) | ReactNode | - | - |

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -50,7 +50,7 @@ config 参数如下：
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| btn | 自定义关闭按钮 | ReactNode | - | - |
+| btn | 自定义按钮组 | ReactNode | - | - |
 | className | 自定义 CSS class | string | - | - |
 | closeIcon | 自定义关闭图标 | ReactNode | true | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
 | description | 通知提醒内容，必选 | ReactNode | - | - |


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement

### 💡 Background and Solution
真实的自定义关闭按钮api实际上是closeIcon，btn的描述会产生误导，目测应该没这么快发 minor 版本，所以可以考虑先在master 纠正回来。
![image](https://github.com/user-attachments/assets/21f3cf92-38f1-4186-8107-5a7bc400205d)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -     |
