### PR TITLE
test: add a11y test for remaining components demo

### DIFF
--- a/components/cascader/__tests__/a11y.test.ts
+++ b/components/cascader/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('cascader', {
+  // we can set aria-label to fix it
+  disabledRules: ['label'],
+  // skip internal demo
+  skip: ['render-panel.tsx'],
+});

--- a/components/config-provider/__tests__/a11y.test.ts
+++ b/components/config-provider/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('config-provider', {
+  // we actually can ignore it
+  skip: true,
+});

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -12,7 +12,7 @@ Array [
         aria-invalid="false"
         autocomplete="off"
         date-range="start"
-        placeholder=""
+        placeholder="Allow Empty"
         size="12"
         value=""
       />
@@ -79631,6 +79631,7 @@ exports[`renders components/date-picker/demo/switchable.tsx extend context corre
     class="ant-space-item"
   >
     <div
+      aria-label="Picker Type"
       class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
     >
       <div
@@ -79647,6 +79648,7 @@ exports[`renders components/date-picker/demo/switchable.tsx extend context corre
               aria-controls="rc_select_TEST_OR_SSR_list"
               aria-expanded="false"
               aria-haspopup="listbox"
+              aria-label="Picker Type"
               aria-owns="rc_select_TEST_OR_SSR_list"
               autocomplete="off"
               class="ant-select-selection-search-input"
@@ -85699,7 +85701,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Outlined"
+          placeholder="Outlined Start"
           size="12"
           value=""
         />
@@ -85739,7 +85741,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Outlined End"
           size="12"
           value=""
         />
@@ -87513,7 +87515,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Filled Start"
           size="12"
           value=""
         />
@@ -87553,7 +87555,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Filled End"
           size="12"
           value=""
         />
@@ -89327,7 +89329,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Borderless"
+          placeholder="Borderless Start"
           size="12"
           value=""
         />
@@ -89367,7 +89369,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Borderless End"
           size="12"
           value=""
         />

--- a/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders components/date-picker/demo/allow-empty.tsx correctly 1`] = `
       aria-invalid="false"
       autocomplete="off"
       date-range="start"
-      placeholder=""
+      placeholder="Allow Empty"
       size="12"
       value=""
     />
@@ -7180,6 +7180,7 @@ exports[`renders components/date-picker/demo/switchable.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="Picker Type"
       class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
     >
       <div
@@ -7196,6 +7197,7 @@ exports[`renders components/date-picker/demo/switchable.tsx correctly 1`] = `
               aria-controls="undefined_list"
               aria-expanded="false"
               aria-haspopup="listbox"
+              aria-label="Picker Type"
               aria-owns="undefined_list"
               autocomplete="off"
               class="ant-select-selection-search-input"
@@ -7485,7 +7487,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Outlined"
+          placeholder="Outlined Start"
           size="12"
           value=""
         />
@@ -7525,7 +7527,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Outlined End"
           size="12"
           value=""
         />
@@ -7611,7 +7613,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Filled Start"
           size="12"
           value=""
         />
@@ -7651,7 +7653,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Filled End"
           size="12"
           value=""
         />
@@ -7737,7 +7739,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Borderless"
+          placeholder="Borderless Start"
           size="12"
           value=""
         />
@@ -7777,7 +7779,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Borderless End"
           size="12"
           value=""
         />

--- a/components/date-picker/__tests__/a11y.test.ts
+++ b/components/date-picker/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('date-picker');

--- a/components/date-picker/demo/allow-empty.tsx
+++ b/components/date-picker/demo/allow-empty.tsx
@@ -3,7 +3,7 @@ import { DatePicker } from 'antd';
 
 const App: React.FC = () => (
   <DatePicker.RangePicker
-    placeholder={['', 'Till Now']}
+    placeholder={['Allow Empty', 'Till Now']}
     allowEmpty={[false, true]}
     onChange={(date, dateString) => {
       console.log(date, dateString);

--- a/components/date-picker/demo/switchable.tsx
+++ b/components/date-picker/demo/switchable.tsx
@@ -23,7 +23,7 @@ const App: React.FC = () => {
 
   return (
     <Space>
-      <Select value={type} onChange={setType}>
+      <Select aria-label="Picker Type" value={type} onChange={setType}>
         <Option value="time">Time</Option>
         <Option value="date">Date</Option>
         <Option value="week">Week</Option>

--- a/components/date-picker/demo/variant.tsx
+++ b/components/date-picker/demo/variant.tsx
@@ -7,15 +7,15 @@ const App: React.FC = () => (
   <Flex vertical gap={12}>
     <Flex gap={8}>
       <DatePicker placeholder="Outlined" />
-      <RangePicker placeholder={['Outlined', '']} />
+      <RangePicker placeholder={['Outlined Start', 'Outlined End']} />
     </Flex>
     <Flex gap={8}>
       <DatePicker placeholder="Filled" variant="filled" />
-      <RangePicker placeholder={['Filled', '']} variant="filled" />
+      <RangePicker placeholder={['Filled Start', 'Filled End']} variant="filled" />
     </Flex>
     <Flex gap={8}>
       <DatePicker placeholder="Borderless" variant="borderless" />
-      <RangePicker placeholder={['Borderless', '']} variant="borderless" />
+      <RangePicker placeholder={['Borderless Start', 'Borderless End']} variant="borderless" />
     </Flex>
   </Flex>
 );

--- a/components/form/__tests__/a11y.test.ts
+++ b/components/form/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('form', {
+  // waiting for fix
+  disabledRules: ['label', 'aria-allowed-attr', 'button-name', 'listitem'],
+});

--- a/components/form/__tests__/a11y.test.ts
+++ b/components/form/__tests__/a11y.test.ts
@@ -2,5 +2,5 @@ import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('form', {
   // waiting for fix
-  disabledRules: ['label', 'aria-allowed-attr', 'button-name', 'listitem'],
+  disabledRules: ['label', 'aria-allowed-attr', 'button-name', 'listitem', 'aria-input-field-name'],
 });

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3544,8 +3544,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
       style="display: none;"
     />
   </header>
-  <main
-    class="ant-layout-content"
+  <div
     style="padding: 0px 48px;"
   >
     <nav
@@ -4272,7 +4271,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
         Content
       </main>
     </div>
-  </main>
+  </div>
   <footer
     class="ant-layout-footer"
     style="text-align: center;"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -2125,8 +2125,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
       style="display:none"
     />
   </header>
-  <main
-    class="ant-layout-content"
+  <div
     style="padding:0 48px"
   >
     <nav
@@ -2378,7 +2377,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
         Content
       </main>
     </div>
-  </main>
+  </div>
   <footer
     class="ant-layout-footer"
     style="text-align:center"

--- a/components/layout/__tests__/a11y.test.ts
+++ b/components/layout/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('layout', {
+  // we can ignore it
+  skip: ['basic.tsx'],
+});

--- a/components/layout/demo/top-side.tsx
+++ b/components/layout/demo/top-side.tsx
@@ -47,7 +47,7 @@ const App: React.FC = () => {
           style={{ flex: 1, minWidth: 0 }}
         />
       </Header>
-      <Content style={{ padding: '0 48px' }}>
+      <div style={{ padding: '0 48px' }}>
         <Breadcrumb style={{ margin: '16px 0' }}>
           <Breadcrumb.Item>Home</Breadcrumb.Item>
           <Breadcrumb.Item>List</Breadcrumb.Item>
@@ -67,7 +67,7 @@ const App: React.FC = () => {
           </Sider>
           <Content style={{ padding: '0 24px', minHeight: 280 }}>Content</Content>
         </Layout>
-      </Content>
+      </div>
       <Footer style={{ textAlign: 'center' }}>
         Ant Design ©{new Date().getFullYear()} Created by Ant UED
       </Footer>

--- a/components/table/__tests__/a11y.test.ts
+++ b/components/table/__tests__/a11y.test.ts
@@ -1,0 +1,7 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('table', {
+  skip: ['virtual-list.tsx'],
+  // waiting for fix
+  disabledRules: ['label', 'empty-table-header', 'nested-interactive', 'button-name'],
+});

--- a/components/tabs/__tests__/a11y.test.ts
+++ b/components/tabs/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('tabs', {
+  // waiting for fix
+  skip: ['custom-indicator.tsx', 'extra.tsx', 'nest.tsx', 'custom-tab-bar-node.tsx'],
+});

--- a/components/tabs/__tests__/a11y.test.ts
+++ b/components/tabs/__tests__/a11y.test.ts
@@ -2,5 +2,6 @@ import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('tabs', {
   // waiting for fix
-  skip: ['custom-indicator.tsx', 'extra.tsx', 'nest.tsx', 'custom-tab-bar-node.tsx'],
+  disabledRules: ['aria-required-children'],
+  skip: ['custom-indicator.tsx', 'custom-tab-bar-node.tsx', 'nest.tsx'],
 });

--- a/components/time-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -35293,7 +35293,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
         <input
           aria-invalid="false"
           autocomplete="off"
-          placeholder="Filled"
+          placeholder="Outlined"
           size="10"
           value=""
         />
@@ -36851,7 +36851,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Outlined Start"
           size="10"
           value=""
         />
@@ -36891,7 +36891,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Outlined End"
           size="10"
           value=""
         />
@@ -40013,7 +40013,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Filled Start"
           size="10"
           value=""
         />
@@ -40053,7 +40053,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Filled End"
           size="10"
           value=""
         />
@@ -43175,7 +43175,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Borderless"
+          placeholder="Borderless Start"
           size="10"
           value=""
         />
@@ -43215,7 +43215,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Borderless End"
           size="10"
           value=""
         />

--- a/components/time-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1472,7 +1472,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
         <input
           aria-invalid="false"
           autocomplete="off"
-          placeholder="Filled"
+          placeholder="Outlined"
           size="10"
           value=""
         />
@@ -1514,7 +1514,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Outlined Start"
           size="10"
           value=""
         />
@@ -1554,7 +1554,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Outlined End"
           size="10"
           value=""
         />
@@ -1646,7 +1646,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Filled"
+          placeholder="Filled Start"
           size="10"
           value=""
         />
@@ -1686,7 +1686,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Filled End"
           size="10"
           value=""
         />
@@ -1778,7 +1778,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="start"
-          placeholder="Borderless"
+          placeholder="Borderless Start"
           size="10"
           value=""
         />
@@ -1818,7 +1818,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
           aria-invalid="false"
           autocomplete="off"
           date-range="end"
-          placeholder=""
+          placeholder="Borderless End"
           size="10"
           value=""
         />

--- a/components/time-picker/__tests__/a11y.test.ts
+++ b/components/time-picker/__tests__/a11y.test.ts
@@ -1,0 +1,3 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('time-picker');

--- a/components/time-picker/demo/variant.tsx
+++ b/components/time-picker/demo/variant.tsx
@@ -6,16 +6,16 @@ const { RangePicker } = TimePicker;
 const App: React.FC = () => (
   <Flex vertical gap={12}>
     <Flex gap={8}>
-      <TimePicker placeholder="Filled" />
-      <RangePicker placeholder={['Filled', '']} />
+      <TimePicker placeholder="Outlined" />
+      <RangePicker placeholder={['Outlined Start', 'Outlined End']} />
     </Flex>
     <Flex gap={8}>
       <TimePicker variant="filled" placeholder="Filled" />
-      <RangePicker variant="filled" placeholder={['Filled', '']} />
+      <RangePicker variant="filled" placeholder={['Filled Start', 'Filled End']} />
     </Flex>
     <Flex gap={8}>
       <TimePicker variant="borderless" placeholder="Borderless" />
-      <RangePicker variant="borderless" placeholder={['Borderless', '']} />
+      <RangePicker variant="borderless" placeholder={['Borderless Start', 'Borderless End']} />
     </Flex>
   </Flex>
 );

--- a/components/tour/__tests__/a11y.test.ts
+++ b/components/tour/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('checkbox', {
+accessibilityDemoTest('tour', {
   // we can set aria attributes to fix it
-  skip: ['custom-line-width.tsx', 'disabled.tsx'],
+  skip: ['gap.tsx'],
 });

--- a/components/transfer/__tests__/a11y.test.ts
+++ b/components/transfer/__tests__/a11y.test.ts
@@ -1,0 +1,6 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('transfer', {
+  // waiting for transfer fix
+  disabledRules: ['label'],
+});

--- a/components/tree-select/__tests__/a11y.test.ts
+++ b/components/tree-select/__tests__/a11y.test.ts
@@ -1,0 +1,8 @@
+import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
+
+accessibilityDemoTest('tree-select', {
+  // we can set aria attributes to fix it
+  disabledRules: ['label'],
+  // skip internal debug demo
+  skip: ['render-panel.tsx'],
+});

--- a/components/typography/__tests__/a11y.test.ts
+++ b/components/typography/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('checkbox', {
+accessibilityDemoTest('typography', {
   // we can set aria attributes to fix it
-  skip: ['custom-line-width.tsx', 'disabled.tsx'],
+  skip: ['suffix.tsx', 'ellipsis.tsx', 'ellipsis-controlled.tsx'],
 });

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -107,7 +107,7 @@ export function accessibilityTest(Component: React.ComponentType, disabledRules?
 
       const results = await runAxe(container, { rules });
       expect(results).toHaveNoViolations();
-    }, 30000);
+    }, 50000);
   });
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📽️ Demo improvement
- [x] ✅ Test Case

### 🔗 Related Issues

none

### 💡 Background and Solution

目前所有的组件都添加了a11y测试，后续要做的就是一个个改，让每个demo都能完全跑通a11y测试

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |    -       |
