### PR TITLE
fix(Form.focusField): improve focus logic

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import FieldForm, { List, useWatch } from 'rc-field-form';
 import type { FormProps as RcFormProps } from 'rc-field-form/lib/Form';
 import type { FormRef, InternalNamePath, ValidateErrorEntity } from 'rc-field-form/lib/interface';
-import type { Options } from 'scroll-into-view-if-needed';
 
 import type { Variant } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
@@ -19,7 +18,7 @@ import type { FeedbackIcons } from './FormItem';
 import useForm from './hooks/useForm';
 import type { FormInstance } from './hooks/useForm';
 import useFormWarning from './hooks/useFormWarning';
-import type { FormLabelAlign } from './interface';
+import type { FormLabelAlign, ScrollFocusOptions } from './interface';
 import useStyle from './style';
 import ValidateMessagesContext from './validateMessagesContext';
 
@@ -30,9 +29,7 @@ export type RequiredMark =
 export type FormLayout = 'horizontal' | 'inline' | 'vertical';
 export type FormItemLayout = 'horizontal' | 'vertical';
 
-export type ScrollFocusOptions = Options & {
-  focus?: boolean;
-};
+export type { ScrollFocusOptions };
 
 export interface FormProps<Values = any> extends Omit<RcFormProps<Values>, 'form'> {
   prefixCls?: string;
@@ -184,9 +181,6 @@ const InternalForm: React.ForwardRefRenderFunction<FormRef, FormProps> = (props,
         defaultScrollToFirstError = { ...defaultScrollToFirstError, ...options };
       }
       wrapForm.scrollToField(fieldName, defaultScrollToFirstError);
-      if (defaultScrollToFirstError.focus) {
-        wrapForm.focusField(fieldName);
-      }
     }
   };
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -474,6 +474,57 @@ describe('Form', () => {
     });
   });
 
+  describe('scrollToField with focus', () => {
+    it('focusField should work', () => {
+      let formInstance: any;
+      const Demo = () => {
+        const [form] = Form.useForm();
+        formInstance = form;
+        return (
+          <Form>
+            <Form.Item name="test">
+              <input type="text" />
+            </Form.Item>
+          </Form>
+        );
+      };
+
+      const { getByRole } = render(<Demo />);
+      const input = getByRole('textbox');
+
+      formInstance.focusField('test');
+      expect(input).toHaveFocus();
+    });
+
+    // https://github.com/ant-design/ant-design/pull/52712#issuecomment-2646831569
+    it('focusField should work with Select', () => {
+      let formInstance: any;
+
+      const Demo = () => {
+        const [form] = Form.useForm();
+        formInstance = form;
+        return (
+          <Form form={form}>
+            <Form.Item name="test">
+              <Select
+                options={[
+                  { label: 'afc163', value: 'A' },
+                  { label: 'Wxh16144', value: 'B' },
+                ]}
+              />
+            </Form.Item>
+          </Form>
+        );
+      };
+
+      const { getByRole } = render(<Demo />);
+      const select = getByRole('combobox');
+
+      formInstance.focusField('test');
+      expect(select).toHaveFocus();
+    });
+  });
+
   describe('scrollToFirstError', () => {
     it('should work with scrollToFirstError', async () => {
       const onFinishFailed = jest.fn();
@@ -562,7 +613,6 @@ describe('Form', () => {
 
     it('should scrollToFirstError work with focus', async () => {
       const onFinishFailed = jest.fn();
-      const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
 
       const { container } = render(
         <Form scrollToFirstError={{ block: 'center', focus: true }} onFinishFailed={onFinishFailed}>
@@ -576,20 +626,17 @@ describe('Form', () => {
       );
 
       expect(scrollIntoView).not.toHaveBeenCalled();
-      expect(focusSpy).not.toHaveBeenCalled();
 
       fireEvent.submit(container.querySelector('form')!);
       await waitFakeTimer();
 
       const inputNode = document.getElementById('test');
-      expect(focusSpy).toHaveBeenCalledWith();
       expect(scrollIntoView).toHaveBeenCalledWith(inputNode, {
         block: 'center',
-        focus: true,
         scrollMode: 'if-needed',
       });
 
-      focusSpy.mockRestore();
+      expect(inputNode).toHaveFocus();
     });
 
     // https://github.com/ant-design/ant-design/issues/28869

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -58,21 +58,29 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
           },
         },
         scrollToField: (name: NamePath, options: ScrollOptions = {}) => {
+          const { focus, ...restOpt } = options;
           const node = getFieldDOMNode(name, wrapForm);
 
           if (node) {
             scrollIntoView(node, {
               scrollMode: 'if-needed',
               block: 'nearest',
-              ...options,
+              ...restOpt,
             } as any);
+
+            // Focus if scroll success
+            if (focus) {
+              wrapForm.focusField(name);
+            }
           }
         },
         focusField: (name: NamePath) => {
-          const node = getFieldDOMNode(name, wrapForm);
+          const itemRef = wrapForm.getFieldInstance(name);
 
-          if (node) {
-            node.focus?.();
+          if (typeof itemRef?.focus === 'function') {
+            itemRef.focus();
+          } else {
+            getFieldDOMNode(name, wrapForm)?.focus?.();
           }
         },
         getFieldInstance: (name: NamePath) => {

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -80,7 +80,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | name | Form name. Will be the prefix of Field `id` | string | - |  |
 | preserve | Keep field value even when field removed. You can get the preserve field value by `getFieldsValue(true)` | boolean | true | 4.4.0 |
 | requiredMark | Required mark style. Can use required mark or optional mark. You can not config to single Form.Item since this is a Form level config | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | true | `renderProps`: 5.9.0 |
-| scrollToFirstError | Auto scroll to first failed field when submit | boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean } | false |  |
+| scrollToFirstError | Auto scroll to first failed field when submit | boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean } | false | focus: 5.24.0 |
 | size | Set field component size (antd components only) | `small` \| `middle` \| `large` | - |  |
 | validateMessages | Validation prompt template, description [see below](#validatemessages) | [ValidateMessages](https://github.com/ant-design/ant-design/blob/6234509d18bac1ac60fbb3f92a5b2c6a6361295a/components/locale/en_US.ts#L88-L134) | - |  |
 | validateTrigger | Config field validate trigger | string \| string\[] | `onChange` | 4.3.0 |
@@ -318,7 +318,7 @@ Provide linkage between forms. If a sub form with `name` prop update, it will au
 | isFieldTouched | Check if a field has been operated | (name: [NamePath](#namepath)) => boolean |  |
 | isFieldValidating | Check field if is in validating | (name: [NamePath](#namepath)) => boolean |  |
 | resetFields | Reset fields to `initialValues` | (fields?: [NamePath](#namepath)\[]) => void |  |
-| scrollToField | Scroll to field position | (name: [NamePath](#namepath), options: \[[ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)]) => void |  |
+| scrollToField | Scroll to field position | (name: [NamePath](#namepath), options: [ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean }) => void | focus: 5.24.0 |
 | setFields | Set fields status | (fields: [FieldData](#fielddata)\[]) => void |  |
 | setFieldValue | Set fields value(Will directly pass to form store and **reset validation message**. If you do not want to modify passed object, please clone first) | (name: [NamePath](#namepath), value: any) => void | 4.22.0 |
 | setFieldsValue | Set fields value(Will directly pass to form store and **reset validation message**. If you do not want to modify passed object, please clone first). Use `setFieldValue` instead if you want to only config single value in Form.List | (values) => void |  |

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -81,7 +81,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ylFATY6w-ygAAA
 | name | 表单名称，会作为表单字段 `id` 前缀使用 | string | - |  |
 | preserve | 当字段被删除时保留字段值。你可以通过 `getFieldsValue(true)` 来获取保留字段值 | boolean | true | 4.4.0 |
 | requiredMark | 必选样式，可以切换为必选或者可选展示样式。此为 Form 配置，Form.Item 无法单独配置 | boolean \| `optional` \| ((label: ReactNode, info: { required: boolean }) => ReactNode) | true | `renderProps`: 5.9.0 |
-| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean } | false |  |
+| scrollToFirstError | 提交失败自动滚动到第一个错误字段 | boolean \| [Options](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean } | false | focus: 5.24.0 |
 | size | 设置字段组件的尺寸（仅限 antd 组件） | `small` \| `middle` \| `large` | - |  |
 | validateMessages | 验证提示模板，说明[见下](#validatemessages) | [ValidateMessages](https://github.com/ant-design/ant-design/blob/6234509d18bac1ac60fbb3f92a5b2c6a6361295a/components/locale/en_US.ts#L88-L134) | - |  |
 | validateTrigger | 统一设置字段触发验证的时机 | string \| string\[] | `onChange` | 4.3.0 |
@@ -317,7 +317,7 @@ Form.List 渲染表单相关操作函数。
 | isFieldTouched | 检查对应字段是否被用户操作过 | (name: [NamePath](#namepath)) => boolean |  |
 | isFieldValidating | 检查对应字段是否正在校验 | (name: [NamePath](#namepath)) => boolean |  |
 | resetFields | 重置一组字段到 `initialValues` | (fields?: [NamePath](#namepath)\[]) => void |  |
-| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#namepath), options: [ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options)) => void |  |
+| scrollToField | 滚动到对应字段位置 | (name: [NamePath](#namepath), options: [ScrollOptions](https://github.com/stipsan/scroll-into-view-if-needed/tree/ece40bd9143f48caf4b99503425ecb16b0ad8249#options) \| { focus: boolean }) => void | focus: 5.24.0 |
 | setFields | 设置一组字段状态 | (fields: [FieldData](#fielddata)\[]) => void |  |
 | setFieldValue | 设置表单的值（该值将直接传入 form store 中并且**重置错误信息**。如果你不希望传入对象被修改，请克隆后传入） | (name: [NamePath](#namepath), value: any) => void | 4.22.0 |
 | setFieldsValue | 设置表单的值（该值将直接传入 form store 中并且**重置错误信息**。如果你不希望传入对象被修改，请克隆后传入）。如果你只想修改 Form.List 中单项值，请通过 `setFieldValue` 进行指定 | (values) => void |  |

--- a/components/form/interface.ts
+++ b/components/form/interface.ts
@@ -1,3 +1,8 @@
+import type { Options } from 'scroll-into-view-if-needed';
+
 export type { InternalNamePath, NamePath, Store, StoreValue } from 'rc-field-form/lib/interface';
-export type { Options as ScrollOptions } from 'scroll-into-view-if-needed';
+export type ScrollFocusOptions = Options & {
+  focus?: boolean;
+};
+export type ScrollOptions = ScrollFocusOptions; // alias
 export type FormLabelAlign = 'left' | 'right';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

background: https://github.com/ant-design/ant-design/pull/52712#issuecomment-2646831569

如上所述，表单实例上的 focusField 方法在针对 antd 的组件时 （比如 Select 是无法工作的），虽然这个功能是在 `5.22.0` 引入的，但是并没有在文档中注明版本， 所以这次 PR 直接将版本提升到 `5.24.0` 中说明

解决方案如下：

```tsx
focusField: (name: NamePath) => {
          const itemRef = wrapForm.getFieldInstance(name);

          if (typeof itemRef?.focus === 'function') {
            itemRef.focus();
          } else {
            getFieldDOMNode(name, wrapForm)?.focus?.();
          }
        },
```

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Improve the `<Form />` form instance `focusField` method     |
| 🇨🇳 Chinese |     改进 `<Form  />`表单实例 `focusField` 方法     |
