### PR TITLE
feat(Table): change rowKey default from key to id

### DIFF
--- a/components/checkbox/__tests__/group.test.tsx
+++ b/components/checkbox/__tests__/group.test.tsx
@@ -210,6 +210,7 @@ describe('CheckboxGroup', () => {
     const { container } = render(
       <Checkbox.Group onChange={onChange}>
         <Table
+          rowKey="key"
           dataSource={[{ key: 1, value: '1' }]}
           columns={[{ title: 'title', dataIndex: 'value' }]}
           rowSelection={{}}

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1152,6 +1152,7 @@ describe('ConfigProvider support style and className props', () => {
         }}
       >
         <Table
+          rowKey="key"
           columns={[{ title: 'Address', dataIndex: 'address', key: 'address 1', ellipsis: true }]}
           dataSource={[{ key: '1', name: 'Jim Green', age: 40, address: 'test', tags: ['loser'] }]}
         />

--- a/components/config-provider/demo/size.tsx
+++ b/components/config-provider/demo/size.tsx
@@ -63,6 +63,7 @@ const App: React.FC = () => {
           <Button>Button</Button>
           <Card title="Card">
             <Table
+              rowKey="key"
               columns={[
                 { title: 'Name', dataIndex: 'name' },
                 { title: 'Age', dataIndex: 'age' },

--- a/components/descriptions/demo/text.tsx
+++ b/components/descriptions/demo/text.tsx
@@ -119,7 +119,13 @@ const items: DescriptionsProps['items'] = [
     key: '12',
     label: 'Config Info',
     children: (
-      <Table<DataType> size="small" pagination={false} dataSource={dataSource} columns={columns} />
+      <Table<DataType>
+        rowKey="key"
+        size="small"
+        pagination={false}
+        dataSource={dataSource}
+        columns={columns}
+      />
     ),
   },
 ];

--- a/components/modal/demo/dark.tsx
+++ b/components/modal/demo/dark.tsx
@@ -156,7 +156,12 @@ const expandColumns: TableProps<ExpandDataType>['columns'] = [
 ];
 
 const expandedRowRender = () => (
-  <Table<ExpandDataType> columns={expandColumns} dataSource={expandDataSource} pagination={false} />
+  <Table<ExpandDataType>
+    rowKey="key"
+    columns={expandColumns}
+    dataSource={expandDataSource}
+    pagination={false}
+  />
 );
 
 const columnsNest: TableProps<NestDataType>['columns'] = [
@@ -238,6 +243,7 @@ const TableTransfer: React.FC<
         return (
           <Table<DataType>
             id="components-transfer-table"
+            rowKey="key"
             rowSelection={rowSelection}
             columns={columns}
             dataSource={filteredItems}
@@ -468,9 +474,15 @@ const Demo: React.FC = () => {
             </TreeNode>
           </TreeNode>
         </Tree>
-        <Table<RecordType> columns={columns} dataSource={dataSource} footer={() => 'Footer'} />
+        <Table<RecordType>
+          rowKey="key"
+          columns={columns}
+          dataSource={dataSource}
+          footer={() => 'Footer'}
+        />
         <Table<DataTableType>
           columns={columnsTable}
+          rowKey="key"
           dataSource={summaryDataSource}
           pagination={false}
           id="table-demo-summary"
@@ -505,11 +517,13 @@ const Demo: React.FC = () => {
         />
         <br />
         <Table<NestDataType>
+          rowKey="key"
           columns={columnsNest}
           expandable={{ expandedRowRender }}
           dataSource={nestDataSource}
         />
         <Table<FixedDataType>
+          rowKey="key"
           columns={columnsFixed}
           dataSource={fixedDataSource}
           scroll={{ x: 1300, y: 100 }}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -132,7 +132,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     dataSource,
     pagination,
     rowSelection,
-    rowKey = 'key',
+    rowKey = 'id',
     rowClassName,
     columns,
     children,

--- a/components/table/__tests__/Sorter.value.test.tsx
+++ b/components/table/__tests__/Sorter.value.test.tsx
@@ -101,6 +101,7 @@ describe('Sorter.value.test.tsx', () => {
       return (
         <>
           <Table
+            rowKey="key"
             columns={columns}
             dataSource={tableData}
             onChange={onChange}
@@ -207,6 +208,7 @@ describe('Sorter.value.test.tsx', () => {
       return (
         <>
           <Table
+            rowKey="key"
             columns={tableData.columns}
             dataSource={tableData.data}
             onChange={onChange}

--- a/components/table/__tests__/Table.expand.test.tsx
+++ b/components/table/__tests__/Table.expand.test.tsx
@@ -40,7 +40,9 @@ const data = [
 
 describe('Table.expand', () => {
   it('click to expand', () => {
-    const { container, asFragment } = render(<Table columns={columns} dataSource={data} />);
+    const { container, asFragment } = render(
+      <Table rowKey="key" columns={columns} dataSource={data} />,
+    );
     fireEvent.click(container.querySelector('.ant-table-row-expand-icon')!);
     expect(asFragment().firstChild).toMatchSnapshot();
   });
@@ -48,6 +50,7 @@ describe('Table.expand', () => {
   it('expandRowByClick should not block click icon', () => {
     const { container } = render(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={[John, Jim]}
         expandable={{
@@ -66,6 +69,7 @@ describe('Table.expand', () => {
   it('show expandIcon', () => {
     const { container } = render(
       <Table
+        rowKey="key"
         columns={[{ dataIndex: 'key' }]}
         dataSource={[{ key: 233 }]}
         expandable={{
@@ -77,7 +81,9 @@ describe('Table.expand', () => {
   });
 
   it('row indent padding should be 0px when indentSize defined as 0', () => {
-    const { container } = render(<Table indentSize={0} columns={columns} dataSource={data} />);
+    const { container } = render(
+      <Table rowKey="key" indentSize={0} columns={columns} dataSource={data} />,
+    );
 
     fireEvent.click(container.querySelector('.ant-table-row-expand-icon')!);
     expect(container.querySelector<HTMLElement>('.indent-level-1')?.style.paddingLeft).toEqual(
@@ -86,7 +92,7 @@ describe('Table.expand', () => {
   });
 
   it('has right aria-expanded state', () => {
-    const { container } = render(<Table columns={columns} dataSource={data} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={data} />);
     expect(container.querySelector('[aria-expanded=false]')).toBeTruthy();
     fireEvent.click(container.querySelector('.ant-table-row-expand-icon')!);
     expect(container.querySelector('[aria-expanded=true]')).toBeTruthy();
@@ -96,6 +102,7 @@ describe('Table.expand', () => {
     it('basic', () => {
       const { container } = render(
         <Table
+          rowKey="key"
           columns={[{ dataIndex: 'key' }]}
           dataSource={[{ key: 'bamboo' }]}
           expandable={{
@@ -115,6 +122,7 @@ describe('Table.expand', () => {
     it('work with selection', () => {
       const { container } = render(
         <Table
+          rowKey="key"
           columns={[{ dataIndex: 'key' }]}
           dataSource={[{ key: 'bamboo' }]}
           expandable={{

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -58,7 +58,9 @@ describe('Table.filter', () => {
   }
 
   function createTable(props?: TableProps<any>) {
-    return <Table columns={[column]} dataSource={data} pagination={false} {...props} />;
+    return (
+      <Table rowKey="key" columns={[column]} dataSource={data} pagination={false} {...props} />
+    );
   }
 
   function renderedNames(container: ReturnType<typeof render>['container']) {
@@ -827,7 +829,7 @@ describe('Table.filter', () => {
         setFilters(filter);
       };
       return (
-        <Table dataSource={data} onChange={handleChange}>
+        <Table rowKey="key" dataSource={data} onChange={handleChange}>
           <Column
             title="name"
             dataIndex="name"
@@ -903,7 +905,7 @@ describe('Table.filter', () => {
       { key: 2, name: 'Tom', age: 21 },
       { key: 3, name: 'Jerry', age: 22 },
     ];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
 
     expect(renderedNames(container)).toEqual(['Jack']);
   });
@@ -1566,7 +1568,7 @@ describe('Table.filter', () => {
           >
             Set
           </Button>
-          <Table columns={columns} dataSource={data} />
+          <Table rowKey="key" columns={columns} dataSource={data} />
         </div>
       );
     };
@@ -1606,7 +1608,7 @@ describe('Table.filter', () => {
     const onFilter = jest.fn((value, record) => record.key === value);
     const columns: TableProps['columns'] = [{ dataIndex: 'key', filteredValue: [5], onFilter }];
     const testData = [{ key: 1 }, { key: 3 }, { key: 5 }];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
 
     expect(onFilter).toHaveBeenCalled();
     expect(container.querySelectorAll('tbody tr')).toHaveLength(1);
@@ -1614,7 +1616,7 @@ describe('Table.filter', () => {
 
   it('jsx work', () => {
     const { container } = render(
-      <Table dataSource={data}>
+      <Table rowKey="key" dataSource={data}>
         <Table.Column
           title="Name"
           dataIndex="name"
@@ -1874,6 +1876,7 @@ describe('Table.filter', () => {
       ];
       return (
         <Table
+          rowKey="key"
           columns={columns}
           onChange={handleChange}
           dataSource={[
@@ -2067,7 +2070,7 @@ describe('Table.filter', () => {
           <span className="rest-btn" onClick={handleClick}>
             refresh
           </span>
-          <Table columns={cs} dataSource={ddd} />
+          <Table rowKey="key" columns={cs} dataSource={ddd} />
         </div>
       );
     };
@@ -2931,7 +2934,7 @@ describe('Table.filter', () => {
       { key: 2, name: 'Tom', age: 21 },
       { key: 3, name: 'Jerry', age: 22 },
     ];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
 
     fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
     fireEvent.click(container.querySelectorAll('.ant-dropdown-menu-item')[0]);
@@ -3034,6 +3037,7 @@ describe('Table.filter', () => {
     const TestDemo = ({ renderEmpty }: any) => (
       <ConfigProvider renderEmpty={renderEmpty}>
         <Table
+          rowKey="name"
           dataSource={[{ name: 'John Brown' }]}
           columns={[
             {

--- a/components/table/__tests__/Table.order.test.tsx
+++ b/components/table/__tests__/Table.order.test.tsx
@@ -34,7 +34,7 @@ describe('Table.order', () => {
   ];
 
   function createTable(props: TableProps<any> = {}) {
-    return <Table columns={columns} dataSource={data} {...props} />;
+    return <Table rowKey="key" columns={columns} dataSource={data} {...props} />;
   }
 
   it('warning if duplicated SELECTION_COLUMN', () => {

--- a/components/table/__tests__/Table.pagination.test.tsx
+++ b/components/table/__tests__/Table.pagination.test.tsx
@@ -31,7 +31,9 @@ describe('Table.pagination', () => {
   const pagination = { className: 'my-page', pageSize: 2 };
 
   function createTable(props?: TableProps<any>) {
-    return <Table columns={columns} dataSource={data} pagination={pagination} {...props} />;
+    return (
+      <Table rowKey="key" columns={columns} dataSource={data} pagination={pagination} {...props} />
+    );
   }
 
   function renderedNames(container: ReturnType<typeof render>['container']) {

--- a/components/table/__tests__/Table.rowSelection.test.tsx
+++ b/components/table/__tests__/Table.rowSelection.test.tsx
@@ -36,7 +36,7 @@ describe('Table.rowSelection', () => {
   ];
 
   function createTable(props: TableProps<any> = {}) {
-    return <Table columns={columns} dataSource={data} rowSelection={{}} {...props} />;
+    return <Table rowKey="key" columns={columns} dataSource={data} rowSelection={{}} {...props} />;
   }
 
   function renderedNames(container: ReturnType<typeof render>['container']) {
@@ -706,6 +706,7 @@ describe('Table.rowSelection', () => {
   it('should allow dynamic getCheckboxProps', () => {
     const { container, rerender } = render(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={data}
         rowSelection={{
@@ -720,6 +721,7 @@ describe('Table.rowSelection', () => {
 
     rerender(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={data}
         rowSelection={{
@@ -845,6 +847,7 @@ describe('Table.rowSelection', () => {
   it('should keep all checked state when remove item from dataSource', () => {
     const { container, rerender } = render(
       <Table
+        rowKey="key"
         rowSelection={{
           selectedRowKeys: [0, 1, 2, 3],
         }}
@@ -861,6 +864,7 @@ describe('Table.rowSelection', () => {
 
     rerender(
       <Table
+        rowKey="key"
         rowSelection={{
           selectedRowKeys: [1, 2, 3],
         }}
@@ -879,11 +883,17 @@ describe('Table.rowSelection', () => {
   // https://github.com/ant-design/ant-design/issues/11042
   it('add columnTitle for rowSelection', () => {
     const { container, rerender } = render(
-      <Table columns={columns} dataSource={data} rowSelection={{ columnTitle: '多选' }} />,
+      <Table
+        rowKey="key"
+        columns={columns}
+        dataSource={data}
+        rowSelection={{ columnTitle: '多选' }}
+      />,
     );
     expect(container.querySelector('thead tr th')?.textContent).toBe('多选');
     rerender(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={data}
         rowSelection={{
@@ -898,6 +908,7 @@ describe('Table.rowSelection', () => {
   it('columnTitle for rowSelection to be renderProps', () => {
     const { container } = render(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={data}
         rowSelection={{
@@ -949,7 +960,7 @@ describe('Table.rowSelection', () => {
     };
 
     const { container } = render(
-      <Table columns={filterColumns} dataSource={data} rowSelection={rowSelection} />,
+      <Table rowKey="key" columns={filterColumns} dataSource={data} rowSelection={rowSelection} />,
     );
 
     function clickFilter(indexList: number[]) {
@@ -1018,7 +1029,13 @@ describe('Table.rowSelection', () => {
       },
     ];
     const { container } = render(
-      <Table columns={columns} dataSource={newData} childrenColumnName="test" rowSelection={{}} />,
+      <Table
+        rowKey="key"
+        columns={columns}
+        dataSource={newData}
+        childrenColumnName="test"
+        rowSelection={{}}
+      />,
     );
     const checkboxes = container.querySelectorAll('input');
     const objectContaining: { checked?: boolean; indeterminate?: boolean } = {};
@@ -1050,6 +1067,7 @@ describe('Table.rowSelection', () => {
     ];
     const { container } = render(
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={newData}
         childrenColumnName="list"
@@ -1711,6 +1729,7 @@ describe('Table.rowSelection', () => {
       ];
       const { container, rerender } = render(
         <Table
+          rowKey="key"
           expandable={{
             defaultExpandAllRows: true,
           }}
@@ -1779,6 +1798,7 @@ describe('Table.rowSelection', () => {
 
       rerender(
         <Table
+          rowKey="key"
           expandable={{
             defaultExpandAllRows: true,
           }}
@@ -1917,6 +1937,7 @@ describe('Table.rowSelection', () => {
 
     const { container } = render(
       <Table
+        rowKey="key"
         rowSelection={{
           type: 'checkbox',
           getCheckboxProps,
@@ -1953,6 +1974,7 @@ describe('Table.rowSelection', () => {
 
     const { container } = render(
       <Table
+        rowKey="key"
         rowSelection={{
           type: 'radio',
           getCheckboxProps,
@@ -2063,6 +2085,7 @@ describe('Table.rowSelection', () => {
     };
     const { container } = render(
       <Table
+        rowKey="key"
         rowSelection={rowSelection}
         columns={treeDataColumns}
         dataSource={treeData}

--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -26,6 +26,7 @@ describe('Table.sorter', () => {
   function createTable(tableProps: TableProps<any> = {}, columnProps = {}) {
     return (
       <Table
+        rowKey="key"
         columns={[{ ...column, ...columnProps }]}
         dataSource={data}
         pagination={false}
@@ -105,6 +106,7 @@ describe('Table.sorter', () => {
     ];
     const TableSorter: React.FC = () => (
       <Table
+        rowKey="key"
         columns={columns}
         dataSource={tableData}
         onChange={onChange}
@@ -619,7 +621,7 @@ describe('Table.sorter', () => {
       { key: 2, name: 'Tom', age: 21 },
       { key: 3, name: 'Jerry', age: 22 },
     ];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
 
     expect(renderedNames(container)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
   });
@@ -636,7 +638,7 @@ describe('Table.sorter', () => {
       { key: 2, name: 'Tom', age: 21 },
       { key: 3, name: 'Jerry', age: 22 },
     ];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
     expect(container.querySelector('.custom-title')?.textContent).toEqual('');
     fireEvent.click(container.querySelector('.ant-table-column-sorters')!);
     expect(container.querySelector('.custom-title')?.textContent).toEqual('ascend');
@@ -656,7 +658,7 @@ describe('Table.sorter', () => {
       { key: 2, name: 'Tom', age: 21 },
       { key: 3, name: 'Jerry', age: 22 },
     ];
-    const { container } = render(<Table columns={columns} dataSource={testData} />);
+    const { container } = render(<Table rowKey="key" columns={columns} dataSource={testData} />);
 
     const getNameColumn = () =>
       container.querySelectorAll<HTMLElement>('.ant-table-column-has-sorters')[0];
@@ -698,6 +700,7 @@ describe('Table.sorter', () => {
       };
       return (
         <Table
+          rowKey="key"
           columns={columns}
           pagination={pagination}
           dataSource={testData}
@@ -760,6 +763,7 @@ describe('Table.sorter', () => {
       };
       return (
         <Table
+          rowKey="key"
           columns={columns}
           pagination={pagination}
           dataSource={testData}
@@ -821,6 +825,7 @@ describe('Table.sorter', () => {
       };
       return (
         <Table
+          rowKey="key"
           columns={columns}
           pagination={pagination}
           dataSource={testData}
@@ -1030,7 +1035,7 @@ describe('Table.sorter', () => {
 
   it('should support defaultOrder in Column', () => {
     const { asFragment } = render(
-      <Table dataSource={[{ key: '1', age: 1 }]}>
+      <Table rowKey="key" dataSource={[{ key: '1', age: 1 }]}>
         <Table.Column title="Age" dataIndex="age" sorter defaultSortOrder="ascend" key="age" />
       </Table>,
     );
@@ -1142,7 +1147,7 @@ describe('Table.sorter', () => {
       },
     ];
     const dataProp = { data: groupData };
-    const { container } = render(<Table columns={groupColumns} {...dataProp} />);
+    const { container } = render(<Table rowKey="key" columns={groupColumns} {...dataProp} />);
 
     expect(
       container
@@ -1185,7 +1190,7 @@ describe('Table.sorter', () => {
     const onChange = jest.fn();
     const dataProp = { data: groupData };
     const { container } = render(
-      <Table columns={groupColumns} {...dataProp} onChange={onChange} />,
+      <Table rowKey="key" columns={groupColumns} {...dataProp} onChange={onChange} />,
     );
 
     function clickToMatchExpect(
@@ -1281,7 +1286,7 @@ describe('Table.sorter', () => {
     const onChange = jest.fn();
 
     const { container } = render(
-      <Table columns={columns} dataSource={tableData} onChange={onChange} />,
+      <Table rowKey="key" columns={columns} dataSource={tableData} onChange={onChange} />,
     );
     const sorterColumns = Array.from(container.querySelectorAll('.ant-table-column-has-sorters'));
     expect(sorterColumns.length).toBe(3);

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -36,7 +36,7 @@ describe('Table', () => {
     ];
 
     const { asFragment } = render(
-      <Table dataSource={data} pagination={false}>
+      <Table rowKey="key" dataSource={data} pagination={false}>
         <ColumnGroup title="Name">
           <Column title="First Name" dataIndex="firstName" key="firstName" />
           <Column title="Last Name" dataIndex="lastName" key="lastName" />
@@ -129,7 +129,7 @@ describe('Table', () => {
   it('support onHeaderCell', () => {
     const onClick = jest.fn();
     const { container } = render(
-      <Table columns={[{ title: 'title', onHeaderCell: () => ({ onClick }) }]} />,
+      <Table rowKey="key" columns={[{ title: 'title', onHeaderCell: () => ({ onClick }) }]} />,
     );
     fireEvent.click(container.querySelector('th')!);
     expect(onClick).toHaveBeenCalled();
@@ -476,6 +476,7 @@ describe('Table', () => {
   it('support disable row hover', () => {
     const { container } = render(
       <Table
+        rowKey="name"
         columns={[
           {
             title: 'Name',

--- a/components/table/__tests__/Table.virtual.test.tsx
+++ b/components/table/__tests__/Table.virtual.test.tsx
@@ -7,6 +7,7 @@ describe('Table.Virtual', () => {
   it('should work', () => {
     const { container } = render(
       <Table
+        rowKey="key"
         virtual
         scroll={{ x: 100, y: 100 }}
         columns={[
@@ -60,6 +61,7 @@ describe('Table.Virtual', () => {
 
     const { container } = render(
       <Table
+        rowKey="key"
         virtual
         components={components}
         scroll={{ y: 100 }}
@@ -109,10 +111,11 @@ describe('Table.Virtual', () => {
           upgradeNum: 'Upgraded: 56',
         });
       }
-      return <Table columns={columns} dataSource={data} pagination={false} />;
+      return <Table rowKey="key" columns={columns} dataSource={data} pagination={false} />;
     };
     const { container } = render(
       <Table
+        rowKey="key"
         columns={[
           {
             dataIndex: 'key',

--- a/components/table/__tests__/empty.test.tsx
+++ b/components/table/__tests__/empty.test.tsx
@@ -49,7 +49,9 @@ const columnsFixed: ColumnsType<any> = [
 
 describe('Table', () => {
   it('renders empty table', () => {
-    const { asFragment } = render(<Table dataSource={[]} columns={columns} pagination={false} />);
+    const { asFragment } = render(
+      <Table rowKey="key" dataSource={[]} columns={columns} pagination={false} />,
+    );
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
@@ -77,7 +79,13 @@ describe('Table', () => {
 
     it('should work', async () => {
       const { container, asFragment } = render(
-        <Table dataSource={[]} columns={columnsFixed} pagination={false} scroll={{ x: 1 }} />,
+        <Table
+          rowKey="key"
+          dataSource={[]}
+          columns={columnsFixed}
+          pagination={false}
+          scroll={{ x: 1 }}
+        />,
       );
 
       triggerResize(container.querySelector('.ant-table')!);
@@ -91,7 +99,13 @@ describe('Table', () => {
 
   it('renders empty table when emptyText is null', () => {
     const { container, asFragment } = render(
-      <Table dataSource={[]} columns={columns} pagination={false} locale={{ emptyText: null }} />,
+      <Table
+        rowKey="key"
+        dataSource={[]}
+        columns={columns}
+        pagination={false}
+        locale={{ emptyText: null }}
+      />,
     );
 
     expect(container.querySelector('.ant-table-placeholder>.ant-table-cell')?.hasChildNodes()).toBe(
@@ -104,6 +118,7 @@ describe('Table', () => {
   it('renders empty table with custom emptyText', () => {
     const { asFragment } = render(
       <Table
+        rowKey="key"
         dataSource={[]}
         columns={columns}
         pagination={false}
@@ -114,7 +129,7 @@ describe('Table', () => {
   });
 
   it('renders empty table without emptyText when loading', () => {
-    const { asFragment } = render(<Table dataSource={[]} columns={columns} loading />);
+    const { asFragment } = render(<Table rowKey="key" dataSource={[]} columns={columns} loading />);
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 });

--- a/components/table/__tests__/type.test.tsx
+++ b/components/table/__tests__/type.test.tsx
@@ -34,7 +34,7 @@ describe('Table.typescript', () => {
     interface RecordType {
       key: string;
     }
-    const table = <Table<RecordType> dataSource={[{ key: 'Bamboo' }]} />;
+    const table = <Table<RecordType> rowKey="key" dataSource={[{ key: 'Bamboo' }]} />;
     expect(table).toBeTruthy();
   });
 

--- a/components/table/demo/basic.tsx
+++ b/components/table/demo/basic.tsx
@@ -3,7 +3,7 @@ import { Flex, Space, Table, Tag } from 'antd';
 import type { TableProps } from 'antd';
 
 interface DataType {
-  key: string;
+  id: number;
   name: string;
   age: number;
   address: string;
@@ -61,21 +61,21 @@ const columns: TableProps<DataType>['columns'] = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: 1,
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
     tags: ['nice', 'developer'],
   },
   {
-    key: '2',
+    id: 2,
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
     tags: ['loser'],
   },
   {
-    key: '3',
+    id: 3,
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/bordered.tsx
+++ b/components/table/demo/bordered.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableProps } from 'antd';
 
 interface DataType {
-  key: string;
+  id: number;
   name: string;
   money: string;
   address: string;
@@ -29,19 +29,19 @@ const columns: TableProps<DataType>['columns'] = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: 1,
     name: 'John Brown',
     money: '￥300,000.00',
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: 2,
     name: 'Jim Green',
     money: '￥1,256,000.00',
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: 3,
     name: 'Joe Black',
     money: '￥120,000.00',
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/colspan-rowspan.tsx
+++ b/components/table/demo/colspan-rowspan.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableProps } from 'antd';
 
 interface DataType {
-  key: string;
+  id: number;
   name: string;
   age: number;
   tel: string;
@@ -24,7 +24,7 @@ const sharedOnCell = (_: DataType, index?: number) => {
 const columns: TableProps<DataType>['columns'] = [
   {
     title: 'RowHead',
-    dataIndex: 'key',
+    dataIndex: 'id',
     rowScope: 'row',
   },
   {
@@ -74,7 +74,7 @@ const columns: TableProps<DataType>['columns'] = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: 1,
     name: 'John Brown',
     age: 32,
     tel: '0571-22098909',
@@ -82,7 +82,7 @@ const data: DataType[] = [
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: 2,
     name: 'Jim Green',
     tel: '0571-22098333',
     phone: 18889898888,
@@ -90,7 +90,7 @@ const data: DataType[] = [
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: 3,
     name: 'Joe Black',
     age: 32,
     tel: '0575-22098909',
@@ -98,7 +98,7 @@ const data: DataType[] = [
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: 4,
     name: 'Jim Red',
     age: 18,
     tel: '0575-22098909',
@@ -106,7 +106,7 @@ const data: DataType[] = [
     address: 'London No. 2 Lake Park',
   },
   {
-    key: '5',
+    id: 5,
     name: 'Jake White',
     age: 18,
     tel: '0575-22098909',

--- a/components/table/demo/component-token.tsx
+++ b/components/table/demo/component-token.tsx
@@ -11,7 +11,7 @@ type ExpandableConfig<T extends object> = GetProp<TableProps<T>, 'expandable'>;
 type TableRowSelection<T extends object> = GetProp<TableProps<T>, 'rowSelection'>;
 
 interface DataType {
-  key: number;
+  id: number;
   name: string;
   age: number;
   address: string;
@@ -62,7 +62,7 @@ const columns: ColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 10 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: 'John Brown',
   age: Number(`${i}2`),
   address: `New York No. ${i} Lake Park`,

--- a/components/table/demo/custom-empty.tsx
+++ b/components/table/demo/custom-empty.tsx
@@ -3,7 +3,7 @@ import type { GetProp } from 'antd';
 import { Button, ConfigProvider, Empty, Table } from 'antd';
 
 interface DataType {
-  key: number;
+  id: number;
   name: string;
   age: number;
   address: string;
@@ -11,7 +11,7 @@ interface DataType {
 
 const genFakeData = (count = 5) =>
   Array.from({ length: count }).map<DataType>((_, index) => ({
-    key: index,
+    id: index,
     name: `Edward King ${index}`,
     age: 32 + index,
     address: `London, Park Lane no. ${index}`,

--- a/components/table/demo/custom-filter-panel.tsx
+++ b/components/table/demo/custom-filter-panel.tsx
@@ -6,7 +6,7 @@ import type { FilterDropdownProps } from 'antd/es/table/interface';
 import Highlighter from 'react-highlight-words';
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;
@@ -16,25 +16,25 @@ type DataIndex = keyof DataType;
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Joe Black',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Jim Green',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     age: 32,
     address: 'London No. 2 Lake Park',

--- a/components/table/demo/drag-column-sorting.tsx
+++ b/components/table/demo/drag-column-sorting.tsx
@@ -19,7 +19,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   gender: string;
   age: number;
@@ -79,7 +79,7 @@ const TableHeaderCell: React.FC<HeaderCellProps> = (props) => {
 
 const dataSource: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     gender: 'male',
     age: 32,
@@ -87,7 +87,7 @@ const dataSource: DataType[] = [
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     gender: 'female',
     age: 42,
@@ -95,7 +95,7 @@ const dataSource: DataType[] = [
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     gender: 'female',
     age: 32,
@@ -103,7 +103,7 @@ const dataSource: DataType[] = [
     address: 'Sidney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'George Hcc',
     gender: 'male',
     age: 20,
@@ -173,7 +173,6 @@ const App: React.FC = () => {
       <SortableContext items={columns.map((i) => i.key)} strategy={horizontalListSortingStrategy}>
         <DragIndexContext.Provider value={dragIndex}>
           <Table<DataType>
-            rowKey="key"
             columns={columns}
             dataSource={dataSource}
             components={{

--- a/components/table/demo/drag-sorting-handler.tsx
+++ b/components/table/demo/drag-sorting-handler.tsx
@@ -15,7 +15,7 @@ import { Button, Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;
@@ -50,9 +50,9 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const initialData: DataType[] = [
-  { key: '1', name: 'John Brown', age: 32, address: 'Long text Long' },
-  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },
-  { key: '3', name: 'Joe Black', age: 32, address: 'Sidney No. 1 Lake Park' },
+  { id: '1', name: 'John Brown', age: 32, address: 'Long text Long' },
+  { id: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },
+  { id: '3', name: 'Joe Black', age: 32, address: 'Sidney No. 1 Lake Park' },
 ];
 
 interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
@@ -95,8 +95,8 @@ const App: React.FC = () => {
   const onDragEnd = ({ active, over }: DragEndEvent) => {
     if (active.id !== over?.id) {
       setDataSource((prevState) => {
-        const activeIndex = prevState.findIndex((record) => record.key === active?.id);
-        const overIndex = prevState.findIndex((record) => record.key === over?.id);
+        const activeIndex = prevState.findIndex((record) => record.id === active?.id);
+        const overIndex = prevState.findIndex((record) => record.id === over?.id);
         return arrayMove(prevState, activeIndex, overIndex);
       });
     }
@@ -104,9 +104,9 @@ const App: React.FC = () => {
 
   return (
     <DndContext modifiers={[restrictToVerticalAxis]} onDragEnd={onDragEnd}>
-      <SortableContext items={dataSource.map((i) => i.key)} strategy={verticalListSortingStrategy}>
+      <SortableContext items={dataSource.map((i) => i.id)} strategy={verticalListSortingStrategy}>
         <Table<DataType>
-          rowKey="key"
+          rowKey="id"
           components={{ body: { row: Row } }}
           columns={columns}
           dataSource={dataSource}

--- a/components/table/demo/drag-sorting.tsx
+++ b/components/table/demo/drag-sorting.tsx
@@ -13,7 +13,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;

--- a/components/table/demo/dynamic-settings.tsx
+++ b/components/table/demo/dynamic-settings.tsx
@@ -11,7 +11,7 @@ type ExpandableConfig<T extends object> = TableProps<T>['expandable'];
 type TableRowSelection<T extends object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: number;
+  id: number;
   name: string;
   age: number;
   address: string;
@@ -62,7 +62,7 @@ const columns: ColumnsType<DataType> = [
 ];
 
 const data = Array.from({ length: 10 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: 'John Brown',
   age: Number(`${i}2`),
   address: `New York No. ${i} Lake Park`,

--- a/components/table/demo/edit-cell.tsx
+++ b/components/table/demo/edit-cell.tsx
@@ -97,7 +97,7 @@ const EditableCell: React.FC<React.PropsWithChildren<EditableCellProps>> = ({
 };
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: string;
   address: string;
@@ -108,13 +108,13 @@ type ColumnTypes = Exclude<TableProps<DataType>['columns'], undefined>;
 const App: React.FC = () => {
   const [dataSource, setDataSource] = useState<DataType[]>([
     {
-      key: '0',
+      id: '0',
       name: 'Edward King 0',
       age: '32',
       address: 'London, Park Lane no. 0',
     },
     {
-      key: '1',
+      id: '1',
       name: 'Edward King 1',
       age: '32',
       address: 'London, Park Lane no. 1',
@@ -124,7 +124,7 @@ const App: React.FC = () => {
   const [count, setCount] = useState(2);
 
   const handleDelete = (key: React.Key) => {
-    const newData = dataSource.filter((item) => item.key !== key);
+    const newData = dataSource.filter((item) => item.id !== key);
     setDataSource(newData);
   };
 
@@ -148,7 +148,7 @@ const App: React.FC = () => {
       dataIndex: 'operation',
       render: (_, record) =>
         dataSource.length >= 1 ? (
-          <Popconfirm title="Sure to delete?" onConfirm={() => handleDelete(record.key)}>
+          <Popconfirm title="Sure to delete?" onConfirm={() => handleDelete(record.id)}>
             <a>Delete</a>
           </Popconfirm>
         ) : null,
@@ -157,7 +157,7 @@ const App: React.FC = () => {
 
   const handleAdd = () => {
     const newData: DataType = {
-      key: count,
+      id: count,
       name: `Edward King ${count}`,
       age: '32',
       address: `London, Park Lane no. ${count}`,
@@ -168,7 +168,7 @@ const App: React.FC = () => {
 
   const handleSave = (row: DataType) => {
     const newData = [...dataSource];
-    const index = newData.findIndex((item) => row.key === item.key);
+    const index = newData.findIndex((item) => row.id === item.id);
     const item = newData[index];
     newData.splice(index, 1, {
       ...item,

--- a/components/table/demo/edit-row.tsx
+++ b/components/table/demo/edit-row.tsx
@@ -3,14 +3,14 @@ import type { TableProps } from 'antd';
 import { Form, Input, InputNumber, Popconfirm, Table, Typography } from 'antd';
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;
 }
 
 const originData = Array.from({ length: 100 }).map<DataType>((_, i) => ({
-  key: i.toString(),
+  id: i.toString(),
   name: `Edward ${i}`,
   age: 32,
   address: `London Park no. ${i}`,
@@ -64,11 +64,11 @@ const App: React.FC = () => {
   const [data, setData] = useState<DataType[]>(originData);
   const [editingKey, setEditingKey] = useState('');
 
-  const isEditing = (record: DataType) => record.key === editingKey;
+  const isEditing = (record: DataType) => record.id === editingKey;
 
   const edit = (record: Partial<DataType> & { key: React.Key }) => {
     form.setFieldsValue({ name: '', age: '', address: '', ...record });
-    setEditingKey(record.key);
+    setEditingKey(record.id);
   };
 
   const cancel = () => {
@@ -80,7 +80,7 @@ const App: React.FC = () => {
       const row = (await form.validateFields()) as DataType;
 
       const newData = [...data];
-      const index = newData.findIndex((item) => key === item.key);
+      const index = newData.findIndex((item) => key === item.id);
       if (index > -1) {
         const item = newData[index];
         newData.splice(index, 1, {
@@ -125,7 +125,7 @@ const App: React.FC = () => {
         const editable = isEditing(record);
         return editable ? (
           <span>
-            <Typography.Link onClick={() => save(record.key)} style={{ marginInlineEnd: 8 }}>
+            <Typography.Link onClick={() => save(record.id)} style={{ marginInlineEnd: 8 }}>
               Save
             </Typography.Link>
             <Popconfirm title="Sure to cancel?" onConfirm={cancel}>

--- a/components/table/demo/ellipsis-custom-tooltip.tsx
+++ b/components/table/demo/ellipsis-custom-tooltip.tsx
@@ -3,7 +3,7 @@ import { Table, Tooltip } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -79,19 +79,19 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park, New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 2 Lake Park, London No. 2 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park, Sydney No. 1 Lake Park',

--- a/components/table/demo/ellipsis.tsx
+++ b/components/table/demo/ellipsis.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -49,27 +49,24 @@ const columns: TableColumnsType<DataType> = [
   },
 ];
 
-const data = [
+const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park, New York No. 1 Lake Park',
-    tags: ['nice', 'developer'],
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 2 Lake Park, London No. 2 Lake Park',
-    tags: ['loser'],
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park, Sydney No. 1 Lake Park',
-    tags: ['cool', 'teacher'],
   },
 ];
 

--- a/components/table/demo/expand.tsx
+++ b/components/table/demo/expand.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -24,28 +24,28 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: 1,
+    id: 1,
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
     description: 'My name is John Brown, I am 32 years old, living in New York No. 1 Lake Park.',
   },
   {
-    key: 2,
+    id: 2,
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
     description: 'My name is Jim Green, I am 42 years old, living in London No. 1 Lake Park.',
   },
   {
-    key: 3,
+    id: 3,
     name: 'Not Expandable',
     age: 29,
     address: 'Jiangsu No. 1 Lake Park',
     description: 'This not expandable',
   },
   {
-    key: 4,
+    id: 4,
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/filter-in-tree.tsx
+++ b/components/table/demo/filter-in-tree.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType, TableProps } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -78,25 +78,25 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     age: 32,
     address: 'London No. 2 Lake Park',

--- a/components/table/demo/filter-search.tsx
+++ b/components/table/demo/filter-search.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType, TableProps } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -58,25 +58,25 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     age: 32,
     address: 'London No. 2 Lake Park',

--- a/components/table/demo/fixed-columns-header.tsx
+++ b/components/table/demo/fixed-columns-header.tsx
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ css, token }) => {
 });
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -108,7 +108,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 100 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: `Edward King ${i}`,
   age: 32,
   address: `London, Park Lane no. ${i}`,

--- a/components/table/demo/fixed-columns.tsx
+++ b/components/table/demo/fixed-columns.tsx
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ css, token }) => {
 });
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -74,8 +74,8 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource: DataType[] = [
-  { key: '1', name: 'Olivia', age: 32, address: 'New York Park' },
-  { key: '2', name: 'Ethan', age: 40, address: 'London Park' },
+  { id: '1', name: 'Olivia', age: 32, address: 'New York Park' },
+  { id: '2', name: 'Ethan', age: 40, address: 'London Park' },
 ];
 
 const App: React.FC = () => {

--- a/components/table/demo/fixed-gapped-columns.tsx
+++ b/components/table/demo/fixed-gapped-columns.tsx
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ css, token }) => {
 });
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -80,8 +80,8 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource: DataType[] = [
-  { key: '1', name: 'Olivia', age: 32, address: 'New York Park' },
-  { key: '2', name: 'Ethan', age: 40, address: 'London Park' },
+  { id: '1', name: 'Olivia', age: 32, address: 'New York Park' },
+  { id: '2', name: 'Ethan', age: 40, address: 'London Park' },
 ];
 
 const App: React.FC = () => {

--- a/components/table/demo/fixed-header.tsx
+++ b/components/table/demo/fixed-header.tsx
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ css, token }) => {
 });
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -46,7 +46,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 100 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: `Edward King ${i}`,
   age: 32,
   address: `London, Park Lane no. ${i}`,

--- a/components/table/demo/grouping-columns.tsx
+++ b/components/table/demo/grouping-columns.tsx
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ css, token }) => {
 });
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   street: string;
@@ -118,7 +118,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 100 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: 'John Brown',
   age: i + 1,
   street: 'Lake Park',

--- a/components/table/demo/head.tsx
+++ b/components/table/demo/head.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType, TableProps } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -67,27 +67,27 @@ const columns: TableColumnsType<DataType> = [
   },
 ];
 
-const data = [
+const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     age: 32,
     address: 'London No. 2 Lake Park',

--- a/components/table/demo/hidden-columns.tsx
+++ b/components/table/demo/hidden-columns.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Divider, Table } from 'antd';
 import type { CheckboxOptionType, TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -22,13 +22,13 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 40,
     address: 'London Park',

--- a/components/table/demo/jsx.tsx
+++ b/components/table/demo/jsx.tsx
@@ -4,7 +4,7 @@ import { Flex, Space, Table, Tag } from 'antd';
 const { Column, ColumnGroup } = Table;
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   firstName: string;
   lastName: string;
   age: number;
@@ -14,7 +14,7 @@ interface DataType {
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     firstName: 'John',
     lastName: 'Brown',
     age: 32,
@@ -22,7 +22,7 @@ const data: DataType[] = [
     tags: ['nice', 'developer'],
   },
   {
-    key: '2',
+    id: '2',
     firstName: 'Jim',
     lastName: 'Green',
     age: 42,
@@ -30,7 +30,7 @@ const data: DataType[] = [
     tags: ['loser'],
   },
   {
-    key: '3',
+    id: '3',
     firstName: 'Joe',
     lastName: 'Black',
     age: 32,

--- a/components/table/demo/multiple-sorter.tsx
+++ b/components/table/demo/multiple-sorter.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType, TableProps } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   chinese: number;
   math: number;
@@ -43,28 +43,28 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     chinese: 98,
     math: 60,
     english: 70,
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     chinese: 98,
     math: 66,
     english: 89,
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     chinese: 98,
     math: 90,
     english: 70,
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     chinese: 88,
     math: 99,

--- a/components/table/demo/narrow.tsx
+++ b/components/table/demo/narrow.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -25,7 +25,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 200 }).map<DataType>((_, key) => ({
-  key,
+  id: key,
   name: 'Sample Name',
   age: 30 + (key % 5),
   address: `Sample Address ${key}`,

--- a/components/table/demo/nest-table-border-debug.tsx
+++ b/components/table/demo/nest-table-border-debug.tsx
@@ -4,7 +4,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 import { Badge, Dropdown, Form, Space, Switch, Table } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   platform: string;
   version: string;
@@ -14,7 +14,7 @@ interface DataType {
 }
 
 interface ExpandedDataType {
-  key: React.Key;
+  id: React.Key;
   date: string;
   name: string;
   upgradeNum: string;
@@ -58,7 +58,7 @@ const expandedColumns: TableProps<ExpandedDataType>['columns'] = [
 ];
 
 const expandedDataSource = Array.from({ length: 3 }).map<ExpandedDataType>((_, i) => ({
-  key: i,
+  id: i,
   date: '2014-12-24 23:12:00',
   name: 'This is production name',
   upgradeNum: 'Upgraded: 56',
@@ -84,7 +84,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 3 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: 'Screem',
   platform: 'iOS',
   version: '10.3.4.5654',

--- a/components/table/demo/nested-table.tsx
+++ b/components/table/demo/nested-table.tsx
@@ -4,14 +4,14 @@ import type { TableColumnsType } from 'antd';
 import { Badge, Dropdown, Space, Table } from 'antd';
 
 interface ExpandedDataType {
-  key: React.Key;
+  id: React.Key;
   date: string;
   name: string;
   upgradeNum: string;
 }
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   platform: string;
   version: string;
@@ -26,14 +26,14 @@ const items = [
 ];
 
 const expandDataSource = Array.from({ length: 3 }).map<ExpandedDataType>((_, i) => ({
-  key: i.toString(),
+  id: i.toString(),
   date: '2014-12-24 23:12:00',
   name: 'This is production name',
   upgradeNum: 'Upgraded: 56',
 }));
 
 const dataSource = Array.from({ length: 3 }).map<DataType>((_, i) => ({
-  key: i.toString(),
+  id: i.toString(),
   name: 'Screen',
   platform: 'iOS',
   version: '10.3.4.5654',

--- a/components/table/demo/order-column.tsx
+++ b/components/table/demo/order-column.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -20,28 +20,28 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: 1,
+    id: 1,
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
     description: 'My name is John Brown, I am 32 years old, living in New York No. 1 Lake Park.',
   },
   {
-    key: 2,
+    id: 2,
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
     description: 'My name is Jim Green, I am 42 years old, living in London No. 1 Lake Park.',
   },
   {
-    key: 3,
+    id: 3,
     name: 'Not Expandable',
     age: 29,
     address: 'Jiangsu No. 1 Lake Park',
     description: 'This not expandable',
   },
   {
-    key: 4,
+    id: 4,
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/pagination.tsx
+++ b/components/table/demo/pagination.tsx
@@ -9,7 +9,7 @@ type TablePaginationPosition<T extends object> = NonNullable<
 >[number];
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;
@@ -81,21 +81,21 @@ const columns: ColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
     tags: ['nice', 'developer'],
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
     tags: ['loser'],
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/reset-filter.tsx
+++ b/components/table/demo/reset-filter.tsx
@@ -9,7 +9,7 @@ type GetSingle<T> = T extends (infer U)[] ? U : never;
 type Sorts = GetSingle<Parameters<OnChange>[2]>;
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   age: number;
   address: string;
@@ -17,25 +17,25 @@ interface DataType {
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     age: 32,
     address: 'London No. 2 Lake Park',

--- a/components/table/demo/resizable-column.tsx
+++ b/components/table/demo/resizable-column.tsx
@@ -5,7 +5,7 @@ import type { ResizeCallbackData } from 'react-resizable';
 import { Resizable } from 'react-resizable';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   date: string;
   amount: number;
   type: string;
@@ -39,21 +39,21 @@ const ResizableTitle: React.FC<Readonly<React.HTMLAttributes<any> & TitlePropsTy
 
 const data: DataType[] = [
   {
-    key: 0,
+    id: 0,
     date: '2018-02-11',
     amount: 120,
     type: 'income',
     note: 'transfer',
   },
   {
-    key: 1,
+    id: 1,
     date: '2018-03-11',
     amount: 243,
     type: 'income',
     note: 'transfer',
   },
   {
-    key: 2,
+    id: 2,
     date: '2018-04-11',
     amount: 98,
     type: 'income',

--- a/components/table/demo/responsive.tsx
+++ b/components/table/demo/responsive.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -32,7 +32,7 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',

--- a/components/table/demo/row-selection-and-operation.tsx
+++ b/components/table/demo/row-selection-and-operation.tsx
@@ -5,7 +5,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -18,7 +18,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from<DataType>({ length: 46 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: `Edward King ${i}`,
   age: 32,
   address: `London, Park Lane no. ${i}`,

--- a/components/table/demo/row-selection-custom-debug.tsx
+++ b/components/table/demo/row-selection-custom-debug.tsx
@@ -5,7 +5,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
 }
 
@@ -17,7 +17,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 46 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: i % 2 === 0 ? `Edward King ${i}` : 'Another Row',
 }));
 

--- a/components/table/demo/row-selection-custom.tsx
+++ b/components/table/demo/row-selection-custom.tsx
@@ -5,7 +5,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -27,7 +27,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 46 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: `Edward King ${i}`,
   age: 32,
   address: `London, Park Lane no. ${i}`,

--- a/components/table/demo/row-selection-debug.tsx
+++ b/components/table/demo/row-selection-debug.tsx
@@ -11,7 +11,7 @@ const RenderTimes: React.FC = () => {
 };
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -45,7 +45,7 @@ const columns: TableColumnsType<DataType> = [
 
 function genData(length: number) {
   return Array.from({ length }).map<DataType>((_, i) => ({
-    key: i,
+    id: i,
     name: `Edward King ${i}`,
     age: 32,
     address: `London, Park Lane no. ${i}`,

--- a/components/table/demo/row-selection.tsx
+++ b/components/table/demo/row-selection.tsx
@@ -3,7 +3,7 @@ import { Divider, Radio, Table } from 'antd';
 import type { TableColumnsType, TableProps } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -27,25 +27,25 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',
   },
   {
-    key: '4',
+    id: '4',
     name: 'Disabled User',
     age: 99,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/selections-debug.tsx
+++ b/components/table/demo/selections-debug.tsx
@@ -3,7 +3,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -26,19 +26,19 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/size.tsx
+++ b/components/table/demo/size.tsx
@@ -3,7 +3,7 @@ import { Divider, Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -26,19 +26,19 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/sticky.tsx
+++ b/components/table/demo/sticky.tsx
@@ -3,7 +3,7 @@ import { Switch, Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   age: number;
   address: string;
@@ -77,7 +77,7 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 100 }).map<DataType>((_, i) => ({
-  key: i,
+  id: i,
   name: `Edward ${i}`,
   age: 32,
   address: `London Park no. ${i}`,

--- a/components/table/demo/summary.tsx
+++ b/components/table/demo/summary.tsx
@@ -24,14 +24,14 @@ const useStyle = createStyles(({ css, token }) => {
 const { Text } = Typography;
 
 interface DataType {
-  key: string;
+  id: string;
   name: string;
   borrow: number;
   repayment: number;
 }
 
 interface FixedDataType {
-  key: React.Key;
+  id: React.Key;
   name: string;
   description: string;
 }
@@ -53,25 +53,25 @@ const columns: TableColumnsType<DataType> = [
 
 const dataSource: DataType[] = [
   {
-    key: '1',
+    id: '1',
     name: 'John Brown',
     borrow: 10,
     repayment: 33,
   },
   {
-    key: '2',
+    id: '2',
     name: 'Jim Green',
     borrow: 100,
     repayment: 0,
   },
   {
-    key: '3',
+    id: '3',
     name: 'Joe Black',
     borrow: 10,
     repayment: 10,
   },
   {
-    key: '4',
+    id: '4',
     name: 'Jim Red',
     borrow: 75,
     repayment: 45,
@@ -92,7 +92,7 @@ const fixedColumns: TableColumnsType<FixedDataType> = [
 ];
 
 const fixedDataSource = Array.from({ length: 20 }).map<FixedDataType>((_, i) => ({
-  key: i,
+  id: i,
   name: ['Light', 'Bamboo', 'Little'][i % 3],
   description: 'Everything that has a beginning, has an end.',
 }));

--- a/components/table/demo/tree-data.tsx
+++ b/components/table/demo/tree-data.tsx
@@ -5,7 +5,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: React.ReactNode;
+  id: React.ReactNode;
   name: string;
   age: number;
   address: string;
@@ -34,25 +34,25 @@ const columns: TableColumnsType<DataType> = [
 
 const data: DataType[] = [
   {
-    key: 1,
+    id: 1,
     name: 'John Brown sr.',
     age: 60,
     address: 'New York No. 1 Lake Park',
     children: [
       {
-        key: 11,
+        id: 11,
         name: 'John Brown',
         age: 42,
         address: 'New York No. 2 Lake Park',
       },
       {
-        key: 12,
+        id: 12,
         name: 'John Brown jr.',
         age: 30,
         address: 'New York No. 3 Lake Park',
         children: [
           {
-            key: 121,
+            id: 121,
             name: 'Jimmy Brown',
             age: 16,
             address: 'New York No. 3 Lake Park',
@@ -60,25 +60,25 @@ const data: DataType[] = [
         ],
       },
       {
-        key: 13,
+        id: 13,
         name: 'Jim Green sr.',
         age: 72,
         address: 'London No. 1 Lake Park',
         children: [
           {
-            key: 131,
+            id: 131,
             name: 'Jim Green',
             age: 42,
             address: 'London No. 2 Lake Park',
             children: [
               {
-                key: 1311,
+                id: 1311,
                 name: 'Jim Green jr.',
                 age: 25,
                 address: 'London No. 3 Lake Park',
               },
               {
-                key: 1312,
+                id: 1312,
                 name: 'Jimmy Green sr.',
                 age: 18,
                 address: 'London No. 4 Lake Park',
@@ -90,7 +90,7 @@ const data: DataType[] = [
     ],
   },
   {
-    key: 2,
+    id: 2,
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/tree-table-ellipsis.tsx
+++ b/components/table/demo/tree-table-ellipsis.tsx
@@ -3,7 +3,7 @@ import { Space, Switch, Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface DataType {
-  key: React.ReactNode;
+  id: React.ReactNode;
   name: string;
   age: number;
   address: string;
@@ -12,25 +12,25 @@ interface DataType {
 
 const data: DataType[] = [
   {
-    key: 1,
+    id: 1,
     name: 'John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr.',
     age: 60,
     address: 'New York No. 1 Lake Park',
     children: [
       {
-        key: 11,
+        id: 11,
         name: 'John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr.',
         age: 42,
         address: 'New York No. 2 Lake Park',
       },
       {
-        key: 12,
+        id: 12,
         name: 'John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr.',
         age: 30,
         address: 'New York No. 3 Lake Park',
         children: [
           {
-            key: 121,
+            id: 121,
             name: 'John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr. John Brown sr.',
             age: 16,
             address: 'New York No. 3 Lake Park',
@@ -38,25 +38,25 @@ const data: DataType[] = [
         ],
       },
       {
-        key: 13,
+        id: 13,
         name: 'Jim Green sr. Jim Green sr. Jim Green sr. Jim Green sr.',
         age: 72,
         address: 'London No. 1 Lake Park',
         children: [
           {
-            key: 131,
+            id: 131,
             name: 'Jim Green. Jim Green. Jim Green. Jim Green. Jim Green. Jim Green.',
             age: 42,
             address: 'London No. 2 Lake Park',
             children: [
               {
-                key: 1311,
+                id: 1311,
                 name: 'Jim Green jr. Jim Green jr. Jim Green jr. Jim Green jr.',
                 age: 25,
                 address: 'London No. 3 Lake Park',
               },
               {
-                key: 1312,
+                id: 1312,
                 name: 'Jimmy Green sr. Jimmy Green sr. Jimmy Green sr.',
                 age: 18,
                 address: 'London No. 4 Lake Park',
@@ -68,7 +68,7 @@ const data: DataType[] = [
     ],
   },
   {
-    key: 2,
+    id: 2,
     name: 'Joe Black',
     age: 32,
     address: 'Sydney No. 1 Lake Park',

--- a/components/table/demo/tree-table-preserveSelectedRowKeys.tsx
+++ b/components/table/demo/tree-table-preserveSelectedRowKeys.tsx
@@ -5,7 +5,7 @@ import type { TableColumnsType, TableProps } from 'antd';
 type TableRowSelection<T extends object = object> = TableProps<T>['rowSelection'];
 
 interface DataType {
-  key: React.ReactNode;
+  id: React.ReactNode;
   name: string;
   age: number;
   address: string;
@@ -33,19 +33,19 @@ const columns: TableColumnsType<DataType> = [
 ];
 
 const dataSource = Array.from({ length: 15 }).map<DataType>((_, i) => ({
-  key: `key${i}`,
+  id: `key${i}`,
   name: `Edward ${i}`,
   age: 32,
   address: `London Park no. ${i}`,
   children: [
     {
-      key: `subKey${i}1`,
+      id: `subKey${i}1`,
       name: 'Brown',
       age: 16,
       address: 'New York No. 3 Lake Park',
     },
     {
-      key: `subKey${i}2`,
+      id: `subKey${i}2`,
       name: 'Jimmy',
       age: 16,
       address: 'New York No. 3 Lake Park',

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -19,13 +19,13 @@ Specify `dataSource` of Table as an array of data.
 ```jsx
 const dataSource = [
   {
-    key: '1',
+    id: '1',
     name: 'Mike',
     age: 32,
     address: '10 Downing Street',
   },
   {
-    key: '2',
+    id: '2',
     name: 'John',
     age: 42,
     address: '10 Downing Street',
@@ -129,7 +129,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | locale | The i18n text including filter, sort, empty text, etc | object | [Default Value](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/en_US.tsx#L19-L37) |  |
 | pagination | Config of pagination. You can ref table pagination [config](#pagination) or full [`pagination`](/components/pagination/) document, hide it by setting it to `false` | object \| `false` | - |  |
 | rowClassName | Row's className | function(record, index): string | - |  |
-| rowKey | Row's unique key, could be a string or function that returns a string | string \| function(record): string | `key` |  |
+| rowKey | Row's unique key, could be a string or function that returns a string | string \| function(record): string | `id` |  |
 | rowSelection | Row selection [config](#rowselection) | object | - |  |
 | rowHoverable | Row hover | boolean | true | 5.16.0 |
 | scroll | Whether the table can be scrollable, [config](#scroll) | object | - |  |
@@ -304,7 +304,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface User {
-  key: number;
+  id: number;
   name: string;
 }
 
@@ -318,7 +318,7 @@ const columns: TableColumnsType<User> = [
 
 const data: User[] = [
   {
-    key: 0,
+    id: 0,
     name: 'Jack',
   },
 ];

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -20,13 +20,13 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Sv8XQ50NB40AAA
 ```jsx
 const dataSource = [
   {
-    key: '1',
+    id: '1',
     name: '胡彦斌',
     age: 32,
     address: '西湖区湖底公园1号',
   },
   {
-    key: '2',
+    id: '2',
     name: '胡彦祖',
     age: 42,
     address: '西湖区湖底公园1号',
@@ -131,7 +131,7 @@ const columns = [
 | locale | 默认文案设置，目前包括排序、过滤、空数据文案 | object | [默认值](https://github.com/ant-design/ant-design/blob/6dae4a7e18ad1ba193aedd5ab6867e1d823e2aa4/components/locale/zh_CN.tsx#L20-L37) |  |
 | pagination | 分页器，参考[配置项](#pagination)或 [pagination](/components/pagination-cn) 文档，设为 false 时不展示和进行分页 | object \| `false` | - |  |
 | rowClassName | 表格行的类名 | function(record, index): string | - |  |
-| rowKey | 表格行 key 的取值，可以是字符串或一个函数 | string \| function(record): string | `key` |  |
+| rowKey | 表格行 key 的取值，可以是字符串或一个函数 | string \| function(record): string | `id` |  |
 | rowSelection | 表格行是否可选择，[配置项](#rowselection) | object | - |  |
 | rowHoverable | 表格行是否开启 hover 交互 | boolean | true | 5.16.0 |
 | scroll | 表格是否可滚动，也可以指定滚动区域的宽、高，[配置项](#scroll) | object | - |  |
@@ -307,7 +307,7 @@ import { Table } from 'antd';
 import type { TableColumnsType } from 'antd';
 
 interface User {
-  key: number;
+  id: number;
   name: string;
 }
 
@@ -321,7 +321,7 @@ const columns: TableColumnsType<User> = [
 
 const data: User[] = [
   {
-    key: 0,
+    id: 0,
     name: 'Jack',
   },
 ];
@@ -347,11 +347,11 @@ TypeScript 里使用 Table 的 [CodeSandbox 实例](https://codesandbox.io/s/ser
 
 ## 注意
 
-按照 [React 的规范](https://zh-hans.react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)，所有的列表必须绑定 `key`。在 Table 中，`dataSource` 和 `columns` 里的数据值都需要指定 `key` 值。对于 `dataSource` 默认将每列数据的 `key` 属性作为唯一的标识。
+按照 [React 的规范](https://zh-hans.react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)，所有的列表必须绑定 `key`。在 Table 中，`dataSource` 和 `columns` 里的数据值都需要指定 `key` 值。对于 `dataSource` 默认将每列数据的 `id` 属性作为唯一的标识。
 
 ![控制台警告](https://os.alipayobjects.com/rmsportal/luLdLvhPOiRpyss.png)
 
-如果 `dataSource[i].key` 没有提供，你应该使用 `rowKey` 来指定 `dataSource` 的主键，如下所示。若没有指定，控制台会出现以上的提示，表格组件也会出现各类奇怪的错误。
+如果 `dataSource[i].id` 没有提供，你应该使用 `rowKey` 来指定 `dataSource` 的主键，如下所示。若没有指定，控制台会出现以上的提示，表格组件也会出现各类奇怪的错误。
 
 ```jsx
 // 比如你的数据主键是 uid

--- a/components/transfer/demo/component-token.tsx
+++ b/components/transfer/demo/component-token.tsx
@@ -62,6 +62,7 @@ const TableTransfer = ({ leftColumns, rightColumns, ...restProps }: TableTransfe
 
       return (
         <Table
+          rowKey="key"
           rowSelection={rowSelection}
           columns={columns}
           dataSource={filteredItems}

--- a/components/transfer/demo/table-transfer.tsx
+++ b/components/transfer/demo/table-transfer.tsx
@@ -43,6 +43,7 @@ const TableTransfer: React.FC<TableTransferProps> = (props) => {
 
         return (
           <Table
+            rowKey="key"
             rowSelection={rowSelection}
             columns={columns}
             dataSource={filteredItems}

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -84,9 +84,9 @@ Transfer accept `children` to customize render list, using follow props:
 
 ## Warning
 
-According the [standard](https://react.dev/learn/rendering-lists#why-does-react-need-keys) of React, the key should always be supplied directly to the elements in the array. In Transfer, the keys should be set on the elements included in `dataSource` array. By default, `key` property is used as an unique identifier.
+According the [standard](https://react.dev/learn/rendering-lists#why-does-react-need-keys) of React, the key should always be supplied directly to the elements in the array. In Transfer, the keys should be set on the elements included in `dataSource` array. By default, `id` property is used as an unique identifier.
 
-If there's no `key` in your data, you should use `rowKey` to specify the key that will be used for uniquely identify each element.
+If there's no `id` in your data, you should use `rowKey` to specify the key that will be used for uniquely identify each element.
 
 ```jsx
 // eg. your primary key is `uid`


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

Table 的 dataSource 通常来自于服务端数据，最常见的主键是 id 而非 key。rowKey 的默认值改为 id 能更容易适配各类业务需求，更符合直觉。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(Table): change rowKey default from key to id |
| 🇨🇳 Chinese | feat(Table): rowKey 默认值从 key 改为 id |
