### PR TITLE
fix(Calendar): disable select item in year and month selector according to disabledDate

### DIFF
--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -62,6 +62,16 @@ describe('Calendar', () => {
     fireEvent.click(findSelectItem(wrapper)[index]);
   }
 
+  function getCell(text: string) {
+    const cells = Array.from(document.querySelectorAll('.ant-picker-cell'));
+    return cells.find((cell) => cell.textContent === text);
+  }
+
+  function getSelectItem(title: string) {
+    const nodes = Array.from(document.querySelectorAll('.ant-select-item'));
+    return nodes.find((node) => node.getAttribute('title') === title);
+  }
+
   // https://github.com/ant-design/ant-design/issues/30392
   it('should be able to set undefined or null', () => {
     expect(() => {
@@ -569,5 +579,26 @@ describe('Calendar', () => {
     expect(container.firstChild).toMatchSnapshot();
 
     jest.useRealTimers();
+  });
+
+  it('disabledDate should work correctly', () => {
+    const disabledDate = (current: any) => current && current < Dayjs('2025-02-11');
+    const zhCN = require('../locale/zh_CN').default;
+    const { container } = render(
+      <Calendar disabledDate={disabledDate} fullscreen={false} locale={zhCN} />,
+    );
+    expect(getCell('10')).toHaveClass('ant-picker-cell-disabled');
+    expect(getCell('11')).not.toHaveClass('ant-picker-cell-disabled');
+    expect(getCell('12')).not.toHaveClass('ant-picker-cell-disabled');
+
+    openSelect(container, '.ant-picker-calendar-year-select');
+    expect(getSelectItem('2024年')).toHaveClass('ant-select-item-option-disabled');
+    expect(getSelectItem('2025年')).not.toHaveClass('ant-select-item-option-disabled');
+    expect(getSelectItem('2026年')).not.toHaveClass('ant-select-item-option-disabled');
+
+    openSelect(container, '.ant-picker-calendar-month-select');
+    expect(getSelectItem('1月')).toHaveClass('ant-select-item-option-disabled');
+    expect(getSelectItem('2月')).not.toHaveClass('ant-select-item-option-disabled');
+    expect(getSelectItem('3月')).not.toHaveClass('ant-select-item-option-disabled');
   });
 });

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -294,6 +294,7 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             validRange={validRange}
             onChange={onInternalSelect}
             onModeChange={triggerModeChange}
+            disabledDate={disabledDate}
           />
         )}
         <RCPickerPanel


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #52658

### 💡 Background and Solution

**Background:**

`Calendar` component only set `disabledDate` to its picker panel, while its header don't hold the attribute. As a result, `YearSelect` and `MonthSelect` won't be affected with `disabledDate`.

**Solution:**

- Extended attributes of `CalendarHeader` with `disabledDate`.

- Disabled part of select item according to this attribute both in `YearSelect` and `MonthSelect`. The logic is similar to [YearPanel](https://github.com/react-component/picker/blob/23ff742b9d557f522e60ea4dcc40066449a10f78/src/PickerPanel/YearPanel/index.tsx#L62) and [MonthPanel](https://github.com/react-component/picker/blob/23ff742b9d557f522e60ea4dcc40066449a10f78/src/PickerPanel/MonthPanel/index.tsx#L56) in rc-picker.

- Added test case relate to this pr.



### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix Calendar won't disable select item according to `disabledDate` in year and month selector      |
| 🇨🇳 Chinese |    修复Calendar年份月份选择器中不会根据`disabledDate`禁用选择项的问题       |