### PR TITLE
fix: Modal quick close lock

### DIFF
--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { SmileOutlined } from '@ant-design/icons';
+import RcCSSMotion from '@rc-component/motion';
+import { genCSSMotion as genRcCSSMotion } from '@rc-component/motion/lib/CSSMotion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import { resetWarned } from '@rc-component/util/lib/warning';
 import CSSMotion from 'rc-motion';
@@ -17,6 +19,7 @@ import destroyFns from '../destroyFns';
 const { confirm } = Modal;
 
 jest.mock('rc-motion');
+jest.mock('@rc-component/motion');
 
 // TODO: Remove this. Mock for React 19
 jest.mock('react-dom', () => {
@@ -70,10 +73,18 @@ jest.mock('../../_util/ActionButton', () => {
 });
 
 describe('Modal.confirm triggers callbacks correctly', () => {
-  // Inject CSSMotion to replace with No transition support
+  // Inject `rc-motion` to replace with No transition support
   const MockCSSMotion = genCSSMotion(false);
   Object.keys(MockCSSMotion).forEach((key) => {
-    (CSSMotion as any)[key] = (MockCSSMotion as any)[key];
+    // @ts-ignore
+    CSSMotion[key] = MockCSSMotion[key];
+  });
+
+  // Inject `@rc-component/motion` to replace with No transition support
+  const MockRcCSSMotion = genRcCSSMotion(false);
+  Object.keys(MockRcCSSMotion).forEach((key) => {
+    // @ts-ignore
+    RcCSSMotion[key] = MockRcCSSMotion[key];
   });
 
   // // Mock for @rc-component/util raf

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -4,8 +4,6 @@ import RcCSSMotion from '@rc-component/motion';
 import { genCSSMotion as genRcCSSMotion } from '@rc-component/motion/lib/CSSMotion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import { resetWarned } from '@rc-component/util/lib/warning';
-import CSSMotion from 'rc-motion';
-import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 
 import type { ModalFuncProps } from '..';
 import Modal from '..';
@@ -18,7 +16,6 @@ import destroyFns from '../destroyFns';
 
 const { confirm } = Modal;
 
-jest.mock('rc-motion');
 jest.mock('@rc-component/motion');
 
 // TODO: Remove this. Mock for React 19
@@ -73,13 +70,6 @@ jest.mock('../../_util/ActionButton', () => {
 });
 
 describe('Modal.confirm triggers callbacks correctly', () => {
-  // Inject `rc-motion` to replace with No transition support
-  const MockCSSMotion = genCSSMotion(false);
-  Object.keys(MockCSSMotion).forEach((key) => {
-    // @ts-ignore
-    CSSMotion[key] = MockCSSMotion[key];
-  });
-
   // Inject `@rc-component/motion` to replace with No transition support
   const MockRcCSSMotion = genRcCSSMotion(false);
   Object.keys(MockRcCSSMotion).forEach((key) => {

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import RcCSSMotion from '@rc-component/motion';
+import { genCSSMotion as genRcCSSMotion } from '@rc-component/motion/lib/CSSMotion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import CSSMotion from 'rc-motion';
 import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
@@ -13,6 +15,7 @@ import type { ModalFunc } from '../confirm';
 
 jest.mock('@rc-component/util/lib/Portal');
 jest.mock('rc-motion');
+jest.mock('@rc-component/motion');
 
 // TODO: Remove this. Mock for React 19
 jest.mock('react-dom', () => {
@@ -27,11 +30,18 @@ jest.mock('react-dom', () => {
 });
 
 describe('Modal.hook', () => {
-  // Inject CSSMotion to replace with No transition support
+  // Inject `rc-motion` to replace with No transition support
   const MockCSSMotion = genCSSMotion(false);
   Object.keys(MockCSSMotion).forEach((key) => {
     // @ts-ignore
     CSSMotion[key] = MockCSSMotion[key];
+  });
+
+  // Inject `@rc-component/motion` to replace with No transition support
+  const MockRcCSSMotion = genRcCSSMotion(false);
+  Object.keys(MockRcCSSMotion).forEach((key) => {
+    // @ts-ignore
+    RcCSSMotion[key] = MockRcCSSMotion[key];
   });
 
   it('hooks support context', () => {

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import RcCSSMotion from '@rc-component/motion';
 import { genCSSMotion as genRcCSSMotion } from '@rc-component/motion/lib/CSSMotion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
-import CSSMotion from 'rc-motion';
-import { genCSSMotion } from 'rc-motion/lib/CSSMotion';
 
 import Modal from '..';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
@@ -14,7 +12,6 @@ import zhCN from '../../locale/zh_CN';
 import type { ModalFunc } from '../confirm';
 
 jest.mock('@rc-component/util/lib/Portal');
-jest.mock('rc-motion');
 jest.mock('@rc-component/motion');
 
 // TODO: Remove this. Mock for React 19
@@ -30,13 +27,6 @@ jest.mock('react-dom', () => {
 });
 
 describe('Modal.hook', () => {
-  // Inject `rc-motion` to replace with No transition support
-  const MockCSSMotion = genCSSMotion(false);
-  Object.keys(MockCSSMotion).forEach((key) => {
-    // @ts-ignore
-    CSSMotion[key] = MockCSSMotion[key];
-  });
-
   // Inject `@rc-component/motion` to replace with No transition support
   const MockRcCSSMotion = genRcCSSMotion(false);
   Object.keys(MockRcCSSMotion).forEach((key) => {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@babel/runtime": "^7.26.0",
     "@rc-component/collapse": "~1.0.1",
     "@rc-component/color-picker": "~2.0.1",
-    "@rc-component/dialog": "~1.0.1",
+    "@rc-component/dialog": "~1.1.0",
     "@rc-component/form": "~1.0.0",
     "@rc-component/mutate-observer": "^2.0.0",
     "@rc-component/qrcode": "~1.0.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #52625

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Modal quick switch `open` state will make screen operation frozen.        |
| 🇨🇳 Chinese |     修复 Modal 快速切换 `open` 状态时，屏幕交互会被锁定的问题。          |
