### PR TITLE
feat(Notification): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -379,7 +379,7 @@ const Header: React.FC = () => {
         >
           <Alert
             className={styles.banner}
-            message={
+            title={
               <>
                 <span>{isMobile ? locale.shortMessage : locale.message}</span>
                 <a

--- a/components/app/__tests__/index.test.tsx
+++ b/components/app/__tests__/index.test.tsx
@@ -55,9 +55,9 @@ describe('App', () => {
       useEffect(() => {
         message.success('Message 1');
         message.success('Message 2');
-        notification.success({ message: 'Notification 1' });
-        notification.success({ message: 'Notification 2' });
-        notification.success({ message: 'Notification 3' });
+        notification.success({ title: 'Notification 1' });
+        notification.success({ title: 'Notification 2' });
+        notification.success({ title: 'Notification 3' });
       }, [message, notification]);
 
       return <div />;
@@ -135,9 +135,9 @@ describe('App', () => {
       consumedConfig = React.useContext(AppConfigContext);
 
       useEffect(() => {
-        notification.success({ message: 'Notification 1' });
-        notification.success({ message: 'Notification 2' });
-        notification.success({ message: 'Notification 3' });
+        notification.success({ title: 'Notification 1' });
+        notification.success({ title: 'Notification 2' });
+        notification.success({ title: 'Notification 3' });
       }, [notification]);
 
       return <div />;

--- a/components/app/demo/basic.tsx
+++ b/components/app/demo/basic.tsx
@@ -18,7 +18,7 @@ const MyPage = () => {
 
   const showNotification = () => {
     notification.info({
-      message: 'Notification topLeft',
+      title: 'Notification topLeft',
       description: 'Hello, Ant Design!!',
       placement: 'topLeft',
     });

--- a/components/app/demo/config.tsx
+++ b/components/app/demo/config.tsx
@@ -11,7 +11,7 @@ const MyPage = () => {
 
   const showNotification = () => {
     notification.info({
-      message: 'Notification',
+      title: 'Notification',
       description: 'Hello, Ant Design!!',
     });
   };

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -34,7 +34,7 @@ import { App } from 'antd';
 const MyPage: React.FC = () => {
   const { message, notification, modal } = App.useApp();
   message.success('Good!');
-  notification.info({ message: 'Good' });
+  notification.info({ title: 'Good' });
   modal.warning({ title: 'Good' });
   // ....
   // other message, notification, modal static function

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -35,7 +35,7 @@ import { App } from 'antd';
 const MyPage: React.FC = () => {
   const { message, notification, modal } = App.useApp();
   message.success('Good!');
-  notification.info({ message: 'Good' });
+  notification.info({ title: 'Good' });
   modal.warning({ title: 'Good' });
   // ....
   // other message, notification, modal static function

--- a/components/config-provider/__tests__/style.test.tsx
+++ b/components/config-provider/__tests__/style.test.tsx
@@ -1396,7 +1396,7 @@ describe('ConfigProvider support style and className props', () => {
             closeIcon: <span className="cp-test-icon">cp-test-icon</span>,
           }}
         >
-          <button type="button" onClick={() => api.open({ message: 'test', duration: 0 })}>
+          <button type="button" onClick={() => api.open({ title: 'test', duration: 0 })}>
             test
           </button>
           {holder}

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -171,7 +171,8 @@ export type TextAreaConfig = ComponentStyleConfig &
 export type ButtonConfig = ComponentStyleConfig &
   Pick<ButtonProps, 'classNames' | 'styles' | 'autoInsertSpace'>;
 
-export type NotificationConfig = ComponentStyleConfig & Pick<ArgsProps, 'closeIcon'>;
+export type NotificationConfig = ComponentStyleConfig &
+  Pick<ArgsProps, 'closeIcon' | 'classNames' | 'styles'>;
 
 export type TagConfig = ComponentStyleConfig & Pick<TagProps, 'closeIcon' | 'closable'>;
 

--- a/components/config-provider/demo/holderRender.tsx
+++ b/components/config-provider/demo/holderRender.tsx
@@ -34,7 +34,7 @@ const Demo: React.FC = () => {
           type="primary"
           onClick={() => {
             notification.open({
-              message: 'Notification Title',
+              title: 'Notification Title',
               description:
                 'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
             });

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -141,7 +141,7 @@ const {
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | Set Message common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties, classNames?: [ModalProps\["classNames"\]](/components/modal#api), styles?: [ModalProps\["styles"\]](/components/modal#api), closeIcon?: React.ReactNode } | - | 5.7.0, `classNames` and `styles`: 5.10.0, `closeIcon`: 5.14.0 |
-| notification | Set Notification common props | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode } | - | 5.7.0, `closeIcon`: 5.14.0 |
+| notification | Set Notification common props | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, classNames?: [NotificationConfig\["classNames"\]](/components/notification#api), styles?: [NotificationConfig\["styles"\]](/components/notification#api) } | - | 5.7.0, `closeIcon`: 5.14.0, `classNames` and `styles`: 6.0.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | progress | Set Progress common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | Set Radio common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -143,7 +143,7 @@ const {
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [ModalProps\["classNames"\]](/components/modal-cn#api), styles?: [ModalProps\["styles"\]](/components/modal-cn#api), closeIcon?: React.ReactNode } | - | 5.7.0, `classNames` 和 `styles`: 5.10.0, `closeIcon`: 5.14.0 |
-| notification | 设置 Notification 组件的通用属性 | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode } | - | 5.7.0, `closeIcon`: 5.14.0 |
+| notification | 设置 Notification 组件的通用属性 | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, classNames?: [NotificationConfig\["classNames"\]](/components/notification-cn#api), styles?: [NotificationConfig\["styles"\]](/components/notification-cn#api) } | - | 5.7.0, `closeIcon`: 5.14.0, `classNames` 和 `styles`: 6.0.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | progress | 设置 Progress 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | radio | 设置 Radio 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/modal/demo/nested.tsx
+++ b/components/modal/demo/nested.tsx
@@ -104,7 +104,7 @@ const Demo: React.FC = () => {
                 onClick={() => {
                   message.success('Hello World');
                   notification.success({
-                    message: 'Hello World',
+                    title: 'Hello World',
                   });
                 }}
               >
@@ -115,7 +115,7 @@ const Demo: React.FC = () => {
                 onClick={() => {
                   messageInstance.success('Hello World');
                   notificationInstance.success({
-                    message: 'Hello World',
+                    title: 'Hello World',
                   });
                 }}
               >

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -180,18 +180,13 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
     >
       <PurePanelStyle prefixCls={prefixCls} />
       <Notice
-        style={{ ...contextStyles.content, ...styles?.content, ...contextStyle, ...style }}
+        style={{ ...contextStyle, ...style }}
         {...restProps}
         prefixCls={prefixCls}
         eventKey="pure"
         duration={null}
         closable={closable}
-        className={classNames(
-          notificationClassName,
-          contextClassName,
-          contextClassNames.content,
-          notificationClassNames?.content,
-        )}
+        className={classNames(notificationClassName, contextClassName)}
         closeIcon={getCloseIcon(prefixCls, closeIcon)}
         content={
           <PureContent

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -10,9 +10,9 @@ import { Notice } from 'rc-notification';
 import type { NoticeProps } from 'rc-notification/lib/Notice';
 
 import { devUseWarning } from '../_util/warning';
-import { ConfigContext } from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
-import type { IconType } from './interface';
+import type { IconType, SemanticName } from './interface';
 import useStyle from './style';
 import PurePanelStyle from './style/pure-panel';
 
@@ -34,13 +34,17 @@ export function getCloseIcon(prefixCls: string, closeIcon?: React.ReactNode): Re
 export interface PureContentProps {
   prefixCls: string;
   icon?: React.ReactNode;
+  /** @deprecated Please use `title` instead */
   message?: React.ReactNode;
+  title?: React.ReactNode;
   description?: React.ReactNode;
   /** @deprecated Please use `actions` instead */
   btn?: React.ReactNode;
   actions?: React.ReactNode;
   type?: IconType;
   role?: 'alert' | 'status';
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 const typeToIcon = {
@@ -51,53 +55,110 @@ const typeToIcon = {
 };
 
 export const PureContent: React.FC<PureContentProps> = (props) => {
-  const { prefixCls, icon, type, message, description, actions, role = 'alert' } = props;
+  const {
+    prefixCls,
+    icon,
+    type,
+    title,
+    description,
+    actions,
+    role = 'alert',
+    styles,
+    classNames: pureContentClassNames,
+  } = props;
+
   let iconNode: React.ReactNode = null;
   if (icon) {
-    iconNode = <span className={`${prefixCls}-icon`}>{icon}</span>;
+    iconNode = (
+      <span
+        className={classNames(`${prefixCls}-icon`, pureContentClassNames?.icon)}
+        style={styles?.icon}
+      >
+        {icon}
+      </span>
+    );
   } else if (type) {
     iconNode = React.createElement(typeToIcon[type] || null, {
-      className: classNames(`${prefixCls}-icon`, `${prefixCls}-icon-${type}`),
+      className: classNames(
+        `${prefixCls}-icon`,
+        pureContentClassNames?.icon,
+        `${prefixCls}-icon-${type}`,
+      ),
+      style: styles?.icon,
     });
   }
   return (
     <div className={classNames({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
-      <div className={`${prefixCls}-message`}>{message}</div>
-      <div className={`${prefixCls}-description`}>{description}</div>
-      {actions && <div className={`${prefixCls}-actions`}>{actions}</div>}
+      <div
+        className={classNames(`${prefixCls}-title`, pureContentClassNames?.title)}
+        style={styles?.title}
+      >
+        {title}
+      </div>
+      <div
+        className={classNames(`${prefixCls}-description`, pureContentClassNames?.description)}
+        style={styles?.description}
+      >
+        {description}
+      </div>
+      {actions && (
+        <div
+          className={classNames(`${prefixCls}-actions`, pureContentClassNames?.actions)}
+          style={styles?.actions}
+        >
+          {actions}
+        </div>
+      )}
     </div>
   );
 };
 
 export interface PurePanelProps
-  extends Omit<NoticeProps, 'prefixCls' | 'eventKey'>,
+  extends Omit<NoticeProps, 'prefixCls' | 'eventKey' | 'classNames' | 'styles'>,
     Omit<PureContentProps, 'prefixCls' | 'children'> {
   prefixCls?: string;
+  classNames?: Record<SemanticName, string>;
+  styles?: Record<SemanticName, React.CSSProperties>;
 }
 
 /** @private Internal Component. Do not use in your production. */
 const PurePanel: React.FC<PurePanelProps> = (props) => {
   const {
     prefixCls: staticPrefixCls,
-    className,
     icon,
     type,
     message,
+    title,
     description,
     btn,
     actions,
     closable = true,
     closeIcon,
     className: notificationClassName,
+    style,
+    styles,
+    classNames: notificationClassNames,
     ...restProps
   } = props;
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const {
+    getPrefixCls,
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('notification');
   const mergedActions = actions ?? btn;
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Notification');
-    warning.deprecated(!btn, 'btn', 'actions');
+    [
+      ['btn', 'actions'],
+      ['message', 'title'],
+    ].forEach(([deprecatedName, newName]) => {
+      warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
+    });
   }
+  const mergedTitle = title ?? message;
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
   const noticePrefixCls = `${prefixCls}-notice`;
 
@@ -106,25 +167,53 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   return wrapCSSVar(
     <div
-      className={classNames(`${noticePrefixCls}-pure-panel`, hashId, className, cssVarCls, rootCls)}
+      className={classNames(
+        `${noticePrefixCls}-pure-panel`,
+        hashId,
+        notificationClassName,
+        cssVarCls,
+        rootCls,
+        notificationClassNames?.root,
+        contextClassNames.root,
+      )}
+      style={{ ...contextStyles.root, ...styles?.root }}
     >
       <PurePanelStyle prefixCls={prefixCls} />
       <Notice
+        style={{ ...contextStyles.content, ...styles?.content, ...contextStyle, ...style }}
         {...restProps}
         prefixCls={prefixCls}
         eventKey="pure"
         duration={null}
         closable={closable}
-        className={classNames({
+        className={classNames(
           notificationClassName,
-        })}
+          contextClassName,
+          contextClassNames.content,
+          notificationClassNames?.content,
+        )}
         closeIcon={getCloseIcon(prefixCls, closeIcon)}
         content={
           <PureContent
+            classNames={{
+              icon: classNames(contextClassNames.icon, notificationClassNames?.icon),
+              title: classNames(contextClassNames.title, notificationClassNames?.title),
+              description: classNames(
+                contextClassNames.description,
+                notificationClassNames?.description,
+              ),
+              actions: classNames(contextClassNames.actions, notificationClassNames?.actions),
+            }}
+            styles={{
+              icon: { ...contextStyles.icon, ...styles?.icon },
+              title: { ...contextStyles.title, ...styles?.title },
+              description: { ...contextStyles.description, ...styles?.description },
+              actions: { ...contextStyles.actions, ...styles?.actions },
+            }}
             prefixCls={noticePrefixCls}
             icon={icon}
             type={type}
-            message={message}
+            title={mergedTitle}
             description={description}
             actions={mergedActions}
           />

--- a/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -482,7 +482,7 @@ exports[`renders components/notification/demo/render-panel.tsx extend context co
           </svg>
         </span>
         <div
-          class="ant-notification-notice-message"
+          class="ant-notification-notice-title"
         >
           Hello World!
         </div>

--- a/components/notification/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo.test.ts.snap
@@ -470,7 +470,7 @@ exports[`renders components/notification/demo/render-panel.tsx correctly 1`] = `
           </svg>
         </span>
         <div
-          class="ant-notification-notice-message"
+          class="ant-notification-notice-title"
         >
           Hello World!
         </div>

--- a/components/notification/__tests__/config.test.tsx
+++ b/components/notification/__tests__/config.test.tsx
@@ -50,7 +50,7 @@ describe('notification.config', () => {
 
     for (let i = 0; i < 10; i += 1) {
       notification.open({
-        message: 'Notification message',
+        title: 'Notification message',
         key: i,
         duration: 999,
       });
@@ -70,7 +70,7 @@ describe('notification.config', () => {
 
     act(() => {
       notification.open({
-        message: 'Notification last',
+        title: 'Notification last',
         key: '11',
         duration: 999,
       });
@@ -109,7 +109,7 @@ describe('notification.config', () => {
       ),
     });
 
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelectorAll('.ant-message')).toHaveLength(0);
     expect(document.querySelectorAll('.anticon-close')).toHaveLength(0);
@@ -123,21 +123,21 @@ describe('notification.config', () => {
     ConfigProvider.config({
       holderRender: (children) => <ConfigProvider direction="rtl">{children}</ConfigProvider>,
     });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelector('.ant-notification-rtl')).toBeTruthy();
 
     document.body.innerHTML = '';
     actDestroy();
     notification.config({ rtl: true });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelector('.ant-notification-rtl')).toBeTruthy();
 
     document.body.innerHTML = '';
     actDestroy();
     notification.config({ rtl: false });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelector('.ant-notification-rtl')).toBeFalsy();
 
@@ -149,7 +149,7 @@ describe('notification.config', () => {
     document.body.innerHTML = '';
     actDestroy();
     ConfigProvider.config({ prefixCls: 'prefix-1' });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelectorAll('.prefix-1-notification')).toHaveLength(1);
 
@@ -160,7 +160,7 @@ describe('notification.config', () => {
       prefixCls: 'prefix-1',
       holderRender: (children) => <ConfigProvider prefixCls="prefix-2">{children}</ConfigProvider>,
     });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelectorAll('.prefix-2-notification')).toHaveLength(1);
 
@@ -168,7 +168,7 @@ describe('notification.config', () => {
     document.body.innerHTML = '';
     actDestroy();
     notification.config({ prefixCls: 'prefix-3-notification' });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
     await awaitPromise();
     expect(document.querySelectorAll('.prefix-3-notification')).toHaveLength(1);
 
@@ -184,8 +184,8 @@ describe('notification.config', () => {
       holderRender: (children) => <App notification={{ maxCount: 1 }}>{children}</App>,
     });
 
-    notification.open({ message: 'Notification message' });
-    notification.open({ message: 'Notification message' });
+    notification.open({ title: 'Notification message' });
+    notification.open({ title: 'Notification message' });
 
     await awaitPromise();
     const noticeWithoutLeaving = Array.from(

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -245,7 +245,7 @@ describe('notification.hooks', () => {
         React.useEffect(() => {
           api.info({
             className,
-            message: 'Notification Title',
+            title: 'Notification Title',
             duration: 0,
           });
         }, []);

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -30,7 +30,7 @@ describe('notification.hooks', () => {
               type="button"
               onClick={() => {
                 api.open({
-                  message: null,
+                  title: null,
                   description: (
                     <Context.Consumer>
                       {(name) => <span className="hook-test-result">{name}</span>}
@@ -68,7 +68,7 @@ describe('notification.hooks', () => {
               type="button"
               onClick={() => {
                 api.success({
-                  message: null,
+                  title: null,
                   description: (
                     <Context.Consumer>
                       {(name) => <span className="hook-test-result">{name}</span>}
@@ -118,7 +118,7 @@ describe('notification.hooks', () => {
 
         React.useEffect(() => {
           api.info({
-            message: null,
+            title: null,
             description: <div className="bamboo" />,
           });
         }, []);
@@ -140,7 +140,7 @@ describe('notification.hooks', () => {
 
         if (!calledRef.current) {
           api.info({
-            message: null,
+            title: null,
             description: <div className="bamboo" />,
           });
           calledRef.current = true;
@@ -181,7 +181,7 @@ describe('notification.hooks', () => {
 
       React.useEffect(() => {
         api.info({
-          message: null,
+          title: null,
           description: 'test',
         });
       }, []);
@@ -203,7 +203,7 @@ describe('notification.hooks', () => {
           <a
             onClick={() => {
               api.info({
-                message: null,
+                title: null,
                 description: 'test',
               });
             }}

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { UserOutlined } from '@ant-design/icons';
+import { SmileOutlined, UserOutlined } from '@ant-design/icons';
 
 import notification, { actWrapper } from '..';
-import { act, fireEvent } from '../../../tests/utils';
+import { act, fireEvent, render } from '../../../tests/utils';
 import ConfigProvider, { defaultPrefixCls } from '../../config-provider';
 import { awaitPromise, triggerMotionEnd } from './util';
 
@@ -412,5 +412,54 @@ describe('notification', () => {
     });
     await awaitPromise();
     expect(document.querySelector('.with-style')).toHaveStyle({ width: '600px' });
+  });
+  it('support classnames', async () => {
+    const TestComponent: React.FC = () => {
+      const [api, contextHolder] = notification.useNotification();
+
+      const openNotification = () => {
+        api.open({
+          title: 'Notification Title',
+          duration: 0,
+          icon: <SmileOutlined />,
+          actions: <button type="button">My Button</button>,
+          styles: {
+            root: { color: 'red' },
+            title: { fontSize: 23 },
+            description: { fontWeight: 'bold' },
+            actions: { background: 'green' },
+            icon: { color: 'blue' },
+          },
+          classNames: {
+            root: 'root-class',
+            title: 'title-class',
+            description: 'description-class',
+            actions: 'actions-class',
+            icon: 'icon-class',
+          },
+        });
+      };
+
+      return (
+        <>
+          {contextHolder}
+          <button type="button" onClick={openNotification}>
+            open
+          </button>
+        </>
+      );
+    };
+    const { getByText } = render(<TestComponent />);
+
+    act(() => {
+      getByText('open').click();
+    });
+
+    await awaitPromise();
+    expect(document.querySelector('.root-class')).toHaveStyle({ color: 'red' });
+    expect(document.querySelector('.title-class')).toHaveStyle({ fontSize: '23px' });
+    expect(document.querySelector('.description-class')).toHaveStyle({ fontWeight: 'bold' });
+    expect(document.querySelector('.actions-class')).toHaveStyle({ background: 'green' });
+    expect(document.querySelector('.icon-class')).toHaveStyle({ color: 'blue' });
   });
 });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -464,6 +464,7 @@ describe('notification', () => {
   });
   it('message API compatibility test', async () => {
     act(() => {
+      // @ts-ignore
       notification.warning({
         message: 'Warning Message',
         duration: 0,

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -49,7 +49,7 @@ describe('notification', () => {
 
     for (let i = 0; i < 5; i += 1) {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
       });
     }
@@ -65,14 +65,14 @@ describe('notification', () => {
 
   it('should be able to hide manually', async () => {
     notification.open({
-      message: 'Notification Title 1',
+      title: 'Notification Title 1',
       duration: 0,
       key: '1',
     });
     await awaitPromise();
 
     notification.open({
-      message: 'Notification Title 2',
+      title: 'Notification Title 2',
       duration: 0,
       key: '2',
     });
@@ -96,13 +96,13 @@ describe('notification', () => {
 
   it('should be able to destroy globally', async () => {
     notification.open({
-      message: 'Notification Title 1',
+      title: 'Notification Title 1',
       duration: 0,
     });
     await awaitPromise();
 
     notification.open({
-      message: 'Notification Title 2',
+      title: 'Notification Title 2',
       duration: 0,
     });
 
@@ -131,7 +131,7 @@ describe('notification', () => {
     });
 
     notification.open({
-      message: 'whatever',
+      title: 'whatever',
     });
     await awaitPromise();
 
@@ -141,7 +141,7 @@ describe('notification', () => {
   it('should be able to global config rootPrefixCls', async () => {
     ConfigProvider.config({ prefixCls: 'prefix-test', iconPrefixCls: 'bamboo' });
 
-    notification.success({ message: 'Notification Title', duration: 0 });
+    notification.success({ title: 'Notification Title', duration: 0 });
     await awaitPromise();
 
     expect(document.querySelectorAll('.ant-notification-notice')).toHaveLength(0);
@@ -157,7 +157,7 @@ describe('notification', () => {
     });
 
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
     });
     await awaitPromise();
@@ -177,7 +177,7 @@ describe('notification', () => {
 
     list.forEach((type) => {
       notification[type]({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         description: 'This is the content of the notification.',
       });
@@ -194,7 +194,7 @@ describe('notification', () => {
     const list = ['success', 'info', 'warning', 'error'] as const;
     list.forEach((type) => {
       notification[type]({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         description: 'This is the content of the notification.',
       });
@@ -211,7 +211,7 @@ describe('notification', () => {
     const onClick = jest.fn();
 
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
       onClick,
     });
@@ -225,7 +225,7 @@ describe('notification', () => {
 
   it('support closeIcon', async () => {
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
       closeIcon: <span className="test-customize-icon" />,
     });
@@ -241,7 +241,7 @@ describe('notification', () => {
 
     // Global Icon
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
     });
     await awaitPromise();
@@ -250,7 +250,7 @@ describe('notification', () => {
 
     // Notice Icon
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
       closeIcon: <span className="replace-icon" />,
     });
@@ -272,7 +272,7 @@ describe('notification', () => {
 
     // Global Icon
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
     });
     await awaitPromise();
@@ -282,7 +282,7 @@ describe('notification', () => {
 
     // Notice Icon
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
       closable: {
         closeIcon: <span className="replace-icon" />,
@@ -302,7 +302,7 @@ describe('notification', () => {
     const list = ['1', '2'];
     list.forEach((type) => {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         closeIcon: <span className={`test-customize-icon-${type}`} />,
         duration: 0,
       });
@@ -321,7 +321,7 @@ describe('notification', () => {
     });
 
     notification.open({
-      message: 'whatever',
+      title: 'whatever',
     });
     await awaitPromise();
 
@@ -330,7 +330,7 @@ describe('notification', () => {
 
   it('support icon', async () => {
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       duration: 0,
       icon: <UserOutlined />,
     });
@@ -342,7 +342,7 @@ describe('notification', () => {
   it('support props', () => {
     act(() => {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         props: { 'data-testid': 'test-notification' },
       });
@@ -354,7 +354,7 @@ describe('notification', () => {
   it('support role', async () => {
     act(() => {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         role: 'status',
       });
@@ -369,24 +369,24 @@ describe('notification', () => {
     });
     act(() => {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         className: 'normal',
       });
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         className: 'custom',
         closeIcon: <span className="custom-close-icon">Close</span>,
       });
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         closeIcon: null,
         className: 'with-null',
       });
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         closeIcon: false,
         className: 'with-false',
@@ -402,7 +402,7 @@ describe('notification', () => {
   it('style.width could be override', async () => {
     act(() => {
       notification.open({
-        message: 'Notification Title',
+        title: 'Notification Title',
         duration: 0,
         style: {
           width: 600,

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -463,6 +463,7 @@ describe('notification', () => {
     expect(document.querySelector('.icon-class')).toHaveStyle({ color: 'blue' });
   });
   it('message API compatibility test', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     act(() => {
       // @ts-ignore
       notification.warning({
@@ -473,5 +474,8 @@ describe('notification', () => {
     });
     await awaitPromise();
     expect(document.querySelector('.warning-message')).toHaveTextContent('Warning Message');
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Notification] `message` is deprecated. Please use `title` instead.',
+    );
   });
 });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -477,5 +477,6 @@ describe('notification', () => {
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: Notification] `message` is deprecated. Please use `title` instead.',
     );
+    errSpy.mockRestore();
   });
 });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -462,4 +462,15 @@ describe('notification', () => {
     expect(document.querySelector('.actions-class')).toHaveStyle({ background: 'green' });
     expect(document.querySelector('.icon-class')).toHaveStyle({ color: 'blue' });
   });
+  it('message API compatibility test', async () => {
+    act(() => {
+      notification.warning({
+        message: 'Warning Message',
+        duration: 0,
+        className: 'warning-message',
+      });
+    });
+    await awaitPromise();
+    expect(document.querySelector('.warning-message')).toHaveTextContent('Warning Message');
+  });
 });

--- a/components/notification/__tests__/placement.test.tsx
+++ b/components/notification/__tests__/placement.test.tsx
@@ -18,7 +18,7 @@ jest.mock('react-dom', () => {
 describe('Notification.placement', () => {
   function open(args?: Partial<ArgsProps>) {
     notification.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description: 'This is the content of the notification.',
       ...args,
     });

--- a/components/notification/__tests__/static-warning.test.tsx
+++ b/components/notification/__tests__/static-warning.test.tsx
@@ -41,7 +41,7 @@ describe('notification static warning', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     notification.open({
-      message: <div className="bamboo" />,
+      title: <div className="bamboo" />,
       duration: 0,
     });
     await waitFakeTimer19();
@@ -57,7 +57,7 @@ describe('notification static warning', () => {
     render(<ConfigProvider theme={{}} />);
 
     notification.open({
-      message: <div className="light" />,
+      title: <div className="light" />,
       duration: 0,
     });
     await waitFakeTimer();

--- a/components/notification/demo/_semantic.tsx
+++ b/components/notification/demo/_semantic.tsx
@@ -9,7 +9,6 @@ const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification;
 const locales = {
   cn: {
     root: '根元素',
-    content: '内容元素',
     icon: '图标元素',
     title: '标题元素',
     description: '描述元素',
@@ -17,7 +16,6 @@ const locales = {
   },
   en: {
     root: 'Root element',
-    content: 'Content element',
     icon: 'Icon element',
     title: 'title element',
     description: 'Description element',
@@ -31,7 +29,6 @@ const App: React.FC = () => {
     <SemanticPreview
       semantics={[
         { name: 'root', desc: locale.root, version: '6.0.0' },
-        { name: 'content', desc: locale.content, version: '6.0.0' },
         { name: 'icon', desc: locale.icon, version: '6.0.0' },
         { name: 'title', desc: locale.title, version: '6.0.0' },
         { name: 'description', desc: locale.description, version: '6.0.0' },

--- a/components/notification/demo/_semantic.tsx
+++ b/components/notification/demo/_semantic.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Button, notification } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification;
+
+const locales = {
+  cn: {
+    root: '根元素',
+    content: '内容元素',
+    icon: '图标元素',
+    title: '标题元素',
+    description: '描述元素',
+    actions: '操作组元素',
+  },
+  en: {
+    root: 'Root element',
+    content: 'Content element',
+    icon: 'Icon element',
+    title: 'title element',
+    description: 'Description element',
+    actions: 'Actions element',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.0.0' },
+        { name: 'content', desc: locale.content, version: '6.0.0' },
+        { name: 'icon', desc: locale.icon, version: '6.0.0' },
+        { name: 'title', desc: locale.title, version: '6.0.0' },
+        { name: 'description', desc: locale.description, version: '6.0.0' },
+        { name: 'actions', desc: locale.actions, version: '6.0.0' },
+      ]}
+    >
+      <InternalPanel
+        title="Hello World!"
+        description="Hello World?"
+        type="success"
+        actions={
+          <Button type="primary" size="small">
+            My Button
+          </Button>
+        }
+      />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/notification/demo/basic.tsx
+++ b/components/notification/demo/basic.tsx
@@ -3,7 +3,7 @@ import { Button, notification } from 'antd';
 
 const openNotification = () => {
   notification.open({
-    message: 'Notification Title',
+    title: 'Notification Title',
     description:
       'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
     onClick: () => {

--- a/components/notification/demo/custom-icon.tsx
+++ b/components/notification/demo/custom-icon.tsx
@@ -7,7 +7,7 @@ const App: React.FC = () => {
 
   const openNotification = () => {
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
       icon: <SmileOutlined style={{ color: '#108ee9' }} />,

--- a/components/notification/demo/custom-style.tsx
+++ b/components/notification/demo/custom-style.tsx
@@ -6,7 +6,7 @@ const App: React.FC = () => {
 
   const openNotification = () => {
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
       className: 'custom-class',

--- a/components/notification/demo/duration.tsx
+++ b/components/notification/demo/duration.tsx
@@ -6,7 +6,7 @@ const App: React.FC = () => {
 
   const openNotification = () => {
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'I will never close automatically. This is a purposely very very long description that has many many characters and words.',
       duration: 0,

--- a/components/notification/demo/hooks.tsx
+++ b/components/notification/demo/hooks.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
 
   const openNotification = (placement: NotificationPlacement) => {
     api.info({
-      message: `Notification ${placement}`,
+      title: `Notification ${placement}`,
       description: <Context.Consumer>{({ name }) => `Hello, ${name}!`}</Context.Consumer>,
       placement,
     });

--- a/components/notification/demo/placement.tsx
+++ b/components/notification/demo/placement.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
 
   const openNotification = (placement: NotificationPlacement) => {
     api.info({
-      message: `Notification ${placement}`,
+      title: `Notification ${placement}`,
       description:
         'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
       placement,

--- a/components/notification/demo/render-panel.tsx
+++ b/components/notification/demo/render-panel.tsx
@@ -6,7 +6,7 @@ const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification;
 
 export default () => (
   <InternalPanel
-    message="Hello World!"
+    title="Hello World!"
     description="Hello World?"
     type="success"
     actions={

--- a/components/notification/demo/show-with-progress.tsx
+++ b/components/notification/demo/show-with-progress.tsx
@@ -6,7 +6,7 @@ const App: React.FC = () => {
 
   const openNotification = (pauseOnHover: boolean) => () => {
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
       showProgress: true,

--- a/components/notification/demo/stack.tsx
+++ b/components/notification/demo/stack.tsx
@@ -16,7 +16,7 @@ const App: React.FC = () => {
 
   const openNotification = () => {
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description: `${new Array(Math.round(Math.random() * 5) + 1)
         .fill('This is the content of the notification.')
         .join('\n')}`,

--- a/components/notification/demo/update.tsx
+++ b/components/notification/demo/update.tsx
@@ -8,14 +8,14 @@ const App: React.FC = () => {
   const openNotification = () => {
     api.open({
       key,
-      message: 'Notification Title',
+      title: 'Notification Title',
       description: 'description.',
     });
 
     setTimeout(() => {
       api.open({
         key,
-        message: 'New Title',
+        title: 'New Title',
         description: 'New description.',
       });
     }, 1000);

--- a/components/notification/demo/with-btn.tsx
+++ b/components/notification/demo/with-btn.tsx
@@ -23,7 +23,7 @@ const App: React.FC = () => {
       </Space>
     );
     api.open({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'A function will be be called after the notification is closed (automatically after the "duration" time of manually).',
       btn,

--- a/components/notification/demo/with-icon.tsx
+++ b/components/notification/demo/with-icon.tsx
@@ -8,7 +8,7 @@ const App: React.FC = () => {
 
   const openNotificationWithIcon = (type: NotificationType) => {
     api[type]({
-      message: 'Notification Title',
+      title: 'Notification Title',
       description:
         'This is the content of the notification. This is the content of the notification. This is the content of the notification.',
     });

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -59,7 +59,8 @@ The properties of config are as follows:
 | pauseOnHover | keep the timer running or not on hover | boolean | true | 5.18.0 |
 | icon | Customized icon | ReactNode | - | - |
 | key | The unique identifier of the Notification | string | - | - |
-| message | The title of notification box (required) | ReactNode | - | - |
+| title | The title of notification box (required) | ReactNode | - | 6.0.0 |
+| ~~message~~ | The title of notification box (required), please use `title` instead | ReactNode | - | - |
 | placement | Position of Notification, can be one of `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | string | `topRight` | - |
 | style | Customized inline style | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - | - |
 | role | The semantics of notification content recognized by screen readers. The default value is `alert`. When set as the default value, the screen reader will promptly interrupt any ongoing content reading and prioritize the notification content for immediate attention. | `alert \| status` | `alert` | 5.6.0 |
@@ -117,6 +118,10 @@ notification.config({
 | rtl | Whether to enable RTL mode | boolean | false |  |
 | top | Distance from the top of the viewport, when `placement` is `top` `topRight` or `topLeft` (unit: pixels) | number | 24 |  |
 | maxCount | Max Notification show, drop oldest if exceed limit | number | - | 4.17.0 |
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## Design Token
 

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -60,7 +60,8 @@ config 参数如下：
 | pauseOnHover | 悬停时是否暂停计时器 | boolean | true | 5.18.0 |
 | icon | 自定义图标 | ReactNode | - | - |
 | key | 当前通知唯一标志 | string | - | - |
-| message | 通知提醒标题，必选 | ReactNode | - | - |
+| title | 通知提醒标题，必选 | ReactNode | - | 6.0.0 |
+| ~~message~~ | 通知提醒标题，必选, 请使用 `title` 替换 | ReactNode | - | - |
 | placement | 弹出位置，可选 `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | string | `topRight` | - |
 | style | 自定义内联样式 | [CSSProperties](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e434515761b36830c3e58a970abf5186f005adac/types/react/index.d.ts#L794) | - | - |
 | role | 供屏幕阅读器识别的通知内容语义，默认为 `alert`。此情况下屏幕阅读器会立即打断当前正在阅读的其他内容，转而阅读通知内容 | `alert \| status` | `alert` | 5.6.0 |
@@ -118,6 +119,10 @@ notification.config({
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |  |
 | maxCount | 最大显示数，超过限制时，最早的消息会被自动关闭 | number | - | 4.17.0 |
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## 主题变量（Design Token）
 

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -18,7 +18,7 @@ export type NotificationPlacement = (typeof NotificationPlacements)[number];
 
 export type IconType = 'success' | 'info' | 'error' | 'warning';
 
-export type SemanticName = 'root' | 'content' | 'title' | 'description' | 'actions' | 'icon';
+export type SemanticName = 'root' | 'title' | 'description' | 'actions' | 'icon';
 export interface ArgsProps {
   /** @deprecated Please use `title` instead */
   message?: React.ReactNode;

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -18,8 +18,11 @@ export type NotificationPlacement = (typeof NotificationPlacements)[number];
 
 export type IconType = 'success' | 'info' | 'error' | 'warning';
 
+export type SemanticName = 'root' | 'content' | 'title' | 'description' | 'actions' | 'icon';
 export interface ArgsProps {
-  message: React.ReactNode;
+  /** @deprecated Please use `title` instead */
+  message?: React.ReactNode;
+  title: React.ReactNode;
   description?: React.ReactNode;
   /** @deprecated Please use `actions` instead */
   btn?: React.ReactNode;
@@ -33,6 +36,8 @@ export interface ArgsProps {
   placement?: NotificationPlacement;
   style?: React.CSSProperties;
   className?: string;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   readonly type?: IconType;
   onClick?: () => void;
   closeIcon?: React.ReactNode;

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -133,7 +133,7 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       wordWrap: 'break-word',
     },
 
-    [`${noticeCls}-message`]: {
+    [`${noticeCls}-title`]: {
       marginBottom: token.marginXS,
       color: colorTextHeading,
       fontSize: fontSizeLG,
@@ -145,11 +145,11 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       color: colorText,
     },
 
-    [`${noticeCls}-closable ${noticeCls}-message`]: {
+    [`${noticeCls}-closable ${noticeCls}-title`]: {
       paddingInlineEnd: token.paddingLG,
     },
 
-    [`${noticeCls}-with-icon ${noticeCls}-message`]: {
+    [`${noticeCls}-with-icon ${noticeCls}-title`]: {
       marginBottom: token.marginXS,
       marginInlineStart: token.calc(token.marginSM).add(notificationIconSize).equal(),
       fontSize: fontSizeLG,

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -122,12 +122,6 @@ export function useInternalNotification(
   notificationConfig?: HolderProps,
 ): readonly [NotificationInstance, React.ReactElement] {
   const holderRef = React.useRef<HolderRef>(null);
-  const {
-    className: contextClassName,
-    style: contextStyle,
-    classNames: contextClassNames,
-    styles: contextStyles,
-  } = useComponentConfig('notification');
   const warning = devUseWarning('Notification');
 
   // ================================ API ================================
@@ -146,6 +140,10 @@ export function useInternalNotification(
       }
 
       const { open: originOpen, prefixCls, notification } = holderRef.current;
+      const contextClassName = notification?.className || {};
+      const contextStyle = notification?.style || {};
+      const contextClassNames = notification?.classNames || {};
+      const contextStyles = notification?.styles || {};
 
       const noticePrefixCls = `${prefixCls}-notice`;
       const {

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -6,6 +6,7 @@ import type { NotificationAPI, NotificationConfig as RcNotificationConfig } from
 
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import type { NotificationConfig as CPNotificationConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { useToken } from '../theme/internal';
@@ -17,7 +18,7 @@ import type {
 } from './interface';
 import { getCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
-import { getMotion, getPlacementStyle, getCloseIconConfig } from './util';
+import { getCloseIconConfig, getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -68,7 +69,8 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     pauseOnHover = true,
     showProgress,
   } = props;
-  const { getPrefixCls, getPopupContainer, notification, direction } = useContext(ConfigContext);
+  const { getPrefixCls, getPopupContainer, direction } = useComponentConfig('notification');
+  const { notification } = useContext(ConfigContext);
   const [, token] = useToken();
 
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
@@ -120,7 +122,12 @@ export function useInternalNotification(
   notificationConfig?: HolderProps,
 ): readonly [NotificationInstance, React.ReactElement] {
   const holderRef = React.useRef<HolderRef>(null);
-
+  const {
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('notification');
   const warning = devUseWarning('Notification');
 
   // ================================ API ================================
@@ -141,8 +148,8 @@ export function useInternalNotification(
       const { open: originOpen, prefixCls, notification } = holderRef.current;
 
       const noticePrefixCls = `${prefixCls}-notice`;
-
       const {
+        title,
         message,
         description,
         icon,
@@ -154,11 +161,19 @@ export function useInternalNotification(
         role = 'alert',
         closeIcon,
         closable,
+        classNames: configClassNames,
+        styles,
         ...restConfig
       } = config;
       if (process.env.NODE_ENV !== 'production') {
-        warning.deprecated(!btn, 'btn', 'actions');
+        [
+          ['btn', 'actions'],
+          ['message', 'title'],
+        ].forEach(([deprecatedName, newName]) => {
+          warning.deprecated(!(deprecatedName in config), deprecatedName, newName);
+        });
       }
+      const mergedTitle = title ?? message;
       const mergedActions = actions ?? btn;
 
       const realCloseIcon = getCloseIcon(
@@ -175,18 +190,32 @@ export function useInternalNotification(
             prefixCls={noticePrefixCls}
             icon={icon}
             type={type}
-            message={message}
+            title={mergedTitle}
             description={description}
             actions={mergedActions}
             role={role}
+            classNames={{
+              icon: classNames(contextClassNames.icon, configClassNames?.icon),
+              title: classNames(contextClassNames.title, configClassNames?.title),
+              description: classNames(contextClassNames.description, configClassNames?.description),
+              actions: classNames(contextClassNames.actions, configClassNames?.actions),
+            }}
+            styles={{
+              icon: { ...contextStyles.icon, ...styles?.icon },
+              title: { ...contextStyles.title, ...styles?.title },
+              description: { ...contextStyles.description, ...styles?.description },
+              actions: { ...contextStyles.actions, ...styles?.actions },
+            }}
           />
         ),
         className: classNames(
           type && `${noticePrefixCls}-${type}`,
           className,
-          notification?.className,
+          contextClassName,
+          configClassNames?.root,
+          contextClassNames.root,
         ),
-        style: { ...notification?.style, ...style },
+        style: { ...contextStyle, ...style, ...contextStyles.root, ...styles?.root },
         closeIcon: realCloseIcon,
         closable: closable ?? !!realCloseIcon,
       });


### PR DESCRIPTION


### 🤔 This is a ...

- [x] 🆕 New feature



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     feat: ConfigProvider support classnames and styles for notification      |
| 🇨🇳 Chinese |      feat: ConfigProvider support classnames and styles for notification     |
