### PR TITLE
feat:For Switch  add two apis checkedValue and uncheckedValue

### DIFF
--- a/components/switch/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/switch/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -25,6 +25,132 @@ exports[`renders components/switch/demo/basic.tsx extend context correctly 1`] =
 
 exports[`renders components/switch/demo/basic.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/switch/demo/custom-value.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: true
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 1
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: hello
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/switch/demo/custom-value.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/switch/demo/disabled.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"

--- a/components/switch/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.ts.snap
@@ -23,6 +23,136 @@ exports[`renders components/switch/demo/basic.tsx correctly 1`] = `
 </button>
 `;
 
+exports[`renders components/switch/demo/custom-value.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 
+          <!-- -->
+          true
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 
+          <!-- -->
+          1
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <button
+          aria-checked="true"
+          class="ant-switch ant-switch-checked"
+          role="switch"
+          type="button"
+        >
+          <div
+            class="ant-switch-handle"
+          />
+          <span
+            class="ant-switch-inner"
+          >
+            <span
+              class="ant-switch-inner-checked"
+            />
+            <span
+              class="ant-switch-inner-unchecked"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <span>
+          value: 
+          <!-- -->
+          hello
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/switch/demo/disabled.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small"

--- a/components/switch/__tests__/index.test.tsx
+++ b/components/switch/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Switch from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -87,5 +87,64 @@ describe('Switch', () => {
 
     rerender(<Switch unCheckedChildren="0" />);
     expect(container.querySelector('.ant-switch-inner-unchecked')).toHaveStyle('min-height: 22px');
+  });
+
+  it('should be uncontrolled by defaultValue when use custom value', () => {
+    const mockChangeHandler = jest.fn();
+    const checkedValue = 1;
+    const uncheckedValue = 0;
+
+    const { getByRole } = render(
+      <Switch
+        defaultValue={checkedValue}
+        checkedValue={checkedValue}
+        uncheckedValue={uncheckedValue}
+        onChange={mockChangeHandler}
+      />,
+    );
+
+    const switchNode = getByRole('switch');
+    expect(switchNode).toBeTruthy();
+    expect(getByRole('switch')).toBeChecked();
+
+    fireEvent.click(switchNode);
+
+    expect(mockChangeHandler).toHaveBeenCalledWith(uncheckedValue, expect.anything());
+    // uncontrolled component, so false after click
+    expect(getByRole('switch')).not.toBeChecked();
+
+    fireEvent.click(switchNode);
+
+    expect(mockChangeHandler).toHaveBeenCalledWith(checkedValue, expect.anything());
+    // uncontrolled component, so false after click
+    expect(getByRole('switch')).toBeChecked();
+  });
+
+  it('should be controlled by value when use custom value', () => {
+    const checkedValue = 1;
+    const uncheckedValue = 0;
+    const App: React.FC = () => {
+      const [value, setValue] = useState(checkedValue);
+
+      return (
+        <Switch
+          value={value}
+          checkedValue={checkedValue}
+          uncheckedValue={uncheckedValue}
+          onChange={(v) => {
+            setValue(v);
+          }}
+        />
+      );
+    };
+
+    const { getByRole, unmount } = render(<App />);
+    const switchNode = getByRole('switch');
+    expect(switchNode).toBeTruthy();
+    expect(getByRole('switch')).toBeChecked();
+
+    fireEvent.click(switchNode);
+    expect(switchNode).not.toBeChecked();
+    unmount();
   });
 });

--- a/components/switch/demo/custom-value.md
+++ b/components/switch/demo/custom-value.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义选中和未选中状态的值
+
+## en-US
+
+Customize the values ​​for checked and unchecked states

--- a/components/switch/demo/custom-value.tsx
+++ b/components/switch/demo/custom-value.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Space, Switch } from 'antd';
+
+const App: React.FC = () => {
+  const [value1, setValue1] = useState(true);
+  const [value2, setValue2] = useState(1);
+  const [value3, setValue3] = useState('hello');
+
+  const onChange1 = (value: boolean) => {
+    setValue1(value);
+  };
+
+  const onChange2 = (value: number) => {
+    setValue2(value);
+  };
+
+  const onChange3 = (value: string) => {
+    setValue3(value);
+  };
+
+  return (
+    <Space direction="vertical">
+      <Space>
+        <Switch value={value1} onChange={onChange1} />
+        <span>value: {value1.toString()}</span>
+      </Space>
+      <Space>
+        <Switch value={value2} checkedValue={1} uncheckedValue={0} onChange={onChange2} />
+        <span>value: {value2}</span>
+      </Space>
+      <Space>
+        <Switch value={value3} checkedValue="hello" uncheckedValue="word" onChange={onChange3} />
+        <span>value: {value3}</span>
+      </Space>
+    </Space>
+  );
+};
+
+export default App;

--- a/components/switch/index.en-US.md
+++ b/components/switch/index.en-US.md
@@ -22,6 +22,7 @@ demo:
 <code src="./demo/text.tsx">Text & icon</code>
 <code src="./demo/size.tsx">Two sizes</code>
 <code src="./demo/loading.tsx">Loading</code>
+<code src="./demo/custom-value.tsx">Custom value</code>
 <code src="./demo/component-token.tsx" debug>Custom component token</code>
 
 ## API

--- a/components/switch/index.zh-CN.md
+++ b/components/switch/index.zh-CN.md
@@ -22,7 +22,7 @@ demo:
 <code src="./demo/disabled.tsx">不可用</code>
 <code src="./demo/text.tsx">文字和图标</code>
 <code src="./demo/size.tsx">两种大小</code>
-<code src="./demo/loading.tsx">加载中</code>
+<code src="./demo/custom-value.tsx">自定义 value</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 Token</code>
 
 ## API
@@ -36,7 +36,9 @@ demo:
 | checkedChildren | 选中时的内容 | ReactNode | - |  |
 | className | Switch 器类名 | string | - |  |
 | defaultChecked | 初始是否选中 | boolean | false |  |
-| defaultValue | `defaultChecked` 的别名 | boolean | - | 5.12.0 |
+| defaultValue | 默认值 | boolean / string / number | - | 5.12.0 |
+| checkedValue | 选中时的值 | boolean / string / number | - | - |
+| uncheckedValue | 未选中时的值 | boolean / string / number | - | - |
 | disabled | 是否禁用 | boolean | false |  |
 | loading | 加载中的开关 | boolean | false |  |
 | size | 开关大小，可选值：`default` `small` | string | `default` |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
    Currently, the Switch only supports the boolean type. In fact, there are times when other types such as numbers (e.g., 0 and 1) and strings are used to represent the checked and unchecked states. Therefore, the function of adding custom values is required.
> - List the final API implementation and usage if needed.
    Add two attributes, checkedValue and uncheckedValue, which represent the values for the checked and unchecked states respectively.
  > - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog                                                                                                                             |
| ---------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| 🇺🇸 English | For the Switch, custom values can be added. You can set the checked value and unchecked value through `checkedValue` and `uncheckedValue` |
| 🇨🇳 Chinese | Switch 增加自定义值，可以通过 `checkedValue` 和 `uncheckedValue` 设置选中值和未选中值 |