### PR TITLE
feat(Message): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -23,8 +23,9 @@ import type { ListItemProps } from '../list';
 import type { Locale } from '../locale';
 import type { MentionsProps } from '../mentions';
 import type { MenuProps } from '../menu';
+import type { ArgsProps as MessageProps } from '../message';
 import type { ModalProps } from '../modal';
-import type { ArgsProps } from '../notification/interface';
+import type { ArgsProps as NotificationProps } from '../notification';
 import type { PaginationProps } from '../pagination';
 import type { PopconfirmProps } from '../popconfirm';
 import type { PopoverProps } from '../popover';
@@ -175,8 +176,10 @@ export type TextAreaConfig = ComponentStyleConfig &
 export type ButtonConfig = ComponentStyleConfig &
   Pick<ButtonProps, 'classNames' | 'styles' | 'autoInsertSpace'>;
 
+export type MessageConfig = ComponentStyleConfig & Pick<MessageProps, 'classNames' | 'styles'>;
+
 export type NotificationConfig = ComponentStyleConfig &
-  Pick<ArgsProps, 'closeIcon' | 'classNames' | 'styles'>;
+  Pick<NotificationProps, 'closeIcon' | 'classNames' | 'styles'>;
 
 export type TagConfig = ComponentStyleConfig &
   Pick<TagProps, 'closeIcon' | 'closable' | 'classNames' | 'styles'>;
@@ -319,7 +322,7 @@ export interface ConfigComponentProps {
   switch?: ComponentStyleConfig;
   transfer?: TransferConfig;
   avatar?: ComponentStyleConfig;
-  message?: ComponentStyleConfig;
+  message?: MessageConfig;
   tag?: TagConfig;
   table?: TableConfig;
   card?: CardConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -140,7 +140,7 @@ const {
 | list | Set List common props | { className?: string, style?: React.CSSProperties, item?:{ classNames: [ListItemProps\["classNames"\]](/components/list#listitem), styles: [ListItemProps\["styles"\]](/components/list#listitem) } } | - | 5.7.0 |
 | menu | Set Menu common props | { className?: string, style?: React.CSSProperties, expandIcon?: ReactNode \| props => ReactNode } | - | 5.7.0, expandIcon: 5.15.0 |
 | mentions | Set Mentions common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| message | Set Message common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| message | Set Message common props | { className?: string, style?: React.CSSProperties, classNames?: [MessageConfig\["classNames"\]](/components/message#api), styles?: [MessageConfig\["styles"\]](/components/message#api) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | modal | Set Modal common props | { className?: string, style?: React.CSSProperties, classNames?: [ModalProps\["classNames"\]](/components/modal#api), styles?: [ModalProps\["styles"\]](/components/modal#api), closeIcon?: React.ReactNode } | - | 5.7.0, `classNames` and `styles`: 5.10.0, `closeIcon`: 5.14.0 |
 | notification | Set Notification common props | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, classNames?: [NotificationConfig\["classNames"\]](/components/notification#api), styles?: [NotificationConfig\["styles"\]](/components/notification#api) } | - | 5.7.0, `closeIcon`: 5.14.0, `classNames` and `styles`: 6.0.0 |
 | pagination | Set Pagination common props | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |
@@ -157,7 +157,7 @@ const {
 | space | Set Space common props, ref [Space](/components/space) | { size: `small` \| `middle` \| `large` \| `number`, className?: string, style?: React.CSSProperties, classNames?: [SpaceProps\["classNames"\]](/components/space#api), styles?: [SpaceProps\["styles"\]](/components/space#api) } | - | 5.6.0 |
 | splitter | Set Splitter common props | { className?: string, style?: React.CSSProperties } | - | 5.21.0 |
 | spin | Set Spin common props | { className?: string, style?: React.CSSProperties, indicator?: React.ReactElement } | - | 5.7.0, indicator: 5.20.0 |
-| statistic | Set Statistic common props | { className?: string, style?: React.CSSProperties, classNames?: [StatisticProps\["classNames"\]](/components/statistic#semantic-dom), styles?: [StatisticProps\["styles"\]](/components/statistic#semantic-dom) | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
+| statistic | Set Statistic common props | { className?: string, style?: React.CSSProperties, classNames?: [StatisticProps\["classNames"\]](/components/statistic#semantic-dom), styles?: [StatisticProps\["styles"\]](/components/statistic#semantic-dom)} | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | steps | Set Steps common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | table | Set Table common props | { className?: string, style?: React.CSSProperties, expandable?: { expandIcon?: props => React.ReactNode } } | - | 5.7.0, expandable: 5.14.0 |
 | tabs | Set Tabs common props | { className?: string, style?: React.CSSProperties, indicator?: { size?: GetIndicatorSize, align?: `start` \| `center` \| `end` }, moreIcon?: ReactNode, addIcon?: ReactNode, removeIcon?: ReactNode } | - | 5.7.0, `moreIcon` and `addIcon`: 5.14.0, `removeIcon`: 5.15.0 |

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -39,6 +39,7 @@ import type {
   ListConfig,
   MentionsConfig,
   MenuConfig,
+  MessageConfig,
   ModalConfig,
   NotificationConfig,
   PaginationConfig,
@@ -226,7 +227,7 @@ export interface ConfigProviderProps {
   switch?: ComponentStyleConfig;
   transfer?: TransferConfig;
   avatar?: ComponentStyleConfig;
-  message?: ComponentStyleConfig;
+  message?: MessageConfig;
   tag?: TagConfig;
   table?: TableConfig;
   card?: CardConfig;

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -142,7 +142,7 @@ const {
 | list | 设置 List 组件的通用属性 | { className?: string, style?: React.CSSProperties, item?:{ classNames: [ListItemProps\["classNames"\]](/components/list-cn#listitem), styles: [ListItemProps\["styles"\]](/components/list-cn#listitem) } } | - | 5.7.0 |
 | menu | 设置 Menu 组件的通用属性 | { className?: string, style?: React.CSSProperties, expandIcon?: ReactNode \| props => ReactNode } | - | 5.7.0, expandIcon: 5.15.0 |
 | mentions | 设置 Mentions 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
-| message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| message | 设置 Message 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [MessageConfig\["classNames"\]](/components/message-cn#api), styles?: [MessageConfig\["styles"\]](/components/message-cn#api) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | modal | 设置 Modal 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [ModalProps\["classNames"\]](/components/modal-cn#api), styles?: [ModalProps\["styles"\]](/components/modal-cn#api), closeIcon?: React.ReactNode } | - | 5.7.0, `classNames` 和 `styles`: 5.10.0, `closeIcon`: 5.14.0 |
 | notification | 设置 Notification 组件的通用属性 | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, classNames?: [NotificationConfig\["classNames"\]](/components/notification-cn#api), styles?: [NotificationConfig\["styles"\]](/components/notification-cn#api) } | - | 5.7.0, `closeIcon`: 5.14.0, `classNames` 和 `styles`: 6.0.0 |
 | pagination | 设置 Pagination 组件的通用属性 | { showSizeChanger?: boolean, className?: string, style?: React.CSSProperties } | - | 5.7.0 |

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -8,9 +8,10 @@ import classNames from 'classnames';
 import { Notice } from 'rc-notification';
 import type { NoticeProps } from 'rc-notification/lib/Notice';
 
-import { ConfigContext } from '../config-provider';
+import { cloneElement } from '../_util/reactNode';
+import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
-import type { NoticeType } from './interface';
+import type { NoticeType, SemanticName } from './interface';
 import useStyle from './style';
 
 export const TypeIcon = {
@@ -26,25 +27,66 @@ export interface PureContentProps {
   type?: NoticeType;
   icon?: React.ReactNode;
   children: React.ReactNode;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
-export const PureContent: React.FC<PureContentProps> = ({ prefixCls, type, icon, children }) => (
-  <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
-    {icon || TypeIcon[type!]}
-    <span>{children}</span>
-  </div>
-);
+export const PureContent: React.FC<PureContentProps> = ({
+  prefixCls,
+  type,
+  icon,
+  children,
+  classNames: PureContentClassNames,
+  styles,
+}) => {
+  const iconElement = icon || (type && TypeIcon[type]);
+  const iconNode: React.ReactNode = cloneElement(iconElement, {
+    className: classNames(
+      React.isValidElement(iconElement)
+        ? (iconElement as React.ReactElement<{ className?: string }>).props?.className
+        : '',
+      PureContentClassNames?.icon,
+    ),
+    style: { ...styles?.icon },
+  });
+  return (
+    <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
+      {iconNode}
+      <span className={PureContentClassNames?.content} style={styles?.content}>
+        {children}
+      </span>
+    </div>
+  );
+};
 
 export interface PurePanelProps
-  extends Omit<NoticeProps, 'prefixCls' | 'eventKey'>,
+  extends Omit<NoticeProps, 'prefixCls' | 'eventKey' | 'classNames' | 'styles'>,
     Omit<PureContentProps, 'prefixCls' | 'children'> {
   prefixCls?: string;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 /** @private Internal Component. Do not use in your production. */
 const PurePanel: React.FC<PurePanelProps> = (props) => {
-  const { prefixCls: staticPrefixCls, className, type, icon, content, ...restProps } = props;
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const {
+    prefixCls: staticPrefixCls,
+    className,
+    style,
+    type,
+    icon,
+    content,
+    classNames: messageClassNames,
+    styles,
+    ...restProps
+  } = props;
+  const {
+    getPrefixCls,
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('message');
 
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
@@ -56,16 +98,32 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
       {...restProps}
       prefixCls={prefixCls}
       className={classNames(
+        contextClassName,
+        contextClassNames.root,
+        messageClassNames?.root,
         className,
         hashId,
         `${prefixCls}-notice-pure-panel`,
         cssVarCls,
         rootCls,
       )}
+      style={{ ...contextStyles.root, ...styles?.root, ...contextStyle, ...style }}
       eventKey="pure"
       duration={null}
       content={
-        <PureContent prefixCls={prefixCls} type={type} icon={icon}>
+        <PureContent
+          prefixCls={prefixCls}
+          type={type}
+          icon={icon}
+          classNames={{
+            icon: classNames(messageClassNames?.icon, contextClassNames.icon),
+            content: classNames(messageClassNames?.content, contextClassNames.content),
+          }}
+          styles={{
+            icon: { ...contextStyles.icon, ...styles?.icon },
+            content: { ...contextStyles.content, ...styles?.content },
+          }}
+        >
           {content}
         </PureContent>
       }

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -40,15 +40,10 @@ export const PureContent: React.FC<PureContentProps> = ({
   styles,
 }) => {
   const iconElement = icon || (type && TypeIcon[type]);
-  const iconNode: React.ReactNode = cloneElement(iconElement, {
-    className: classNames(
-      React.isValidElement(iconElement)
-        ? (iconElement as React.ReactElement<{ className?: string }>).props?.className
-        : '',
-      PureContentClassNames?.icon,
-    ),
-    style: { ...styles?.icon },
-  });
+  const iconNode: React.ReactNode = cloneElement(iconElement, (currentProps) => ({
+    className: classNames(currentProps?.className, PureContentClassNames?.icon),
+    style: { ...currentProps?.style, ...styles?.icon },
+  }));
   return (
     <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
       {iconNode}

--- a/components/message/PurePanel.tsx
+++ b/components/message/PurePanel.tsx
@@ -36,18 +36,18 @@ export const PureContent: React.FC<PureContentProps> = ({
   type,
   icon,
   children,
-  classNames: PureContentClassNames,
+  classNames: pureContentClassNames,
   styles,
 }) => {
   const iconElement = icon || (type && TypeIcon[type]);
   const iconNode: React.ReactNode = cloneElement(iconElement, (currentProps) => ({
-    className: classNames(currentProps?.className, PureContentClassNames?.icon),
-    style: { ...currentProps?.style, ...styles?.icon },
+    className: classNames(currentProps.className, pureContentClassNames?.icon),
+    style: { ...currentProps.style, ...styles?.icon },
   }));
   return (
     <div className={classNames(`${prefixCls}-custom-content`, `${prefixCls}-${type}`)}>
       {iconNode}
-      <span className={PureContentClassNames?.content} style={styles?.content}>
+      <span className={pureContentClassNames?.content} style={styles?.content}>
         {children}
       </span>
     </div>

--- a/components/message/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/message/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -31,7 +31,9 @@ Array [
             />
           </svg>
         </span>
-        <span>
+        <span
+          class=""
+        >
           Hello World!
         </span>
       </div>
@@ -66,7 +68,9 @@ Array [
             />
           </svg>
         </span>
-        <span>
+        <span
+          class=""
+        >
           Hello World!
         </span>
       </div>
@@ -217,7 +221,9 @@ exports[`renders components/message/demo/render-panel.tsx extend context correct
           />
         </svg>
       </span>
-      <span>
+      <span
+        class=""
+      >
         Hello World!
       </span>
     </div>

--- a/components/message/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/message/__tests__/__snapshots__/demo.test.ts.snap
@@ -31,7 +31,9 @@ Array [
             />
           </svg>
         </span>
-        <span>
+        <span
+          class=""
+        >
           Hello World!
         </span>
       </div>
@@ -66,7 +68,9 @@ Array [
             />
           </svg>
         </span>
-        <span>
+        <span
+          class=""
+        >
           Hello World!
         </span>
       </div>
@@ -203,7 +207,9 @@ exports[`renders components/message/demo/render-panel.tsx correctly 1`] = `
           />
         </svg>
       </span>
-      <span>
+      <span
+        class=""
+      >
         Hello World!
       </span>
     </div>

--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -298,4 +298,40 @@ describe('message.hooks', () => {
       fontSize: '20px',
     });
   });
+  it('classNames and styles should work', () => {
+    const Demo = () => {
+      const [api, holder] = message.useMessage();
+
+      useEffect(() => {
+        api.info({
+          content: <div />,
+          classNames: {
+            root: 'custom-root',
+            icon: 'custom-icon',
+            content: 'custom-content',
+          },
+          styles: {
+            root: { color: 'red' },
+            icon: { fontSize: 20 },
+            content: { backgroundColor: 'green' },
+          },
+        });
+      }, []);
+
+      return <div>{holder}</div>;
+    };
+
+    render(<Demo />);
+
+    const root = document.querySelector('.custom-root');
+    const icon = document.querySelector('.custom-icon');
+    const content = document.querySelector('.custom-content');
+
+    expect(root).toBeTruthy();
+    expect(icon).toBeTruthy();
+    expect(content).toBeTruthy();
+    expect(root).toHaveStyle({ color: 'red' });
+    expect(icon).toHaveStyle({ fontSize: '20px' });
+    expect(content).toHaveStyle({ backgroundColor: 'green' });
+  });
 });

--- a/components/message/demo/_semantic.tsx
+++ b/components/message/demo/_semantic.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { message } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = message;
+
+const locales = {
+  cn: {
+    root: '根元素',
+    icon: '图标元素',
+    content: '内容元素',
+  },
+  en: {
+    root: 'Root element',
+    icon: 'Icon element',
+    content: 'Content element',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.0.0' },
+        { name: 'icon', desc: locale.icon, version: '6.0.0' },
+        { name: 'content', desc: locale.content, version: '6.0.0' },
+      ]}
+    >
+      <InternalPanel type="success" content="Hello, Ant Design!" />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -110,6 +110,10 @@ message.config({
 | rtl | Whether to enable RTL mode | boolean | false |  |
 | top | Distance from top | string \| number | 8 |  |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="Message"></ComponentTokenTable>

--- a/components/message/index.zh-CN.md
+++ b/components/message/index.zh-CN.md
@@ -111,6 +111,10 @@ message.config({
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
 | top | 消息距离顶部的位置 | string \| number | 8 |  |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Message"></ComponentTokenTable>

--- a/components/message/interface.ts
+++ b/components/message/interface.ts
@@ -11,6 +11,7 @@ export interface ConfigOptions {
   maxCount?: number;
   rtl?: boolean;
 }
+export type SemanticName = 'root' | 'icon' | 'content';
 
 export interface ArgsProps {
   /**
@@ -37,6 +38,8 @@ export interface ArgsProps {
   key?: string | number;
   style?: React.CSSProperties;
   className?: string;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   /**
    * @descCN 消息通知点击时的回调函数
    * @descEN Callback function when message notification is clicked

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -154,7 +154,7 @@ export function useInternalMessage(
       }
 
       const { open: originOpen, prefixCls, message } = holderRef.current;
-      const contextClassName = message?.classNames || {};
+      const contextClassName = message?.className || {};
       const contextClassNames = message?.classNames || {};
       const contextStyle = message?.style || {};
       const contextStyles = message?.styles || {};

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import type { FC, PropsWithChildren } from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import classNames from 'classnames';
 import { NotificationProvider, useNotification as useRcNotification } from 'rc-notification';
@@ -7,7 +6,8 @@ import type { NotificationAPI, NotificationConfig as RcNotificationConfig } from
 
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
-import type { ComponentStyleConfig } from '../config-provider/context';
+import { useComponentConfig } from '../config-provider/context';
+import type { MessageConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type {
   ArgsProps,
@@ -33,10 +33,13 @@ type HolderProps = ConfigOptions & {
 
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
-  message?: ComponentStyleConfig;
+  message?: MessageConfig;
 }
 
-const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
+const Wrapper: React.FC<React.PropsWithChildren<{ prefixCls: string }>> = ({
+  children,
+  prefixCls,
+}) => {
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   return wrapCSSVar(
@@ -66,7 +69,8 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     transitionName,
     onAllRemoved,
   } = props;
-  const { getPrefixCls, getPopupContainer, message, direction } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction, getPopupContainer } = useComponentConfig('message');
+  const { message } = React.useContext(ConfigContext);
 
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
@@ -150,22 +154,49 @@ export function useInternalMessage(
       }
 
       const { open: originOpen, prefixCls, message } = holderRef.current;
+      const contextClassName = message?.classNames || {};
+      const contextClassNames = message?.classNames || {};
+      const contextStyle = message?.style || {};
+      const contextStyles = message?.styles || {};
+
       const noticePrefixCls = `${prefixCls}-notice`;
 
-      const { content, icon, type, key, className, style, onClose, ...restConfig } = config;
+      const {
+        content,
+        icon,
+        type,
+        key,
+        className,
+        style,
+        onClose,
+        classNames: configClassNames,
+        styles,
+        ...restConfig
+      } = config;
 
       let mergedKey: React.Key = key!;
       if (mergedKey === undefined || mergedKey === null) {
         keyIndex += 1;
         mergedKey = `antd-message-${keyIndex}`;
       }
-
       return wrapPromiseFn((resolve) => {
         originOpen({
           ...restConfig,
           key: mergedKey,
           content: (
-            <PureContent prefixCls={prefixCls} type={type} icon={icon}>
+            <PureContent
+              prefixCls={prefixCls}
+              type={type}
+              icon={icon}
+              classNames={{
+                icon: classNames(configClassNames?.icon, contextClassNames.icon),
+                content: classNames(configClassNames?.content, contextClassNames.content),
+              }}
+              styles={{
+                icon: { ...contextStyles.icon, ...styles?.icon },
+                content: { ...contextStyles.content, ...styles?.content },
+              }}
+            >
               {content}
             </PureContent>
           ),
@@ -173,9 +204,11 @@ export function useInternalMessage(
           className: classNames(
             type && `${noticePrefixCls}-${type}`,
             className,
-            message?.className,
+            contextClassName,
+            contextClassNames.root,
+            configClassNames?.root,
           ),
-          style: { ...message?.style, ...style },
+          style: { ...contextStyles.root, ...styles?.root, ...contextStyle, ...style },
           onClose: () => {
             onClose?.();
             resolve();


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🆕 New feature

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        feat: ConfigProvider support classnames and styles for message   |
| 🇨🇳 Chinese |        feat: ConfigProvider support classnames and styles for message   |
