### PR TITLE
fix: Button missing primary style

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -37,7 +37,7 @@ exports[`renders components/button/demo/basic.tsx extend context correctly 1`] =
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+    class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
     type="button"
   >
     <span>
@@ -96,7 +96,7 @@ exports[`renders components/button/demo/block.tsx extend context correctly 1`] =
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-block"
+    class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-block"
     type="button"
   >
     <span>
@@ -776,7 +776,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -784,7 +784,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -828,7 +828,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link acss-1r0846s"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link acss-1r0846s"
       type="button"
     >
       <span>
@@ -872,7 +872,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1825,7 +1825,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1833,7 +1833,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       disabled=""
       type="button"
     >
@@ -3802,7 +3802,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-lg"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-lg"
       type="button"
     >
       <span>

--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -37,7 +37,7 @@ exports[`renders components/button/demo/basic.tsx extend context correctly 1`] =
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
     type="button"
   >
     <span>
@@ -96,7 +96,7 @@ exports[`renders components/button/demo/block.tsx extend context correctly 1`] =
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-block"
+    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-block"
     type="button"
   >
     <span>
@@ -776,7 +776,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -784,7 +784,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -828,7 +828,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link acss-1r0846s"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link acss-1r0846s"
       type="button"
     >
       <span>
@@ -872,7 +872,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1825,7 +1825,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1833,7 +1833,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       disabled=""
       type="button"
     >
@@ -3802,7 +3802,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-lg"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-lg"
       type="button"
     >
       <span>

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -37,7 +37,7 @@ exports[`renders components/button/demo/basic.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
     type="button"
   >
     <span>
@@ -94,7 +94,7 @@ exports[`renders components/button/demo/block.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-block"
+    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-block"
     type="button"
   >
     <span>
@@ -762,7 +762,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -770,7 +770,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -814,7 +814,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link acss-1r0846s"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link acss-1r0846s"
       type="button"
     >
       <span>
@@ -858,7 +858,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1727,7 +1727,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1735,7 +1735,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       disabled=""
       type="button"
     >
@@ -3295,7 +3295,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-lg"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-lg"
       type="button"
     >
       <span>

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -37,7 +37,7 @@ exports[`renders components/button/demo/basic.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+    class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
     type="button"
   >
     <span>
@@ -94,7 +94,7 @@ exports[`renders components/button/demo/block.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-block"
+    class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-block"
     type="button"
   >
     <span>
@@ -762,7 +762,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -770,7 +770,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -814,7 +814,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link acss-1r0846s"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link acss-1r0846s"
       type="button"
     >
       <span>
@@ -858,7 +858,7 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1727,7 +1727,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
     class="ant-flex ant-flex-gap-small"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>
@@ -1735,7 +1735,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       disabled=""
       type="button"
     >
@@ -3295,7 +3295,7 @@ Array [
       </button>
     </div>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-lg"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-lg"
       type="button"
     >
       <span>

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -88,7 +88,7 @@ const ButtonTypeMap: Partial<Record<ButtonType, ColorVariantPairType>> = {
   default: ['default', 'outlined'],
   primary: ['primary', 'solid'],
   dashed: ['default', 'dashed'],
-  link: ['primary', 'link'],
+  link: ['info', 'link'],
   text: ['default', 'text'],
 };
 
@@ -243,12 +243,12 @@ const InternalCompoundedButton = React.forwardRef<
         e.preventDefault();
         return;
       }
-     
-    props.onClick?.(
-      'href' in props
-        ? (e as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
-        : (e as React.MouseEvent<HTMLButtonElement, MouseEvent>)
-    );
+
+      props.onClick?.(
+        'href' in props
+          ? (e as React.MouseEvent<HTMLAnchorElement, MouseEvent>)
+          : (e as React.MouseEvent<HTMLButtonElement, MouseEvent>),
+      );
     },
     [props.onClick, innerLoading, mergedDisabled],
   );

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -88,7 +88,8 @@ const ButtonTypeMap: Partial<Record<ButtonType, ColorVariantPairType>> = {
   default: ['default', 'outlined'],
   primary: ['primary', 'solid'],
   dashed: ['default', 'dashed'],
-  link: ['info', 'link'],
+  // `link` is not a real color but we should compatible with it
+  link: ['link' as any, 'link'],
   text: ['default', 'text'],
 };
 

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -107,6 +107,6 @@ export const _ButtonVariantTypes = [
 ] as const;
 export type ButtonVariantType = (typeof _ButtonVariantTypes)[number];
 
-export const _ButtonColorTypes = ['default', 'primary', 'danger', ...PresetColors] as const;
+export const _ButtonColorTypes = ['default', 'primary', 'danger', 'info', ...PresetColors] as const;
 
 export type ButtonColorType = (typeof _ButtonColorTypes)[number];

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -107,6 +107,6 @@ export const _ButtonVariantTypes = [
 ] as const;
 export type ButtonVariantType = (typeof _ButtonVariantTypes)[number];
 
-export const _ButtonColorTypes = ['default', 'primary', 'danger', 'info', ...PresetColors] as const;
+export const _ButtonColorTypes = ['default', 'primary', 'danger', ...PresetColors] as const;
 
 export type ButtonColorType = (typeof _ButtonColorTypes)[number];

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -85,6 +85,27 @@ const App: React.FC = () => (
         </Button>
       </Flex>
     </ConfigProvider>
+
+    <Flex gap="small" wrap>
+      <Button color="info" variant="solid">
+        Solid
+      </Button>
+      <Button color="info" variant="outlined">
+        Outlined
+      </Button>
+      <Button color="info" variant="dashed">
+        Dashed
+      </Button>
+      <Button color="info" variant="filled">
+        Filled
+      </Button>
+      <Button color="info" variant="text">
+        Text
+      </Button>
+      <Button color="info" variant="link">
+        Link
+      </Button>
+    </Flex>
   </Flex>
 );
 

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -77,27 +77,6 @@ const App: React.FC = () => (
         </Button>
       </Flex>
     </ConfigProvider>
-
-    <Flex gap="small" wrap>
-      <Button color="info" variant="solid">
-        Solid
-      </Button>
-      <Button color="info" variant="outlined">
-        Outlined
-      </Button>
-      <Button color="info" variant="dashed">
-        Dashed
-      </Button>
-      <Button color="info" variant="filled">
-        Filled
-      </Button>
-      <Button color="info" variant="text">
-        Text
-      </Button>
-      <Button color="info" variant="link">
-        Link
-      </Button>
-    </Flex>
   </Flex>
 );
 

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => (
           theme={{
             components: {
               Button: {
-                colorBorderDisabled: 'rgba(0, 0, 0, 0.12)',
+                borderColorDisabled: 'rgba(0, 0, 0, 0.12)',
                 colorBgContainerDisabled: 'transparent',
               },
             },

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -59,14 +59,6 @@ const App: React.FC = () => (
         <Button size="small">OUTLINED</Button>
       </Flex>
     </ConfigProvider>
-    <Flex gap="small" wrap>
-      <ConfigProvider theme={{ components: { Button: { colorBorderDisabled: 'red' } } }}>
-        <Button disabled>Custom Red Disabled</Button>
-      </ConfigProvider>
-      <ConfigProvider theme={{ components: { Button: { borderColorDisabled: 'blue' } } }}>
-        <Button disabled>Legacy Blue Disabled</Button>
-      </ConfigProvider>
-    </Flex>
     <ConfigProvider
       theme={{
         token: {

--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -2,28 +2,28 @@ import React from 'react';
 import { Button, ConfigProvider, Flex } from 'antd';
 
 const App: React.FC = () => (
-  <ConfigProvider
-    theme={{
-      components: {
-        Button: {
-          algorithm: true,
-          colorPrimary: '#1976d2',
-          controlHeight: 36,
-          primaryShadow:
-            '0 3px 1px -2px rgba(0,0,0,0.2), 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12)',
-          fontWeight: 500,
-          defaultBorderColor: 'rgba(25, 118, 210, 0.5)',
-          colorText: '#1976d2',
-          defaultColor: '#1976d2',
-          borderRadius: 4,
-          colorTextDisabled: 'rgba(0, 0, 0, 0.26)',
-          colorBgContainerDisabled: 'rgba(0, 0, 0, 0.12)',
-          contentFontSizeSM: 12,
+  <Flex gap="small" vertical>
+    <ConfigProvider
+      theme={{
+        components: {
+          Button: {
+            algorithm: true,
+            colorPrimary: '#1976d2',
+            controlHeight: 36,
+            primaryShadow:
+              '0 3px 1px -2px rgba(0,0,0,0.2), 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12)',
+            fontWeight: 500,
+            defaultBorderColor: 'rgba(25, 118, 210, 0.5)',
+            colorText: '#1976d2',
+            defaultColor: '#1976d2',
+            borderRadius: 4,
+            colorTextDisabled: 'rgba(0, 0, 0, 0.26)',
+            colorBgContainerDisabled: 'rgba(0, 0, 0, 0.12)',
+            contentFontSizeSM: 12,
+          },
         },
-      },
-    }}
-  >
-    <Flex gap="small" vertical>
+      }}
+    >
       <Flex wrap gap="small">
         <Button type="text">TEXT</Button>
         <Button type="primary">CONTAINED</Button>
@@ -36,7 +36,18 @@ const App: React.FC = () => (
         <Button type="primary" disabled>
           CONTAINED
         </Button>
-        <Button disabled>OUTLINED</Button>
+        <ConfigProvider
+          theme={{
+            components: {
+              Button: {
+                colorBorderDisabled: 'rgba(0, 0, 0, 0.12)',
+                colorBgContainerDisabled: 'transparent',
+              },
+            },
+          }}
+        >
+          <Button disabled>OUTLINED</Button>
+        </ConfigProvider>
       </Flex>
       <Flex wrap gap="small">
         <Button type="text" size="small">
@@ -47,8 +58,34 @@ const App: React.FC = () => (
         </Button>
         <Button size="small">OUTLINED</Button>
       </Flex>
+    </ConfigProvider>
+    <Flex gap="small" wrap>
+      <ConfigProvider theme={{ components: { Button: { colorBorderDisabled: 'red' } } }}>
+        <Button disabled>Custom Red Disabled</Button>
+      </ConfigProvider>
+      <ConfigProvider theme={{ components: { Button: { borderColorDisabled: 'blue' } } }}>
+        <Button disabled>Legacy Blue Disabled</Button>
+      </ConfigProvider>
     </Flex>
-  </ConfigProvider>
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#FF0000',
+        },
+      }}
+    >
+      <Flex gap="small" wrap>
+        <Button type="text">Text</Button>
+        <Button type="link">Link</Button>
+        <Button color="primary" variant="text">
+          Primary Text
+        </Button>
+        <Button color="primary" variant="link">
+          Primary Link
+        </Button>
+      </Flex>
+    </ConfigProvider>
+  </Flex>
 );
 
 export default App;

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -607,63 +607,7 @@ const genDangerousStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ),
 });
 
-const genInfoStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
-  color: token.colorInfo,
-  boxShadow: token.defaultShadow,
-
-  ...genSolidButtonStyle(
-    token,
-    token.dangerColor,
-    token.colorInfo,
-    {
-      background: token.colorInfoHover,
-    },
-    {
-      background: token.colorInfoActive,
-    },
-  ),
-
-  ...genOutlinedDashedButtonStyle(
-    token,
-    token.colorInfo,
-    token.colorBgContainer,
-    {
-      color: token.colorInfoHover,
-      borderColor: token.colorInfoBorderHover,
-    },
-    {
-      color: token.colorInfoActive,
-      borderColor: token.colorInfoActive,
-    },
-  ),
-
-  ...genDashedButtonStyle(token),
-
-  ...genFilledButtonStyle(
-    token,
-    token.colorInfoBg,
-    {
-      background: token.colorInfoBgHover,
-    },
-    {
-      background: token.colorInfoBorder,
-    },
-  ),
-
-  ...genTextLinkButtonStyle(
-    token,
-    token.colorInfo,
-    'text',
-    {
-      color: token.colorInfoHover,
-      background: token.colorInfoBg,
-    },
-    {
-      color: token.colorInfoHover,
-      background: token.colorInfoBorder,
-    },
-  ),
-
+const genLinkStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ...genTextLinkButtonStyle(
     token,
     token.colorLink,
@@ -701,7 +645,7 @@ const genColorButtonStyle: GenerateStyle<ButtonToken> = (token) => {
     [`${componentCls}-color-default`]: genDefaultButtonStyle(token),
     [`${componentCls}-color-primary`]: genPrimaryButtonStyle(token),
     [`${componentCls}-color-dangerous`]: genDangerousStyle(token),
-    [`${componentCls}-color-info`]: genInfoStyle(token),
+    [`${componentCls}-color-link`]: genLinkStyle(token),
 
     ...genPresetColorStyle(token),
   };

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -418,19 +418,6 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     },
   ),
 
-  ...genTextLinkButtonStyle(
-    token,
-    token.textTextColor,
-    'link',
-    {
-      color: token.colorLinkHover,
-      background: token.linkHoverBg,
-    },
-    {
-      color: token.colorLinkActive,
-    },
-  ),
-
   ...genGhostButtonStyle(
     token.componentCls,
     token.ghostBg,
@@ -477,7 +464,7 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
 
   ...genTextLinkButtonStyle(
     token,
-    token.colorLink,
+    token.colorPrimaryText,
     'text',
     {
       color: token.colorPrimaryTextHover,
@@ -486,6 +473,19 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     {
       color: token.colorPrimaryTextActive,
       background: token.colorPrimaryBorder,
+    },
+  ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    token.colorPrimaryText,
+    'link',
+    {
+      color: token.colorPrimaryTextHover,
+      background: token.linkHoverBg,
+    },
+    {
+      color: token.colorPrimaryTextActive,
     },
   ),
 

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -666,13 +666,13 @@ const genInfoStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
 
   ...genTextLinkButtonStyle(
     token,
-    token.colorInfo,
+    token.colorLink,
     'link',
     {
-      color: token.colorInfoHover,
+      color: token.colorLinkHover,
     },
     {
-      color: token.colorInfoActive,
+      color: token.colorLinkActive,
     },
   ),
 

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -594,6 +594,93 @@ const genDangerousStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   ),
 });
 
+const genInfoStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
+  color: token.colorInfo,
+  boxShadow: token.defaultShadow,
+
+  ...genSolidButtonStyle(
+    token,
+    token.dangerColor,
+    token.colorInfo,
+    {
+      background: token.colorInfoHover,
+    },
+    {
+      background: token.colorInfoActive,
+    },
+  ),
+
+  ...genOutlinedDashedButtonStyle(
+    token,
+    token.colorInfo,
+    token.colorBgContainer,
+    {
+      color: token.colorInfoHover,
+      borderColor: token.colorInfoBorderHover,
+    },
+    {
+      color: token.colorInfoActive,
+      borderColor: token.colorInfoActive,
+    },
+  ),
+
+  ...genDashedButtonStyle(token),
+
+  ...genFilledButtonStyle(
+    token,
+    token.colorInfoBg,
+    {
+      background: token.colorInfoBgHover,
+    },
+    {
+      background: token.colorInfoBorder,
+    },
+  ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    token.colorInfo,
+    'text',
+    {
+      color: token.colorInfoHover,
+      background: token.colorInfoBg,
+    },
+    {
+      color: token.colorInfoHover,
+      background: token.colorInfoBorder,
+    },
+  ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    token.colorInfo,
+    'link',
+    {
+      color: token.colorInfoHover,
+    },
+    {
+      color: token.colorInfoActive,
+    },
+  ),
+
+  ...genGhostButtonStyle(
+    token.componentCls,
+    token.ghostBg,
+    token.colorInfo,
+    token.colorInfo,
+    token.colorTextDisabled,
+    token.colorBorder,
+    {
+      color: token.colorInfoHover,
+      borderColor: token.colorInfoHover,
+    },
+    {
+      color: token.colorInfoActive,
+      borderColor: token.colorInfoActive,
+    },
+  ),
+});
+
 const genColorButtonStyle: GenerateStyle<ButtonToken> = (token) => {
   const { componentCls } = token;
 
@@ -601,6 +688,7 @@ const genColorButtonStyle: GenerateStyle<ButtonToken> = (token) => {
     [`${componentCls}-color-default`]: genDefaultButtonStyle(token),
     [`${componentCls}-color-primary`]: genPrimaryButtonStyle(token),
     [`${componentCls}-color-dangerous`]: genDangerousStyle(token),
+    [`${componentCls}-color-info`]: genInfoStyle(token),
 
     ...genPresetColorStyle(token),
   };

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -426,6 +426,19 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     token.colorTextDisabled,
     token.colorBorder,
   ),
+
+  ...genTextLinkButtonStyle(
+    token,
+    token.textTextColor,
+    'link',
+    {
+      color: token.colorLinkHover,
+      background: token.linkHoverBg,
+    },
+    {
+      color: token.colorLinkActive,
+    },
+  ),
 });
 
 const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -27178,7 +27178,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-primary config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -27488,7 +27488,7 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-primary config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -27798,7 +27798,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-primary config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28107,7 +28107,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-primary config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28416,7 +28416,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-primary config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28725,7 +28725,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -29034,7 +29034,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                             class="prefix-Table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -27178,7 +27178,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-link config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -27488,7 +27488,7 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-link config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -27798,7 +27798,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-link config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28107,7 +28107,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-link config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28416,7 +28416,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                             class="config-table-filter-dropdown-btns"
                           >
                             <button
-                              class="config-btn config-btn-link config-btn-color-info config-btn-variant-link config-btn-sm"
+                              class="config-btn config-btn-link config-btn-color-link config-btn-variant-link config-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -28725,7 +28725,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -29034,7 +29034,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                             class="prefix-Table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -503,7 +503,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -503,7 +503,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -495,7 +495,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
       type="button"
     >
       <span>

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -495,7 +495,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
       </span>
     </button>
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
       type="button"
     >
       <span>

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1948,7 +1948,7 @@ exports[`renders components/form/demo/control-hooks.tsx extend context correctly
                 class="ant-space-item"
               >
                 <button
-                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
                   type="button"
                 >
                   <span>

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1948,7 +1948,7 @@ exports[`renders components/form/demo/control-hooks.tsx extend context correctly
                 class="ant-space-item"
               >
                 <button
-                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
                   type="button"
                 >
                   <span>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1475,7 +1475,7 @@ exports[`renders components/form/demo/control-hooks.tsx correctly 1`] = `
                 class="ant-space-item"
               >
                 <button
-                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
                   type="button"
                 >
                   <span>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1475,7 +1475,7 @@ exports[`renders components/form/demo/control-hooks.tsx correctly 1`] = `
                 class="ant-space-item"
               >
                 <button
-                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
                   type="button"
                 >
                   <span>

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -303,7 +303,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx extend context c
          QR code expired
         <p>
           <button
-            class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+            class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
             type="button"
           >
             <span
@@ -637,7 +637,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
         QR code expired
       </p>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
         type="button"
       >
         <span

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -303,7 +303,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx extend context c
          QR code expired
         <p>
           <button
-            class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+            class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
             type="button"
           >
             <span
@@ -637,7 +637,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
         QR code expired
       </p>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
         type="button"
       >
         <span

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -261,7 +261,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx correctly 1`] = 
         QR code expired
         <p>
           <button
-            class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+            class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
             type="button"
           >
             <span
@@ -588,7 +588,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
         QR code expired
       </p>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
         type="button"
       >
         <span

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -261,7 +261,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx correctly 1`] = 
         QR code expired
         <p>
           <button
-            class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+            class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
             type="button"
           >
             <span
@@ -588,7 +588,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
         QR code expired
       </p>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
         type="button"
       >
         <span

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10488,7 +10488,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-compact-item"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-compact-item"
         type="button"
       >
         <span>
@@ -16875,7 +16875,7 @@ Array [
       class="ant-space-item"
     >
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
         type="button"
       >
         <span>

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10488,7 +10488,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-compact-item"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-compact-item"
         type="button"
       >
         <span>
@@ -16875,7 +16875,7 @@ Array [
       class="ant-space-item"
     >
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
         type="button"
       >
         <span>

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2664,7 +2664,7 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-compact-item"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-compact-item"
         type="button"
       >
         <span>
@@ -4682,7 +4682,7 @@ Array [
       class="ant-space-item"
     >
       <button
-        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link"
         type="button"
       >
         <span>

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2664,7 +2664,7 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
         </span>
       </button>
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-compact-item"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-compact-item"
         type="button"
       >
         <span>
@@ -4682,7 +4682,7 @@ Array [
       class="ant-space-item"
     >
       <button
-        class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link"
+        class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link"
         type="button"
       >
         <span>

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -683,7 +683,7 @@ exports[`Table.filter renders menu correctly 1`] = `
     class="ant-table-filter-dropdown-btns"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
       disabled=""
       type="button"
     >
@@ -825,7 +825,7 @@ exports[`Table.filter renders radio filter correctly 1`] = `
     class="ant-table-filter-dropdown-btns"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+      class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
       disabled=""
       type="button"
     >

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -683,7 +683,7 @@ exports[`Table.filter renders menu correctly 1`] = `
     class="ant-table-filter-dropdown-btns"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
       disabled=""
       type="button"
     >
@@ -825,7 +825,7 @@ exports[`Table.filter renders radio filter correctly 1`] = `
     class="ant-table-filter-dropdown-btns"
   >
     <button
-      class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+      class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
       disabled=""
       type="button"
     >

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2204,7 +2204,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -3631,7 +3631,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -3999,7 +3999,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4011,7 +4011,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4135,7 +4135,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4147,7 +4147,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4349,7 +4349,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4361,7 +4361,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -6815,7 +6815,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -10792,7 +10792,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11090,7 +11090,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11576,7 +11576,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11874,7 +11874,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -13625,7 +13625,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -15129,7 +15129,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -15390,7 +15390,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -21935,7 +21935,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -22275,7 +22275,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-primary ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2204,7 +2204,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -3631,7 +3631,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -3999,7 +3999,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4011,7 +4011,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4135,7 +4135,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4147,7 +4147,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4349,7 +4349,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -4361,7 +4361,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                                 class="ant-space-item"
                               >
                                 <button
-                                  class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                  class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                   type="button"
                                 >
                                   <span>
@@ -6815,7 +6815,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -10792,7 +10792,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11090,7 +11090,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11576,7 +11576,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -11874,7 +11874,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -13625,7 +13625,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -15129,7 +15129,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -15390,7 +15390,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                             class="ant-table-filter-dropdown-btns"
                           >
                             <button
-                              class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                              class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                               disabled=""
                               type="button"
                             >
@@ -21935,7 +21935,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >
@@ -22275,7 +22275,7 @@ Array [
                               class="ant-table-filter-dropdown-btns"
                             >
                               <button
-                                class="ant-btn ant-btn-link ant-btn-color-info ant-btn-variant-link ant-btn-sm"
+                                class="ant-btn ant-btn-link ant-btn-color-link ant-btn-variant-link ant-btn-sm"
                                 disabled=""
                                 type="button"
                               >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #52468

### 💡 Background and Solution

看了一下是因为 `color` 缺少 `info` 类型，所以导致 `link` 变体取用的是 `primary` 组合，导致了 `primary` 为了兼容用的 `info` 色板。在 style 里添加一个 `info` 样式集合来解决这个问题。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix Button with `color` to be `primary` and `variant` to be `text` or `link` will not use correct color.        |
| 🇨🇳 Chinese |   修复 Button 配置 `color` 为 `primary` 并且 `variant` 为 `text` 或 `link` 时，没有取用正确的色板的问题。      |
