### PR TITLE
ci: Add try catch to issue inactivity reminder script

### DIFF
--- a/.github/workflows/issue-inactivity-reminder.yml
+++ b/.github/workflows/issue-inactivity-reminder.yml
@@ -18,69 +18,74 @@ jobs:
             const daysBeforeReminder = 14;
             let page = 1;
             const perPage = 100;
-            
+
             const reminderSignature = "This issue has been inactive for more than 14 days";
 
             while (true) {
-              const { data: issues } = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                assignee: '*',
-                per_page: perPage,
-                page: page,
-              });
-
-              if (issues.length === 0) {
-                break;
-              }
-
-              const now = new Date();
-
-              for (const issue of issues) {
-                if (issue.pull_request) continue;
-
-                const updatedAt = new Date(issue.updated_at);
-                const daysInactive = (now - updatedAt) / (1000 * 60 * 60 * 24);
-
-                const { data: timeline } = await github.rest.issues.listEventsForTimeline({
+              try {
+                const { data: issues } = await github.rest.issues.listForRepo({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issue.number,
+                  state: 'open',
+                  assignee: '*',
+                  per_page: perPage,
+                  page: page,
                 });
 
-                const hasLinkedPR = timeline.some(event => 
-                  event.event === 'connected' || // PR connected via keywords
-                  event.event === 'referenced' && event.commit_id // Connected via commit
-                );
+                if (issues.length === 0) {
+                  break;
+                }
 
-                if (daysInactive >= daysBeforeReminder && !hasLinkedPR) {
-                  // get issue comments
-                  const { data: comments } = await github.rest.issues.listComments({
+                const now = new Date();
+
+                for (const issue of issues) {
+                  if (issue.pull_request) continue;
+
+                  const updatedAt = new Date(issue.updated_at);
+                  const daysInactive = (now - updatedAt) / (1000 * 60 * 60 * 24);
+
+                  const { data: timeline } = await github.rest.issues.listEventsForTimeline({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
                   });
 
-                  // check if reminder has been sent
-                  const hasReminder = comments.some(comment => 
-                    comment.body.includes(reminderSignature)
+                  const hasLinkedPR = timeline.some(event =>
+                    event.event === 'connected' || // PR connected via keywords
+                    event.event === 'referenced' && event.commit_id // Connected via commit
                   );
 
-                  if (!hasReminder) {
-                    const assigneesMentions = issue.assignees
-                      .map(user => `@${user.login}`)
-                      .join(' ');
-                      
-                    await github.rest.issues.createComment({
+                  if (daysInactive >= daysBeforeReminder && !hasLinkedPR) {
+                    // get issue comments
+                    const { data: comments } = await github.rest.issues.listComments({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       issue_number: issue.number,
-                      body: `${assigneesMentions} 这个 issue 已经超过 14 天没有更新或关联 PR。如果您仍在处理这个 issue，请更新进度；如果您无法继续处理，请联系维护者重新分配。\n\nThis issue has been inactive for more than 14 days without any updates or linked PR. If you are still working on this issue, please provide a progress update. If you are unable to continue, please contact the maintainers for reassignment.`,
                     });
+
+                    // check if reminder has been sent
+                    const hasReminder = comments.some(comment =>
+                      comment.body.includes(reminderSignature)
+                    );
+
+                    if (!hasReminder) {
+                      const assigneesMentions = issue.assignees
+                        .map(user => `@${user.login}`)
+                        .join(' ');
+
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        body: `${assigneesMentions} 这个 issue 已经超过 14 天没有更新或关联 PR。如果您仍在处理这个 issue，请更新进度；如果您无法继续处理，请联系维护者重新分配。\n\nThis issue has been inactive for more than 14 days without any updates or linked PR. If you are still working on this issue, please provide a progress update. If you are unable to continue, please contact the maintainers for reassignment.`,
+                      });
+                    }
                   }
                 }
-              }
 
-              page += 1;
+                page += 1;
+              } catch (error) {
+                console.error(`Error processing page ${page}:`, error);
+                break;
+              }
             }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] ⏩ Workflow


### 💡 Background and Solution
issue-inactivity-reminder 脚本可能会因为 github 接口访问频繁，导致限额或者网络或者其他原因，经常出现 failled，从而会导致reminder_job 影响到 合并分支的 bot的合并工作。

故先加上try catch 以观其效，或许也可以在 合并分支的 ci 中skip reminder_job
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/82196b1a-9663-44ef-b925-ab2769b039be" />

<img width="1640" alt="image" src="https://github.com/user-attachments/assets/715ad715-20e3-44fa-b0bd-c21f05d8c6d7" />
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/a96f53c6-3022-41a9-b310-6ba815785a76" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |      -     |
