### PR TITLE
Fixed the extra text now showing and text overflowing bug in navigation menu.

### DIFF
--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -38,7 +38,7 @@ type GenericComponent = Omit<MenuItemComponent, ''> &
 const useStyle = createStyles(({ css }) => ({
   extraText: css`
       color: var(--ant-menu-group-title-color);
-      width: 30%;
+      width: 40%;
       font-weight: 500;
       padding-left: 2px;
     `,

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -4,7 +4,6 @@ import type { MenuItemProps as RcMenuItemProps } from 'rc-menu';
 import { Item } from 'rc-menu';
 import toArray from 'rc-util/lib/Children/toArray';
 import omit from 'rc-util/lib/omit';
-import { createStyles } from 'antd-style';
 import { cloneElement } from '../_util/reactNode';
 import type { SiderContextProps } from '../layout/Sider';
 import { SiderContext } from '../layout/Sider';
@@ -35,17 +34,7 @@ type GenericComponent = Omit<MenuItemComponent, ''> &
     ...args: RestArgs<MenuItemComponent>
   ) => ReturnType<MenuItemComponent>);
 
-const useStyle = createStyles(({ css }) => ({
-  extraText: css`
-      color: var(--ant-menu-group-title-color);
-      width: 40%;
-      font-weight: 500;
-      padding-left: 2px;
-    `,
-}));
-
 const MenuItem: GenericComponent = (props) => {
-  const { styles } = useStyle();
   const { className, children, icon, title, danger, extra } = props;
   const {
     prefixCls,
@@ -61,7 +50,12 @@ const MenuItem: GenericComponent = (props) => {
       <>
         <span className={classNames(`${prefixCls}-title-content`)}>{children}</span>
         {extra && (
-          <span className={classNames(`${prefixCls}-title-content`, `${styles.extraText}`)}>
+          <span
+            className={classNames(
+              `${prefixCls}-title-content`,
+              `${prefixCls}-title-content-with-extra`,
+            )}
+          >
             {extra}
           </span>
         )}

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -4,7 +4,7 @@ import type { MenuItemProps as RcMenuItemProps } from 'rc-menu';
 import { Item } from 'rc-menu';
 import toArray from 'rc-util/lib/Children/toArray';
 import omit from 'rc-util/lib/omit';
-
+import { createStyles } from 'antd-style';
 import { cloneElement } from '../_util/reactNode';
 import type { SiderContextProps } from '../layout/Sider';
 import { SiderContext } from '../layout/Sider';
@@ -35,7 +35,17 @@ type GenericComponent = Omit<MenuItemComponent, ''> &
     ...args: RestArgs<MenuItemComponent>
   ) => ReturnType<MenuItemComponent>);
 
+const useStyle = createStyles(({ css }) => ({
+  extraText: css`
+      color: var(--ant-menu-group-title-color);
+      width: 30%;
+      font-weight: 500;
+      padding-left: 2px;
+    `,
+}));
+
 const MenuItem: GenericComponent = (props) => {
+  const { styles } = useStyle();
   const { className, children, icon, title, danger, extra } = props;
   const {
     prefixCls,
@@ -48,13 +58,14 @@ const MenuItem: GenericComponent = (props) => {
     const label = (children as React.ReactNode[])?.[0];
 
     const wrapNode = (
-      <span
-        className={classNames(`${prefixCls}-title-content`, {
-          [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
-        })}
-      >
-        {children}
-      </span>
+      <>
+        <span className={classNames(`${prefixCls}-title-content`)}>{children}</span>
+        {extra && (
+          <span className={classNames(`${prefixCls}-title-content`, `${styles.extraText}`)}>
+            {extra}
+          </span>
+        )}
+      </>
     );
     // inline-collapsed.md demo 依赖 span 来隐藏文字,有 icon 属性，则内部包裹一个 span
     // ref: https://github.com/ant-design/ant-design/pull/23456

--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -646,7 +646,7 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
 
           '&-with-extra': {
             color: 'rgba(0,0,0,0.45)',
-            width: '30%',
+            width: '40%',
             fontWeight: '500',
             paddingLeft: '2px',
           },

--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -645,9 +645,10 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
           transition: `color ${motionDurationSlow}`,
 
           '&-with-extra': {
-            display: 'inline-flex',
-            alignItems: 'center',
-            width: '100%',
+            color: 'rgba(0,0,0,0.45)',
+            width: '30%',
+            fontWeight: '500',
+            paddingLeft: '2px',
           },
 
           // https://github.com/ant-design/ant-design/issues/41143


### PR DESCRIPTION
This PR fixes issue #52602, where extra text in the Menu was not visible when it exceeded the available width. The issue has been resolved by ensuring that both hidden and overflowing text are properly handled.  

Fixes: #52602 

Screenshots of the fixed version are attached to this PR for reference.


![image](https://github.com/user-attachments/assets/1fd44b56-3b80-4688-985e-f101b7abecac)
![image](https://github.com/user-attachments/assets/202147bd-dc8b-4bfc-9a1f-2042c12f4b10)


