### PR TITLE
fix(tabs): add missing style design token for card tabs

### DIFF
--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -776,1012 +776,1014 @@ exports[`renders components/tabs/demo/centered.tsx extend context correctly 1`] 
 exports[`renders components/tabs/demo/centered.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/tabs/demo/component-token.tsx extend context correctly 1`] = `
-<div>
-  <div
-    class="ant-tabs ant-tabs-top"
-    style="margin-bottom: 32px;"
-  >
+Array [
+  <div>
     <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
+      class="ant-tabs ant-tabs-top"
+      style="margin-bottom: 32px;"
     >
       <div
-        class="ant-tabs-nav-wrap"
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
       >
         <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
+          class="ant-tabs-nav-wrap"
         >
           <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
-              Tab 1
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="2"
             >
-              Tab 2
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="3"
             >
-              Tab 3
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
             </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
           </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
         </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
         >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
           >
-            <svg
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
+              style="display: none;"
+            />
+          </div>
+        </div>
         <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          class="ant-tabs-extra-content"
         >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
         </div>
       </div>
       <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
+        class="ant-tabs-content-holder"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
+          class="ant-tabs-content ant-tabs-content-top"
         >
-          Content of tab 1
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-left"
-    style="margin-bottom: 32px;"
-  >
     <div
-      aria-orientation="vertical"
-      class="ant-tabs-nav"
-      role="tablist"
+      class="ant-tabs ant-tabs-left"
+      style="margin-bottom: 32px;"
     >
       <div
-        class="ant-tabs-nav-wrap"
+        aria-orientation="vertical"
+        class="ant-tabs-nav"
+        role="tablist"
       >
         <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
+          class="ant-tabs-nav-wrap"
         >
           <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
-              Tab 1
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="2"
             >
-              Tab 2
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="3"
             >
-              Tab 3
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
             </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
           </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
         </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
         >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
           >
-            <svg
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
+              style="display: none;"
+            />
+          </div>
+        </div>
         <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          class="ant-tabs-extra-content"
         >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
         </div>
       </div>
       <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-left"
+        class="ant-tabs-content-holder"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
+          class="ant-tabs-content ant-tabs-content-left"
         >
-          Content of tab 1
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-small"
-    style="margin-bottom: 32px;"
-  >
     <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
+      class="ant-tabs ant-tabs-top ant-tabs-small"
+      style="margin-bottom: 32px;"
     >
       <div
-        class="ant-tabs-nav-wrap"
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
       >
         <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
+          class="ant-tabs-nav-wrap"
         >
           <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
-              Tab 1
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="2"
             >
-              Tab 2
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="3"
             >
-              Tab 3
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
             </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
           </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
         </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
         >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
           >
-            <svg
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
+              style="display: none;"
+            />
+          </div>
+        </div>
         <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          class="ant-tabs-extra-content"
         >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
         </div>
       </div>
       <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
+        class="ant-tabs-content-holder"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
+          class="ant-tabs-content ant-tabs-content-top"
         >
-          Content of tab 1
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-large"
-    style="margin-bottom: 32px;"
-  >
     <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
+      class="ant-tabs ant-tabs-top ant-tabs-large"
+      style="margin-bottom: 32px;"
     >
       <div
-        class="ant-tabs-nav-wrap"
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
       >
         <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
+          class="ant-tabs-nav-wrap"
         >
           <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
             >
-              Tab 1
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="2"
             >
-              Tab 2
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
             </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-              tabindex="-1"
+              class="ant-tabs-tab"
+              data-node-key="3"
             >
-              Tab 3
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
             </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
           </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
         </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
         >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
           >
-            <svg
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-        <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-        >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of tab 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
+              style="display: none;"
+            />
           </div>
+        </div>
+        <div
+          class="ant-tabs-extra-content"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
           <div
-            class="ant-tabs-tab"
-            data-node-key="2"
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
               tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
+            />
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-        <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-        >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of Tab Pane 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
+              style="display: none;"
+            />
           </div>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
           <div
-            class="ant-tabs-tab"
-            data-node-key="2"
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
               tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
+            />
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-        <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-        >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of Tab Pane 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform: translate(0px, 0px);"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-controls="rc-tabs-test-panel-1"
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-1"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
+              style="display: none;"
+            />
           </div>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
           <div
-            class="ant-tabs-tab"
-            data-node-key="2"
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
           >
             <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-3"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
               tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
+            />
             <div
-              aria-controls="rc-tabs-test-panel-3"
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-3"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="rc-tabs-test-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="rc-tabs-test-more"
-          style="visibility: hidden; order: 1;"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
               aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-        <div
-          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
-          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
-        >
-          <ul
-            aria-label="expanded dropdown"
-            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
-            data-menu-list="true"
-            id="rc-tabs-test-more-popup"
-            role="listbox"
-            tabindex="-1"
-          />
-          <div
-            aria-hidden="true"
-            style="display: none;"
-          />
+              style="display: none;"
+            />
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
       <div
-        class="ant-tabs-content ant-tabs-content-top"
+        class="ant-tabs-content-holder"
       >
         <div
-          aria-hidden="false"
-          aria-labelledby="rc-tabs-test-tab-1"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          id="rc-tabs-test-panel-1"
-          role="tabpanel"
-          tabindex="0"
+          class="ant-tabs-content ant-tabs-content-top"
         >
-          Content of Tab Pane 1
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card ant-tabs-centered"
+    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-small ant-tabs-card ant-tabs-editable-card"
   >
     <div
       aria-orientation="horizontal"
@@ -2028,8 +2030,8 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/tabs/demo/component-token.tsx extend context correctly 2`] = `[]`;

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -800,6 +800,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-1"
@@ -815,6 +816,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-2"
@@ -825,16 +827,16 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
                 aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-3"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -921,7 +923,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -948,6 +950,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-1"
@@ -963,6 +966,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-2"
@@ -973,16 +977,16 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
                 aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-3"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1069,7 +1073,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -1096,6 +1100,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-1"
@@ -1111,6 +1116,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-2"
@@ -1121,16 +1127,16 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
                 aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-3"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1217,7 +1223,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -1244,6 +1250,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-1"
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-1"
@@ -1259,6 +1266,7 @@ Array [
             >
               <div
                 aria-controls="rc-tabs-test-panel-2"
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-2"
@@ -1269,16 +1277,16 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
                 aria-controls="rc-tabs-test-panel-3"
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 id="rc-tabs-test-tab-3"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1365,7 +1373,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -2027,6 +2035,602 @@ Array [
           tabindex="0"
         >
           Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-flex ant-flex-align-flex-end"
+  >
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background: red;"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background: red;"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
+              aria-hidden="true"
+              style="display: none;"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-middle ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background: red;"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background: red;"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
+              aria-hidden="true"
+              style="display: none;"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-small ant-tabs-card ant-tabs-editable-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background: red;"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+              <button
+                aria-label="remove"
+                class="ant-tabs-tab-remove"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  aria-label="close"
+                  class="anticon anticon-close"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-with-remove"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+              <button
+                aria-label="remove"
+                class="ant-tabs-tab-remove"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="close"
+                  class="anticon anticon-close"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <button
+              aria-label="Add tab"
+              class="ant-tabs-nav-add"
+              type="button"
+            >
+              <span
+                aria-label="plus"
+                class="anticon anticon-plus"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="plus"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                  />
+                  <path
+                    d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background: red;"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
+              aria-hidden="true"
+              style="display: none;"
+            />
+          </div>
+          <button
+            aria-label="Add tab"
+            class="ant-tabs-nav-add"
+            type="button"
+          >
+            <span
+              aria-label="plus"
+              class="anticon anticon-plus"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="plus"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                />
+                <path
+                  d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background: red;"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform: translate(0px, 0px);"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-1"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-1"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-controls="rc-tabs-test-panel-2"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                id="rc-tabs-test-tab-2"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background: red;"
+        >
+          <button
+            aria-controls="rc-tabs-test-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="rc-tabs-test-more"
+            style="visibility: hidden; order: 1;"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+          >
+            <ul
+              aria-label="expanded dropdown"
+              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+              data-menu-list="true"
+              id="rc-tabs-test-more-popup"
+              role="listbox"
+              tabindex="-1"
+            />
+            <div
+              aria-hidden="true"
+              style="display: none;"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            aria-labelledby="rc-tabs-test-tab-1"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            id="rc-tabs-test-panel-1"
+            role="tabpanel"
+            tabindex="0"
+          />
         </div>
       </div>
     </div>

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1780,6 +1780,255 @@ exports[`renders components/tabs/demo/component-token.tsx extend context correct
       </div>
     </div>
   </div>
+  <div
+    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card ant-tabs-centered"
+  >
+    <div
+      aria-orientation="horizontal"
+      class="ant-tabs-nav"
+      role="tablist"
+    >
+      <div
+        class="ant-tabs-nav-wrap"
+      >
+        <div
+          class="ant-tabs-nav-list"
+          style="transform: translate(0px, 0px);"
+        >
+          <div
+            class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+            data-node-key="1"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-1"
+              aria-disabled="false"
+              aria-selected="true"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-1"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 1
+            </div>
+            <button
+              aria-label="remove"
+              class="ant-tabs-tab-remove"
+              role="tab"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                aria-label="close"
+                class="anticon anticon-close"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-tabs-tab ant-tabs-tab-with-remove"
+            data-node-key="2"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-2"
+              aria-disabled="false"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-2"
+              role="tab"
+              tabindex="-1"
+            >
+              Tab 2
+            </div>
+            <button
+              aria-label="remove"
+              class="ant-tabs-tab-remove"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="close"
+                class="anticon anticon-close"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-tabs-tab ant-tabs-tab-disabled"
+            data-node-key="3"
+          >
+            <div
+              aria-controls="rc-tabs-test-panel-3"
+              aria-disabled="true"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              id="rc-tabs-test-tab-3"
+              role="tab"
+            >
+              Tab 3
+            </div>
+          </div>
+          <button
+            aria-label="Add tab"
+            class="ant-tabs-nav-add"
+            type="button"
+          >
+            <span
+              aria-label="plus"
+              class="anticon anticon-plus"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="plus"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                />
+                <path
+                  d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+      >
+        <button
+          aria-controls="rc-tabs-test-more-popup"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          class="ant-tabs-nav-more"
+          id="rc-tabs-test-more"
+          style="visibility: hidden; order: 1;"
+          type="button"
+        >
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </button>
+        <div
+          class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tabs-dropdown-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            aria-label="expanded dropdown"
+            class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+            data-menu-list="true"
+            id="rc-tabs-test-more-popup"
+            role="listbox"
+            tabindex="-1"
+          />
+          <div
+            aria-hidden="true"
+            style="display: none;"
+          />
+        </div>
+        <button
+          aria-label="Add tab"
+          class="ant-tabs-nav-add"
+          type="button"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="ant-tabs-content-holder"
+    >
+      <div
+        class="ant-tabs-content ant-tabs-content-top"
+      >
+        <div
+          aria-hidden="false"
+          aria-labelledby="rc-tabs-test-tab-1"
+          class="ant-tabs-tabpane ant-tabs-tabpane-active"
+          id="rc-tabs-test-panel-1"
+          role="tabpanel"
+          tabindex="0"
+        >
+          Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -647,837 +647,839 @@ exports[`renders components/tabs/demo/centered.tsx correctly 1`] = `
 `;
 
 exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
-<div>
+Array [
+  <div>
+    <div
+      class="ant-tabs ant-tabs-top"
+      style="margin-bottom:32px"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="3"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-tabs-extra-content"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-left"
+      style="margin-bottom:32px"
+    >
+      <div
+        aria-orientation="vertical"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="3"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-tabs-extra-content"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-left"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-small"
+      style="margin-bottom:32px"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="3"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-tabs-extra-content"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-large"
+      style="margin-bottom:32px"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="3"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div
+          class="ant-tabs-extra-content"
+        >
+          <button
+            class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span>
+              Extra Action
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of tab 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card ant-tabs-centered"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-disabled"
+              data-node-key="3"
+            >
+              <div
+                aria-disabled="true"
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+              >
+                Tab 3
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          >
+            Content of Tab Pane 1
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
   <div
-    class="ant-tabs ant-tabs-top"
-    style="margin-bottom:32px"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of tab 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-left"
-    style="margin-bottom:32px"
-  >
-    <div
-      aria-orientation="vertical"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-left"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of tab 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-small"
-    style="margin-bottom:32px"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of tab 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-large"
-    style="margin-bottom:32px"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="3"
-          >
-            <div
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-tabs-extra-content"
-      >
-        <button
-          class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-          type="button"
-        >
-          <span>
-            Extra Action
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of tab 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
-            <div
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of Tab Pane 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
-            <div
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of Tab Pane 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card ant-tabs-centered"
-  >
-    <div
-      aria-orientation="horizontal"
-      class="ant-tabs-nav"
-      role="tablist"
-    >
-      <div
-        class="ant-tabs-nav-wrap"
-      >
-        <div
-          class="ant-tabs-nav-list"
-          style="transform:translate(0px, 0px)"
-        >
-          <div
-            class="ant-tabs-tab ant-tabs-tab-active"
-            data-node-key="1"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="true"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="0"
-            >
-              Tab 1
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-disabled="false"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-              tabindex="-1"
-            >
-              Tab 2
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab ant-tabs-tab-disabled"
-            data-node-key="3"
-          >
-            <div
-              aria-disabled="true"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              role="tab"
-            >
-              Tab 3
-            </div>
-          </div>
-          <div
-            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-          />
-        </div>
-      </div>
-      <div
-        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
-      >
-        <button
-          aria-controls="null-more-popup"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          class="ant-tabs-nav-more"
-          id="null-more"
-          style="visibility:hidden;order:1"
-          type="button"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <div
-      class="ant-tabs-content-holder"
-    >
-      <div
-        class="ant-tabs-content ant-tabs-content-top"
-      >
-        <div
-          aria-hidden="false"
-          class="ant-tabs-tabpane ant-tabs-tabpane-active"
-          role="tabpanel"
-          tabindex="0"
-        >
-          Content of Tab Pane 1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card ant-tabs-centered"
+    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-small ant-tabs-card ant-tabs-editable-card"
   >
     <div
       aria-orientation="horizontal"
@@ -1699,8 +1701,8 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`renders components/tabs/demo/custom-add-trigger.tsx correctly 1`] = `

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -670,6 +670,7 @@ Array [
               data-node-key="1"
             >
               <div
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -683,6 +684,7 @@ Array [
               data-node-key="2"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -692,14 +694,14 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -767,7 +769,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -793,6 +795,7 @@ Array [
               data-node-key="1"
             >
               <div
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -806,6 +809,7 @@ Array [
               data-node-key="2"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -815,14 +819,14 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -890,7 +894,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -916,6 +920,7 @@ Array [
               data-node-key="1"
             >
               <div
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -929,6 +934,7 @@ Array [
               data-node-key="2"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -938,14 +944,14 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1013,7 +1019,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -1039,6 +1045,7 @@ Array [
               data-node-key="1"
             >
               <div
+                aria-disabled="false"
                 aria-selected="true"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -1052,6 +1059,7 @@ Array [
               data-node-key="2"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
@@ -1061,14 +1069,14 @@ Array [
               </div>
             </div>
             <div
-              class="ant-tabs-tab"
+              class="ant-tabs-tab ant-tabs-tab-disabled"
               data-node-key="3"
             >
               <div
+                aria-disabled="true"
                 aria-selected="false"
                 class="ant-tabs-tab-btn"
                 role="tab"
-                tabindex="-1"
               >
                 Tab 3
               </div>
@@ -1136,7 +1144,7 @@ Array [
             role="tabpanel"
             tabindex="0"
           >
-            Content of tab 1
+            Content of Tab Pane 1
           </div>
         </div>
       </div>
@@ -1698,6 +1706,510 @@ Array [
           tabindex="0"
         >
           Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="ant-flex ant-flex-align-flex-end"
+  >
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-large ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background:red"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background:red"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-middle ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background:red"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background:red"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-small ant-tabs-card ant-tabs-editable-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background:red"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+              <button
+                aria-label="remove"
+                class="ant-tabs-tab-remove"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  aria-label="close"
+                  class="anticon anticon-close"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="ant-tabs-tab ant-tabs-tab-with-remove"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+              <button
+                aria-label="remove"
+                class="ant-tabs-tab-remove"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  aria-label="close"
+                  class="anticon anticon-close"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="close"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <button
+              aria-label="Add tab"
+              class="ant-tabs-nav-add"
+              type="button"
+            >
+              <span
+                aria-label="plus"
+                class="anticon anticon-plus"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="plus"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                  />
+                  <path
+                    d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                  />
+                </svg>
+              </span>
+            </button>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background:red"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
+            aria-label="Add tab"
+            class="ant-tabs-nav-add"
+            type="button"
+          >
+            <span
+              aria-label="plus"
+              class="anticon anticon-plus"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="plus"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                />
+                <path
+                  d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-tabs ant-tabs-top ant-tabs-small ant-tabs-card"
+    >
+      <div
+        aria-orientation="horizontal"
+        class="ant-tabs-nav"
+        role="tablist"
+        style="background:red"
+      >
+        <div
+          class="ant-tabs-nav-wrap"
+        >
+          <div
+            class="ant-tabs-nav-list"
+            style="transform:translate(0px, 0px)"
+          >
+            <div
+              class="ant-tabs-tab ant-tabs-tab-active"
+              data-node-key="1"
+            >
+              <div
+                aria-selected="true"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="0"
+              >
+                Tab 1
+              </div>
+            </div>
+            <div
+              class="ant-tabs-tab"
+              data-node-key="2"
+            >
+              <div
+                aria-selected="false"
+                class="ant-tabs-tab-btn"
+                role="tab"
+                tabindex="-1"
+              >
+                Tab 2
+              </div>
+            </div>
+            <div
+              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          style="background:red"
+        >
+          <button
+            aria-controls="null-more-popup"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="ant-tabs-nav-more"
+            id="null-more"
+            style="visibility:hidden;order:1"
+            type="button"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="ant-tabs-content-holder"
+      >
+        <div
+          class="ant-tabs-content ant-tabs-content-top"
+        >
+          <div
+            aria-hidden="false"
+            class="ant-tabs-tabpane ant-tabs-tabpane-active"
+            role="tabpanel"
+            tabindex="0"
+          />
         </div>
       </div>
     </div>

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -1476,6 +1476,230 @@ exports[`renders components/tabs/demo/component-token.tsx correctly 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card ant-tabs-centered"
+  >
+    <div
+      aria-orientation="horizontal"
+      class="ant-tabs-nav"
+      role="tablist"
+    >
+      <div
+        class="ant-tabs-nav-wrap"
+      >
+        <div
+          class="ant-tabs-nav-list"
+          style="transform:translate(0px, 0px)"
+        >
+          <div
+            class="ant-tabs-tab ant-tabs-tab-with-remove ant-tabs-tab-active"
+            data-node-key="1"
+          >
+            <div
+              aria-disabled="false"
+              aria-selected="true"
+              class="ant-tabs-tab-btn"
+              role="tab"
+              tabindex="0"
+            >
+              Tab 1
+            </div>
+            <button
+              aria-label="remove"
+              class="ant-tabs-tab-remove"
+              role="tab"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                aria-label="close"
+                class="anticon anticon-close"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-tabs-tab ant-tabs-tab-with-remove"
+            data-node-key="2"
+          >
+            <div
+              aria-disabled="false"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              role="tab"
+              tabindex="-1"
+            >
+              Tab 2
+            </div>
+            <button
+              aria-label="remove"
+              class="ant-tabs-tab-remove"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="close"
+                class="anticon anticon-close"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            class="ant-tabs-tab ant-tabs-tab-disabled"
+            data-node-key="3"
+          >
+            <div
+              aria-disabled="true"
+              aria-selected="false"
+              class="ant-tabs-tab-btn"
+              role="tab"
+            >
+              Tab 3
+            </div>
+          </div>
+          <button
+            aria-label="Add tab"
+            class="ant-tabs-nav-add"
+            type="button"
+          >
+            <span
+              aria-label="plus"
+              class="anticon anticon-plus"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="plus"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+                />
+                <path
+                  d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+                />
+              </svg>
+            </span>
+          </button>
+          <div
+            class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+      >
+        <button
+          aria-controls="null-more-popup"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          class="ant-tabs-nav-more"
+          id="null-more"
+          style="visibility:hidden;order:1"
+          type="button"
+        >
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </button>
+        <button
+          aria-label="Add tab"
+          class="ant-tabs-nav-add"
+          type="button"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="ant-tabs-content-holder"
+    >
+      <div
+        class="ant-tabs-content ant-tabs-content-top"
+      >
+        <div
+          aria-hidden="false"
+          class="ant-tabs-tabpane ant-tabs-tabpane-active"
+          role="tabpanel"
+          tabindex="0"
+        >
+          Content of Tab Pane 1
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/tabs/demo/component-token.tsx
+++ b/components/tabs/demo/component-token.tsx
@@ -1,5 +1,26 @@
 import React from 'react';
-import { Button, ConfigProvider, Tabs } from 'antd';
+import { Button, ConfigProvider, Flex, Tabs } from 'antd';
+
+const tabItems = Array.from({ length: 3 }).map((_, i) => {
+  const id = String(i + 1);
+  return {
+    disabled: i === 2,
+    label: `Tab ${id}`,
+    key: id,
+    children: `Content of Tab Pane ${id}`,
+  };
+});
+
+const sharedTabsProps = {
+  items: Array.from({ length: 2 }).map((_, i) => {
+    const id = String(i + 1);
+    return {
+      label: `Tab ${id}`,
+      key: id,
+    };
+  }),
+  tabBarStyle: { background: 'red' },
+};
 
 const App: React.FC = () => (
   <>
@@ -37,101 +58,32 @@ const App: React.FC = () => (
           defaultActiveKey="1"
           tabBarExtraContent={<Button>Extra Action</Button>}
           style={{ marginBottom: 32 }}
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of tab ${id}`,
-            };
-          })}
+          items={tabItems}
         />
         <Tabs
           tabPosition="left"
           defaultActiveKey="1"
           tabBarExtraContent={<Button>Extra Action</Button>}
           style={{ marginBottom: 32 }}
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of tab ${id}`,
-            };
-          })}
+          items={tabItems}
         />
         <Tabs
           size="small"
           defaultActiveKey="1"
           tabBarExtraContent={<Button>Extra Action</Button>}
           style={{ marginBottom: 32 }}
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of tab ${id}`,
-            };
-          })}
+          items={tabItems}
         />
         <Tabs
           size="large"
           defaultActiveKey="1"
           tabBarExtraContent={<Button>Extra Action</Button>}
           style={{ marginBottom: 32 }}
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of tab ${id}`,
-            };
-          })}
+          items={tabItems}
         />
-        <Tabs
-          defaultActiveKey="1"
-          centered
-          type="card"
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              disabled: i === 2,
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of Tab Pane ${id}`,
-            };
-          })}
-        />
-        <Tabs
-          size="small"
-          defaultActiveKey="1"
-          centered
-          type="card"
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              disabled: i === 2,
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of Tab Pane ${id}`,
-            };
-          })}
-        />
-        <Tabs
-          size="large"
-          defaultActiveKey="1"
-          centered
-          type="card"
-          items={Array.from({ length: 3 }).map((_, i) => {
-            const id = String(i + 1);
-            return {
-              disabled: i === 2,
-              label: `Tab ${id}`,
-              key: id,
-              children: `Content of Tab Pane ${id}`,
-            };
-          })}
-        />
+        <Tabs defaultActiveKey="1" centered type="card" items={tabItems} />
+        <Tabs size="small" defaultActiveKey="1" centered type="card" items={tabItems} />
+        <Tabs size="large" defaultActiveKey="1" centered type="card" items={tabItems} />
       </div>
     </ConfigProvider>
     <ConfigProvider
@@ -151,20 +103,14 @@ const App: React.FC = () => (
         },
       }}
     >
-      <Tabs
-        size="small"
-        type="editable-card"
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            disabled: i === 2,
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of Tab Pane ${id}`,
-          };
-        })}
-      />
+      <Tabs size="small" type="editable-card" items={tabItems} />
     </ConfigProvider>
+    <Flex align="flex-end">
+      <Tabs size="large" type="card" {...sharedTabsProps} />
+      <Tabs size="middle" type="card" {...sharedTabsProps} />
+      <Tabs size="small" type="editable-card" {...sharedTabsProps} />
+      <Tabs size="small" type="card" {...sharedTabsProps} />
+    </Flex>
   </>
 );
 

--- a/components/tabs/demo/component-token.tsx
+++ b/components/tabs/demo/component-token.tsx
@@ -131,6 +131,20 @@ const App: React.FC = () => (
           };
         })}
       />
+      <Tabs
+        defaultActiveKey="1"
+        centered
+        type="editable-card"
+        items={Array.from({ length: 3 }).map((_, i) => {
+          const id = String(i + 1);
+          return {
+            disabled: i === 2,
+            label: `Tab ${id}`,
+            key: id,
+            children: `Content of Tab Pane ${id}`,
+          };
+        })}
+      />
     </div>
   </ConfigProvider>
 );

--- a/components/tabs/demo/component-token.tsx
+++ b/components/tabs/demo/component-token.tsx
@@ -2,138 +2,157 @@ import React from 'react';
 import { Button, ConfigProvider, Tabs } from 'antd';
 
 const App: React.FC = () => (
-  <ConfigProvider
-    theme={{
-      components: {
-        Tabs: {
-          cardBg: '#f6ffed',
-          cardHeight: 60,
-          cardPadding: `20px`,
-          cardPaddingSM: `20px`,
-          cardPaddingLG: `20px`,
-          titleFontSize: 20,
-          titleFontSizeLG: 20,
-          titleFontSizeSM: 20,
-          inkBarColor: '#52C41A',
-          horizontalMargin: `0 0 12px 0`,
-          horizontalItemGutter: 12, // Fixed Value
-          horizontalItemPadding: `20px`,
-          horizontalItemPaddingSM: `20px`,
-          horizontalItemPaddingLG: `20px`,
-          verticalItemPadding: `8px`,
-          verticalItemMargin: `4px 0 0 0`,
-          itemColor: 'rgba(0,0,0,0.85)',
-          itemSelectedColor: '#389e0d',
-          itemHoverColor: '#d9f7be',
-          itemActiveColor: '#b7eb8f',
-          cardGutter: 12,
+  <>
+    <ConfigProvider
+      theme={{
+        components: {
+          Tabs: {
+            cardBg: '#f6ffed',
+            cardHeight: 60,
+            cardPadding: `20px`,
+            cardPaddingSM: `20px`,
+            cardPaddingLG: `20px`,
+            titleFontSize: 20,
+            titleFontSizeLG: 20,
+            titleFontSizeSM: 20,
+            inkBarColor: '#52C41A',
+            horizontalMargin: `0 0 12px 0`,
+            horizontalItemGutter: 12, // Fixed Value
+            horizontalItemPadding: `20px`,
+            horizontalItemPaddingSM: `20px`,
+            horizontalItemPaddingLG: `20px`,
+            verticalItemPadding: `8px`,
+            verticalItemMargin: `4px 0 0 0`,
+            itemColor: 'rgba(0,0,0,0.85)',
+            itemSelectedColor: '#389e0d',
+            itemHoverColor: '#d9f7be',
+            itemActiveColor: '#b7eb8f',
+            cardGutter: 12,
+          },
         },
-      },
-    }}
-  >
-    <div>
-      <Tabs
-        defaultActiveKey="1"
-        tabBarExtraContent={<Button>Extra Action</Button>}
-        style={{ marginBottom: 32 }}
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of tab ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        tabPosition="left"
-        defaultActiveKey="1"
-        tabBarExtraContent={<Button>Extra Action</Button>}
-        style={{ marginBottom: 32 }}
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of tab ${id}`,
-          };
-        })}
-      />
+      }}
+    >
+      <div>
+        <Tabs
+          defaultActiveKey="1"
+          tabBarExtraContent={<Button>Extra Action</Button>}
+          style={{ marginBottom: 32 }}
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of tab ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          tabPosition="left"
+          defaultActiveKey="1"
+          tabBarExtraContent={<Button>Extra Action</Button>}
+          style={{ marginBottom: 32 }}
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of tab ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          size="small"
+          defaultActiveKey="1"
+          tabBarExtraContent={<Button>Extra Action</Button>}
+          style={{ marginBottom: 32 }}
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of tab ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          size="large"
+          defaultActiveKey="1"
+          tabBarExtraContent={<Button>Extra Action</Button>}
+          style={{ marginBottom: 32 }}
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of tab ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          defaultActiveKey="1"
+          centered
+          type="card"
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              disabled: i === 2,
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of Tab Pane ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          size="small"
+          defaultActiveKey="1"
+          centered
+          type="card"
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              disabled: i === 2,
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of Tab Pane ${id}`,
+            };
+          })}
+        />
+        <Tabs
+          size="large"
+          defaultActiveKey="1"
+          centered
+          type="card"
+          items={Array.from({ length: 3 }).map((_, i) => {
+            const id = String(i + 1);
+            return {
+              disabled: i === 2,
+              label: `Tab ${id}`,
+              key: id,
+              children: `Content of Tab Pane ${id}`,
+            };
+          })}
+        />
+      </div>
+    </ConfigProvider>
+    <ConfigProvider
+      theme={{
+        components: {
+          Tabs: {
+            cardHeight: 180,
+            cardPadding: '0px 0px 0px 0px',
+            cardPaddingSM: '0px 0px 0px 0px',
+            verticalItemPadding: '0px 0px',
+            borderRadiusLG: 0,
+            borderRadius: 0,
+            horizontalItemPadding: '0px 0px 0px 0px',
+            horizontalMargin: '0 0 0 0',
+            inkBarColor: '#ffa940',
+          },
+        },
+      }}
+    >
       <Tabs
         size="small"
-        defaultActiveKey="1"
-        tabBarExtraContent={<Button>Extra Action</Button>}
-        style={{ marginBottom: 32 }}
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of tab ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        size="large"
-        defaultActiveKey="1"
-        tabBarExtraContent={<Button>Extra Action</Button>}
-        style={{ marginBottom: 32 }}
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of tab ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        defaultActiveKey="1"
-        centered
-        type="card"
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            disabled: i === 2,
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of Tab Pane ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        size="small"
-        defaultActiveKey="1"
-        centered
-        type="card"
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            disabled: i === 2,
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of Tab Pane ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        size="large"
-        defaultActiveKey="1"
-        centered
-        type="card"
-        items={Array.from({ length: 3 }).map((_, i) => {
-          const id = String(i + 1);
-          return {
-            disabled: i === 2,
-            label: `Tab ${id}`,
-            key: id,
-            children: `Content of Tab Pane ${id}`,
-          };
-        })}
-      />
-      <Tabs
-        defaultActiveKey="1"
-        centered
         type="editable-card"
         items={Array.from({ length: 3 }).map((_, i) => {
           const id = String(i + 1);
@@ -145,8 +164,8 @@ const App: React.FC = () => (
           };
         })}
       />
-    </div>
-  </ConfigProvider>
+    </ConfigProvider>
+  </>
 );
 
 export default App;

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -623,6 +623,7 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-small`]: {
         [`> ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
+            minHeight: 'auto',
             padding: cardPaddingSM,
           },
         },
@@ -871,11 +872,11 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
   const {
     componentCls,
     tabsCardPadding,
-    cardHeight,
     cardGutter,
     itemHoverColor,
     itemActiveColor,
     colorBorderSecondary,
+    controlHeightLG,
   } = token;
 
   return {
@@ -953,7 +954,7 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
         },
 
         [`${componentCls}-nav-add`]: {
-          minWidth: cardHeight,
+          minWidth: controlHeightLG,
           marginLeft: {
             _skip_check_: true,
             value: cardGutter,

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -21,7 +21,17 @@ export interface ComponentToken {
    * @desc 卡片标签页高度
    * @descEN Height of card tab
    */
-  cardHeight: number | string;
+  cardHeight: number;
+  /**
+   * @desc 小尺寸卡片标签页高度
+   * @descEN Height of small card tab
+   */
+  cardHeightSM: number;
+  /**
+   * @desc 大尺寸卡片标签页高度
+   * @descEN Height of large card tab
+   */
+  cardHeightLG: number;
   /**
    * @desc 卡片标签页内间距
    * @descEN Padding of card tab
@@ -593,10 +603,13 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     componentCls,
     cardPaddingSM,
     cardPaddingLG,
+    cardHeightSM,
+    cardHeightLG,
     horizontalItemPaddingSM,
     horizontalItemPaddingLG,
   } = token;
   return {
+    // >>>>> shared
     [componentCls]: {
       '&-small': {
         [`> ${componentCls}-nav`]: {
@@ -612,16 +625,23 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           [`${componentCls}-tab`]: {
             padding: horizontalItemPaddingLG,
             fontSize: token.titleFontSizeLG,
+            lineHeight: token.lineHeightLG,
           },
         },
       },
     },
 
+    // >>>>> card
     [`${componentCls}-card`]: {
+      // Small
       [`&${componentCls}-small`]: {
         [`> ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
             padding: cardPaddingSM,
+          },
+          [`${componentCls}-nav-add`]: {
+            minWidth: cardHeightSM,
+            minHeight: cardHeightSM,
           },
         },
         [`&${componentCls}-bottom`]: {
@@ -652,10 +672,15 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
         },
       },
 
+      // Large
       [`&${componentCls}-large`]: {
         [`> ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
             padding: cardPaddingLG,
+          },
+          [`${componentCls}-nav-add`]: {
+            minWidth: cardHeightLG,
+            minHeight: cardHeightLG,
           },
         },
       },
@@ -957,7 +982,6 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
             _skip_check_: true,
             value: cardGutter,
           },
-          padding: unit(token.paddingXS),
           background: 'transparent',
           border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
@@ -1025,21 +1049,31 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
 };
 
 export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
-  const { cardHeight, controlHeightLG } = token;
-  const mergedCardHeight = typeof cardHeight === 'number' ? cardHeight : controlHeightLG;
+  const { cardHeight, cardHeightSM, cardHeightLG, controlHeight, controlHeightLG } = token;
+
+  const mergedCardHeight = cardHeight || controlHeightLG;
+  const mergedCardHeightSM = cardHeightSM || controlHeight;
+  // `controlHeight` missing XL variable, so we directly write it here:
+  const mergedCardHeightLG = cardHeightLG || controlHeightLG + 8;
 
   return {
     zIndexPopup: token.zIndexPopupBase + 50,
     cardBg: token.colorFillAlter,
     // We can not pass this as valid value,
     // Since `cardHeight` will lock nav add button height.
-    cardHeight: undefined!,
+    cardHeight: mergedCardHeight,
+    cardHeightSM: mergedCardHeightSM,
+    cardHeightLG: mergedCardHeightLG,
     // Initialize with empty string, because cardPadding will be calculated with cardHeight by default.
     cardPadding: `${
       (mergedCardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
     }px ${token.padding}px`,
-    cardPaddingSM: `${token.paddingXXS * 1.5}px ${token.padding}px`,
-    cardPaddingLG: `${token.paddingXS}px ${token.padding}px ${token.paddingXXS * 1.5}px`,
+    cardPaddingSM: `${
+      (mergedCardHeightSM - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
+    }px ${token.paddingXS}px`,
+    cardPaddingLG: `${
+      (mergedCardHeightLG - Math.round(token.fontSizeLG * token.lineHeightLG)) / 2 - token.lineWidth
+    }px ${token.padding}px`,
     titleFontSize: token.fontSize,
     titleFontSizeLG: token.fontSizeLG,
     titleFontSizeSM: token.fontSize,

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -148,6 +148,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     cardGutter,
     colorBorderSecondary,
     itemSelectedColor,
+    cardHeight,
   } = token;
   return {
     [`${componentCls}-card`]: {
@@ -158,6 +159,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           background: cardBg,
           border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           transition: `all ${token.motionDurationSlow} ${token.motionEaseInOut}`,
+          height: cardHeight,
         },
 
         [`${componentCls}-tab-active`]: {

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -148,7 +148,6 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     cardGutter,
     colorBorderSecondary,
     itemSelectedColor,
-    cardHeight,
   } = token;
   return {
     [`${componentCls}-card`]: {
@@ -159,7 +158,6 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           background: cardBg,
           border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           transition: `all ${token.motionDurationSlow} ${token.motionEaseInOut}`,
-          minHeight: cardHeight,
         },
 
         [`${componentCls}-tab-active`]: {
@@ -597,8 +595,6 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     cardPaddingLG,
     horizontalItemPaddingSM,
     horizontalItemPaddingLG,
-    cardHeight,
-    calc,
   } = token;
   return {
     [componentCls]: {
@@ -625,7 +621,6 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-small`]: {
         [`> ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
-            minHeight: calc(cardHeight).mul(0.9).equal(),
             padding: cardPaddingSM,
           },
         },
@@ -874,11 +869,11 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
   const {
     componentCls,
     tabsCardPadding,
+    cardHeight,
     cardGutter,
     itemHoverColor,
     itemActiveColor,
     colorBorderSecondary,
-    controlHeightLG,
   } = token;
 
   return {
@@ -956,7 +951,8 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
         },
 
         [`${componentCls}-nav-add`]: {
-          minWidth: controlHeightLG,
+          minWidth: cardHeight,
+          minHeight: cardHeight,
           marginLeft: {
             _skip_check_: true,
             value: cardGutter,
@@ -1029,15 +1025,18 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
 };
 
 export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
-  const cardHeight = token.controlHeightLG;
+  const { cardHeight, controlHeightLG } = token;
+  const mergedCardHeight = typeof cardHeight === 'number' ? cardHeight : controlHeightLG;
 
   return {
     zIndexPopup: token.zIndexPopupBase + 50,
     cardBg: token.colorFillAlter,
-    cardHeight,
+    // We can not pass this as valid value,
+    // Since `cardHeight` will lock nav add button height.
+    cardHeight: undefined!,
     // Initialize with empty string, because cardPadding will be calculated with cardHeight by default.
     cardPadding: `${
-      (cardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
+      (mergedCardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
     }px ${token.padding}px`,
     cardPaddingSM: `${token.paddingXXS * 1.5}px ${token.padding}px`,
     cardPaddingLG: `${token.paddingXS}px ${token.padding}px ${token.paddingXXS * 1.5}px`,

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -159,7 +159,7 @@ const genCardStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
           background: cardBg,
           border: `${unit(token.lineWidth)} ${token.lineType} ${colorBorderSecondary}`,
           transition: `all ${token.motionDurationSlow} ${token.motionEaseInOut}`,
-          height: cardHeight,
+          minHeight: cardHeight,
         },
 
         [`${componentCls}-tab-active`]: {

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -597,6 +597,8 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     cardPaddingLG,
     horizontalItemPaddingSM,
     horizontalItemPaddingLG,
+    cardHeight,
+    calc,
   } = token;
   return {
     [componentCls]: {
@@ -623,7 +625,7 @@ const genSizeStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
       [`&${componentCls}-small`]: {
         [`> ${componentCls}-nav`]: {
           [`${componentCls}-tab`]: {
-            minHeight: 'auto',
+            minHeight: calc(cardHeight).mul(0.9).equal(),
             padding: cardPaddingSM,
           },
         },

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -1066,13 +1066,13 @@ export const prepareComponentToken: GetDefaultToken<'Tabs'> = (token) => {
     cardHeightLG: mergedCardHeightLG,
     // Initialize with empty string, because cardPadding will be calculated with cardHeight by default.
     cardPadding: `${
-      (mergedCardHeight - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
+      (mergedCardHeight - token.fontHeight) / 2 - token.lineWidth
     }px ${token.padding}px`,
     cardPaddingSM: `${
-      (mergedCardHeightSM - Math.round(token.fontSize * token.lineHeight)) / 2 - token.lineWidth
+      (mergedCardHeightSM - token.fontHeight) / 2 - token.lineWidth
     }px ${token.paddingXS}px`,
     cardPaddingLG: `${
-      (mergedCardHeightLG - Math.round(token.fontSizeLG * token.lineHeightLG)) / 2 - token.lineWidth
+      (mergedCardHeightLG - token.fontHeightLG) / 2 - token.lineWidth
     }px ${token.padding}px`,
     titleFontSize: token.fontSize,
     titleFontSizeLG: token.fontSizeLG,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- fix #52830 

### 💡 Background and Solution

排查了一下，引起问题的pr是：
- #51935 
具体代码如下：
![QQ_1739630654340](https://github.com/user-attachments/assets/f411ed53-ae2b-47d5-add4-a69494c3d24b)

之前cardHeight其实是设置给了add button，然后add button将整个tabs的高度撑开了。但是在上面这个pr里将minHeight给去掉了，导致add button无法撑开其它tabs的高度。其实这种实现本来也是不合理的，cardHeight应该设置在页签上，而非button上

------

<div id="zombie_update"></div>

@zombieJ Update:

这是一个复合问题：
* Tabs 添加了一个 Component Token 叫 `cardHeight`，这个用于控制 Tabs 的高度。但 Tabs 本身有 3 个 `size`，所以 `cardHeight` 对所有 `size` 都是共用的。
* Tabs 的 `prepareToken` 会预生成 `cardHeight` 来用于最终样式计算。
* Tabs 的 `editable-card` 中，添加按钮为正方形。所以使用 `cardHeight` 来同时设置 `width` 和 `height`。
* Tabs 的标签高度则通过 `cardHeight = controlHeightLG` 生成 `cardPadding` 来最终撑开这个高度。
  * 这里有个错误，`cardPadding` 没有采纳用户传入的 `cardHeight` 所以应该用 `cardHeight = cardHeight || controlHeightLG`  再来计算。
  * 但是在中 #49855 PR 中把 `cardHeight` 改成了 `string | number` 类型，所以这导致了在原本的 bug 上又叠了一层。使得 `cardPadding` 无法使用正确的值来进行计算。

为了解决这个问题：

* `cardHeight` 恢复为 `number` 类型
* 以下几种选择择一：
  1. 拆分 `cardHeight` 为 `cardHeight`, `cardHeightSM`, `cardHeightLG`，分开计算
  2. 仍然是单个 `cardHeight`，但是同时对所有三种 `size` 的不同 `type` 都生效（目前 `type` 只对 `editable-card` 有作用）

cc @MadCcc  @aojunhao123  @thinkasany 

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    🐞 Fix Tabs card type height not working correctly when using cardHeight token       |
| 🇨🇳 Chinese |    🐞 修复卡片类型页签在使用 cardHeight token时高度设置不正确的问题       |
