### PR TITLE
feat: Customize background colors of default & dashed buttons in disabled state

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -653,6 +653,42 @@ exports[`renders components/button/demo/color-variant.tsx extend context correct
 
 exports[`renders components/button/demo/color-variant.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/button/demo/custom-disabled-bg.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <button
+    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Primary Button
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Default Button
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Dashed Button
+    </span>
+  </button>
+</div>
+`;
+
+exports[`renders components/button/demo/custom-disabled-bg.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/button/demo/danger.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"

--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -655,11 +655,10 @@ exports[`renders components/button/demo/color-variant.tsx extend context correct
 
 exports[`renders components/button/demo/custom-disabled-bg.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex ant-flex-wrap-wrap ant-flex-gap-small"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
 >
   <button
-    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-    disabled=""
+    class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
     type="button"
   >
     <span>
@@ -667,8 +666,9 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx extend context co
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
     disabled=""
+    id="dadd"
     type="button"
   >
     <span>
@@ -676,12 +676,20 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx extend context co
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+    class="ant-btn css-var-test-id ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
     disabled=""
     type="button"
   >
     <span>
       Dashed Button
+    </span>
+  </button>
+  <button
+    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-solid"
+    type="button"
+  >
+    <span>
+      btn2
     </span>
   </button>
 </div>

--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -659,6 +659,7 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx extend context co
 >
   <button
     class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    disabled=""
     type="button"
   >
     <span>
@@ -668,7 +669,6 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx extend context co
   <button
     class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
     disabled=""
-    id="dadd"
     type="button"
   >
     <span>
@@ -682,14 +682,6 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx extend context co
   >
     <span>
       Dashed Button
-    </span>
-  </button>
-  <button
-    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-solid"
-    type="button"
-  >
-    <span>
-      btn2
     </span>
   </button>
 </div>

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -649,6 +649,7 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
 >
   <button
     class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    disabled=""
     type="button"
   >
     <span>
@@ -658,7 +659,6 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
   <button
     class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
     disabled=""
-    id="dadd"
     type="button"
   >
     <span>
@@ -672,14 +672,6 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
   >
     <span>
       Dashed Button
-    </span>
-  </button>
-  <button
-    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-solid"
-    type="button"
-  >
-    <span>
-      btn2
     </span>
   </button>
 </div>

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -643,6 +643,40 @@ exports[`renders components/button/demo/color-variant.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
+<div
+  class="ant-flex ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <button
+    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Primary Button
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Default Button
+    </span>
+  </button>
+  <button
+    class="ant-btn ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+    disabled=""
+    type="button"
+  >
+    <span>
+      Dashed Button
+    </span>
+  </button>
+</div>
+`;
+
 exports[`renders components/button/demo/danger.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -645,11 +645,10 @@ exports[`renders components/button/demo/color-variant.tsx correctly 1`] = `
 
 exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
 <div
-  class="ant-flex ant-flex-wrap-wrap ant-flex-gap-small"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
 >
   <button
-    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-    disabled=""
+    class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
     type="button"
   >
     <span>
@@ -657,8 +656,9 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
     disabled=""
+    id="dadd"
     type="button"
   >
     <span>
@@ -666,12 +666,20 @@ exports[`renders components/button/demo/custom-disabled-bg.tsx correctly 1`] = `
     </span>
   </button>
   <button
-    class="ant-btn ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
+    class="ant-btn css-var-test-id ant-btn-dashed ant-btn-color-default ant-btn-variant-dashed"
     disabled=""
     type="button"
   >
     <span>
       Dashed Button
+    </span>
+  </button>
+  <button
+    class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-solid"
+    type="button"
+  >
+    <span>
+      btn2
     </span>
   </button>
 </div>

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -538,7 +538,7 @@ describe('Button', () => {
     expect(container.querySelector(`.${customClassNames.content}`)).toHaveStyle(
       cusomStyles.content,
     );
-  })
+  });
 
   it('should support customizing the background color of default type button in disabled state', () => {
     const { container } = render(
@@ -557,7 +557,9 @@ describe('Button', () => {
 
     const button = container.querySelector('.ant-btn-default')!;
     expect(button).toBeDisabled();
-    expect(window.getComputedStyle(button).background).toBe('rgba(0, 0, 0, 0.1)');
+    expect(button).toHaveStyle({
+      '--ant-button-default-bg-disabled': 'rgba(0, 0, 0, 0.1)',
+    });
   });
 
   it('should support customizing the background color of dashed type button in disabled state', () => {
@@ -579,6 +581,8 @@ describe('Button', () => {
 
     const button = container.querySelector('.ant-btn-dashed')!;
     expect(button).toBeDisabled();
-    expect(window.getComputedStyle(button).background).toBe('rgba(0, 0, 0, 0.2)');
+    expect(button).toHaveStyle({
+      '--ant-button-dashed-bg-disabled': 'rgba(0, 0, 0, 0.2)',
+    });
   });
 });

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -546,7 +546,7 @@ describe('Button', () => {
         theme={{
           components: {
             Button: {
-              colorBgDefaultDisabled: 'rgba(0, 0, 0, 0.1)',
+              defaultBgDisabled: 'rgba(0, 0, 0, 0.1)',
             },
           },
         }}
@@ -566,7 +566,7 @@ describe('Button', () => {
         theme={{
           components: {
             Button: {
-              colorBgDashedDisabled: 'rgba(0, 0, 0, 0.2)',
+              dashedBgDisabled: 'rgba(0, 0, 0, 0.2)',
             },
           },
         }}

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -538,5 +538,25 @@ describe('Button', () => {
     expect(container.querySelector(`.${customClassNames.content}`)).toHaveStyle(
       cusomStyles.content,
     );
+  })
+
+  it('should support customizing the background color of default type button in disabled state', () => {
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          components: {
+            Button: {
+              colorBgDefaultDisabled: 'rgba(0, 0, 0, 0.1)',
+            },
+          },
+        }}
+      >
+        <Button disabled>button</Button>
+      </ConfigProvider>,
+    );
+
+    const button = container.querySelector('.ant-btn-default')!;
+    expect(button).toBeDisabled();
+    expect(window.getComputedStyle(button).background).toBe('rgba(0, 0, 0, 0.1)');
   });
 });

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -559,4 +559,26 @@ describe('Button', () => {
     expect(button).toBeDisabled();
     expect(window.getComputedStyle(button).background).toBe('rgba(0, 0, 0, 0.1)');
   });
+
+  it('should support customizing the background color of dashed type button in disabled state', () => {
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          components: {
+            Button: {
+              colorBgDashedDisabled: 'rgba(0, 0, 0, 0.2)',
+            },
+          },
+        }}
+      >
+        <Button type="dashed" disabled>
+          button
+        </Button>
+      </ConfigProvider>,
+    );
+
+    const button = container.querySelector('.ant-btn-dashed')!;
+    expect(button).toBeDisabled();
+    expect(window.getComputedStyle(button).background).toBe('rgba(0, 0, 0, 0.2)');
+  });
 });

--- a/components/button/demo/custom-disabled-bg.md
+++ b/components/button/demo/custom-disabled-bg.md
@@ -1,6 +1,6 @@
 ## zh-CN
 
-自定义disable下的背景颜色(适用`default`和`dashed`类型)
+自定义disable下的背景颜色(适用 `default` 和 `dashed` 类型)
 
 ## en-US
 

--- a/components/button/demo/custom-disabled-bg.md
+++ b/components/button/demo/custom-disabled-bg.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+自定义disable下的背景颜色(适用`default`和`dashed`类型)
+
+## en-US
+
+Customize the background color with disable (applicable to type `default` and `dashed`)

--- a/components/button/demo/custom-disabled-bg.tsx
+++ b/components/button/demo/custom-disabled-bg.tsx
@@ -7,8 +7,8 @@ const App: React.FC = () => (
       theme={{
         components: {
           Button: {
-            colorBgDefaultDisabled: 'rgba(0,0,0,0.1)',
-            colorBgDashedDisabled: 'rgba(0,0,0,0.4)',
+            defaultBgDisabled: 'rgba(0,0,0,0.1)',
+            dashedBgDisabled: 'rgba(0,0,0,0.4)',
           },
         },
       }}

--- a/components/button/demo/custom-disabled-bg.tsx
+++ b/components/button/demo/custom-disabled-bg.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button, Flex, ConfigProvider } from 'antd';
+
+const App: React.FC = () => (
+  <Flex gap="small" wrap>
+    <ConfigProvider
+      theme={{
+        components: {
+          Button: {
+            colorBgDefaultDisabled: 'rgba(0,0,0,0.1)',
+            colorBgDashedDisabled: 'rgba(0,0,0,0.4)',
+          },
+        },
+      }}
+    >
+      <Button type="primary" disabled>
+        Primary Button
+      </Button>
+      <Button disabled>Default Button</Button>
+      <Button type="dashed" disabled>
+        Dashed Button
+      </Button>
+    </ConfigProvider>
+  </Flex>
+);
+
+export default App;

--- a/components/button/index.en-US.md
+++ b/components/button/index.en-US.md
@@ -51,6 +51,7 @@ And 4 other properties additionally.
 <code src="./demo/chinese-chars-loading.tsx" debug>Loading style bug</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 <code src="./demo/linear-gradient.tsx">Gradient Button</code>
+<code src="./demo/custom-disabled-bg.tsx">Custom disabled backgroundColor</code>
 
 ## API
 

--- a/components/button/index.zh-CN.md
+++ b/components/button/index.zh-CN.md
@@ -55,6 +55,7 @@ group:
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 <code src="./demo/linear-gradient.tsx">渐变按钮</code>
 <code src="./demo/chinese-space.tsx" version="5.17.0">移除两个汉字之间的空格</code>
+<code src="./demo/custom-disabled-bg.tsx">自定义禁用样式背景</code>
 
 ## API
 

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -205,6 +205,10 @@ const genSolidDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (toke
   [`&:disabled, &${token.componentCls}-disabled`]: {
     ...genDisabledStyle(token),
   },
+
+  [`${token.componentCls}-default&:disabled`]: {
+    background: token.colorBgDefaultDisabled,
+  },
 });
 
 const genPureDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -209,6 +209,10 @@ const genSolidDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (toke
   [`${token.componentCls}-default&:disabled`]: {
     background: token.colorBgDefaultDisabled,
   },
+
+  [`${token.componentCls}-dashed&:disabled`]: {
+    background: token.colorBgDashedDisabled,
+  },
 });
 
 const genPureDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -207,11 +207,11 @@ const genSolidDisabledButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (toke
   },
 
   [`${token.componentCls}-default&:disabled`]: {
-    background: token.colorBgDefaultDisabled,
+    background: token.defaultBgDisabled,
   },
 
   [`${token.componentCls}-dashed&:disabled`]: {
-    background: token.colorBgDashedDisabled,
+    background: token.dashedBgDisabled,
   },
 });
 

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -226,6 +226,11 @@ export interface ComponentToken {
    * @descE background color when type='default' is disabled
    */
   colorBgDefaultDisabled: string;
+  /**
+   * @desc type='dashed'禁用下的背景颜色
+   * @descE background color when type='dashed' is disabled
+   */
+  colorBgDashedDisabled: string;
 }
 
 type ShadowColorMap = {
@@ -288,6 +293,7 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     {},
   );
   const colorBgDefaultDisabled = token.colorBgDefaultDisabled ?? token.colorBgContainerDisabled;
+  const colorBgDashedDisabled = token.colorBgDashedDisabled ?? token.colorBgContainerDisabled;
 
   return {
     ...shadowColorTokens,
@@ -343,5 +349,6 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
       0,
     ),
     colorBgDefaultDisabled,
+    colorBgDashedDisabled,
   };
 };

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -221,6 +221,11 @@ export interface ComponentToken {
    * @descEN Line height of small button content
    */
   contentLineHeightSM: number;
+  /**
+   * @desc type='default'禁用下的背景颜色
+   * @descE background color when type='default' is disabled
+   */
+  colorBgDefaultDisabled: string;
 }
 
 type ShadowColorMap = {
@@ -282,6 +287,7 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     }),
     {},
   );
+  const colorBgDefaultDisabled = token.colorBgDefaultDisabled ?? token.colorBgContainerDisabled;
 
   return {
     ...shadowColorTokens,
@@ -336,5 +342,6 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
       (token.controlHeightLG - contentFontSizeLG * contentLineHeightLG) / 2 - token.lineWidth,
       0,
     ),
+    colorBgDefaultDisabled,
   };
 };

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -222,12 +222,12 @@ export interface ComponentToken {
    */
   contentLineHeightSM: number;
   /**
-   * @desc type='default'禁用下的背景颜色
+   * @desc type='default' 禁用状态下的背景颜色
    * @descE background color when type='default' is disabled
    */
   defaultBgDisabled: string;
   /**
-   * @desc type='dashed'禁用下的背景颜色
+   * @desc type='dashed' 禁用状态下的背景颜色
    * @descE background color when type='dashed' is disabled
    */
   dashedBgDisabled: string;

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -225,12 +225,12 @@ export interface ComponentToken {
    * @desc type='default'禁用下的背景颜色
    * @descE background color when type='default' is disabled
    */
-  colorBgDefaultDisabled: string;
+  defaultBgDisabled: string;
   /**
    * @desc type='dashed'禁用下的背景颜色
    * @descE background color when type='dashed' is disabled
    */
-  colorBgDashedDisabled: string;
+  dashedBgDisabled: string;
 }
 
 type ShadowColorMap = {
@@ -292,8 +292,8 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
     }),
     {},
   );
-  const colorBgDefaultDisabled = token.colorBgDefaultDisabled ?? token.colorBgContainerDisabled;
-  const colorBgDashedDisabled = token.colorBgDashedDisabled ?? token.colorBgContainerDisabled;
+  const defaultBgDisabled = token.colorBgContainerDisabled;
+  const dashedBgDisabled = token.colorBgContainerDisabled;
 
   return {
     ...shadowColorTokens,
@@ -348,7 +348,7 @@ export const prepareComponentToken: GetDefaultToken<'Button'> = (token) => {
       (token.controlHeightLG - contentFontSizeLG * contentLineHeightLG) / 2 - token.lineWidth,
       0,
     ),
-    colorBgDefaultDisabled,
-    colorBgDashedDisabled,
+    defaultBgDisabled,
+    dashedBgDisabled,
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

related to [#52758](https://github.com/ant-design/ant-design/issues/52758)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Added Custom default and dashed type button background color in disabled state        |
| 🇨🇳 Chinese |   新增自定义普通、虚线类型的按钮在禁用状态下的背景颜色       |
