### PR TITLE
feat(Cascader): support icons in global config

### DIFF
--- a/components/cascader/Panel.tsx
+++ b/components/cascader/Panel.tsx
@@ -5,6 +5,7 @@ import { Panel } from '@rc-component/cascader';
 import type { PickType } from '@rc-component/cascader/lib/Panel';
 
 import type { CascaderProps, DefaultOptionType } from '.';
+import { useComponentConfig } from '../config-provider/context';
 import DefaultRenderEmpty from '../config-provider/defaultRenderEmpty';
 import DisabledContext from '../config-provider/DisabledContext';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
@@ -14,7 +15,7 @@ import useColumnIcons from './hooks/useColumnIcons';
 import useStyle from './style';
 import usePanelStyle from './style/panel';
 
-export type PanelPickType = Exclude<PickType, 'checkable'> | 'multiple' | 'rootClassName';
+export type PanelPickType = Exclude<PickType, 'checkable'> | 'multiple' | 'rootClassName' | 'icons';
 
 export type CascaderPanelProps<
   OptionType extends DefaultOptionType = DefaultOptionType,
@@ -42,7 +43,10 @@ function CascaderPanel<
     direction,
     expandIcon,
     disabled: customDisabled,
+    icons,
   } = props;
+
+  const { icons: contextIcons } = useComponentConfig('cascader');
 
   const disabled = React.useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
@@ -59,7 +63,10 @@ function CascaderPanel<
   const isRtl = mergedDirection === 'rtl';
 
   // ===================== Icon ======================
-  const [mergedExpandIcon, loadingIcon] = useColumnIcons(prefixCls, isRtl, expandIcon);
+  const [mergedExpandIcon, loadingIcon] = useColumnIcons(prefixCls, isRtl, expandIcon, {
+    ...contextIcons,
+    ...icons,
+  });
 
   // ===================== Empty =====================
   const mergedNotFoundContent = notFoundContent || renderEmpty?.('Cascader') || (

--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ import excludeAllWarning from '../../../tests/shared/excludeWarning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, screen } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 
 const { SHOW_CHILD, SHOW_PARENT } = Cascader;
@@ -792,6 +792,7 @@ describe('Cascader', () => {
 
     errSpy.mockRestore();
   });
+
   it('Support aria-* and data-* in options', () => {
     const { container } = render(
       <Cascader options={options} open defaultValue={['zhejiang', 'hangzhou']} />,
@@ -801,5 +802,27 @@ describe('Cascader', () => {
     expect(menuItems[0].getAttribute('data-title')).toBe('Zhejiang');
     expect(menuItems[2].getAttribute('aria-label')).toBe('Hangzhou');
     expect(menuItems[2].getAttribute('data-title')).toBe('Hangzhou');
+  });
+
+  it('should support custom icons via global config', () => {
+    render(
+      <ConfigProvider cascader={{ icons: { expand: <span>foobar</span> } }}>
+        <Cascader open options={[{ value: 1, label: '1', children: [{ value: 2, label: '2' }] }]} />
+      </ConfigProvider>,
+    );
+    expect(screen.getByText('foobar')).toBeTruthy();
+  });
+
+  it('should prefer custom icons via props over global config', () => {
+    render(
+      <ConfigProvider cascader={{ icons: { expand: <span>foobar</span> } }}>
+        <Cascader
+          icons={{ expand: 'bamboo' }}
+          open
+          options={[{ value: 1, label: '1', children: [{ value: 2, label: '2' }] }]}
+        />
+      </ConfigProvider>,
+    );
+    expect(screen.getByText('bamboo')).toBeTruthy();
   });
 });

--- a/components/cascader/hooks/useColumnIcons.tsx
+++ b/components/cascader/hooks/useColumnIcons.tsx
@@ -2,23 +2,24 @@ import * as React from 'react';
 import LeftOutlined from '@ant-design/icons/LeftOutlined';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import RightOutlined from '@ant-design/icons/RightOutlined';
+import type { CascaderProps } from '..';
 
-const useColumnIcons = (prefixCls: string, rtl: boolean, expandIcon?: React.ReactNode) => {
-  let mergedExpandIcon = expandIcon;
-  if (!expandIcon) {
-    mergedExpandIcon = rtl ? <LeftOutlined /> : <RightOutlined />;
-  }
+const useColumnIcons = (
+  prefixCls: string,
+  rtl: boolean,
+  expandIcon?: React.ReactNode,
+  icons?: CascaderProps['icons'],
+) => {
+  const mergedExpandIcon =
+    expandIcon ?? icons?.expand ?? (rtl ? <LeftOutlined /> : <RightOutlined />);
 
   const loadingIcon = (
     <span className={`${prefixCls}-menu-item-loading-icon`}>
-      <LoadingOutlined spin />
+      {icons?.loading ?? <LoadingOutlined spin />}
     </span>
   );
 
-  return React.useMemo<Readonly<[React.ReactNode, React.ReactNode]>>(
-    () => [mergedExpandIcon, loadingIcon] as const,
-    [mergedExpandIcon],
-  );
+  return [mergedExpandIcon, loadingIcon] as const;
 };
 
 export default useColumnIcons;

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -98,6 +98,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | popupMenuColumnStyle | The style of the drop-down menu column | CSSProperties | - |  |
 | loadingIcon | The appearance of lazy loading (now is useless) | ReactNode | - |  |
 | optionRender | Customize the rendering dropdown options | (option: Option) => React.ReactNode | - | 5.16.0 |
+| icons | Built-in icons | { expand?: ReactNode; loading?: ReactNode; } | `{ expand: <RightOutlined/>, loading: <LoadingOutlined/> }` |  |
 
 ### showSearch
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -162,6 +162,16 @@ export interface CascaderProps<
   classNames?: Partial<Record<SemanticName, string>> & {
     popup?: Partial<Record<PopupSemantic, string>>;
   };
+
+  /** @deprecated Please use `icons.expand` instead */
+  expandIcon?: React.ReactNode;
+  /** @deprecated Please use `icons.loading` instead */
+  loadingIcon?: React.ReactNode;
+
+  icons?: {
+    expand?: React.ReactNode;
+    loading?: React.ReactNode;
+  };
 }
 export type CascaderAutoProps<
   OptionType extends DefaultOptionType = DefaultOptionType,
@@ -210,6 +220,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     onOpenChange,
     styles,
     classNames,
+    icons,
     ...rest
   } = props;
 
@@ -219,6 +230,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     getPrefixCls,
     getPopupContainer: getContextPopupContainer,
     className: contextClassName,
+    icons: contextIcons,
     style: contextStyle,
     classNames: contextClassNames,
     styles: contextStyles,
@@ -343,7 +355,10 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
   const mergedDisabled = customDisabled ?? disabled;
 
   // ===================== Icon ======================
-  const [mergedExpandIcon, loadingIcon] = useColumnIcons(prefixCls, isRtl, expandIcon);
+  const [mergedExpandIcon, loadingIcon] = useColumnIcons(prefixCls, isRtl, expandIcon, {
+    ...contextIcons,
+    ...icons,
+  });
 
   // =================== Multiple ====================
   const checkable = useCheckable(cascaderPrefixCls, multiple);

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -98,6 +98,7 @@ demo:
 | ~~dropdownMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `popupMenuColumnStyle` 替换 | CSSProperties | - |  |
 | popupMenuColumnStyle | 下拉菜单列的样式 | CSSProperties | - |  |
 | optionRender | 自定义渲染下拉选项 | (option: Option) => React.ReactNode | - | 5.16.0 |
+| icons | 内置图标 | { expand?: ReactNode; loading?: ReactNode; } | `{ expand: <RightOutlined/>, loading: <LoadingOutlined/> }` |  |
 
 ### showSearch
 

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -322,7 +322,7 @@ export type InputNumberConfig = ComponentStyleConfig &
   Pick<InputNumberProps, 'variant' | 'classNames' | 'styles'>;
 
 export type CascaderConfig = ComponentStyleConfig &
-  Pick<CascaderProps, 'variant' | 'styles' | 'classNames'>;
+  Pick<CascaderProps, 'variant' | 'styles' | 'classNames' | 'icons'>;
 
 export type TreeSelectConfig = ComponentStyleConfig &
   Pick<TreeSelectProps, 'variant' | 'classNames' | 'styles'>;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

支持全局配置 Cascader 图标。目前

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(Cascader): support icons in global config |
| 🇨🇳 Chinese | feat(Cascader): 支持图标全局配置 |
