### PR TITLE
ci: try fix CI deploy failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "pub": "echo 'Please use `npm publish` instead.'",
     "postpublish": "tsx scripts/post-publish.ts",
     "presite": "npm run prestart",
-    "site": "npm i --no-save --legacy-peer-deps react@19.0.0 react-dom@19.0.0 && dumi build && cp .surgeignore _site",
+    "site": "dumi build && cp .surgeignore _site",
     "size-limit": "size-limit",
     "sort:api-table": "antd-tools run sort-api-table",
     "sort:package-json": "npx sort-package-json",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->


### 🤔 This is a ...
- [x] ⏩ Workflow
- [ ] ❓ Other (about what?)

ci log https://github.com/ant-design/ant-design/actions/runs/13367350546/job/37333101830

根据日志 和 ci 文件，我怀疑是 bun 安装的依赖被 npm cli 破坏掉了。

发现 `site` 命令有一个 npm 安装 react19 的操作。但是 packagejson 文件中 react 和 react-dom 的依赖已经是 `^19` 

所以可以安全的删除这个安装操作，以解决 deploy site 的 ci 错误
