### PR TITLE
fix: token calc of padding input

### DIFF
--- a/components/input/demo/component-token.tsx
+++ b/components/input/demo/component-token.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UserOutlined } from '@ant-design/icons';
 import { ConfigProvider, Input } from 'antd';
 
 const App: React.FC = () => (
@@ -11,6 +12,9 @@ const App: React.FC = () => (
       theme={{ token: {}, components: { Input: { inputFontSizeSM: 12 } } }}
     >
       <Input placeholder="Basic usage" />
+    </ConfigProvider>
+    <ConfigProvider theme={{ components: { Input: { inputFontSize: 10 } } }}>
+      <Input placeholder="With prefix" prefix={<UserOutlined />} />
     </ConfigProvider>
   </>
 );

--- a/components/input/style/token.ts
+++ b/components/input/style/token.ts
@@ -103,7 +103,9 @@ export function initInputToken(token: AliasToken): SharedInputToken {
   });
 }
 
-export const initComponentToken = (token: AliasToken): SharedComponentToken => {
+export const initComponentToken = (
+  token: AliasToken & Partial<SharedComponentToken>,
+): SharedComponentToken => {
   const {
     controlHeight,
     fontSize,
@@ -124,19 +126,26 @@ export const initComponentToken = (token: AliasToken): SharedComponentToken => {
     colorErrorOutline,
     colorWarningOutline,
     colorBgContainer,
+    inputFontSize,
+    inputFontSizeLG,
+    inputFontSizeSM,
   } = token;
+
+  const mergedFontSize = inputFontSize || fontSize;
+  const mergedFontSizeSM = inputFontSizeSM || mergedFontSize;
+  const mergedFontSizeLG = inputFontSizeLG || fontSizeLG;
 
   return {
     paddingBlock: Math.max(
-      Math.round(((controlHeight - fontSize * lineHeight) / 2) * 10) / 10 - lineWidth,
+      Math.round(((controlHeight - mergedFontSize * lineHeight) / 2) * 10) / 10 - lineWidth,
       0,
     ),
     paddingBlockSM: Math.max(
-      Math.round(((controlHeightSM - fontSize * lineHeight) / 2) * 10) / 10 - lineWidth,
+      Math.round(((controlHeightSM - mergedFontSizeSM * lineHeight) / 2) * 10) / 10 - lineWidth,
       0,
     ),
     paddingBlockLG:
-      Math.ceil(((controlHeightLG - fontSizeLG * lineHeightLG) / 2) * 10) / 10 - lineWidth,
+      Math.ceil(((controlHeightLG - mergedFontSizeLG * lineHeightLG) / 2) * 10) / 10 - lineWidth,
     paddingInline: paddingSM - lineWidth,
     paddingInlineSM: controlPaddingHorizontalSM - lineWidth,
     paddingInlineLG: controlPaddingHorizontal - lineWidth,
@@ -148,8 +157,8 @@ export const initComponentToken = (token: AliasToken): SharedComponentToken => {
     warningActiveShadow: `0 0 0 ${controlOutlineWidth}px ${colorWarningOutline}`,
     hoverBg: colorBgContainer,
     activeBg: colorBgContainer,
-    inputFontSize: fontSize,
-    inputFontSizeLG: fontSizeLG,
-    inputFontSizeSM: fontSize,
+    inputFontSize: mergedFontSize,
+    inputFontSizeLG: mergedFontSizeLG,
+    inputFontSizeSM: mergedFontSizeSM,
   };
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input with component token `inputFontSize` breaks the height of `controlHeight`.      |
| 🇨🇳 Chinese |      修复 Input 配置 `inputFontSize` component token 时，`controlHeight` 会不生效的问题。    |
