### PR TITLE
perf(OTPInput): useState initializer function called only once

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -139,7 +139,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
   const internalFormatter = (txt: string) => (formatter ? formatter(txt) : txt);
 
   // ======================== Values ========================
-  const [valueCells, setValueCells] = React.useState<string[]>(
+  const [valueCells, setValueCells] = React.useState<string[]>(() =>
     strToArr(internalFormatter(defaultValue || '')),
   );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

### 💡 Background and Solution

`useState` 传初始化函数，避免每次渲染重新执行

[参考](https://react.dev/reference/react/useState#usestate:~:text=If%20you%20pass%20a%20function%20as%20initialState%2C%20it%20will%20be%20treated%20as%20an%20initializer%20function.%20It%20should%20be%20pure%2C%20should%20take%20no%20arguments%2C%20and%20should%20return%20a%20value%20of%20any%20type.%20React%20will%20call%20your%20initializer%20function%20when%20initializing%20the%20component%2C%20and%20store%20its%20return%20value%20as%20the%20initial%20state.)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Optimize useState initial value generation |
| 🇨🇳 Chinese | 优化 useState 初始值生成 |
