### PR TITLE
fix: dropdown submenu arrow wrong direction in rtl

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { TriggerProps } from '@rc-component/trigger';
+import ConfigProvider from '../../config-provider';
 
 import type { DropDownProps } from '..';
 import Dropdown from '..';
@@ -375,5 +376,37 @@ describe('Dropdown', () => {
       container.querySelector('.ant-dropdown-menu-title-content-with-extra'),
     ).toBeInTheDocument();
     expect(container.querySelector('.ant-dropdown-menu-item-extra')?.textContent).toBe(text);
+  });
+
+  it('should show correct arrow direction in rtl mode', () => {
+    const items = [
+      {
+        key: '1',
+        label: 'sub menu',
+        children: [
+          {
+            key: '1-1',
+            label: '1rd menu item',
+          },
+          {
+            key: '1-2',
+            label: '2th menu item',
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(
+      <ConfigProvider direction="rtl">
+        <Dropdown menu={{ items, openKeys: ['2'] }} open autoAdjustOverflow={false}>
+          <a onClick={(e) => e.preventDefault()}>Cascading menu</a>
+        </Dropdown>
+      </ConfigProvider>,
+    );
+    expect(
+      container.querySelector(
+        '.ant-dropdown-menu-submenu-arrow .ant-dropdown-menu-submenu-arrow-icon',
+      ),
+    ).toHaveClass('anticon-left');
   });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { RightOutlined, LeftOutlined } from '@ant-design/icons';
+import LeftOutlined from '@ant-design/icons/LeftOutlined';
+import RightOutlined from '@ant-design/icons/RightOutlined';
 import type { AlignType } from '@rc-component/trigger';
 import classNames from 'classnames';
 import RcDropdown from 'rc-dropdown';

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import RightOutlined from '@ant-design/icons/RightOutlined';
+import { RightOutlined, LeftOutlined } from '@ant-design/icons';
 import type { AlignType } from '@rc-component/trigger';
 import classNames from 'classnames';
 import RcDropdown from 'rc-dropdown';
@@ -252,14 +252,17 @@ const Dropdown: CompoundedComponent = (props) => {
     overlayNode = React.Children.only(
       typeof overlayNode === 'string' ? <span>{overlayNode}</span> : overlayNode,
     );
-
     return (
       <OverrideProvider
         prefixCls={`${prefixCls}-menu`}
         rootClassName={classNames(cssVarCls, rootCls)}
         expandIcon={
           <span className={`${prefixCls}-menu-submenu-arrow`}>
-            <RightOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />
+            {direction === 'rtl' ? (
+              <LeftOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />
+            ) : (
+              <RightOutlined className={`${prefixCls}-menu-submenu-arrow-icon`} />
+            )}
           </span>
         }
         mode="vertical"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

related to [#52882](https://github.com/ant-design/ant-design/issues/52882)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fixed wrong direction of dropdown multi-level menu arrow in rtl |
| 🇨🇳 Chinese |   修复dropdown多级菜单箭头在 rtl 中方向错误        |
