### PR TITLE
fix: update genStyleUtils to correct linkStyle

### DIFF
--- a/components/theme/util/genStyleUtils.ts
+++ b/components/theme/util/genStyleUtils.ts
@@ -30,10 +30,14 @@ export const { genStyleHooks, genComponentStyleHook, genSubStyleComponent } = ge
     const { csp } = useContext(ConfigContext);
     return csp ?? {};
   },
-  getResetStyles: (token, config) => [
-    genLinkStyle(token),
-    genIconStyle(config?.prefix.iconPrefixCls ?? defaultIconPrefixCls),
-  ],
+  getResetStyles: (token, config) => {
+    const linkStyle = genLinkStyle(token);
+    return [
+      linkStyle,
+      { '&': linkStyle },
+      genIconStyle(config?.prefix.iconPrefixCls ?? defaultIconPrefixCls),
+    ];
+  },
   getCommonStyle: genCommonStyle,
   getCompUnitless: (() => unitless) as GetCompUnitless<ComponentTokenMap, AliasToken>,
 });

--- a/components/theme/util/genStyleUtils.ts
+++ b/components/theme/util/genStyleUtils.ts
@@ -3,7 +3,7 @@ import { genStyleUtils } from '@ant-design/cssinjs-utils';
 import type { GetCompUnitless } from '@ant-design/cssinjs-utils/es/util/genStyleUtils';
 
 import { ConfigContext, defaultIconPrefixCls } from '../../config-provider/context';
-import { genCommonStyle, genLinkStyle, genIconStyle } from '../../style';
+import { genCommonStyle, genIconStyle, genLinkStyle } from '../../style';
 import type { AliasToken, ComponentTokenMap, SeedToken } from '../interface';
 import useLocalToken, { unitless } from '../useToken';
 
@@ -31,7 +31,7 @@ export const { genStyleHooks, genComponentStyleHook, genSubStyleComponent } = ge
     return csp ?? {};
   },
   getResetStyles: (token, config) => [
-    { '&': genLinkStyle(token) },
+    genLinkStyle(token),
     genIconStyle(config?.prefix.iconPrefixCls ?? defaultIconPrefixCls),
   ],
   getCommonStyle: genCommonStyle,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix: #52879

### 💡 Background and Solution

Add styles to ensure that the basic `a` tag styles can be applied when the `a` tag is already the outermost antd component element.
 
example:  `a:where(.css-dev-only-do-not-override-xxxx)`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed button hyperlink style     |
| 🇨🇳 Chinese |     修复按钮超链接样式      |
