### PR TITLE
fix(Table):The single word column title does not wrap for sortable column

### DIFF
--- a/components/table/style/sorter.ts
+++ b/components/table/style/sorter.ts
@@ -51,6 +51,7 @@ const genSorterStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         position: 'relative',
         zIndex: 1,
         flex: 1,
+        minWidth: 0,
       },
 
       [`${componentCls}-column-sorters`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ √ ] 🐞 Bug 修复

### 🔗 相关 Issue
https://github.com/ant-design/ant-design/issues/52873

### 💡 需求背景和解决方案
给子元素min-width：0，使得flex1生效

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fix The single word column title does not wrap for sortable column     |
| 🇨🇳 中文 |     解决可排序列的单字列标题不换行     |