### PR TITLE
demo(form): correct disabled styles

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5138,7 +5138,7 @@ Array [
                         type="file"
                       />
                       <button
-                        style="border: 0px; background: none;"
+                        style="cursor: inherit; border: 0px; background: none;"
                         type="button"
                       >
                         <span

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2648,7 +2648,7 @@ Array [
                         type="file"
                       />
                       <button
-                        style="border:0;background:none"
+                        style="color:inherit;cursor:inherit;border:0;background:none"
                         type="button"
                       >
                         <span

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -103,7 +103,10 @@ const FormDisabledDemo: React.FC = () => {
         </Form.Item>
         <Form.Item label="Upload" valuePropName="fileList" getValueFromEvent={normFile}>
           <Upload action="/upload.do" listType="picture-card">
-            <button style={{ border: 0, background: 'none' }} type="button">
+            <button
+              style={{ color: 'inherit', cursor: 'inherit', border: 0, background: 'none' }}
+              type="button"
+            >
               <PlusOutlined />
               <div style={{ marginTop: 8 }}>Upload</div>
             </button>

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -576,6 +576,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
           />
           <button
             class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            disabled=""
             type="button"
           >
             <span
@@ -853,7 +854,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               type="file"
             />
             <button
-              style="border: 0px; background: none;"
+              style="cursor: inherit; border: 0px; background: none;"
               type="button"
             >
               <span
@@ -1130,7 +1131,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               type="file"
             />
             <button
-              style="border: 0px; background: none;"
+              style="cursor: inherit; border: 0px; background: none;"
               type="button"
             >
               <span

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -576,7 +576,6 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
           />
           <button
             class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-            disabled=""
             type="button"
           >
             <span

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -548,6 +548,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
           />
           <button
             class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            disabled=""
             type="button"
           >
             <span
@@ -805,7 +806,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               type="file"
             />
             <button
-              style="border:0;background:none"
+              style="color:inherit;cursor:inherit;border:0;background:none"
               type="button"
             >
               <span
@@ -1062,7 +1063,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               type="file"
             />
             <button
-              style="border:0;background:none"
+              style="color:inherit;cursor:inherit;border:0;background:none"
               type="button"
             >
               <span

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -548,7 +548,6 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
           />
           <button
             class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-            disabled=""
             type="button"
           >
             <span

--- a/components/upload/demo/debug-disabled.tsx
+++ b/components/upload/demo/debug-disabled.tsx
@@ -47,9 +47,7 @@ const App: React.FC = () => {
     <Space direction="vertical">
       <Upload disabled>Click Text to Upload</Upload>
       <Upload disabled>
-        <Button disabled icon={<UploadOutlined />}>
-          Click to Upload
-        </Button>
+        <Button icon={<UploadOutlined />}>Click to Upload</Button>
       </Upload>
       <Upload name="avatar" listType="picture-card" fileList={fileList} disabled>
         {uploadButton}

--- a/components/upload/demo/debug-disabled.tsx
+++ b/components/upload/demo/debug-disabled.tsx
@@ -34,7 +34,10 @@ const fileList: UploadFile[] = [
 
 const App: React.FC = () => {
   const uploadButton = (
-    <button style={{ border: 0, background: 'none' }} type="button">
+    <button
+      style={{ color: 'inherit', cursor: 'inherit', border: 0, background: 'none' }}
+      type="button"
+    >
       <PlusOutlined />
       <div style={{ marginTop: 8 }}>Upload</div>
     </button>
@@ -44,7 +47,9 @@ const App: React.FC = () => {
     <Space direction="vertical">
       <Upload disabled>Click Text to Upload</Upload>
       <Upload disabled>
-        <Button icon={<UploadOutlined />}>Click to Upload</Button>
+        <Button disabled icon={<UploadOutlined />}>
+          Click to Upload
+        </Button>
       </Upload>
       <Upload name="avatar" listType="picture-card" fileList={fileList} disabled>
         {uploadButton}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ❓ Other (about what?)

### 🔗 Related Issues


### 💡 Background and Solution

[link: form-demo-disabled](https://ant.design/components/form-cn#form-demo-disabled)
The disabled styles for buttons were being overridden by the user agent stylesheet, causing the buttons to not display the expected disabled styles. By explicitly inheriting styles from parent elements, we ensure a consistent appearance.

#### Before:
![0zRtQTiWcP](https://github.com/user-attachments/assets/43dca573-371c-409a-8a38-3f5f5a43de04)

#### After:
![QP6fJkGakF](https://github.com/user-attachments/assets/0282a967-1fcf-4f6d-b87c-71560d3be321)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Demo: Improve the style of the Upload in the disabled form.     |
| 🇨🇳 Chinese |     Demo: 改进禁用表单中Upload的样式      |
