### PR TITLE
feat(Table):issues52919 filterDropdownProps accept custom OK and Reset button text

### DIFF
--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -364,6 +364,9 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   const { direction, renderEmpty } = React.useContext(ConfigContext);
 
+  const filterReset = filterDropdownProps.resetText ?? locale.filterReset;
+  const filterConfirm = filterDropdownProps.okText ?? locale.filterConfirm;
+
   if (typeof column.filterDropdown === 'function') {
     dropdownContent = column.filterDropdown({
       prefixCls: `${dropdownPrefixCls}-custom`,
@@ -376,6 +379,8 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       close: () => {
         triggerVisible(false);
       },
+      okText: filterConfirm,
+      resetText: filterReset,
     });
   } else if (column.filterDropdown) {
     dropdownContent = column.filterDropdown;
@@ -510,10 +515,10 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
         {getFilterComponent()}
         <div className={`${prefixCls}-dropdown-btns`}>
           <Button type="link" size="small" disabled={getResetDisabled()} onClick={() => onReset()}>
-            {locale.filterReset}
+            {filterReset}
           </Button>
           <Button type="primary" size="small" onClick={onConfirm}>
-            {locale.filterConfirm}
+            {filterConfirm}
           </Button>
         </div>
       </>

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -200,7 +200,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | filterMode | To specify the filter interface | 'menu' \| 'tree' | 'menu' | 4.17.0 |
 | filterSearch | Whether to be searchable for filter menu | boolean \| function(input, record):boolean | false | boolean:4.17.0 function:4.19.0 |
 | filters | Filter menu config | object\[] | - |  |
-| filterDropdownProps | Customized dropdown props, `filterDropdownOpen` and `onFilterDropdownOpenChange` were available before `<5.22.0` | [DropdownProps](/components/dropdown#api) | - | 5.22.0 |
+| filterDropdownProps | Customized dropdown props, `filterDropdownOpen` and `onFilterDropdownOpenChange` were available before `<5.22.0` | [DropdownProps](/components/dropdown#api) & {okText?: ReactNode; resetText?: ReactNode;} | - | 5.22.0 |
 | fixed | (IE not support) Set column to be fixed: `true`(same as left) `'left'` `'right'` | boolean \| string | false |  |
 | key | Unique key of this column, you can ignore this prop if you've set a unique `dataIndex` | string | - |  |
 | render | Renderer of the table cell. `value` is the value of current cell; `record` is the value object of current row; `index` is the row number. The return value should be a ReactNode | function(value, record, index) {} | - |  |

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -202,7 +202,7 @@ const columns = [
 | filterMode | 指定筛选菜单的用户界面 | 'menu' \| 'tree' | 'menu' | 4.17.0 |
 | filterSearch | 筛选菜单项是否可搜索 | boolean \| function(input, record):boolean | false | boolean:4.17.0 function:4.19.0 |
 | filters | 表头的筛选菜单项 | object\[] | - |  |
-| filterDropdownProps | 自定义下拉属性，在 `<5.22.0` 之前可用 `filterDropdownOpen` 和 `onFilterDropdownOpenChange` | [DropdownProps](/components/dropdown#api) | - | 5.22.0 |
+| filterDropdownProps | 自定义下拉属性，在 `<5.22.0` 之前可用 `filterDropdownOpen` 和 `onFilterDropdownOpenChange` | [DropdownProps](/components/dropdown#api) & {okText?: ReactNode; resetText?: ReactNode;} | - | 5.22.0 |
 | fixed | （IE 下无效）列是否固定，可选 `true` (等效于 `left`) `left` `right` | boolean \| string | false |  |
 | key | React 需要的 key，如果已经设置了唯一的 `dataIndex`，可以忽略这个属性 | string | - |  |
 | render | 生成复杂数据的渲染函数，参数分别为当前单元格的值，当前行数据，行索引 | function(value, record, index) {} | - |  |

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -122,6 +122,8 @@ export interface FilterDropdownProps {
   /** Only close filterDropdown */
   close: () => void;
   visible: boolean;
+  okText: React.ReactNode;
+  resetText: React.ReactNode;
 }
 
 // 非必要请勿导出
@@ -135,6 +137,8 @@ interface CoverableDropdownProps
     | 'onVisibleChange'
   > {
   onOpenChange?: (open: boolean) => void;
+  okText?: React.ReactNode;
+  resetText?: React.ReactNode;
 }
 
 export interface ColumnType<RecordType = AnyObject>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

 [ √ ] 🆕 新特性提交


### 🔗 相关 Issue
https://github.com/ant-design/ant-design/issues/52919

filterDropdownProps添加okText?: ReactNode; resetText?: ReactNode;

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     filterDropdownProps accept custom OK and Reset button text     |
| 🇨🇳 中文 |     filterDropdownProps接受自定义的OK和Reset按钮文本     |