### PR TITLE
fix: remove unexpected input underlined border when hover

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -406,7 +406,7 @@ const genUnderlinedStatusStyle = (
     },
   },
   [`&${token.componentCls}-status-${options.status}${token.componentCls}-disabled`]: {
-    borderColor: options.borderColor,
+    borderColor: `transparent transparent ${options.borderColor} transparent`,
   },
 });
 
@@ -425,7 +425,7 @@ export const genUnderlinedStyle = (token: InputToken, extraStyles?: CSSObject): 
       boxShadow: 'none',
       cursor: 'not-allowed',
       '&:hover': {
-        borderColor: token.colorBorder,
+        borderColor: `transparent transparent ${token.colorBorder} transparent`,
       },
     },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [✅ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

to #52947 

### 📝 Change Log
去除 Input 组件开启 variant="underlined" 时 disabled 状态下 hover 时出现的上边框。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove the top border that appears when hovering in disabled state when variant="underlined" is enabled on the Input component. |
| 🇨🇳 Chinese | 去除 Input 组件开启 variant="underlined" 时 disabled 状态下 hover 时出现的上边框。 |
