### PR TITLE
fix: Input incorrect focus behavious when pressing Tab 

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -30051,6 +30051,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -30233,6 +30234,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -30627,6 +30629,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -12326,6 +12326,7 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -12508,6 +12509,7 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -12902,6 +12904,7 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
               >
                 <button
                   class="ant-input-clear-icon ant-input-clear-icon-hidden ant-input-clear-icon-has-suffix"
+                  tabindex="-1"
                   type="button"
                 >
                   <span

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5421,6 +5421,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -5460,6 +5461,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -5561,6 +5563,7 @@ exports[`renders components/input/demo/borderless-debug.tsx extend context corre
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -5600,6 +5603,7 @@ exports[`renders components/input/demo/borderless-debug.tsx extend context corre
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -5676,6 +5680,7 @@ exports[`renders components/input/demo/borderless-debug.tsx extend context corre
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -5812,6 +5817,7 @@ exports[`renders components/input/demo/compact-style.tsx extend context correctl
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -6546,6 +6552,7 @@ exports[`renders components/input/demo/filled-debug.tsx extend context correctly
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -7032,6 +7039,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
           >
             <button
               class="ant-input-clear-icon"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -7111,6 +7119,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
           >
             <button
               class="ant-input-clear-icon"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -11104,6 +11113,7 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -11193,6 +11203,7 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -11326,6 +11337,7 @@ exports[`renders components/input/demo/search-input.tsx extend context correctly
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -11918,6 +11930,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1313,6 +1313,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -1352,6 +1353,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -1444,6 +1446,7 @@ exports[`renders components/input/demo/borderless-debug.tsx correctly 1`] = `
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -1483,6 +1486,7 @@ exports[`renders components/input/demo/borderless-debug.tsx correctly 1`] = `
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -1559,6 +1563,7 @@ exports[`renders components/input/demo/borderless-debug.tsx correctly 1`] = `
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -1693,6 +1698,7 @@ exports[`renders components/input/demo/compact-style.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -2342,6 +2348,7 @@ exports[`renders components/input/demo/filled-debug.tsx correctly 1`] = `
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -2723,6 +2730,7 @@ exports[`renders components/input/demo/group.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -2802,6 +2810,7 @@ exports[`renders components/input/demo/group.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -4424,6 +4433,7 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -4513,6 +4523,7 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -4646,6 +4657,7 @@ exports[`renders components/input/demo/search-input.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -5226,6 +5238,7 @@ Array [
     >
       <button
         class="ant-input-clear-icon ant-input-clear-icon-hidden"
+        tabindex="-1"
         type="button"
       >
         <span

--- a/components/input/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Input allowClear should change type when click 1`] = `
   >
     <button
       class="ant-input-clear-icon"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -55,6 +56,7 @@ exports[`Input allowClear should change type when click 2`] = `
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -96,6 +98,7 @@ exports[`Input allowClear should not show icon if defaultValue is undefined, nul
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -137,6 +140,7 @@ exports[`Input allowClear should not show icon if defaultValue is undefined, nul
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -178,6 +182,7 @@ exports[`Input allowClear should not show icon if defaultValue is undefined, nul
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -219,6 +224,7 @@ exports[`Input allowClear should not show icon if value is undefined, null or em
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -260,6 +266,7 @@ exports[`Input allowClear should not show icon if value is undefined, null or em
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -301,6 +308,7 @@ exports[`Input allowClear should not show icon if value is undefined, null or em
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span

--- a/components/input/__tests__/__snapshots__/textarea.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/textarea.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`TextArea allowClear should change type when click 1`] = `
   >
     <button
       class="ant-input-clear-icon"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -82,6 +83,7 @@ exports[`TextArea allowClear should change type when click 2`] = `
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -121,6 +123,7 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -160,6 +163,7 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -199,6 +203,7 @@ exports[`TextArea allowClear should not show icon if defaultValue is undefined, 
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -238,6 +243,7 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -277,6 +283,7 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -316,6 +323,7 @@ exports[`TextArea allowClear should not show icon if value is undefined, null or
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -20,6 +20,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -65,6 +66,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -110,6 +112,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span

--- a/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
@@ -20,6 +20,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -65,6 +66,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -110,6 +112,7 @@ Array [
     >
       <button
         class="ant-mentions-clear-icon"
+        tabindex="-1"
         type="button"
       >
         <span

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10167,6 +10167,7 @@ Array [
       >
         <button
           class="ant-input-clear-icon ant-input-clear-icon-hidden"
+          tabindex="-1"
           type="button"
         >
           <span

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3760,6 +3760,7 @@ Array [
       >
         <button
           class="ant-input-clear-icon ant-input-clear-icon-hidden"
+          tabindex="-1"
           type="button"
         >
           <span

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -962,6 +962,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
             >
               <button
                 class="ant-input-clear-icon"
+                tabindex="-1"
                 type="button"
               >
                 <span

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -679,6 +679,7 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon"
+                tabindex="-1"
                 type="button"
               >
                 <span

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -175,6 +175,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -709,6 +710,7 @@ exports[`renders components/transfer/demo/advanced.tsx extend context correctly 
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -3315,6 +3317,7 @@ Array [
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -3628,6 +3631,7 @@ Array [
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -8766,6 +8770,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -9280,6 +9285,7 @@ exports[`renders components/transfer/demo/search.tsx extend context correctly 1`
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -10181,6 +10187,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -10494,6 +10501,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -10646,6 +10654,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -11550,6 +11559,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -101,6 +101,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -359,6 +360,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -2234,6 +2236,7 @@ Array [
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -2472,6 +2475,7 @@ Array [
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -5685,6 +5689,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -5923,6 +5928,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
           >
             <button
               class="ant-input-clear-icon ant-input-clear-icon-hidden"
+              tabindex="-1"
               type="button"
             >
               <span
@@ -6395,6 +6401,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -6633,6 +6640,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -6786,6 +6794,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -7584,6 +7593,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
             >
               <button
                 class="ant-input-clear-icon ant-input-clear-icon-hidden"
+                tabindex="-1"
                 type="button"
               >
                 <span

--- a/components/transfer/__tests__/__snapshots__/search.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/search.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Transfer.Search should show cross icon when input value exists 1`] = `
   >
     <button
       class="ant-input-clear-icon ant-input-clear-icon-hidden"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -103,6 +104,7 @@ exports[`Transfer.Search should show cross icon when input value exists 2`] = `
   >
     <button
       class="ant-input-clear-icon"
+      tabindex="-1"
       type="button"
     >
       <span

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "rc-dropdown": "~4.2.1",
     "rc-field-form": "~2.7.0",
     "rc-image": "~7.11.0",
-    "rc-input": "~1.7.2",
+    "rc-input": "~1.7.3",
     "rc-input-number": "~9.4.0",
     "rc-mentions": "~2.19.1",
     "rc-menu": "~9.16.1",


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- ref https://github.com/react-component/input/pull/111

### 💡 Background and Solution


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fixed the issue that the next element was not selected correctly after pressing the Tab key after turning on allowClear       |
| 🇨🇳 Chinese |     修复开启 allowClear 后按下 Tab 键后没有正确选中下个元素        |
