### PR TITLE
fix: DatePicker header misalignment caused by unexpected button spacing

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -293,6 +293,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
           '> button': {
             color: 'inherit',
             fontWeight: 'inherit',
+            verticalAlign: 'top',
 
             '&:not(:first-child)': {
               marginInlineStart: paddingXS,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #53001

### 💡 Background and Solution

The `DatePicker` component's header buttons were causing unexpected spacing issues, making the header's height larger than the specified `lineHeight`. This happened because the buttons, being `inline-flex` elements, were aligned to the text `baseline` by default, which introduced unintended space. To resolve this, we set `vertical-align: top` on the header buttons. This adjustment eliminated the extra space and ensured the buttons aligned correctly with their container, maintaining the precise height specified by `lineHeight`.
> This issue doesn't always occur, but on my computer, it can be reproduced when the browser is zoomed to 90%.

#### Before
![image](https://github.com/user-attachments/assets/1598b8fc-0e07-42d6-a8d4-09200f80dd6f)

#### After
![image](https://github.com/user-attachments/assets/06e30e3d-1be9-4343-a0f8-a3baa366ce76)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix DatePicker header button alignment issue caused by unexpected spacing       |
| 🇨🇳 Chinese |     修复 DatePicker 头部按钮意外间距导致的对齐问题      |
