### PR TITLE
fix: dynamically resize the textarea's wrapper

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -21,6 +21,7 @@ import type { InputFocusOptions } from './Input';
 import { triggerFocus } from './Input';
 import { useSharedStyle } from './style';
 import useStyle from './style/textarea';
+import useHandleResizeWrapper from './hooks/useHandleResizeWrapper';
 
 export interface TextAreaProps extends Omit<RcTextAreaProps, 'suffix'> {
   /** @deprecated Use `variant` instead */
@@ -55,6 +56,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
     style,
     styles,
     variant: customVariant,
+    showCount,
     ...rest
   } = props;
 
@@ -113,6 +115,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   const [variant, enableVariantCls] = useVariant('textArea', customVariant, bordered);
 
   const mergedAllowClear = getAllowClear(allowClear ?? contextAllowClear);
+  const { handleResizeWrapper } = useHandleResizeWrapper();
 
   return wrapSharedCSSVar(
     wrapCSSVar(
@@ -164,6 +167,11 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
         suffix={
           hasFeedback && <span className={`${prefixCls}-textarea-suffix`}>{feedbackIcon}</span>
         }
+        showCount={showCount}
+        onResize={(size) => {
+          rest.onResize?.(size);
+          showCount && handleResizeWrapper(innerRef.current);
+        }}
         ref={innerRef}
       />,
     ),

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -170,7 +170,9 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
         showCount={showCount}
         onResize={(size) => {
           rest.onResize?.(size);
-          showCount && handleResizeWrapper(innerRef.current);
+          showCount &&
+            innerRef.current &&
+            handleResizeWrapper(innerRef.current.resizableTextArea, innerRef.current.nativeElement);
         }}
         ref={innerRef}
       />,

--- a/components/input/hooks/useHandleResizeWrapper.ts
+++ b/components/input/hooks/useHandleResizeWrapper.ts
@@ -1,28 +1,30 @@
-import { TextAreaRef } from 'rc-textarea';
+import { ResizableTextAreaRef } from 'rc-textarea';
 import React from 'react';
 
-type ResizeWrapperHandler = (rcTextArea: TextAreaRef | null) => void;
+type ResizeWrapperHandler = (resizableTextArea: ResizableTextAreaRef, wrapper: HTMLElement) => void;
 
 const ELEMENT_GAP = 2;
 
-export default function useHandleResizeWrapper(): { handleResizeWrapper: ResizeWrapperHandler } {
-  const prevWidthRef = React.useRef<number | null>(null);
+const adjustElementWidth = (width: number, wrapper: HTMLElement): void => {
+  if (wrapper.offsetWidth - width < ELEMENT_GAP) {
+    // The textarea's width is increased
+    wrapper.style.width = `${width + ELEMENT_GAP}px`;
+  } else if (wrapper.offsetWidth - width > ELEMENT_GAP) {
+    // The textarea's width is decreased
+    wrapper.style.width = `${width + ELEMENT_GAP}px`;
+  }
+};
 
-  const handleResizeWrapper: ResizeWrapperHandler = React.useCallback((rcTextArea) => {
-    if (!rcTextArea) return;
-    if (rcTextArea.resizableTextArea.textArea.style.width.includes('px')) {
-      const width = parseInt(rcTextArea.resizableTextArea.textArea.style.width.replace('px', ''));
-      if (rcTextArea.nativeElement.offsetWidth - width < ELEMENT_GAP) {
-        // The textarea's width is increased
-        rcTextArea.nativeElement.style.width = `${width + ELEMENT_GAP}px`;
-        prevWidthRef.current = width;
-      } else if (rcTextArea.nativeElement.offsetWidth - width > ELEMENT_GAP) {
-        // The textarea's width is decreased
-        rcTextArea.nativeElement.style.width = `${width + ELEMENT_GAP}px`;
-        prevWidthRef.current = width;
+export default function useHandleResizeWrapper(): { handleResizeWrapper: ResizeWrapperHandler } {
+  const handleResizeWrapper: ResizeWrapperHandler = React.useCallback(
+    (resizableTextArea, wrapper) => {
+      if (resizableTextArea.textArea.style.width.includes('px')) {
+        const width = parseInt(resizableTextArea.textArea.style.width.replace('px', ''));
+        adjustElementWidth(width, wrapper);
       }
-    }
-  }, []);
+    },
+    [],
+  );
 
   return { handleResizeWrapper };
 }

--- a/components/input/hooks/useHandleResizeWrapper.ts
+++ b/components/input/hooks/useHandleResizeWrapper.ts
@@ -1,0 +1,28 @@
+import { TextAreaRef } from 'rc-textarea';
+import React from 'react';
+
+type ResizeWrapperHandler = (rcTextArea: TextAreaRef | null) => void;
+
+const ELEMENT_GAP = 2;
+
+export default function useHandleResizeWrapper(): { handleResizeWrapper: ResizeWrapperHandler } {
+  const prevWidthRef = React.useRef<number | null>(null);
+
+  const handleResizeWrapper: ResizeWrapperHandler = React.useCallback((rcTextArea) => {
+    if (!rcTextArea) return;
+    if (rcTextArea.resizableTextArea.textArea.style.width.includes('px')) {
+      const width = parseInt(rcTextArea.resizableTextArea.textArea.style.width.replace('px', ''));
+      if (rcTextArea.nativeElement.offsetWidth - width < ELEMENT_GAP) {
+        // The textarea's width is increased
+        rcTextArea.nativeElement.style.width = `${width + ELEMENT_GAP}px`;
+        prevWidthRef.current = width;
+      } else if (rcTextArea.nativeElement.offsetWidth - width > ELEMENT_GAP) {
+        // The textarea's width is decreased
+        rcTextArea.nativeElement.style.width = `${width + ELEMENT_GAP}px`;
+        prevWidthRef.current = width;
+      }
+    }
+  }, []);
+
+  return { handleResizeWrapper };
+}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

fix https://github.com/ant-design/ant-design/issues/51594

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

- Solution: Both the wrapper `<span>` and the `<textarea>` should update their width simultaneously during resizing.
- UI/interaction changes:

![Screen Recording 2025-03-01 at 00 34 18](https://github.com/user-attachments/assets/8858d35b-f747-4d68-9c90-2709d6d7eb28)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Input.TextArea by updating the resize handling logic to synchronize the width of the wrapper and the `<textarea>`     |
| 🇨🇳 Chinese |     Fix Input.TextArea by updating the resize handling logic to synchronize the width of the wrapper and the `<textarea>`      |
