### PR TITLE
fix(affix): fixes unexpected onChange event behavior in React versions below 18

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -116,6 +116,12 @@ describe('Affix Render', () => {
     expect(onChange).toHaveBeenLastCalledWith(true);
     expect(container.querySelector('.ant-affix')).toHaveStyle({ top: 0 });
 
+    await movePlaceholder(100);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    await movePlaceholder(-100);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
     rerender(<AffixMounter offsetTop={10} onChange={onChange} />);
     await waitFakeTimer();
     expect(container.querySelector('.ant-affix')).toHaveStyle({ top: `10px` });

--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -238,7 +238,7 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
 
   React.useEffect(() => {
     addListeners();
-  }, [target, affixStyle]);
+  }, [target, affixStyle, lastAffix]);
 
   React.useEffect(() => {
     updatePosition();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 1. https://github.com/ant-design/ant-design/pull/51984

### 💡 需求背景和解决方案

> 1. Affix 在 React 17 及以下时，onChange 事件，在元素 吸顶，然后 不吸顶 之后，无论元素是否吸顶，onChange 都会返回 false
> 2. 核心原因是这个场景下，setState（ https://github.com/waiter/ant-design/blob/master/components/affix/index.tsx#L159 ） 并不会自动进行 批处理，而事件监听处，未对 lastAffix 做依赖（ https://github.com/waiter/ant-design/blob/master/components/affix/index.tsx#L241 ），导致状态不同步
> 3. 复现地址：https://codepen.io/waiter-the-animator/pen/ogNZaLr

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     fixes unexpected onChange event behavior in React versions below 18     |
| 🇨🇳 中文 |     修复在 React 版本低于 18 时，onChange 事件返回不符合预期     |