### PR TITLE
demo: use `null` instead  `''` for tooltip's disabled demo

### DIFF
--- a/components/tooltip/demo/disabled.tsx
+++ b/components/tooltip/demo/disabled.tsx
@@ -5,7 +5,7 @@ const App: React.FC = () => {
   const [disabled, setDisabled] = useState(true);
 
   return (
-    <Tooltip title={disabled ? '' : 'prompt text'}>
+    <Tooltip title={disabled ? null : 'prompt text'}>
       <Button onClick={() => setDisabled(!disabled)}>{disabled ? 'Enable' : 'Disable'}</Button>
     </Tooltip>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📽️ Demo improvement


### 💡 Background and Solution
既然有更好的，就主动推荐更好的吧。
<img width="951" alt="image" src="https://github.com/user-attachments/assets/2cb020d9-9f26-4ae9-a9e7-153bc1cb076a" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |         -  |
