### PR TITLE
chore: add overrides lock for pnpm、yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,15 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "xhr-mock": "^2.5.1"
   },
+  "pnpm": {
+    "overrides": {
+      "nwsapi": "2.2.16"
+    }
+  },
   "overrides": {
+    "nwsapi": "2.2.16"
+  },
+  "resolutions": {
     "nwsapi": "2.2.16"
   },
   "publishConfig": {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...


- [x] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
近期在开发next的功能，经常来在 master和next来回切，每次一安装依赖就挂了，jsdom的错误影响范围比较大。频繁重装依赖，感觉pnpm的会快一些，相信也有很多社区同学会用 pnpm or yarn，所以希望使用更严格的 overrides
![image](https://github.com/user-attachments/assets/a6521d29-fbeb-4b41-9792-0479d44303b6)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         -  |
| 🇨🇳 Chinese |       -    |
