### PR TITLE
feat: Transfer operations prop supports ReactNode array

### DIFF
--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6067,6 +6067,860 @@ exports[`renders components/transfer/demo/custom-item.tsx extend context correct
 
 exports[`renders components/transfer/demo/custom-item.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/transfer/demo/custom-operations.tsx extend context correctly 1`] = `
+Array [
+  <p>
+    This example demonstrates how to customize operation buttons, including handling disabled and loading states.
+  </p>,
+  <div
+    class="ant-transfer"
+  >
+    <div
+      class="ant-transfer-list"
+    >
+      <div
+        class="ant-transfer-list-header"
+      >
+        <label
+          class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+        >
+          <span
+            class="ant-checkbox ant-wave-target"
+          >
+            <input
+              class="ant-checkbox-input"
+              type="checkbox"
+            />
+            <span
+              class="ant-checkbox-inner"
+            />
+          </span>
+        </label>
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-dropdown-trigger ant-transfer-list-header-dropdown"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+        <div
+          class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
+            data-menu-list="true"
+            role="menu"
+            tabindex="0"
+          >
+            <li
+              aria-describedby="test-id"
+              class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-selectAll"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-dropdown-menu-title-content"
+              >
+                Select all data
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  id="test-id"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              aria-describedby="test-id"
+              class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-selectInvert"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-dropdown-menu-title-content"
+              >
+                Invert current page
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  id="test-id"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+          </ul>
+          <div
+            aria-hidden="true"
+            style="display: none;"
+          />
+        </div>
+        <span
+          class="ant-transfer-list-header-selected"
+        >
+          11 items
+        </span>
+        <span
+          class="ant-transfer-list-header-title"
+        />
+      </div>
+      <div
+        class="ant-transfer-list-body"
+      >
+        <ul
+          class="ant-transfer-list-content"
+        >
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 1"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 1
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 2"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 2
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 3"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 3
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 4"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 4
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 5"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 5
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 6"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 6
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 7"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 7
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 8"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 8
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 9"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 9
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 10"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 10
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 11"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 11
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="ant-transfer-operation"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+          To right
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="double-left"
+            class="anticon anticon-double-left"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M272.9 512l265.4-339.1c4.1-5.2.4-12.9-6.3-12.9h-77.3c-4.9 0-9.6 2.3-12.6 6.1L186.8 492.3a31.99 31.99 0 000 39.5l255.3 326.1c3 3.9 7.7 6.1 12.6 6.1H532c6.7 0 10.4-7.7 6.3-12.9L272.9 512zm304 0l265.4-339.1c4.1-5.2.4-12.9-6.3-12.9h-77.3c-4.9 0-9.6 2.3-12.6 6.1L490.8 492.3a31.99 31.99 0 000 39.5l255.3 326.1c3 3.9 7.7 6.1 12.6 6.1H836c6.7 0 10.4-7.7 6.3-12.9L576.9 512z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+          To left
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-transfer-list"
+    >
+      <div
+        class="ant-transfer-list-header"
+      >
+        <label
+          class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+        >
+          <span
+            class="ant-checkbox ant-wave-target"
+          >
+            <input
+              class="ant-checkbox-input"
+              type="checkbox"
+            />
+            <span
+              class="ant-checkbox-inner"
+            />
+          </span>
+        </label>
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-dropdown-trigger ant-transfer-list-header-dropdown"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+        <div
+          class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomLeft"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+        >
+          <ul
+            class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
+            data-menu-list="true"
+            role="menu"
+            tabindex="0"
+          >
+            <li
+              aria-describedby="test-id"
+              class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-selectAll"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-dropdown-menu-title-content"
+              >
+                Select all data
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  id="test-id"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+            <li
+              aria-describedby="test-id"
+              class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+              data-menu-id="rc-menu-uuid-test-selectInvert"
+              role="menuitem"
+              tabindex="-1"
+            >
+              <span
+                class="ant-dropdown-menu-title-content"
+              >
+                Invert current page
+              </span>
+            </li>
+            <div
+              class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-dropdown-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+            >
+              <div
+                class="ant-tooltip-arrow"
+                style="position: absolute; top: 0px; left: 0px;"
+              />
+              <div
+                class="ant-tooltip-content"
+              >
+                <div
+                  class="ant-tooltip-inner"
+                  id="test-id"
+                  role="tooltip"
+                />
+              </div>
+            </div>
+          </ul>
+          <div
+            aria-hidden="true"
+            style="display: none;"
+          />
+        </div>
+        <span
+          class="ant-transfer-list-header-selected"
+        >
+          9 items
+        </span>
+        <span
+          class="ant-transfer-list-header-title"
+        />
+      </div>
+      <div
+        class="ant-transfer-list-body"
+      >
+        <ul
+          class="ant-transfer-list-content"
+        >
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 12"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 12
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 13"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 13
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 14"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 14
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 15"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 15
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 16"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 16
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 17"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 17
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 18"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 18
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 19"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 19
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 20"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 20
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`renders components/transfer/demo/custom-operations.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/transfer/demo/custom-select-all-labels.tsx extend context correctly 1`] = `
 <div
   class="ant-transfer"

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -4125,6 +4125,708 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/transfer/demo/custom-operations.tsx correctly 1`] = `
+Array [
+  <p>
+    This example demonstrates how to customize operation buttons, including handling disabled and loading states.
+  </p>,
+  <div
+    class="ant-transfer"
+  >
+    <div
+      class="ant-transfer-list"
+    >
+      <div
+        class="ant-transfer-list-header"
+      >
+        <label
+          class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+        >
+          <span
+            class="ant-checkbox ant-wave-target"
+          >
+            <input
+              class="ant-checkbox-input"
+              type="checkbox"
+            />
+            <span
+              class="ant-checkbox-inner"
+            />
+          </span>
+        </label>
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-dropdown-trigger ant-transfer-list-header-dropdown"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-transfer-list-header-selected"
+        >
+          11
+          <!-- -->
+          <!-- -->
+          items
+        </span>
+        <span
+          class="ant-transfer-list-header-title"
+        />
+      </div>
+      <div
+        class="ant-transfer-list-body"
+      >
+        <ul
+          class="ant-transfer-list-content"
+        >
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 1"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 1
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 2"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 2
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 3"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 3
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 4"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 4
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 5"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 5
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 6"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 6
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 7"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 7
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 8"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 8
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 9"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 9
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 10"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 10
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 11"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 11
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="ant-transfer-operation"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+          To right
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="double-left"
+            class="anticon anticon-double-left"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M272.9 512l265.4-339.1c4.1-5.2.4-12.9-6.3-12.9h-77.3c-4.9 0-9.6 2.3-12.6 6.1L186.8 492.3a31.99 31.99 0 000 39.5l255.3 326.1c3 3.9 7.7 6.1 12.6 6.1H532c6.7 0 10.4-7.7 6.3-12.9L272.9 512zm304 0l265.4-339.1c4.1-5.2.4-12.9-6.3-12.9h-77.3c-4.9 0-9.6 2.3-12.6 6.1L490.8 492.3a31.99 31.99 0 000 39.5l255.3 326.1c3 3.9 7.7 6.1 12.6 6.1H836c6.7 0 10.4-7.7 6.3-12.9L576.9 512z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span>
+          To left
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-transfer-list"
+    >
+      <div
+        class="ant-transfer-list-header"
+      >
+        <label
+          class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+        >
+          <span
+            class="ant-checkbox ant-wave-target"
+          >
+            <input
+              class="ant-checkbox-input"
+              type="checkbox"
+            />
+            <span
+              class="ant-checkbox-inner"
+            />
+          </span>
+        </label>
+        <span
+          aria-label="down"
+          class="anticon anticon-down ant-dropdown-trigger ant-transfer-list-header-dropdown"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-transfer-list-header-selected"
+        >
+          9
+          <!-- -->
+          <!-- -->
+          items
+        </span>
+        <span
+          class="ant-transfer-list-header-title"
+        />
+      </div>
+      <div
+        class="ant-transfer-list-body"
+      >
+        <ul
+          class="ant-transfer-list-content"
+        >
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 12"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 12
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 13"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 13
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 14"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 14
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 15"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 15
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 16"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 16
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 17"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 17
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 18"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 18
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 19"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 19
+            </span>
+          </li>
+          <li
+            class="ant-transfer-list-content-item"
+            title="Content 20"
+          >
+            <label
+              class="ant-checkbox-wrapper ant-transfer-list-checkbox"
+            >
+              <span
+                class="ant-checkbox ant-wave-target"
+              >
+                <input
+                  class="ant-checkbox-input"
+                  type="checkbox"
+                />
+                <span
+                  class="ant-checkbox-inner"
+                />
+              </span>
+            </label>
+            <span
+              class="ant-transfer-list-content-item-text"
+            >
+              Content 20
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/transfer/demo/custom-select-all-labels.tsx correctly 1`] = `
 <div
   class="ant-transfer"

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -88,6 +88,12 @@ const generateData = (n = 20) => {
   return data;
 };
 
+const ButtonRender = ({ onClick }: { onClick: () => void }) => (
+  <Button type="link" onClick={onClick}>
+    Custom Button
+  </Button>
+);
+
 describe('Transfer', () => {
   mountTest(Transfer);
   rtlTest(Transfer);
@@ -862,11 +868,31 @@ describe('Transfer', () => {
       expect(input).toHaveValue('values');
     });
   });
-});
 
-const ButtonRender = ({ onClick }: { onClick: () => void }) => (
-  <Button onClick={onClick}>Right button reload</Button>
-);
+  it('should handle custom button click correctly', () => {
+    const handleChange = jest.fn();
+    const customButtonClick = jest.fn();
+
+    const CustomButton = ({ onClick }: { onClick: () => void }) => (
+      <Button type="link" onClick={onClick}>
+        Custom Button
+      </Button>
+    );
+
+    const { getByText } = render(
+      <Transfer
+        {...listCommonProps}
+        onChange={handleChange}
+        oneWay
+        operations={[<CustomButton key="test" onClick={customButtonClick} />]}
+      />,
+    );
+
+    fireEvent.click(getByText('Custom Button'));
+    expect(customButtonClick).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalled();
+  });
+});
 
 describe('immutable data', () => {
   // https://github.com/ant-design/ant-design/issues/28662

--- a/components/transfer/demo/custom-operations.md
+++ b/components/transfer/demo/custom-operations.md
@@ -1,0 +1,27 @@
+## zh-CN
+
+使用 `operations` 属性可以自定义操作按钮。
+
+当 `operations` 传入字符串数组时，会使用默认的 Button 组件，并将字符串作为按钮文本。
+
+当 `operations` 传入 React 元素数组时，会直接使用这些元素作为操作按钮，这样你可以使用自定义的按钮组件，如本例中的带有加载状态的按钮。
+
+注意：
+
+1. 当使用自定义按钮时，Transfer 组件会自动处理按钮的禁用状态和点击事件。
+2. 你可以在自定义按钮上添加 `disabled` 属性来控制按钮的禁用状态。
+3. 你可以在自定义按钮上添加 `onClick` 事件处理函数，它会与 Transfer 组件的内部处理函数合并执行。
+
+## en-US
+
+You can customize operations with the `operations` prop.
+
+When `operations` is an array of strings, it will use the default Button component and set the strings as button text.
+
+When `operations` is an array of React elements, it will use these elements directly as operation buttons, allowing you to use custom button components, such as buttons with loading state in this example.
+
+Note:
+
+1. When using custom buttons, the Transfer component will automatically handle the button's disabled state and click events.
+2. You can add a `disabled` property to your custom button to control its disabled state.
+3. You can add an `onClick` event handler to your custom button, which will be merged with the Transfer component's internal handler.

--- a/components/transfer/demo/custom-operations.tsx
+++ b/components/transfer/demo/custom-operations.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { Button, Transfer, message } from 'antd';
+import { DoubleLeftOutlined, DoubleRightOutlined } from '@ant-design/icons';
+import type { TransferProps } from 'antd';
+
+interface RecordType {
+  key: string;
+  title: string;
+  description: string;
+}
+
+const mockData: RecordType[] = Array.from({ length: 20 }).map((_, i) => ({
+  key: i.toString(),
+  title: `Content ${i + 1}`,
+  description: `Description ${i + 1}`,
+}));
+
+const initialTargetKeys = mockData.filter((item) => Number(item.key) > 10).map((item) => item.key);
+
+const App: React.FC = () => {
+  const [targetKeys, setTargetKeys] = useState<string[]>(initialTargetKeys);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [loadingRight, setLoadingRight] = useState<boolean>(false);
+  const [loadingLeft, setLoadingLeft] = useState<boolean>(false);
+
+  // Handle data transfer
+  const handleChange: TransferProps['onChange'] = (newTargetKeys, direction, moveKeys) => {
+    setTargetKeys(newTargetKeys as string[]);
+
+    // Simulate async operation
+    if (direction === 'right') {
+      setLoadingRight(true);
+      setTimeout(() => {
+        setLoadingRight(false);
+        message.success(`Successfully added ${moveKeys.length} items to the right`);
+      }, 1000);
+    } else {
+      setLoadingLeft(true);
+      setTimeout(() => {
+        setLoadingLeft(false);
+        message.success(`Successfully added ${moveKeys.length} items to the left`);
+      }, 1000);
+    }
+  };
+
+  // Handle selection change
+  const handleSelectChange: TransferProps['onSelectChange'] = (
+    sourceSelectedKeys,
+    targetSelectedKeys,
+  ) => {
+    setSelectedKeys([...sourceSelectedKeys, ...targetSelectedKeys] as string[]);
+  };
+
+  // Right button is disabled (no selected items on the left or all selected items are already in the right list)
+  const rightButtonDisabled =
+    selectedKeys.length === 0 || selectedKeys.every((key) => targetKeys.includes(key));
+
+  // Left button is disabled (no selected items on the right)
+  const leftButtonDisabled =
+    selectedKeys.length === 0 || selectedKeys.every((key) => !targetKeys.includes(key));
+
+  // Custom right button click handler
+  const handleRightButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // You can add custom logic here, such as showing a confirmation dialog
+    console.log('Right button clicked', event);
+    // The Transfer component will automatically handle data transfer
+  };
+
+  // Custom left button click handler
+  const handleLeftButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // You can add custom logic here, such as showing a confirmation dialog
+    console.log('Left button clicked', event);
+    // The Transfer component will automatically handle data transfer
+  };
+
+  return (
+    <>
+      <p>
+        This example demonstrates how to customize operation buttons, including handling disabled
+        and loading states.
+      </p>
+      <Transfer
+        dataSource={mockData}
+        targetKeys={targetKeys}
+        selectedKeys={selectedKeys}
+        onChange={handleChange}
+        onSelectChange={handleSelectChange}
+        render={(item) => item.title}
+        operations={[
+          // Custom right button (transfer data to the right)
+          <Button
+            key="to-right"
+            type="primary"
+            icon={<DoubleRightOutlined />}
+            loading={loadingRight}
+            disabled={rightButtonDisabled}
+            onClick={handleRightButtonClick}
+          >
+            To right
+          </Button>,
+          // Custom left button (transfer data to the left)
+          <Button
+            key="to-left"
+            type="primary"
+            icon={<DoubleLeftOutlined />}
+            loading={loadingLeft}
+            disabled={leftButtonDisabled}
+            onClick={handleLeftButtonClick}
+          >
+            To left
+          </Button>,
+        ]}
+      />
+    </>
+  );
+};
+
+export default App;

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -26,6 +26,7 @@ One or more elements can be selected from either column, one click on the proper
 <code src="./demo/search.tsx">Search</code>
 <code src="./demo/advanced.tsx">Advanced</code>
 <code src="./demo/custom-item.tsx">Custom datasource</code>
+<code src="./demo/custom-operations.tsx">Custom Operations</code>
 <code src="./demo/large-data.tsx">Pagination</code>
 <code src="./demo/table-transfer.tsx">Table Transfer</code>
 <code src="./demo/tree-transfer.tsx">Tree Transfer</code>
@@ -47,7 +48,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | listStyle | A custom CSS style used for rendering the transfer columns | object \| ({direction: `left` \| `right`}) => object | - |  |
 | locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 |
-| operations | A set of operations that are sorted from top to bottom | string\[] | \[`>`, `<`] |  |
+| operations | A set of operations that are sorted from top to bottom. When array of string provided, default buttons will be used, when array of ReactNode provided, custom elements will be used | ReactNode\[] | \[`>`, `<`] |  |
 | operationStyle | A custom CSS style used for rendering the operations column | object | - |  |
 | pagination | Use pagination. Not work in render props | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
 | render | The function to generate the item shown on a column. Based on an record (element of the dataSource array), this function should return a React element which is generated from that record. Also, it can return a plain object with `value` and `label`, `label` is a React element and `value` is for title | (record) => ReactNode | - |  |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -26,7 +26,7 @@ One or more elements can be selected from either column, one click on the proper
 <code src="./demo/search.tsx">Search</code>
 <code src="./demo/advanced.tsx">Advanced</code>
 <code src="./demo/custom-item.tsx">Custom datasource</code>
-<code src="./demo/custom-operations.tsx">Custom Operations</code>
+<code src="./demo/custom-operations.tsx" version="6.0.0">Custom Operations</code>
 <code src="./demo/large-data.tsx">Pagination</code>
 <code src="./demo/table-transfer.tsx">Table Transfer</code>
 <code src="./demo/tree-transfer.tsx">Tree Transfer</code>

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -98,7 +98,7 @@ export interface TransferProps<RecordType = any> {
   listStyle?: ((style: ListStyle) => CSSProperties) | CSSProperties;
   operationStyle?: CSSProperties;
   titles?: React.ReactNode[];
-  operations?: string[];
+  operations?: React.ReactNode[];
   showSearch?: boolean | TransferSearchOption;
   filterOption?: (inputValue: string, item: RecordType, direction: TransferDirection) => boolean;
   locale?: Partial<TransferLocale>;
@@ -468,10 +468,10 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
       <Operation
         className={`${prefixCls}-operation`}
         rightActive={rightActive}
-        rightArrowText={operations[0]}
+        rightButton={operations[0]}
         moveToRight={moveToRight}
         leftActive={leftActive}
-        leftArrowText={operations[1]}
+        leftButton={operations[1]}
         moveToLeft={moveToLeft}
         style={operationStyle}
         disabled={disabled}

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,6 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 <code src="./demo/search.tsx">带搜索框</code>
 <code src="./demo/advanced.tsx">高级用法</code>
 <code src="./demo/custom-item.tsx">自定义渲染行数据</code>
+<code src="./demo/custom-operations.tsx">自定义操作按钮</code>
 <code src="./demo/large-data.tsx">分页</code>
 <code src="./demo/table-transfer.tsx">表格穿梭框</code>
 <code src="./demo/tree-transfer.tsx">树穿梭框</code>
@@ -50,7 +51,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | listStyle | 两个穿梭框的自定义样式 | object\|({direction: `left` \| `right`}) => object | - |  |
 | locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容` } |  |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 |
-| operations | 操作文案集合，顺序从上至下 | string\[] | \[`>`, `<`] |  |
+| operations | 操作文案集合，顺序从上至下。当为字符串数组时使用默认的按钮，当为 ReactNode 数组时直接使用自定义元素 | ReactNode\[] | \[`>`, `<`] |  |
 | operationStyle | 操作栏的自定义样式 | CSSProperties | - |  |
 | pagination | 使用分页样式，自定义渲染列表下无效 | boolean \| { pageSize: number, simple: boolean, showSizeChanger?: boolean, showLessItems?: boolean } | false | 4.3.0 |
 | render | 每行数据渲染函数，该函数的入参为 `dataSource` 中的项，返回值为 ReactElement。或者返回一个普通对象，其中 `label` 字段为 ReactElement，`value` 字段为 title | (record) => ReactNode | - |  |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -27,7 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 <code src="./demo/search.tsx">带搜索框</code>
 <code src="./demo/advanced.tsx">高级用法</code>
 <code src="./demo/custom-item.tsx">自定义渲染行数据</code>
-<code src="./demo/custom-operations.tsx">自定义操作按钮</code>
+<code src="./demo/custom-operations.tsx" version="6.0.0">自定义操作按钮</code>
 <code src="./demo/large-data.tsx">分页</code>
 <code src="./demo/table-transfer.tsx">表格穿梭框</code>
 <code src="./demo/tree-transfer.tsx">树穿梭框</code>

--- a/components/transfer/operation.tsx
+++ b/components/transfer/operation.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback } from 'react';
 import LeftOutlined from '@ant-design/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/RightOutlined';
 
@@ -7,8 +8,8 @@ import type { DirectionType } from '../config-provider';
 
 export interface TransferOperationProps {
   className?: string;
-  leftArrowText?: string;
-  rightArrowText?: string;
+  leftButton?: React.ReactNode;
+  rightButton?: React.ReactNode;
   moveToLeft?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
   moveToRight?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
   leftActive?: boolean;
@@ -19,42 +20,96 @@ export interface TransferOperationProps {
   oneWay?: boolean;
 }
 
+// 定义按钮元素的类型
+type ButtonElementType = React.ReactElement<{
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+}>;
+
 const Operation: React.FC<TransferOperationProps> = (props) => {
   const {
     disabled,
     moveToLeft,
     moveToRight,
-    leftArrowText = '',
-    rightArrowText = '',
     leftActive,
     rightActive,
     className,
     style,
     direction,
     oneWay,
+    leftButton = '',
+    rightButton = '',
   } = props;
-  return (
-    <div className={className} style={style}>
-      <Button
-        type="primary"
-        size="small"
-        disabled={disabled || !rightActive}
-        onClick={moveToRight}
-        icon={direction !== 'rtl' ? <RightOutlined /> : <LeftOutlined />}
-      >
-        {rightArrowText}
-      </Button>
-      {!oneWay && (
+
+  // 通用的箭头渲染函数，处理两种方向的按钮
+  const renderArrow = useCallback(
+    (
+      button: React.ReactNode,
+      moveHandler: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement> | undefined,
+      active: boolean | undefined,
+      icon: React.ReactNode,
+    ) => {
+      // 如果是 React 元素，尝试传递必要属性
+      if (React.isValidElement(button)) {
+        const element = button as ButtonElementType;
+
+        const onClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement> = (event) => {
+          element?.props?.onClick?.(event);
+          moveHandler?.(event);
+        };
+
+        return React.cloneElement(element, {
+          disabled: disabled || !active,
+          onClick,
+        });
+      }
+
+      // 如果不是 React 元素，使用默认的 Button
+      return (
         <Button
           type="primary"
           size="small"
-          disabled={disabled || !leftActive}
-          onClick={moveToLeft}
-          icon={direction !== 'rtl' ? <LeftOutlined /> : <RightOutlined />}
+          disabled={disabled || !active}
+          onClick={(event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) =>
+            moveHandler?.(event)
+          }
+          icon={icon}
         >
-          {leftArrowText}
+          {button}
         </Button>
-      )}
+      );
+    },
+    [disabled],
+  );
+
+  // 使用通用函数渲染右箭头
+  const renderRightArrow = useCallback(
+    () =>
+      renderArrow(
+        rightButton,
+        moveToRight,
+        !!rightActive,
+        direction !== 'rtl' ? <RightOutlined /> : <LeftOutlined />,
+      ),
+    [renderArrow, rightButton, moveToRight, rightActive, direction],
+  );
+
+  // 使用通用函数渲染左箭头
+  const renderLeftArrow = useCallback(
+    () =>
+      renderArrow(
+        leftButton,
+        moveToLeft,
+        !!leftActive,
+        direction !== 'rtl' ? <LeftOutlined /> : <RightOutlined />,
+      ),
+    [renderArrow, leftButton, moveToLeft, leftActive, direction],
+  );
+
+  return (
+    <div className={className} style={style}>
+      {renderRightArrow()}
+      {!oneWay && renderLeftArrow()}
     </div>
   );
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

<!-- close #xxxx, fix #xxxx -->

close https://github.com/ant-design/ant-design/issues/25815
close https://github.com/ant-design/ant-design/issues/53110

### 💡 Background and Solution

The Transfer component currently only supports string arrays for the `operations` prop. This PR enhances the component to support ReactNode arrays, allowing for custom operation buttons with more flexibility.

Changes include:
1. Modified the `Operation` component to handle ReactNode types for operation buttons
2. Optimized implementation using `useCallback` for better performance
3. Enhanced example code to demonstrate custom buttons usage
4. Updated documentation to clarify the two usage types of the `operations` prop

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Transfer `operations` prop now supports ReactNode array for custom operation buttons. |
| 🇨🇳 Chinese | Transfer 组件 `operations` 属性支持传入 ReactNode 数组，可以自定义操作按钮。 |