### PR TITLE
chore: use affix instead button for default selection in local visual

### DIFF
--- a/scripts/visual-regression/local.ts
+++ b/scripts/visual-regression/local.ts
@@ -181,7 +181,7 @@ async function run() {
     theme: { helpMode: 'always' },
     choices: components.map((component) => ({
       value: component,
-      checked: component.endsWith('components/button'), // 默认选中 button
+      checked: component.endsWith('components/affix'), // 默认选中 affix
     })),
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...


- [x] ❓ Other (about what?)



### 💡 Background and Solution
1. affix 位置更靠前，如果要取消选择的话更方便。
2. button 的 demo 多了好多，会比较慢，如果想去取消它要按的键盘次数也更多。
<img width="839" alt="image" src="https://github.com/user-attachments/assets/a22df8ae-0470-484c-a5d5-58aa44b6c8c6" />

### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |       -    |
