### PR TITLE
feat(AutoComplete): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -122,7 +122,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
     [
       ['dropdownClassName', 'classNames.popup'],
-      ['popupClassName', 'classNames.popup}'],
+      ['popupClassName', 'classNames.popup'],
       ['dataSource', 'options'],
     ].forEach(([deprecatedName, newName]) => {
       warning.deprecated(!(deprecatedName in props), deprecatedName, newName);

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -7,7 +7,8 @@ import classNames from 'classnames';
 import { useZIndex } from '../_util/hooks/useZIndex';
 import type { InputStatus } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
-import { useComponentConfig } from '../config-provider/context';
+import type { ConfigConsumerProps } from '../config-provider';
+import { ConfigContext } from '../config-provider';
 import type {
   BaseOptionType,
   DefaultOptionType,
@@ -143,13 +144,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     );
   }
 
-  const {
-    getPrefixCls,
-    style: contextStyle,
-    styles: contextStyles,
-    className: contextClassName,
-    classNames: contextClassNames,
-  } = useComponentConfig('autoComplete');
+  const { getPrefixCls } = React.useContext<ConfigConsumerProps>(ConfigContext);
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
   const mergedPopupStyle = popupStyle ?? dropdownStyle;
@@ -157,39 +152,26 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
   // ============================ zIndex ============================
   const [zIndex] = useZIndex('SelectLike', mergedPopupStyle?.zIndex as number);
 
-  const mergedClassNames = React.useMemo(
-    () => ({
-      root: classNames(
-        `${prefixCls}-auto-complete`,
-        className,
-        contextClassName,
-        rootClassName,
-        contextClassNames.root,
-        autoCompleteClassNames?.root,
-      ),
-      popup: classNames(
-        popupClassName,
-        dropdownClassName,
-        contextClassNames.popup,
-        autoCompleteClassNames?.popup,
-      ),
-      list: classNames(contextClassNames.list, autoCompleteClassNames?.list),
-      listItem: classNames(contextClassNames.listItem, autoCompleteClassNames?.listItem),
-      input: classNames(contextClassNames.input, autoCompleteClassNames?.input),
-    }),
-    [autoCompleteClassNames, contextClassNames],
-  );
+  const mergedClassNames = {
+    root: classNames(
+      `${prefixCls}-auto-complete`,
+      className,
+      rootClassName,
+      autoCompleteClassNames?.root,
+    ),
+    popup: classNames(popupClassName, dropdownClassName, autoCompleteClassNames?.popup),
+    list: autoCompleteClassNames?.list,
+    listItem: autoCompleteClassNames?.listItem,
+    input: autoCompleteClassNames?.input,
+  };
 
-  const mergedStyles = React.useMemo(
-    () => ({
-      root: { ...contextStyles.root, ...styles?.root, ...contextStyle, ...style },
-      popup: { ...contextStyles.popup, ...styles?.popup, ...mergedPopupStyle, zIndex },
-      list: { ...contextStyles.list, ...styles?.list },
-      listItem: { ...contextStyles.listItem, ...styles?.listItem },
-      input: { ...contextStyles.input, ...styles?.input },
-    }),
-    [styles, contextStyles],
-  );
+  const mergedStyles = {
+    root: { ...styles?.root, ...style },
+    popup: { ...styles?.popup, ...mergedPopupStyle, zIndex },
+    list: styles?.list,
+    listItem: styles?.listItem,
+    input: styles?.input,
+  };
 
   return (
     <Select

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -38,14 +38,12 @@ export interface AutoCompleteProps<
   /** @deprecated Please use `options` instead */
   dataSource?: DataSourceItemType[];
   status?: InputStatus;
-  /** @deprecated Please use `classNames: {{ popup: ""}}` instead */
+  /** @deprecated Please use `classNames.popup` instead */
   popupClassName?: string;
-  /** @deprecated Please use `classNames: {{ popup: ""}}` instead */
+  /** @deprecated Please use `classNames.popup` instead */
   dropdownClassName?: string;
-  /** @deprecated Please use `styles: {{ popup: {}}}` instead */
+  /** @deprecated Please use `styles.popup` instead */
   dropdownStyle?: React.CSSProperties;
-  /** @deprecated Please use `styles: {{ popup: {}}}` instead */
-  popupStyle?: React.CSSProperties;
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
@@ -67,7 +65,6 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     style,
     popupClassName,
     dropdownClassName,
-    popupStyle,
     dropdownStyle,
     children,
     dataSource,
@@ -128,10 +125,9 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     const warning = devUseWarning('AutoComplete');
 
     [
-      ['dropdownClassName', 'classNames: {{ popup: ""}}'],
-      ['popupClassName', 'classNames: {{ popup: ""}}'],
-      ['dropdownStyle', 'styles: {{ popup: {}}}'],
-      ['popupStyle', 'styles: {{ popup: {}}}'],
+      ['dropdownClassName', 'classNames.popup'],
+      ['popupClassName', 'classNames.popup}'],
+      ['dropdownStyle', 'styles.popup'],
       ['dataSource', 'options'],
     ].forEach(([deprecatedName, newName]) => {
       warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
@@ -147,10 +143,9 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
   const { getPrefixCls } = React.useContext<ConfigConsumerProps>(ConfigContext);
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
-  const mergedPopupStyle = popupStyle ?? dropdownStyle;
 
   // ============================ zIndex ============================
-  const [zIndex] = useZIndex('SelectLike', mergedPopupStyle?.zIndex as number);
+  const [zIndex] = useZIndex('SelectLike', dropdownStyle?.zIndex as number);
 
   const mergedClassNames = {
     root: classNames(
@@ -167,7 +162,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
   const mergedStyles = {
     root: { ...styles?.root, ...style },
-    popup: { ...styles?.popup, ...mergedPopupStyle, zIndex },
+    popup: { ...styles?.popup, ...dropdownStyle, zIndex },
     list: styles?.list,
     listItem: styles?.listItem,
     input: styles?.input,

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -4,7 +4,6 @@ import toArray from '@rc-component/util/lib/Children/toArray';
 import omit from '@rc-component/util/lib/omit';
 import classNames from 'classnames';
 
-import { useZIndex } from '../_util/hooks/useZIndex';
 import type { InputStatus } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
 import type { ConfigConsumerProps } from '../config-provider';
@@ -42,8 +41,6 @@ export interface AutoCompleteProps<
   popupClassName?: string;
   /** @deprecated Please use `classNames.popup` instead */
   dropdownClassName?: string;
-  /** @deprecated Please use `styles.popup` instead */
-  dropdownStyle?: React.CSSProperties;
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
@@ -65,7 +62,6 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     style,
     popupClassName,
     dropdownClassName,
-    dropdownStyle,
     children,
     dataSource,
     rootClassName,
@@ -143,9 +139,6 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
 
-  // ============================ zIndex ============================
-  const [zIndex] = useZIndex('SelectLike', dropdownStyle?.zIndex as number);
-
   const mergedClassNames = {
     root: classNames(
       `${prefixCls}-auto-complete`,
@@ -161,7 +154,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
   const mergedStyles = {
     root: { ...styles?.root, ...style },
-    popup: { ...styles?.popup, ...dropdownStyle, zIndex },
+    popup: { ...styles?.popup },
     list: styles?.list,
     listItem: styles?.listItem,
     input: styles?.input,

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import classNames from 'classnames';
 import type { BaseSelectRef } from '@rc-component/select';
 import toArray from '@rc-component/util/lib/Children/toArray';
 import omit from '@rc-component/util/lib/omit';
+import classNames from 'classnames';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
 import type { InputStatus } from '../_util/statusUtils';
 import { devUseWarning } from '../_util/warning';
-import type { ConfigConsumerProps } from '../config-provider';
-import { ConfigContext } from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import type {
   BaseOptionType,
   DefaultOptionType,
@@ -17,6 +16,8 @@ import type {
   SelectProps,
 } from '../select';
 import Select from '../select';
+
+type SemanticName = 'root' | 'input' | 'popup' | 'list' | 'listItem';
 
 const { Option } = Select;
 
@@ -36,12 +37,19 @@ export interface AutoCompleteProps<
   /** @deprecated Please use `options` instead */
   dataSource?: DataSourceItemType[];
   status?: InputStatus;
+  /** @deprecated Please use `classNames: {{ popup: ""}}` instead */
   popupClassName?: string;
-  /** @deprecated Please use `popupClassName` instead */
+  /** @deprecated Please use `classNames: {{ popup: ""}}` instead */
   dropdownClassName?: string;
+  /** @deprecated Please use `styles: {{ popup: {}}}` instead */
+  dropdownStyle?: React.CSSProperties;
+  /** @deprecated Please use `styles: {{ popup: {}}}` instead */
+  popupStyle?: React.CSSProperties;
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 function isSelectOptionOrSelectOptGroup(child: any): boolean {
@@ -55,10 +63,16 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
   const {
     prefixCls: customizePrefixCls,
     className,
+    style,
     popupClassName,
     dropdownClassName,
+    popupStyle,
+    dropdownStyle,
     children,
     dataSource,
+    rootClassName,
+    styles,
+    classNames: autoCompleteClassNames,
   } = props;
   const childNodes: React.ReactElement[] = toArray(children);
 
@@ -108,27 +122,74 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
         })
       : [];
   }
-
+  // ====================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('AutoComplete');
 
-    warning.deprecated(!('dataSource' in props), 'dataSource', 'options');
+    [
+      ['dropdownClassName', 'classNames: {{ popup: ""}}'],
+      ['popupClassName', 'classNames: {{ popup: ""}}'],
+      ['dropdownStyle', 'styles: {{ popup: {}}}'],
+      ['popupStyle', 'styles: {{ popup: {}}}'],
+      ['dataSource', 'options'],
+    ].forEach(([deprecatedName, newName]) => {
+      warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
+    });
 
     warning(
       !customizeInput || !('size' in props),
       'usage',
       'You need to control style self instead of setting `size` when using customize input.',
     );
-
-    warning.deprecated(!dropdownClassName, 'dropdownClassName', 'popupClassName');
   }
 
-  const { getPrefixCls } = React.useContext<ConfigConsumerProps>(ConfigContext);
+  const {
+    getPrefixCls,
+    style: contextStyle,
+    styles: contextStyles,
+    className: contextClassName,
+    classNames: contextClassNames,
+  } = useComponentConfig('autoComplete');
 
   const prefixCls = getPrefixCls('select', customizePrefixCls);
+  const mergedPopupStyle = popupStyle ?? dropdownStyle;
 
   // ============================ zIndex ============================
-  const [zIndex] = useZIndex('SelectLike', props.popupStyle?.zIndex as number);
+  const [zIndex] = useZIndex('SelectLike', mergedPopupStyle?.zIndex as number);
+
+  const mergedClassNames = React.useMemo(
+    () => ({
+      root: classNames(
+        `${prefixCls}-auto-complete`,
+        className,
+        contextClassName,
+        rootClassName,
+        contextClassNames.root,
+        autoCompleteClassNames?.root,
+      ),
+      popup: classNames(
+        popupClassName,
+        dropdownClassName,
+        contextClassNames.popup,
+        autoCompleteClassNames?.popup,
+      ),
+      list: classNames(contextClassNames.list, autoCompleteClassNames?.list),
+      listItem: classNames(contextClassNames.listItem, autoCompleteClassNames?.listItem),
+      input: classNames(contextClassNames.input, autoCompleteClassNames?.input),
+    }),
+    [autoCompleteClassNames, contextClassNames],
+  );
+
+  const mergedStyles = React.useMemo(
+    () => ({
+      root: { ...contextStyles.root, ...styles?.root, ...contextStyle, ...style },
+      popup: { ...contextStyles.popup, ...styles?.popup, ...mergedPopupStyle, zIndex },
+      list: { ...contextStyles.list, ...styles?.list },
+      listItem: { ...contextStyles.listItem, ...styles?.listItem },
+      input: { ...contextStyles.input, ...styles?.input },
+    }),
+    [styles, contextStyles],
+  );
 
   return (
     <Select
@@ -136,9 +197,8 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
       suffixIcon={null}
       {...omit(props, ['dataSource', 'dropdownClassName', 'popupClassName'])}
       prefixCls={prefixCls}
-      classNames={{ popup: popupClassName || dropdownClassName }}
-      styles={{ popup: { ...props.popupStyle, zIndex } }}
-      className={classNames(`${prefixCls}-auto-complete`, className)}
+      classNames={mergedClassNames}
+      styles={mergedStyles}
       mode={Select.SECRET_COMBOBOX_MODE_DO_NOT_USE as SelectProps['mode']}
       {...{
         // Internal api

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -127,7 +127,6 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     [
       ['dropdownClassName', 'classNames.popup'],
       ['popupClassName', 'classNames.popup}'],
-      ['dropdownStyle', 'styles.popup'],
       ['dataSource', 'options'],
     ].forEach(([deprecatedName, newName]) => {
       warning.deprecated(!(deprecatedName in props), deprecatedName, newName);

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -96,4 +96,47 @@ describe('AutoComplete', () => {
     );
     expect(screen.getByRole('combobox')).toHaveClass('custom');
   });
+
+  it('should support classNames and styles', () => {
+    const customClassNames = {
+      root: 'custom-root',
+      input: 'custom-input',
+      list: 'custom-list',
+      listItem: 'custom-list-item',
+      popup: 'custom-popup',
+    };
+    const customStyles = {
+      root: { color: 'red' },
+      input: { color: 'green' },
+      list: { color: 'blue' },
+      listItem: { color: 'yellow' },
+      popup: { color: 'purple' },
+    };
+    const { container } = render(
+      <AutoComplete
+        options={[{ label: '123', value: '123' }]}
+        classNames={customClassNames}
+        styles={customStyles}
+        open
+      />,
+    );
+
+    const root = container.querySelector('.ant-select-auto-complete');
+    const input = container.querySelector('.ant-select-selection-search-input');
+    const list = container.querySelector('.rc-virtual-list');
+    const listItem = container.querySelector('.ant-select-item-option');
+    const popup = container.querySelector('.ant-select-dropdown');
+
+    expect(root).toHaveClass(customClassNames.root);
+    expect(input).toHaveClass(customClassNames.input);
+    expect(list).toHaveClass(customClassNames.list);
+    expect(listItem).toHaveClass(customClassNames.listItem);
+    expect(popup).toHaveClass(customClassNames.popup);
+
+    expect(root).toHaveStyle(customStyles.root);
+    expect(input).toHaveStyle(customStyles.input);
+    expect(list).toHaveStyle(customStyles.list);
+    expect(listItem).toHaveStyle(customStyles.listItem);
+    expect(popup).toHaveStyle(customStyles.popup);
+  });
 });

--- a/components/auto-complete/demo/_semantic.tsx
+++ b/components/auto-complete/demo/_semantic.tsx
@@ -37,7 +37,7 @@ const Block = (prop: any) => {
         {...prop}
         open
         placement="bottomLeft"
-        style={{ width: 200 }}
+        styles={{ root: { zIndex: 1000, width: 200 } }}
         getPopupContainer={() => divRef.current}
         onSearch={(text) => setOptions(getPanelValue(text))}
         placeholder="input here"

--- a/components/auto-complete/demo/_semantic.tsx
+++ b/components/auto-complete/demo/_semantic.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { SmileOutlined } from '@ant-design/icons';
-import { Select } from 'antd';
+import { AutoComplete, AutoCompleteProps } from 'antd';
 
 import SemanticPreview from '../../../.dumi/components/SemanticPreview';
 import useLocale from '../../../.dumi/hooks/useLocale';
@@ -8,8 +7,6 @@ import useLocale from '../../../.dumi/hooks/useLocale';
 const locales = {
   cn: {
     root: '根元素',
-    prefix: '前缀元素',
-    suffix: '后缀元素',
     popup: '弹出菜单元素',
     list: '列表元素',
     listItem: '条目元素',
@@ -17,31 +14,34 @@ const locales = {
   },
   en: {
     root: 'Root element',
-    prefix: 'Prefix element',
-    suffix: 'Suffix element',
     popup: 'Popup element',
     list: 'List element',
     listItem: 'Item element',
     input: 'Input element',
   },
 };
+const mockVal = (str: string, repeat = 1) => ({
+  value: str.repeat(repeat),
+});
 const Block = (prop: any) => {
   const divRef = React.useRef<HTMLDivElement>(null);
+  const [options, setOptions] = React.useState<AutoCompleteProps['options']>([
+    { value: 'thinkasany' },
+  ]);
+  const getPanelValue = (searchText: string) =>
+    !searchText ? [] : [mockVal(searchText), mockVal(searchText, 2), mockVal(searchText, 3)];
+
   return (
     <div ref={divRef} style={{ position: 'absolute', marginBottom: 80 }}>
-      <Select
+      <AutoComplete
         {...prop}
-        prefix="User"
         open
         placement="bottomLeft"
-        suffixIcon={<SmileOutlined />}
-        defaultValue="thinkasany"
         style={{ width: 200 }}
         getPopupContainer={() => divRef.current}
-        options={[
-          { value: 'thinkasany', label: 'thinkasany' },
-          { value: 'lucy', label: 'Lucy' },
-        ]}
+        onSearch={(text) => setOptions(getPanelValue(text))}
+        placeholder="input here"
+        options={options}
       />
     </div>
   );
@@ -53,9 +53,7 @@ const App: React.FC = () => {
     <SemanticPreview
       semantics={[
         { name: 'root', desc: locale.root, version: '6.0.0' },
-        { name: 'prefix', desc: locale.prefix, version: '6.0.0' },
         { name: 'input', desc: locale.input, version: '6.0.0' },
-        { name: 'suffix', desc: locale.suffix, version: '6.0.0' },
         { name: 'popup', desc: locale.popup, version: '6.0.0' },
         { name: 'list', desc: locale.list, version: '6.0.0' },
         { name: 'listItem', desc: locale.listItem, version: '6.0.0' },

--- a/components/auto-complete/demo/certain-category.tsx
+++ b/components/auto-complete/demo/certain-category.tsx
@@ -40,7 +40,7 @@ const options = [
 
 const App: React.FC = () => (
   <AutoComplete
-    popupClassName="certain-category-search-dropdown"
+    classNames={{ popup: 'certain-category-search-dropdown' }}
     popupMatchSelectWidth={500}
     style={{ width: 250 }}
     options={options}

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -83,6 +83,10 @@ Common props ref：[Common props](/docs/react/common-props)
 | blur()  | Remove focus |         |
 | focus() | Get focus    |         |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="Select"></ComponentTokenTable>

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -84,6 +84,10 @@ demo:
 | blur()  | 移除焦点 |      |
 | focus() | 获取焦点 |      |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Select"></ComponentTokenTable>

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -4,6 +4,7 @@ import type { WarningContextProps } from '../_util/warning';
 import type { ShowWaveEffect } from '../_util/wave/interface';
 import type { AlertProps } from '../alert';
 import type { AnchorProps } from '../anchor';
+import type { AutoCompleteProps } from '../auto-complete';
 import type { BadgeProps } from '../badge';
 import type { RibbonProps } from '../badge/Ribbon';
 import type { BreadcrumbProps } from '../breadcrumb';
@@ -25,6 +26,7 @@ import type { InputProps, TextAreaProps } from '../input';
 import type { InputNumberProps } from '../input-number';
 import type { ListItemProps } from '../list';
 import type { Locale } from '../locale';
+import type { MasonryProps } from '../masonry';
 import type { MentionsProps } from '../mentions';
 import type { MenuProps } from '../menu';
 import type { ArgsProps as MessageProps } from '../message';
@@ -55,7 +57,6 @@ import type { TransferProps } from '../transfer';
 import type { TreeSelectProps } from '../tree-select';
 import type { UploadProps } from '../upload';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
-import type { MasonryProps } from '../masonry';
 
 export const defaultPrefixCls = 'ant';
 export const defaultIconPrefixCls = 'anticon';
@@ -184,6 +185,9 @@ export type TabsConfig = ComponentStyleConfig &
   >;
 
 export type AnchorStyleConfig = ComponentStyleConfig & Pick<AnchorProps, 'classNames' | 'styles'>;
+
+export type AutoCompleteConfig = ComponentStyleConfig &
+  Pick<AutoCompleteProps, 'classNames' | 'styles'>;
 
 export type AlertConfig = ComponentStyleConfig &
   Pick<AlertProps, 'closable' | 'closeIcon' | 'classNames' | 'styles'>;
@@ -323,6 +327,7 @@ export interface ConfigComponentProps {
   select?: SelectConfig;
   alert?: AlertConfig;
   affix?: ComponentStyleConfig;
+  autoComplete?: AutoCompleteConfig;
   anchor?: AnchorStyleConfig;
   button?: ButtonConfig;
   divider?: ComponentStyleConfig;

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -4,7 +4,6 @@ import type { WarningContextProps } from '../_util/warning';
 import type { ShowWaveEffect } from '../_util/wave/interface';
 import type { AlertProps } from '../alert';
 import type { AnchorProps } from '../anchor';
-import type { AutoCompleteProps } from '../auto-complete';
 import type { BadgeProps } from '../badge';
 import type { RibbonProps } from '../badge/Ribbon';
 import type { BreadcrumbProps } from '../breadcrumb';
@@ -186,9 +185,6 @@ export type TabsConfig = ComponentStyleConfig &
 
 export type AnchorStyleConfig = ComponentStyleConfig & Pick<AnchorProps, 'classNames' | 'styles'>;
 
-export type AutoCompleteConfig = ComponentStyleConfig &
-  Pick<AutoCompleteProps, 'classNames' | 'styles'>;
-
 export type AlertConfig = ComponentStyleConfig &
   Pick<AlertProps, 'closable' | 'closeIcon' | 'classNames' | 'styles'>;
 
@@ -327,7 +323,6 @@ export interface ConfigComponentProps {
   select?: SelectConfig;
   alert?: AlertConfig;
   affix?: ComponentStyleConfig;
-  autoComplete?: AutoCompleteConfig;
   anchor?: AnchorStyleConfig;
   button?: ButtonConfig;
   divider?: ComponentStyleConfig;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -16,7 +16,6 @@ import { defaultTheme, DesignTokenContext } from '../theme/context';
 import defaultSeedToken from '../theme/themes/seed';
 import type {
   AlertConfig,
-  AutoCompleteConfig,
   BadgeConfig,
   ButtonConfig,
   CardConfig,
@@ -191,7 +190,6 @@ export interface ConfigProviderProps {
   warning?: WarningContextProps;
   alert?: AlertConfig;
   affix?: ComponentStyleConfig;
-  autoComplete?: AutoCompleteConfig;
   anchor?: ComponentStyleConfig;
   button?: ButtonConfig;
   calendar?: ComponentStyleConfig;
@@ -328,7 +326,6 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     autoInsertSpaceInButton,
     alert,
     affix,
-    autoComplete,
     anchor,
     form,
     locale,
@@ -442,7 +439,6 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     autoInsertSpaceInButton,
     alert,
     affix,
-    autoComplete,
     anchor,
     locale: locale || legacyLocale,
     direction,

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -16,6 +16,7 @@ import { defaultTheme, DesignTokenContext } from '../theme/context';
 import defaultSeedToken from '../theme/themes/seed';
 import type {
   AlertConfig,
+  AutoCompleteConfig,
   BadgeConfig,
   ButtonConfig,
   CardConfig,
@@ -190,6 +191,7 @@ export interface ConfigProviderProps {
   warning?: WarningContextProps;
   alert?: AlertConfig;
   affix?: ComponentStyleConfig;
+  autoComplete?: AutoCompleteConfig;
   anchor?: ComponentStyleConfig;
   button?: ButtonConfig;
   calendar?: ComponentStyleConfig;
@@ -326,6 +328,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     autoInsertSpaceInButton,
     alert,
     affix,
+    autoComplete,
     anchor,
     form,
     locale,
@@ -439,6 +442,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
     autoInsertSpaceInButton,
     alert,
     affix,
+    autoComplete,
     anchor,
     locale: locale || legacyLocale,
     direction,

--- a/components/select/demo/_semantic.tsx
+++ b/components/select/demo/_semantic.tsx
@@ -36,7 +36,7 @@ const Block = (prop: any) => {
         placement="bottomLeft"
         suffixIcon={<SmileOutlined />}
         defaultValue="thinkasany"
-        style={{ width: 200 }}
+        styles={{ root: { zIndex: 1000, width: 200 } }}
         getPopupContainer={() => divRef.current}
         options={[
           { value: 'thinkasany', label: 'thinkasany' },


### PR DESCRIPTION


### 🤔 This is a ...

- [x] 🆕 New feature



### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      feat: ConfigProvider support classNames and styles for autoComplete     |
| 🇨🇳 Chinese |      feat: ConfigProvider support classNames and styles for autoComplete     |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强 AutoComplete 组件样式定制能力，支持自定义类名和样式，提升组件灵活性。
  - 更新示例组件，提供多语言支持和交互式自动补全体验。
  - 调整 Select 组件下拉菜单位置，默认显示在组件左下方，优化界面布局。

- **测试**
  - 添加测试用例，确保 AutoComplete 组件在应用自定义类名和样式时表现正常。

- **文档**
  - 新增“Semantic DOM”部分，提供示例和交互说明，便于用户参考组件语义结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->