### PR TITLE
fix: ConfigProvider Typography titleMarginTop not work

### DIFF
--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ import Text from '../Text';
 import type { TitleProps } from '../Title';
 import Title from '../Title';
 import Typography from '../Typography';
+import ConfigProvider from '../../config-provider';
 
 jest.mock('copy-to-clipboard');
 
@@ -496,5 +497,26 @@ describe('Typography', () => {
     editButton.focus();
     userEvent.keyboard('{enter}');
     await waitFor(() => expect(onEditStart).toHaveBeenCalledTimes(1));
+  });
+
+  it('should support config-provider margin-top and margin-bottom', () => {
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          components: {
+            Typography: {
+              titleMarginBottom: 120,
+              titleMarginTop: 100,
+            },
+          },
+        }}
+      >
+        <Title level={4}>There should hava margin-top and margin-bottom</Title>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-typography')).toHaveStyle({
+      marginTop: '100px',
+      marginBottom: '120px',
+    });
   });
 });

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -131,7 +131,7 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
 };
 
 export const prepareComponentToken: GetDefaultToken<'Typography'> = () => ({
-  titleMarginTop: '1.2em',
+  titleMarginTop: '0',
   titleMarginBottom: '0.5em',
 });
 

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -131,7 +131,7 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
 };
 
 export const prepareComponentToken: GetDefaultToken<'Typography'> = () => ({
-  titleMarginTop: '0',
+  titleMarginTop: '1.2em',
   titleMarginBottom: '0.5em',
 });
 

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -81,22 +81,13 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
         marginTop: titleMarginTop,
       },
 
-      [`
-      div,
-      ul,
-      li,
-      p,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5`]: {
+      '&': {
         [`
-        + h1,
-        + h2,
-        + h3,
-        + h4,
-        + h5
+         h1&,
+         h2&,
+         h3&,
+         h4&,
+         h5&
         `]: {
           marginTop: titleMarginTop,
         },

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -21,9 +21,10 @@ const getTitleStyle = (
   color: string,
   token: TypographyToken,
 ) => {
-  const { titleMarginBottom, fontWeightStrong } = token;
+  const { titleMarginBottom, fontWeightStrong, titleMarginTop } = token;
 
   return {
+    marginTop: titleMarginTop,
     marginBottom: titleMarginBottom,
     color,
     fontWeight: fontWeightStrong,

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -21,10 +21,9 @@ const getTitleStyle = (
   color: string,
   token: TypographyToken,
 ) => {
-  const { titleMarginBottom, fontWeightStrong, titleMarginTop } = token;
+  const { titleMarginBottom, fontWeightStrong } = token;
 
   return {
-    marginTop: titleMarginTop,
     marginBottom: titleMarginBottom,
     color,
     fontWeight: fontWeightStrong,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixed [#53162](https://github.com/ant-design/ant-design/issues/53162)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fixed the titleMarginTop of Typography in ConfigProvider has not effect      |
| 🇨🇳 Chinese |    修复ConfigProvider中Typography的titleMarginTop不生效的问题       |
