### PR TITLE
feat(Tree): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -25,6 +25,7 @@ import type { InputProps, TextAreaProps } from '../input';
 import type { InputNumberProps } from '../input-number';
 import type { ListItemProps } from '../list';
 import type { Locale } from '../locale';
+import type { MasonryProps } from '../masonry';
 import type { MentionsProps } from '../mentions';
 import type { MenuProps } from '../menu';
 import type { ArgsProps as MessageProps } from '../message';
@@ -52,10 +53,10 @@ import type { TimelineProps } from '../timeline';
 import type { TooltipProps } from '../tooltip';
 import type { TourProps } from '../tour/interface';
 import type { TransferProps } from '../transfer';
+import type { TreeProps } from '../tree';
 import type { TreeSelectProps } from '../tree-select';
 import type { UploadProps } from '../upload';
 import type { RenderEmptyHandler } from './defaultRenderEmpty';
-import type { MasonryProps } from '../masonry';
 
 export const defaultPrefixCls = 'ant';
 export const defaultIconPrefixCls = 'anticon';
@@ -273,6 +274,8 @@ export type CascaderConfig = ComponentStyleConfig & Pick<CascaderProps, 'variant
 
 export type TreeSelectConfig = ComponentStyleConfig & Pick<TreeSelectProps, 'variant'>;
 
+export type TreeConfig = ComponentStyleConfig & Pick<TreeProps, 'classNames' | 'styles'>;
+
 export type DatePickerConfig = ComponentStyleConfig & Pick<DatePickerProps, 'variant'>;
 
 export type RangePickerConfig = ComponentStyleConfig & Pick<RangePickerProps, 'variant'>;
@@ -373,7 +376,7 @@ export interface ConfigComponentProps {
   popconfirm?: PopconfirmConfig;
   upload?: UploadConfig;
   notification?: NotificationConfig;
-  tree?: ComponentStyleConfig;
+  tree?: TreeConfig;
   colorPicker?: ComponentStyleConfig;
   datePicker?: DatePickerConfig;
   rangePicker?: RangePickerConfig;

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -170,7 +170,7 @@ const {
 | popover | Set Popover common props | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover#api), styles?: [Popover\["styles"\]](/components/popover#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | popconfirm | Set Popconfirm common props | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | transfer | Set Transfer common props | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, `selectionsIcon`: 5.14.0 |
-| tree | Set Tree common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tree | Set Tree common props | { className?: string, style?: React.CSSProperties, classNames?: [TreeConfig\["classNames"\]](/components/tree#semantic-dom), styles?: [TreeConfig\["styles"\]](/components/tree#semantic-dom) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | Set Upload common props | { className?: string, style?: React.CSSProperties, classNames?:[UploadConfig\["classNames"\]](/components/upload#semantic-dom), styles?: [UploadConfig\["styles"\]](/components/upload#semantic-dom) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | wave | Config wave effect | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -172,7 +172,7 @@ const {
 | popover | 设置 Popover 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popover\["classNames"\]](/components/popover-cn#api), styles?: [Popover\["styles"\]](/components/popover-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | popconfirm | 设置 Popconfirm 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm-cn#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | transfer | 设置 Transfer 组件的通用属性 | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, `selectionsIcon`: 5.14.0 |
-| tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
+| tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [TreeConfig\["classNames"\]](/components/tree-cn#semantic-dom), styles?: [TreeConfig\["styles"\]](/components/tree-cn#semantic-dom) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[UploadConfig\["classNames"\]](/components/upload-cn#semantic-dom), styles?: [UploadConfig\["styles"\]](/components/upload-cn#semantic-dom) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | wave | 设置水波纹特效 | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -109,7 +109,7 @@ interface DraggableConfig {
   nodeDraggable?: DraggableFn;
 }
 
-type SemanticName = 'root' | 'item' | 'icon' | 'title';
+type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemTitle';
 
 export interface TreeProps<T extends BasicDataNode = DataNode>
   extends Omit<
@@ -283,13 +283,13 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
       rootStyle={{ ...contextStyles.root, ...styles?.root, ...rootStyle }}
       classNames={{
         item: classNames(contextClassNames.item, treeClassNames?.item),
-        icon: classNames(contextClassNames.icon, treeClassNames?.icon),
-        title: classNames(contextClassNames.title, treeClassNames?.title),
+        itemIcon: classNames(contextClassNames.itemIcon, treeClassNames?.itemIcon),
+        itemTitle: classNames(contextClassNames.itemTitle, treeClassNames?.itemTitle),
       }}
       styles={{
         item: { ...contextStyles.item, ...styles?.item },
-        icon: { ...contextStyles.icon, ...styles?.icon },
-        title: { ...contextStyles.title, ...styles?.title },
+        itemIcon: { ...contextStyles.itemIcon, ...styles?.itemIcon },
+        itemTitle: { ...contextStyles.itemTitle, ...styles?.itemTitle },
       }}
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -7,6 +7,7 @@ import RcTree from '@rc-component/tree';
 import type { DataNode, Key } from '@rc-component/tree/lib/interface';
 import classNames from 'classnames';
 
+import useMergeSemantic from '../_util/hooks/useMergeSemantic';
 import initCollapseMotion from '../_util/motion';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
@@ -194,10 +195,14 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     motion: customMotion,
     style,
     rootClassName,
-    rootStyle,
     classNames: treeClassNames,
     styles,
   } = props;
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic(
+    [contextClassNames, treeClassNames],
+    [contextStyles, styles],
+  );
 
   const prefixCls = getPrefixCls('tree', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
@@ -279,18 +284,10 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
         cssVarCls,
       )}
       style={{ ...contextStyle, ...style }}
-      rootClassName={classNames(contextClassNames.root, treeClassNames?.root, rootClassName)}
-      rootStyle={{ ...contextStyles.root, ...styles?.root, ...rootStyle }}
-      classNames={{
-        item: classNames(contextClassNames.item, treeClassNames?.item),
-        itemIcon: classNames(contextClassNames.itemIcon, treeClassNames?.itemIcon),
-        itemTitle: classNames(contextClassNames.itemTitle, treeClassNames?.itemTitle),
-      }}
-      styles={{
-        item: { ...contextStyles.item, ...styles?.item },
-        itemIcon: { ...contextStyles.itemIcon, ...styles?.itemIcon },
-        itemTitle: { ...contextStyles.itemTitle, ...styles?.itemTitle },
-      }}
+      rootClassName={classNames(mergedClassNames?.root, rootClassName)}
+      rootStyle={mergedStyles?.root}
+      classNames={mergedClassNames}
+      styles={mergedStyles}
       direction={direction}
       checkable={checkable ? <span className={`${prefixCls}-checkbox-inner`} /> : checkable}
       selectable={selectable}

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen } from '../../../tests/utils';
 import Tree from '../index';
 import type { AntTreeNodeProps } from '../Tree';
+import { SmileOutlined } from '@ant-design/icons';
 
 const { TreeNode } = Tree;
 
@@ -237,5 +238,59 @@ describe('Tree', () => {
         expect(el.children.length).toBe(0);
       });
     });
+  });
+  it('customize classNames and styles', () => {
+    const data = [
+      {
+        title: 'parent 1',
+        key: '0-0',
+        icon: <SmileOutlined />,
+        children: [
+          {
+            title: 'leaf',
+            key: '0-0-0',
+            icon: <SmileOutlined />,
+          },
+          {
+            title: 'leaf',
+            key: '0-0-1',
+            icon: <SmileOutlined />,
+          },
+        ],
+      },
+    ];
+    const testClassNames = {
+      item: 'test-item',
+      icon: 'test-icon',
+      title: 'test-title',
+      root: 'test-root',
+    };
+    const testStyles = {
+      item: { background: 'red' },
+      icon: { color: 'blue' },
+      title: { color: 'yellow' },
+      root: { color: 'green' },
+    };
+    const { container } = render(
+      <Tree
+        treeData={data}
+        showIcon
+        defaultExpandAll
+        styles={testStyles}
+        classNames={testClassNames}
+      />,
+    );
+    const root = container.querySelector('.ant-tree');
+    const title = container.querySelector('.ant-tree-title');
+    const item = container.querySelector(`.${testClassNames.item}`);
+    const icon = container.querySelector('.ant-tree-iconEle');
+
+    expect(root).toHaveStyle(testStyles.root);
+    expect(root).toHaveClass(testClassNames.root);
+    expect(icon).toHaveStyle(testStyles.icon);
+    expect(icon).toHaveClass(testClassNames.icon);
+    expect(title).toHaveStyle(testStyles.title);
+    expect(title).toHaveClass(testClassNames.title);
+    expect(item).toHaveStyle(testStyles.item);
   });
 });

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -261,14 +261,14 @@ describe('Tree', () => {
     ];
     const testClassNames = {
       item: 'test-item',
-      icon: 'test-icon',
-      title: 'test-title',
+      itemIcon: 'test-icon',
+      itemTitle: 'test-title',
       root: 'test-root',
     };
     const testStyles = {
       item: { background: 'red' },
-      icon: { color: 'blue' },
-      title: { color: 'yellow' },
+      itemIcon: { color: 'blue' },
+      itemTitle: { color: 'yellow' },
       root: { color: 'green' },
     };
     const { container } = render(
@@ -287,10 +287,10 @@ describe('Tree', () => {
 
     expect(root).toHaveStyle(testStyles.root);
     expect(root).toHaveClass(testClassNames.root);
-    expect(icon).toHaveStyle(testStyles.icon);
-    expect(icon).toHaveClass(testClassNames.icon);
-    expect(title).toHaveStyle(testStyles.title);
-    expect(title).toHaveClass(testClassNames.title);
+    expect(icon).toHaveStyle(testStyles.itemIcon);
+    expect(icon).toHaveClass(testClassNames.itemIcon);
+    expect(title).toHaveStyle(testStyles.itemTitle);
+    expect(title).toHaveClass(testClassNames.itemTitle);
     expect(item).toHaveStyle(testStyles.item);
   });
 });

--- a/components/tree/demo/_semantic.tsx
+++ b/components/tree/demo/_semantic.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  DownOutlined,
+  FrownFilled,
+  FrownOutlined,
+  MehOutlined,
+  SmileOutlined,
+} from '@ant-design/icons';
+import { Tree, TreeDataNode } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素',
+    item: '条目元素',
+    title: '标题元素',
+    icon: '图标元素',
+  },
+  en: {
+    root: 'Root element',
+    item: 'Item element',
+    title: 'title element',
+    icon: 'Icon element',
+  },
+};
+
+const treeData: TreeDataNode[] = [
+  {
+    title: 'parent 1',
+    key: '0-0',
+    icon: <SmileOutlined />,
+    children: [
+      {
+        title: 'leaf',
+        key: '0-0-0',
+        icon: <MehOutlined />,
+      },
+      {
+        title: 'leaf',
+        key: '0-0-1',
+        icon: ({ selected }) => (selected ? <FrownFilled /> : <FrownOutlined />),
+      },
+    ],
+  },
+];
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.0.0' },
+        { name: 'item', desc: locale.item, version: '6.0.0' },
+        { name: 'icon', desc: locale.icon, version: '6.0.0' },
+        { name: 'title', desc: locale.title, version: '6.0.0' },
+      ]}
+    >
+      <Tree
+        showIcon
+        defaultExpandAll
+        defaultSelectedKeys={['0-0-0']}
+        switcherIcon={<DownOutlined />}
+        treeData={treeData}
+      />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/tree/demo/_semantic.tsx
+++ b/components/tree/demo/_semantic.tsx
@@ -15,14 +15,14 @@ const locales = {
   cn: {
     root: '根元素',
     item: '条目元素',
-    title: '标题元素',
-    icon: '图标元素',
+    itemTitle: '标题元素',
+    itemIcon: '图标元素',
   },
   en: {
     root: 'Root element',
     item: 'Item element',
-    title: 'title element',
-    icon: 'Icon element',
+    itemTitle: 'title element',
+    itemIcon: 'Icon element',
   },
 };
 
@@ -52,8 +52,8 @@ const App: React.FC = () => {
       semantics={[
         { name: 'root', desc: locale.root, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
-        { name: 'icon', desc: locale.icon, version: '6.0.0' },
-        { name: 'title', desc: locale.title, version: '6.0.0' },
+        { name: 'itemIcon', desc: locale.itemIcon, version: '6.0.0' },
+        { name: 'itemTitle', desc: locale.itemTitle, version: '6.0.0' },
       ]}
     >
       <Tree

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -127,6 +127,10 @@ Before `3.4.0`: The number of treeNodes can be very large, but when `checkable=t
 | --- | --- |
 | scrollTo({ key: string \| number; align?: 'top' \| 'bottom' \| 'auto'; offset?: number }) | Scroll to key item in virtual scroll |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="Tree"></ComponentTokenTable>

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -129,6 +129,10 @@ demo:
 | --- | --- |
 | scrollTo({ key: string \| number; align?: 'top' \| 'bottom' \| 'auto'; offset?: number }) | 虚拟滚动下，滚动到指定 key 条目 |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Tree"></ComponentTokenTable>

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@rc-component/textarea": "~1.0.0",
     "@rc-component/tooltip": "~1.1.0",
     "@rc-component/tour": "~2.1.3",
-    "@rc-component/tree": "~1.0.0",
+    "@rc-component/tree": "~1.0.1",
     "@rc-component/tree-select": "~1.1.0",
     "@rc-component/trigger": "~3.1.0",
     "@rc-component/util": "^1.0.1",


### PR DESCRIPTION

### 🤔 This is a ...
- [x] 🆕 New feature

wait for https://github.com/react-component/tree/pull/928 

and needs test.

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       feat: ConfigProvider support classNames and styles for tree    |
| 🇨🇳 Chinese |      feat: ConfigProvider support classNames and styles for tree     |
