### PR TITLE
ci: skip Verify Files modify for renovate bot

### DIFF
--- a/.github/workflows/verify-files-modify.yml
+++ b/.github/workflows/verify-files-modify.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   verify:
+    if: github.event.pull_request.user.login != 'renovate'
     permissions:
       pull-requests: write  # for actions-cool/verify-files-modify to update status of PRs
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-files-modify.yml
+++ b/.github/workflows/verify-files-modify.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   verify:
-    if: github.event.pull_request.user.login != 'renovate'
+    if: github.event.pull_request.user.login != 'renovate[bot]'
     permissions:
       pull-requests: write  # for actions-cool/verify-files-modify to update status of PRs
     runs-on: ubuntu-latest


### PR DESCRIPTION


### 🤔 This is a ...

- [x] ⏩ Workflow


### 💡 Background and Solution

.github/ 文件下的ci 有的版本其实也需要升级的，renovate bot 升级的 pr会被github 机器人关掉。

希望能够跳过这个，让他正常运行 ci 结果，让 member 选择是否升级还是关闭。


https://github.com/ant-design/ant-design/pull/53193

![image](https://github.com/user-attachments/assets/3c237ea2-73fb-40fd-af1d-7599ecde15d5)


### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |    -       |
