### PR TITLE
deps: bump dumi-plugin-color-chunk to 2.1.0

### DIFF
--- a/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -29,10 +29,7 @@ const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) =
   const { styles } = useStyle();
   const { value, children } = props;
 
-  const dotColor = React.useMemo(() => {
-    const _color = new FastColor(value).toHexString();
-    return _color.endsWith('ff') ? _color.slice(0, -2) : _color;
-  }, [value]);
+  const dotColor = React.useMemo(() => new FastColor(value).toHexString(), [value]);
 
   return (
     <span className={styles.codeSpan}>

--- a/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-// @ts-ignore
-import { TinyColor } from 'dumi-plugin-color-chunk/component';
+import { FastColor } from '@ant-design/fast-color';
+import type { ColorInput } from '@ant-design/fast-color';
 import { createStyles } from 'antd-style';
 
 const useStyle = createStyles(({ token, css }) => ({
@@ -22,7 +22,7 @@ const useStyle = createStyles(({ token, css }) => ({
 }));
 
 interface ColorChunkProps {
-  value: any;
+  value: ColorInput;
 }
 
 const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) => {
@@ -30,7 +30,7 @@ const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) =
   const { value, children } = props;
 
   const dotColor = React.useMemo(() => {
-    const _color = new TinyColor(value).toHex8String();
+    const _color = new FastColor(value).toHexString();
     return _color.endsWith('ff') ? _color.slice(0, -2) : _color;
   }, [value]);
 

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "dekko": "^0.2.1",
     "dotenv": "^16.4.5",
     "dumi": "~2.4.17",
-    "dumi-plugin-color-chunk": "^1.1.2",
+    "dumi-plugin-color-chunk": "^2.1.0",
     "env-paths": "^3.0.0",
     "eslint": "^9.15.0",
     "eslint-plugin-compat": "^6.0.1",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

回滚 https://github.com/ant-design/ant-design/pull/52459 临时修复，`dumi-plugin-color-chunk` 重构了一版，精简了冗余逻辑。并且发了 major。 antd 这边就不再需要引入 `@ctrl/tinycolor` 了，

插件[将永远返回十六进制的颜色值](https://github.com/Wxh16144/dumi-plugin-color-chunk/blob/v2.1.0/src/core/remarkPlugin.ts#L14)，而不需要组件内再转一遍。


> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |     依赖更新-与站点有关      |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
  - 优化了颜色处理流程，提高了显示的一致性和数据安全性。
  
- **维护**
  - 升级了 `dumi-plugin-color-chunk` 依赖至版本 `^2.1.0`，带来了更好的性能和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->