### PR TITLE
feat(TreeSelect): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -287,7 +287,8 @@ export type InputNumberConfig = ComponentStyleConfig & Pick<InputNumberProps, 'v
 
 export type CascaderConfig = ComponentStyleConfig & Pick<CascaderProps, 'variant'>;
 
-export type TreeSelectConfig = ComponentStyleConfig & Pick<TreeSelectProps, 'variant'>;
+export type TreeSelectConfig = ComponentStyleConfig &
+  Pick<TreeSelectProps, 'variant' | 'classNames' | 'styles'>;
 
 export type TreeConfig = ComponentStyleConfig & Pick<TreeProps, 'classNames' | 'styles'>;
 

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -325,7 +325,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               <TreeSelect
                 showSearch
                 style={{ width: '100%' }}
-                popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+                styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
                 placeholder="Please select"
                 allowClear
                 treeDefaultExpandAll

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -171,6 +171,7 @@ const {
 | popconfirm | Set Popconfirm common props | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | transfer | Set Transfer common props | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, `selectionsIcon`: 5.14.0 |
 | tree | Set Tree common props | { className?: string, style?: React.CSSProperties, classNames?: [TreeConfig\["classNames"\]](/components/tree#semantic-dom), styles?: [TreeConfig\["styles"\]](/components/tree#semantic-dom) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
+| treeSelect | Set TreeSelect common props | { className?: string, style?: React.CSSProperties, classNames?: [TreeSelectConfig\["classNames"\]](/components/tree-select#semantic-dom), styles?: [TreeSelectConfig\["styles"\]](/components/tree-select#semantic-dom) } | - | |
 | typography | Set Typography common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | Set Upload common props | { className?: string, style?: React.CSSProperties, classNames?:[UploadConfig\["classNames"\]](/components/upload#semantic-dom), styles?: [UploadConfig\["styles"\]](/components/upload#semantic-dom) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | wave | Config wave effect | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -173,6 +173,7 @@ const {
 | popconfirm | 设置 Popconfirm 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[Popconfirm\["classNames"\]](/components/popconfirm-cn#api), styles?: [Popconfirm\["styles"\]](/components/popconfirm-cn#api), arrow: boolean \| { pointAtCenter: boolean } } | - | 5.23.0, `arrow`: 6.0.0 |
 | transfer | 设置 Transfer 组件的通用属性 | { className?: string, style?: React.CSSProperties, selectionsIcon?: React.ReactNode } | - | 5.7.0, `selectionsIcon`: 5.14.0 |
 | tree | 设置 Tree 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [TreeConfig\["classNames"\]](/components/tree-cn#semantic-dom), styles?: [TreeConfig\["styles"\]](/components/tree-cn#semantic-dom) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
+| treeSelect | 设置 TreeSelect 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [TreeSelectConfig\["classNames"\]](/components/tree-select-cn#semantic-dom), styles?: [TreeSelectConfig\["styles"\]](/components/tree-select-cn#semantic-dom) } | - | |
 | typography | 设置 Typography 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | upload | 设置 Upload 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?:[UploadConfig\["classNames"\]](/components/upload-cn#semantic-dom), styles?: [UploadConfig\["styles"\]](/components/upload-cn#semantic-dom) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | wave | 设置水波纹特效 | { disabled?: boolean, showEffect?: (node: HTMLElement, info: { className, token, component }) => void } | - | 5.8.0 |

--- a/components/select/demo/_semantic.tsx
+++ b/components/select/demo/_semantic.tsx
@@ -36,7 +36,7 @@ const Block = (prop: any) => {
         placement="bottomLeft"
         suffixIcon={<SmileOutlined />}
         defaultValue="thinkasany"
-        styles={{ root: { zIndex: 1000, width: 200 } }}
+        styles={{ root: { zIndex: 1, width: 200 }, popup: { zIndex: 1 } }}
         getPopupContainer={() => divRef.current}
         options={[
           { value: 'thinkasany', label: 'thinkasany' },

--- a/components/space/demo/compact.tsx
+++ b/components/space/demo/compact.tsx
@@ -175,7 +175,7 @@ const App: React.FC = () => (
         showSearch
         style={{ width: '60%' }}
         value="leaf1"
-        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -151,6 +151,8 @@ describe('TreeSelect', () => {
     const popup = container.querySelector('.ant-tree-select-dropdown');
     const itemTitle = container.querySelector('.ant-select-tree-title');
     const root = container.querySelector('.ant-tree-select-dropdown');
+    const selectRoot = container.querySelector('.ant-tree-select');
+
     const item = container.querySelector(`.${customClassNames.item}`);
     expect(prefix).toHaveClass(customClassNames.prefix);
     expect(input).toHaveClass(customClassNames.input);
@@ -158,6 +160,7 @@ describe('TreeSelect', () => {
     expect(popup).toHaveClass(customClassNames.popup);
     expect(itemTitle).toHaveClass(customClassNames.itemTitle);
     expect(root).toHaveClass(customClassNames.root);
+    expect(selectRoot).toHaveClass(customClassNames.root);
 
     expect(prefix).toHaveStyle(customStyles.prefix);
     expect(input).toHaveStyle(customStyles.input);
@@ -165,6 +168,7 @@ describe('TreeSelect', () => {
     expect(popup).toHaveStyle(customStyles.popup);
     expect(itemTitle).toHaveStyle(customStyles.itemTitle);
     expect(root).toHaveStyle(customStyles.root);
+    expect(selectRoot).toHaveStyle(customStyles.root);
     expect(item).toHaveStyle(customStyles.item);
   });
 });

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -124,7 +124,7 @@ describe('TreeSelect', () => {
       popup: 'test-popup',
     };
     const customStyles = {
-      root: { color: 'red' },
+      root: { backgroundColor: 'red' },
       prefix: { color: 'green' },
       input: { color: 'blue' },
       suffix: { color: 'yellow' },
@@ -150,21 +150,21 @@ describe('TreeSelect', () => {
     const suffix = container.querySelector('.ant-select-arrow');
     const popup = container.querySelector('.ant-tree-select-dropdown');
     const itemTitle = container.querySelector('.ant-select-tree-title');
-    // const root = container.querySelector('.ant-select');
+    const root = container.querySelector('.ant-tree-select-dropdown');
     const item = container.querySelector(`.${customClassNames.item}`);
     expect(prefix).toHaveClass(customClassNames.prefix);
     expect(input).toHaveClass(customClassNames.input);
     expect(suffix).toHaveClass(customClassNames.suffix);
     expect(popup).toHaveClass(customClassNames.popup);
     expect(itemTitle).toHaveClass(customClassNames.itemTitle);
-    // expect(root).toHaveClass(customClassNames.root);
+    expect(root).toHaveClass(customClassNames.root);
 
     expect(prefix).toHaveStyle(customStyles.prefix);
     expect(input).toHaveStyle(customStyles.input);
     expect(suffix).toHaveStyle(customStyles.suffix);
     expect(popup).toHaveStyle(customStyles.popup);
     expect(itemTitle).toHaveStyle(customStyles.itemTitle);
-    // expect(root).toHaveStyle(customStyles.root);
+    expect(root).toHaveStyle(customStyles.root);
     expect(item).toHaveStyle(customStyles.item);
   });
 });

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SmileOutlined } from '@ant-design/icons';
 
 import TreeSelect, { TreeNode } from '..';
 import { resetWarned } from '../../_util/warning';
@@ -89,5 +90,81 @@ describe('TreeSelect', () => {
     expect(container.querySelector('.ant-select-show-arrow')).toBeTruthy();
 
     errSpy.mockRestore();
+  });
+  it('support classNames and styles', () => {
+    const treeData = [
+      {
+        value: 'parent 1',
+        title: 'parent 1',
+        children: [
+          {
+            value: 'parent 1-0',
+            title: 'parent 1-0',
+            children: [
+              {
+                value: 'leaf1',
+                title: 'my leaf',
+              },
+              {
+                value: 'leaf2',
+                title: 'your leaf',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const customClassNames = {
+      root: 'test-root',
+      prefix: 'test-prefix',
+      input: 'test-input',
+      suffix: 'test-suffix',
+      item: 'test-item',
+      itemTitle: 'test-item-title',
+      popup: 'test-popup',
+    };
+    const customStyles = {
+      root: { color: 'red' },
+      prefix: { color: 'green' },
+      input: { color: 'blue' },
+      suffix: { color: 'yellow' },
+      item: { color: 'black' },
+      itemTitle: { color: 'purple' },
+      popup: { color: 'orange' },
+    };
+    const { container } = render(
+      <TreeSelect
+        classNames={customClassNames}
+        styles={customStyles}
+        showSearch
+        prefix="Prefix"
+        open
+        suffixIcon={<SmileOutlined />}
+        placeholder="Please select"
+        treeDefaultExpandAll
+        treeData={treeData}
+      />,
+    );
+    const prefix = container.querySelector('.ant-select-prefix');
+    const input = container.querySelector('.ant-select-selection-search-input');
+    const suffix = container.querySelector('.ant-select-arrow');
+    const popup = container.querySelector('.ant-tree-select-dropdown');
+    const itemTitle = container.querySelector('.ant-select-tree-title');
+    // const root = container.querySelector('.ant-select');
+    const item = container.querySelector(`.${customClassNames.item}`);
+    expect(prefix).toHaveClass(customClassNames.prefix);
+    expect(input).toHaveClass(customClassNames.input);
+    expect(suffix).toHaveClass(customClassNames.suffix);
+    expect(popup).toHaveClass(customClassNames.popup);
+    expect(itemTitle).toHaveClass(customClassNames.itemTitle);
+    // expect(root).toHaveClass(customClassNames.root);
+
+    expect(prefix).toHaveStyle(customStyles.prefix);
+    expect(input).toHaveStyle(customStyles.input);
+    expect(suffix).toHaveStyle(customStyles.suffix);
+    expect(popup).toHaveStyle(customStyles.popup);
+    expect(itemTitle).toHaveStyle(customStyles.itemTitle);
+    // expect(root).toHaveStyle(customStyles.root);
+    expect(item).toHaveStyle(customStyles.item);
   });
 });

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -13,7 +13,7 @@ const locales = {
     suffix: '后缀元素',
     item: '条目元素',
     itemTitle: '标题元素',
-    itemIcon: '图标元素',
+    popup: '弹出菜单元素',
   },
   en: {
     root: 'Root element',
@@ -22,7 +22,7 @@ const locales = {
     suffix: 'Suffix element',
     item: 'Item element',
     itemTitle: 'title element',
-    itemIcon: 'Icon element',
+    popup: 'Popup element',
   },
 };
 const icon = <SmileOutlined />;
@@ -53,7 +53,6 @@ const Block = (props: any) => {
   const divRef = React.useRef<HTMLDivElement>(null);
   const [value, setValue] = React.useState<string>();
   const onChange = (newValue: string) => {
-    console.log(newValue);
     setValue(newValue);
   };
   return (
@@ -62,12 +61,18 @@ const Block = (props: any) => {
         {...props}
         getPopupContainer={() => divRef.current}
         showSearch
+        placement="bottomLeft"
         prefix="Prefix"
         open
         suffixIcon={icon}
-        style={{ width: '100%' }}
+        styles={{
+          input: { zIndex: 1000 },
+          popup: {
+            maxHeight: 400,
+            overflow: 'auto',
+          },
+        }}
         value={value}
-        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll
@@ -87,9 +92,9 @@ const App: React.FC = () => {
         { name: 'prefix', desc: locale.prefix, version: '6.0.0' },
         { name: 'input', desc: locale.input, version: '6.0.0' },
         { name: 'suffix', desc: locale.suffix, version: '6.0.0' },
+        { name: 'popup', desc: locale.popup, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
         { name: 'itemTitle', desc: locale.itemTitle, version: '6.0.0' },
-        { name: 'itemIcon', desc: locale.itemIcon, version: '6.0.0' },
       ]}
     >
       <Block />

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -66,7 +66,7 @@ const Block = (props: any) => {
         open
         suffixIcon={icon}
         styles={{
-          input: { zIndex: 1000 },
+          root: { zIndex: 1000 },
           popup: {
             maxHeight: 400,
             overflow: 'auto',

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { SmileOutlined } from '@ant-design/icons';
+import { TreeSelect } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素',
+    prefix: '前缀元素',
+    input: '输入框元素',
+    suffix: '后缀元素',
+    item: '条目元素',
+    itemTitle: '标题元素',
+    itemIcon: '图标元素',
+  },
+  en: {
+    root: 'Root element',
+    prefix: 'Prefix element',
+    input: 'Input element',
+    suffix: 'Suffix element',
+    item: 'Item element',
+    itemTitle: 'title element',
+    itemIcon: 'Icon element',
+  },
+};
+const icon = <SmileOutlined />;
+const treeData = [
+  {
+    value: 'parent 1',
+    title: 'parent 1',
+    children: [
+      {
+        value: 'parent 1-0',
+        title: 'parent 1-0',
+        children: [
+          {
+            value: 'leaf1',
+            title: 'my leaf',
+          },
+          {
+            value: 'leaf2',
+            title: 'your leaf',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const Block = (props: any) => {
+  const divRef = React.useRef<HTMLDivElement>(null);
+  const [value, setValue] = React.useState<string>();
+  const onChange = (newValue: string) => {
+    console.log(newValue);
+    setValue(newValue);
+  };
+  return (
+    <div ref={divRef}>
+      <TreeSelect
+        {...props}
+        getPopupContainer={() => divRef.current}
+        showSearch
+        prefix="Prefix"
+        open
+        suffixIcon={icon}
+        style={{ width: '100%' }}
+        value={value}
+        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+        placeholder="Please select"
+        allowClear
+        treeDefaultExpandAll
+        onChange={onChange}
+        treeData={treeData}
+      />
+    </div>
+  );
+};
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+
+  return (
+    <SemanticPreview
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.0.0' },
+        { name: 'prefix', desc: locale.prefix, version: '6.0.0' },
+        { name: 'input', desc: locale.input, version: '6.0.0' },
+        { name: 'suffix', desc: locale.suffix, version: '6.0.0' },
+        { name: 'item', desc: locale.item, version: '6.0.0' },
+        { name: 'itemTitle', desc: locale.itemTitle, version: '6.0.0' },
+        { name: 'itemIcon', desc: locale.itemIcon, version: '6.0.0' },
+      ]}
+    >
+      <Block />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -66,8 +66,9 @@ const Block = (props: any) => {
         open
         suffixIcon={icon}
         styles={{
-          root: { zIndex: 1000 },
+          root: { zIndex: 1 },
           popup: {
+            zIndex: 1,
             maxHeight: 400,
             overflow: 'auto',
           },

--- a/components/tree-select/demo/async.tsx
+++ b/components/tree-select/demo/async.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => {
       treeDataSimpleMode
       style={{ width: '100%' }}
       value={value}
-      popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
       placeholder="Please select"
       onChange={onChange}
       loadData={onLoadData}

--- a/components/tree-select/demo/basic.tsx
+++ b/components/tree-select/demo/basic.tsx
@@ -66,7 +66,7 @@ const App: React.FC = () => {
       showSearch
       style={{ width: '100%' }}
       value={value}
-      popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
       placeholder="Please select"
       allowClear
       treeDefaultExpandAll

--- a/components/tree-select/demo/component-token.tsx
+++ b/components/tree-select/demo/component-token.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
         showSearch
         style={{ width: '100%' }}
         value={value}
-        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll

--- a/components/tree-select/demo/multiple.tsx
+++ b/components/tree-select/demo/multiple.tsx
@@ -46,7 +46,7 @@ const App: React.FC = () => {
       showSearch
       style={{ width: '100%' }}
       value={value}
-      popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
       placeholder="Please select"
       allowClear
       multiple

--- a/components/tree-select/demo/placement.tsx
+++ b/components/tree-select/demo/placement.tsx
@@ -56,7 +56,7 @@ const App: React.FC = () => {
 
       <TreeSelect
         showSearch
-        popupStyle={{ maxHeight: 400, overflow: 'auto', minWidth: 300 }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto', minWidth: 300 } }}
         placeholder="Please select"
         popupMatchSelectWidth={false}
         placement={placement}

--- a/components/tree-select/demo/suffix.tsx
+++ b/components/tree-select/demo/suffix.tsx
@@ -51,7 +51,7 @@ const App: React.FC = () => {
         suffixIcon={icon}
         style={{ width: '100%' }}
         value={value}
-        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll
@@ -65,7 +65,7 @@ const App: React.FC = () => {
         prefix="Prefix"
         style={{ width: '100%' }}
         value={value}
-        popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll

--- a/components/tree-select/demo/treeData.tsx
+++ b/components/tree-select/demo/treeData.tsx
@@ -34,7 +34,7 @@ const App: React.FC = () => {
     <TreeSelect
       style={{ width: '100%' }}
       value={value}
-      popupStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
       treeData={treeData}
       placeholder="Please select"
       treeDefaultExpandAll

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -115,6 +115,10 @@ Common props ref：[Common props](/docs/react/common-props)
 | title | Content showed on the treeNodes | ReactNode | `---` |  |
 | value | Will be treated as `treeNodeFilterProp` by default, should be unique in the tree | string | - |  |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="TreeSelect"></ComponentTokenTable>

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -51,7 +51,7 @@ export interface LabeledValue {
 
 export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[];
 
-type SemanticName = 'root' | 'prefix' | 'input' | 'suffix' | 'item' | 'itemTitle' | 'itemIcon';
+type SemanticName = 'root' | 'prefix' | 'input' | 'suffix' | 'item' | 'itemTitle' | 'popup';
 export interface TreeSelectProps<ValueType = any, OptionType extends DataNode = DataNode>
   extends Omit<
     RcTreeSelectProps<ValueType, OptionType>,
@@ -123,7 +123,6 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
     popupMatchSelectWidth,
     allowClear,
     variant: customVariant,
-    popupStyle,
     tagRender,
     maxCount,
     showCheckedStrategy,
@@ -137,8 +136,6 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
     getPrefixCls,
     getPopupContainer: getContextPopupContainer,
     direction,
-    // className: contextClassName,
-    // style: contextStyle,
     styles: contextStyles,
     classNames: contextClassNames,
   } = useComponentConfig('treeSelect');
@@ -202,6 +199,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
     },
     rootClassName,
     mergedClassNames?.root,
+    mergedClassNames?.popup,
     cssVarCls,
     rootCls,
     treeSelectRootCls,
@@ -308,7 +306,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
   );
 
   // ============================ zIndex ============================
-  const [zIndex] = useZIndex('SelectLike', popupStyle?.zIndex as number);
+  const [zIndex] = useZIndex('SelectLike', mergedStyles?.popup?.zIndex as number);
 
   return (
     <RcTreeSelect
@@ -339,7 +337,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
       getPopupContainer={getPopupContainer || getContextPopupContainer}
       treeMotion={null}
       popupClassName={mergedDropdownClassName}
-      popupStyle={{ ...popupStyle, zIndex }}
+      popupStyle={{ ...mergedStyles?.root, ...mergedStyles?.popup, zIndex }}
       choiceTransitionName={getTransitionName(rootPrefixCls, '', choiceTransitionName)}
       transitionName={getTransitionName(rootPrefixCls, 'slide-up', transitionName)}
       treeExpandAction={treeExpandAction}

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -291,6 +291,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
     compactItemClassnames,
     className,
     rootClassName,
+    mergedClassNames?.root,
     cssVarCls,
     rootCls,
     treeSelectRootCls,

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -127,6 +127,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
     maxCount,
     showCheckedStrategy,
     treeCheckStrictly,
+    style,
     classNames: treeSelectClassNames,
     styles,
     ...restProps
@@ -320,6 +321,7 @@ const InternalTreeSelect = <ValueType = any, OptionType extends DataNode = DataN
       ref={ref}
       prefixCls={prefixCls}
       className={mergedClassName}
+      style={{ ...mergedStyles?.root, ...style }}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
       treeCheckable={

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -116,6 +116,10 @@ demo:
 | title           | 树节点显示的内容                                   | ReactNode | `---`  |      |
 | value           | 默认根据此属性值进行筛选（其值在整个树范围内唯一） | string    | -      |      |
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="TreeSelect"></ComponentTokenTable>

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@rc-component/tooltip": "~1.1.0",
     "@rc-component/tour": "~2.1.3",
     "@rc-component/tree": "~1.0.1",
-    "@rc-component/tree-select": "~1.1.0",
+    "@rc-component/tree-select": "~1.1.1",
     "@rc-component/trigger": "~3.1.0",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@rc-component/qrcode": "~1.0.0",
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/segmented": "~1.1.0",
-    "@rc-component/select": "~1.0.1",
+    "@rc-component/select": "~1.0.2",
     "@rc-component/switch": "~1.0.0",
     "@rc-component/table": "~1.2.7",
     "@rc-component/tabs": "~1.3.0",


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🆕 New feature

wait for https://github.com/react-component/tree-select/pull/638/files

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   feat: ConfigProvider support classNames and styles for treeSelect        |
| 🇨🇳 Chinese |     feat: ConfigProvider support classNames and styles for treeSelect      |
