### PR TITLE
feat: ColorPicker presets support liner gradient

### DIFF
--- a/components/color-picker/__tests__/demo-extend.test.ts
+++ b/components/color-picker/__tests__/demo-extend.test.ts
@@ -1,3 +1,5 @@
 import { extendTest } from '../../../tests/shared/demoTest';
 
-extendTest('color-picker');
+extendTest('color-picker', {
+  skip: ['presets-line-gradient.tsx'],
+});

--- a/components/color-picker/__tests__/demo.test.tsx
+++ b/components/color-picker/__tests__/demo.test.tsx
@@ -4,6 +4,7 @@ import demoTest, { rootPropsTest } from '../../../tests/shared/demoTest';
 
 demoTest('color-picker', {
   testRootProps: false,
+  skip: ['presets-line-gradient.tsx'],
 });
 
 rootPropsTest('color-picker', (ColorPicker, props) => <ColorPicker {...props} value={undefined} />);

--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -340,4 +340,45 @@ describe('ColorPicker.gradient', () => {
       backgroundColor: 'rgb(255,0,0)',
     });
   });
+
+  it('preset color', () => {
+    const onChange = jest.fn();
+
+    render(
+      <ColorPicker
+        mode={['gradient']}
+        open
+        presets={[
+          {
+            label: 'Liner',
+            colors: [
+              [
+                {
+                  color: '#FF0000',
+                  percent: 0,
+                },
+                {
+                  color: '#0000FF',
+                  percent: 100,
+                },
+              ],
+            ],
+          },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    expect(document.querySelector('.ant-color-picker-presets-color-checked')).toBeFalsy();
+
+    // Select preset
+    fireEvent.click(
+      document.querySelector('.ant-color-picker-presets .ant-color-picker-color-block-inner')!,
+    );
+    const color = onChange.mock.calls[0][0];
+    expect(color.toCssString()).toEqual(
+      'linear-gradient(90deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%)',
+    );
+    expect(document.querySelector('.ant-color-picker-presets-color-checked')).toBeTruthy();
+  });
 });

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -71,23 +71,27 @@ const ColorPresets: FC<ColorPresetsProps> = ({ prefixCls, presets, value: color,
     children: (
       <div className={`${colorPresetsPrefixCls}-items`}>
         {Array.isArray(preset?.colors) && preset.colors?.length > 0 ? (
-          (preset.colors as AggregationColor[]).map((presetColor, index) => (
-            <ColorBlock
-              // eslint-disable-next-line react/no-array-index-key
-              key={`preset-${index}-${presetColor.toHexString()}`}
-              color={generateColor(presetColor).toRgbString()}
-              prefixCls={prefixCls}
-              className={classNames(`${colorPresetsPrefixCls}-color`, {
-                [`${colorPresetsPrefixCls}-color-checked`]:
-                  presetColor.toHexString() === color?.toHexString(),
-                [`${colorPresetsPrefixCls}-color-bright`]: isBright(
-                  presetColor,
-                  token.colorBgElevated,
-                ),
-              })}
-              onClick={() => handleClick(presetColor)}
-            />
-          ))
+          (preset.colors as AggregationColor[]).map((presetColor, index) => {
+            const colorInst = generateColor(presetColor);
+
+            return (
+              <ColorBlock
+                // eslint-disable-next-line react/no-array-index-key
+                key={`preset-${index}-${presetColor.toHexString()}`}
+                color={colorInst.toCssString()}
+                prefixCls={prefixCls}
+                className={classNames(`${colorPresetsPrefixCls}-color`, {
+                  [`${colorPresetsPrefixCls}-color-checked`]:
+                    presetColor.toCssString() === color?.toCssString(),
+                  [`${colorPresetsPrefixCls}-color-bright`]: isBright(
+                    presetColor,
+                    token.colorBgElevated,
+                  ),
+                })}
+                onClick={() => handleClick(presetColor)}
+              />
+            );
+          })
         ) : (
           <span className={`${colorPresetsPrefixCls}-empty`}>{locale.presetEmpty}</span>
         )}

--- a/components/color-picker/demo/presets-line-gradient.md
+++ b/components/color-picker/demo/presets-line-gradient.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+设置颜色选择器的预设渐变色。
+
+## en-US
+
+Set the presets gradient color of the color picker.

--- a/components/color-picker/demo/presets-line-gradient.tsx
+++ b/components/color-picker/demo/presets-line-gradient.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ColorPicker } from 'antd';
+
+const PRESET_COLORS = [
+  ['rgb(42, 188, 191)', 'rgb(56, 54, 221)'],
+  ['rgb(34, 73, 254)', 'rgb(199, 74, 168)'],
+  ['rgb(255, 111, 4)', 'rgb(243, 48, 171)'],
+  ['rgb(244, 170, 6)', 'rgb(229, 70, 49)'],
+];
+
+const Demo: React.FC = () => {
+  return (
+    <ColorPicker
+      mode={['single', 'gradient']}
+      presets={[
+        {
+          label: 'Liner',
+          colors: PRESET_COLORS.map((colors) => [
+            {
+              color: colors[0],
+              percent: 0,
+            },
+            {
+              color: colors[1],
+              percent: 100,
+            },
+          ]),
+          defaultOpen: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -30,6 +30,7 @@ Used when the user needs to make a customized color selection.
 <code src="./demo/trigger-event.tsx">Custom Trigger Event</code>
 <code src="./demo/format.tsx">Color Format</code>
 <code src="./demo/presets.tsx">Preset Colors</code>
+<code src="./demo/presets-line-gradient.tsx" debug>Preset Line Gradient</code>
 <code src="./demo/panel-render.tsx">Custom Render Panel</code>
 <code src="./demo/pure-panel.tsx" debug>Pure Render</code>
 
@@ -45,7 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | allowClear | 	Allow clearing color selected | boolean | false | |
 | arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | true | |
 | children | Trigger of ColorPicker | React.ReactNode | - | |
-| defaultValue | Default value of color | string \| `Color` | - | |
+| defaultValue | Default value of color | [ColorType](#colortype) | - | |
 | defaultFormat | Default format of color | `rgb` \| `hex` \| `hsb` | - | 5.9.0 |
 | disabled | Disable ColorPicker | boolean | - | |
 | disabledAlpha | Disable Alpha | boolean | - | 5.8.0 |
@@ -54,18 +55,41 @@ Common props ref：[Common props](/docs/react/common-props)
 | format | Format of color | `rgb` \| `hex` \| `hsb` | `hex` | |
 | mode | Configure single or gradient color | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 |
 | open | Whether to show popup | boolean | - | |
-| presets | Preset colors | `{ label: ReactNode, colors: Array<string \| Color>, defaultOpen?: boolean, key?: React.Key }[]` | - | `defaultOpen: 5.11.0, key: 5.23.0` |
+| presets | Preset colors | [PresetColorType](#presetcolortype) | - | |
 | placement | Placement of popup | The design of the [placement](/components/tooltip/#api) parameter is the same as the `Tooltips` component. | `bottomLeft` | |
 | panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
 | size | Setting the trigger size | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | |
-| value | Value of color | string \| `Color` | - | |
+| value | Value of color | [ColorType](#colortype) | - | |
 | onChange | Callback when `value` is changed | `(value: Color, css: string) => void` | - | |
 | onChangeComplete | Called when color pick ends. Will not change the display color when `value` controlled by `onChangeComplete` | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | |
 | onClear | Called when clear | `() => void` | - | 5.6.0 |
+
+#### ColorType
+
+```typescript
+type ColorType =
+  | string
+  | Color
+  | {
+      color: string;
+      percent: number;
+    }[];
+```
+
+#### PresetColorType
+
+```typescript
+type PresetColorType = {
+  label: React.ReactNode;
+  defaultOpen?: boolean;
+  key?: React.Key;
+  colors: ColorType[];
+};
+```
 
 ### Color
 

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -31,6 +31,7 @@ group:
 <code src="./demo/trigger-event.tsx">自定义触发事件</code>
 <code src="./demo/format.tsx">颜色编码</code>
 <code src="./demo/presets.tsx">预设颜色</code>
+<code src="./demo/presets-line-gradient.tsx" debug>预设渐变色</code>
 <code src="./demo/panel-render.tsx">自定义面板</code>
 <code src="./demo/pure-panel.tsx" debug>Pure Render</code>
 
@@ -46,7 +47,7 @@ group:
 | allowClear | 允许清除选择的颜色 | boolean | false | |
 | arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | true | |
 | children | 颜色选择器的触发器 | React.ReactNode | - | |
-| defaultValue | 颜色默认的值 | string \| `Color` | - | |
+| defaultValue | 颜色默认的值 | [ColorType](#colortype) | - | |
 | defaultFormat | 颜色格式默认的值 | `rgb` \| `hex` \| `hsb` | - | 5.9.0 |
 | disabled | 禁用颜色选择器 | boolean | - | |
 | disabledAlpha | 禁用透明度 | boolean | - | 5.8.0 |
@@ -55,18 +56,41 @@ group:
 | format | 颜色格式 | `rgb` \| `hex` \| `hsb` | `hex` | |
 | mode | 选择器模式，用于配置单色与渐变 | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 |
 | open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色 | `{ label: ReactNode, colors: Array<string \| Color>, defaultOpen?: boolean, key?: React.Key }[]` | - | `defaultOpen: 5.11.0, key: 5.23.0` |
+| presets | 预设的颜色 | [PresetColorType](#presetcolortype) | - | |
 | placement | 弹出窗口的位置 | 同 `Tooltips` 组件的 [placement](/components/tooltip-cn/#api) 参数设计 | `bottomLeft` | |
 | panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
 | showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
 | size | 设置触发器大小 | `large` \| `middle` \| `small` | `middle` | 5.7.0 |
 | trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | |
-| value | 颜色的值 | string \| `Color` | - | |
+| value | 颜色的值 | [ColorType](#colortype) | - | |
 | onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | |
 | onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色 | `(value: Color) => void` | - | 5.7.0 |
 | onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
 | onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |
 | onClear | 清除的回调 | `() => void` | - | 5.6.0 |
+
+#### ColorType
+
+```typescript
+type ColorType =
+  | string
+  | Color
+  | {
+      color: string;
+      percent: number;
+    }[];
+```
+
+#### PresetColorType
+
+```typescript
+type PresetColorType = {
+  label: React.ReactNode;
+  defaultOpen?: boolean;
+  key?: React.Key;
+  colors: ColorType[];
+};
+```
 
 ### Color
 

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -25,7 +25,7 @@ export type ColorFormatType = typeof FORMAT_HEX | typeof FORMAT_RGB | typeof FOR
 
 export interface PresetsItem {
   label: ReactNode;
-  colors: (string | AggregationColor)[];
+  colors: (string | AggregationColor | LineGradientType)[];
   /**
    * Whether the initial state is collapsed
    * @since 5.11.0
@@ -45,13 +45,12 @@ export type TriggerPlacement = TooltipPlacement; // Alias, to prevent breaking c
 
 export type SingleValueType = AggregationColor | string;
 
-export type ColorValueType =
-  | SingleValueType
-  | null
-  | {
-      color: SingleValueType;
-      percent: number;
-    }[];
+export type LineGradientType = {
+  color: SingleValueType;
+  percent: number;
+}[];
+
+export type ColorValueType = SingleValueType | null | LineGradientType;
 
 export type ModeType = 'single' | 'gradient';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

resolve #52255

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      ColorPicker `presets` support liner gradient color.     |
| 🇨🇳 Chinese |     ColorPicker `presets` 支持渐变色预设值。     |
