### PR TITLE
fix: add missing translations and fix typos for Farsi language (fa_IR)

### DIFF
--- a/components/locale/fa_IR.ts
+++ b/components/locale/fa_IR.ts
@@ -25,7 +25,7 @@ const localeValues: Locale = {
     filterSearchPlaceholder: 'جستجو در فیلترها',
     emptyText: 'بدون داده',
     selectAll: 'انتخاب صفحه‌ی کنونی',
-    selectInvert: 'معکوس کردن انتخاب‌ها در صفحه ی کنونی',
+    selectInvert: 'معکوس کردن انتخاب‌ها در صفحه‌ی کنونی',
     selectNone: 'انتخاب هیچکدام',
     selectionAll: 'انتخاب همه‌ی داده‌ها',
     sortTitle: 'مرتب سازی',
@@ -58,8 +58,9 @@ const localeValues: Locale = {
     selectCurrent: 'انتخاب صفحه فعلی',
     removeCurrent: 'پاک کردن انتخاب‌های صفحه فعلی',
     selectAll: 'انتخاب همه',
+    deselectAll: 'لغو انتخاب همه',
     removeAll: 'پاک کردن همه انتخاب‌ها',
-    selectInvert: 'معکوس کردن انتخاب‌ها در صفحه ی کنونی',
+    selectInvert: 'معکوس کردن انتخاب‌ها در صفحه‌ی کنونی',
   },
   Upload: {
     uploading: 'در حال آپلود...',
@@ -79,6 +80,7 @@ const localeValues: Locale = {
     copy: 'کپی',
     copied: 'کپی شد',
     expand: 'توسعه',
+    collapse: 'بستن',
   },
   Form: {
     optional: '(اختیاری)',
@@ -134,8 +136,15 @@ const localeValues: Locale = {
     preview: 'پیش‌نمایش',
   },
   QRCode: {
-    expired: 'QR Code منقضی شذد',
+    expired: 'کد QR منقضی شد',
     refresh: 'به‌روزرسانی',
+    scanned: 'اسکن شد',
+  },
+  ColorPicker: {
+    presetEmpty: 'خالی',
+    transparent: 'شفاف',
+    singleColor: 'تک‌رنگ',
+    gradientColor: 'گرادینت',
   },
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🌐 Internationalization


### 🔗 Related Issues

> - This PR complete missing translations and fix typos in Farsi locale in components like ColorPicker, QRCode, ...

### 💡 Background and Solution

> - The specific problem to be addressed: There was no keys for ColorPicker and some keys like `scanned` not exists in QRCode component

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: add missing translations and fix typos for Farsi language (fa_IR) |
| 🇨🇳 Chinese | fix: 添加缺失的波斯语 (fa_IR) 翻译并修正拼写错误 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增了多项本地化文本，覆盖操作提示与颜色选择器相关说明，提升用户界面的语言体验。
  - 添加了二维码扫描状态提示，以便提供更全面的反馈信息。

- **修复**
  - 调整了二维码过期提示，确保文案准确清晰。
  - 修改了反选描述格式，提高文案的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->