### PR TITLE
docs: icon版本使用提示

### DIFF
--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -14,7 +14,7 @@ demo:
 
 Before using icons, you need to install the [@ant-design/icons](https://github.com/ant-design/ant-design-icons) package:
 
-<InstallDependencies npm='npm install @ant-design/icons --save' yarn='yarn add @ant-design/icons' pnpm='pnpm install @ant-design/icons --save' bun='bun add @ant-design/icons'></InstallDependencies>
+<InstallDependencies npm='npm install @ant-design/icons@5.x --save' yarn='yarn add @ant-design/icons@5.x' pnpm='pnpm install @ant-design/icons@5.x --save' bun='bun add @ant-design/icons@5.x'></InstallDependencies>
 
 ## List of icons
 

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -15,7 +15,7 @@ demo:
 
 使用图标组件，你需要安装 [@ant-design/icons](https://github.com/ant-design/ant-design-icons) 图标组件包：
 
-<InstallDependencies npm='npm install @ant-design/icons --save' yarn='yarn add @ant-design/icons' pnpm='pnpm install @ant-design/icons --save' bun='bun add @ant-design/icons'></InstallDependencies>
+<InstallDependencies npm='npm install @ant-design/icons@5.x --save' yarn='yarn add @ant-design/icons@5.x' pnpm='pnpm install @ant-design/icons@5.x --save' bun='bun add @ant-design/icons@5.x'></InstallDependencies>
 
 ## 设计师专属
 


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 📝 Site / documentation improvement


### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/53275

### 💡 Background and Solution

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Icon document prompt, corresponding version needs to be used     |
| 🇨🇳 Chinese |     icon文档提示，需要使用对应版本      |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新了安装说明，明确要求在安装 @ant-design/icons 时指定 5.x 版本，确保用户在使用 npm、yarn、pnpm 和 bun 等工具安装时获得兼容的版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->