### PR TITLE
feat(tree-select): popup support semantic dom and deprecated some api

### DIFF
--- a/components/space/demo/compact.tsx
+++ b/components/space/demo/compact.tsx
@@ -175,7 +175,9 @@ const App: React.FC = () => (
         showSearch
         style={{ width: '60%' }}
         value="leaf1"
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{
+          popup: { maxHeight: 400, overflow: 'auto' },
+        }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll

--- a/components/tree-select/__tests__/index.test.tsx
+++ b/components/tree-select/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import { resetWarned } from '../../_util/warning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { render } from '../../../tests/utils';
+import { render, fireEvent } from '../../../tests/utils';
 
 describe('TreeSelect', () => {
   focusTest(TreeSelect, { refFocus: true });
@@ -54,20 +54,33 @@ describe('TreeSelect', () => {
     expect(container.querySelector('.ant-select-empty')?.innerHTML).toBe(content);
   });
 
-  it('legacy dropdownClassName', () => {
+  it('legacy popupClassName', () => {
     resetWarned();
 
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { container } = render(<TreeSelect dropdownClassName="legacy" open />);
+    const { container } = render(<TreeSelect popupClassName="legacy" open />);
     expect(errSpy).toHaveBeenCalledWith(
-      'Warning: [antd: TreeSelect] `dropdownClassName` is deprecated. Please use `popupClassName` instead.',
+      'Warning: [antd: TreeSelect] `popupClassName` is deprecated. Please use `classNames.popup` instead.',
     );
     expect(container.querySelector('.legacy')).toBeTruthy();
 
     errSpy.mockRestore();
   });
 
-  it('warning for legacy dropdownMatchSelectWidth', () => {
+  it('legacy dropdownClassName', () => {
+    resetWarned();
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(<TreeSelect dropdownClassName="legacy" open />);
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: TreeSelect] `dropdownClassName` is deprecated. Please use `classNames.popup` instead.',
+    );
+    expect(container.querySelector('.legacy')).toBeTruthy();
+
+    errSpy.mockRestore();
+  });
+
+  it('legacy dropdownMatchSelectWidth', () => {
     resetWarned();
 
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -75,6 +88,52 @@ describe('TreeSelect', () => {
     expect(errSpy).toHaveBeenCalledWith(
       'Warning: [antd: TreeSelect] `dropdownMatchSelectWidth` is deprecated. Please use `popupMatchSelectWidth` instead.',
     );
+
+    errSpy.mockRestore();
+  });
+
+  it('legacy dropdownStyle', () => {
+    resetWarned();
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(<TreeSelect dropdownStyle={{ color: 'red' }} open />);
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: TreeSelect] `dropdownStyle` is deprecated. Please use `styles.popup` instead.',
+    );
+    expect(container.querySelector('.ant-select-dropdown')).toBeTruthy();
+
+    errSpy.mockRestore();
+  });
+
+  it('legacy dropdownRender', () => {
+    resetWarned();
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(
+      <TreeSelect dropdownRender={(menu) => <div className="custom-dropdown">{menu}</div>} open />,
+    );
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: TreeSelect] `dropdownRender` is deprecated. Please use `popupRender` instead.',
+    );
+    expect(container.querySelector('.custom-dropdown')).toBeTruthy();
+
+    errSpy.mockRestore();
+  });
+
+  it('legacy onDropdownVisibleChange', () => {
+    resetWarned();
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const onDropdownVisibleChange = jest.fn();
+
+    const { container } = render(<TreeSelect onDropdownVisibleChange={onDropdownVisibleChange} />);
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'Warning: [antd: TreeSelect] `onDropdownVisibleChange` is deprecated. Please use `onOpenChange` instead.',
+    );
+
+    fireEvent.mouseDown(container.querySelector('.ant-select-selector')!);
+    expect(onDropdownVisibleChange).toHaveBeenCalled();
 
     errSpy.mockRestore();
   });

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -43,7 +43,7 @@ const Block = (props: any) => {
         showSearch
         placement="bottomLeft"
         open
-        style={{ marginBottom: 80, width: 200 }}
+        style={{ marginBottom: 100, width: 200 }}
         styles={{
           popup: {
             zIndex: 1,

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { TreeSelect } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    popup: '弹出菜单元素',
+  },
+  en: {
+    popup: 'Popup element',
+  },
+};
+const treeData = [
+  {
+    value: 'aojunhao123',
+    title: 'aojunhao123',
+    children: [
+      {
+        value: 'thinkasany',
+        title: 'thinkasany',
+      },
+    ],
+  },
+];
+
+const Block = (props: any) => {
+  const divRef = React.useRef<HTMLDivElement>(null);
+  const [value, setValue] = React.useState<string>();
+  const onChange = (newValue: string) => {
+    setValue(newValue);
+  };
+  return (
+    <div ref={divRef}>
+      <TreeSelect
+        {...props}
+        getPopupContainer={() => divRef.current}
+        showSearch
+        placement="bottomLeft"
+        open
+        style={{ marginBottom: 80, width: 200 }}
+        styles={{
+          popup: {
+            zIndex: 1,
+          },
+        }}
+        value={value}
+        placeholder="Please select"
+        treeDefaultExpandAll
+        onChange={onChange}
+        treeData={treeData}
+      />
+    </div>
+  );
+};
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+
+  return (
+    <SemanticPreview
+      semantics={[{ name: 'popup', desc: locale.popup, version: '5.25.0' }]}
+      height={200}
+    >
+      <Block />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/tree-select/demo/_semantic.tsx
+++ b/components/tree-select/demo/_semantic.tsx
@@ -14,12 +14,16 @@ const locales = {
 };
 const treeData = [
   {
-    value: 'aojunhao123',
-    title: 'aojunhao123',
+    value: 'contributors',
+    title: 'contributors',
     children: [
       {
         value: 'thinkasany',
         title: 'thinkasany',
+      },
+      {
+        value: 'aojunhao123',
+        title: 'aojunhao123',
       },
     ],
   },

--- a/components/tree-select/demo/async.tsx
+++ b/components/tree-select/demo/async.tsx
@@ -43,7 +43,9 @@ const App: React.FC = () => {
       treeDataSimpleMode
       style={{ width: '100%' }}
       value={value}
-      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{
+        popup: { maxHeight: 400, overflow: 'auto' },
+      }}
       placeholder="Please select"
       onChange={onChange}
       loadData={onLoadData}

--- a/components/tree-select/demo/basic.tsx
+++ b/components/tree-select/demo/basic.tsx
@@ -66,7 +66,9 @@ const App: React.FC = () => {
       showSearch
       style={{ width: '100%' }}
       value={value}
-      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{
+        popup: { maxHeight: 400, overflow: 'auto' },
+      }}
       placeholder="Please select"
       allowClear
       treeDefaultExpandAll

--- a/components/tree-select/demo/multiple.tsx
+++ b/components/tree-select/demo/multiple.tsx
@@ -46,7 +46,9 @@ const App: React.FC = () => {
       showSearch
       style={{ width: '100%' }}
       value={value}
-      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{
+        popup: { maxHeight: 400, overflow: 'auto' },
+      }}
       placeholder="Please select"
       allowClear
       multiple

--- a/components/tree-select/demo/placement.tsx
+++ b/components/tree-select/demo/placement.tsx
@@ -56,7 +56,9 @@ const App: React.FC = () => {
 
       <TreeSelect
         showSearch
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto', minWidth: 300 }}
+        styles={{
+          popup: { maxHeight: 400, overflow: 'auto', minWidth: 300 },
+        }}
         placeholder="Please select"
         popupMatchSelectWidth={false}
         placement={placement}

--- a/components/tree-select/demo/suffix.tsx
+++ b/components/tree-select/demo/suffix.tsx
@@ -51,7 +51,9 @@ const App: React.FC = () => {
         suffixIcon={icon}
         style={{ width: '100%' }}
         value={value}
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{
+          popup: { maxHeight: 400, overflow: 'auto' },
+        }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll
@@ -65,7 +67,9 @@ const App: React.FC = () => {
         prefix="Prefix"
         style={{ width: '100%' }}
         value={value}
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{
+          popup: { maxHeight: 400, overflow: 'auto' },
+        }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll

--- a/components/tree-select/demo/treeData.tsx
+++ b/components/tree-select/demo/treeData.tsx
@@ -34,7 +34,9 @@ const App: React.FC = () => {
     <TreeSelect
       style={{ width: '100%' }}
       value={value}
-      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      styles={{
+        popup: { maxHeight: 400, overflow: 'auto' },
+      }}
       treeData={treeData}
       placeholder="Please select"
       treeDefaultExpandAll

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -42,10 +42,11 @@ Common props ref：[Common props](/docs/react/common-props)
 | autoClearSearchValue | If auto clear search input value when multiple select is selected/deselected | boolean | true |  |
 | defaultValue | To set the initial selected treeNode(s) | string \| string\[] | - |  |
 | disabled | Disabled or not | boolean | false |  |
-| popupClassName | The className of dropdown menu | string | - | 4.23.0 |
+| ~~popupClassName~~ | The className of dropdown menu, use `classNames.popup` instead | string | - | 4.23.0 |
 | popupMatchSelectWidth | Determine whether the popup menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | 5.5.0 |
-| dropdownRender | Customize dropdown content | (originNode: ReactNode, props) => ReactNode | - |  |
-| dropdownStyle | To set the style of the dropdown menu | CSSProperties | - |  |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactNode, props) => ReactNode | - |  |
+| popupRender | Customize dropdown content | (originNode: ReactNode, props) => ReactNode | - |  |
+| ~~dropdownStyle~~ | To set the style of the dropdown menu, use `styles.popup` instead | CSSProperties | - |  |
 | fieldNames | Customize node label, value, children field name | object | { label: `label`, value: `value`, children: `children` } | 4.17.0 |
 | filterTreeNode | Whether to filter treeNodes by input value. The value of `treeNodeFilterProp` is used for filtering by default | boolean \| function(inputValue: string, treeNode: TreeNode) (should return boolean) | function |  |
 | getPopupContainer | To set the container of the dropdown menu. The default is to create a `div` element in `body`, you can reset it to the scrolling area and make a relative reposition. [example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  |
@@ -87,7 +88,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | variant | Variants of selector | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
 | virtual | Disable virtual scroll when set to false | boolean | true | 4.1.0 |
 | onChange | A callback function, can be executed when selected treeNodes or input value change | function(value, label, extra) | - |  |
-| onDropdownVisibleChange | Called when dropdown open | function(open) | - |  |
+| ~~onDropdownVisibleChange~~ | Called when dropdown open, use `onOpenChange` instead | function(open) | - |  |
 | onSearch | A callback function, can be executed when the search input changes | function(value: string) | - |  |
 | onSelect | A callback function, can be executed when you select a treeNode | function(value, node, extra) | - |  |
 | onTreeExpand | A callback function, can be executed when treeNode expanded | function(expandedKeys) | - |  |
@@ -114,6 +115,10 @@ Common props ref：[Common props](/docs/react/common-props)
 | selectable | Whether can be selected | boolean | true |  |
 | title | Content showed on the treeNodes | ReactNode | `---` |  |
 | value | Will be treated as `treeNodeFilterProp` by default, should be unique in the tree | string | - |  |
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## Design Token
 

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -43,10 +43,11 @@ demo:
 | autoClearSearchValue | 当多选模式下值被选择，自动清空搜索框 | boolean | true |  |
 | defaultValue | 指定默认选中的条目 | string \| string\[] | - |  |
 | disabled | 是否禁用 | boolean | false |  |
-| popupClassName | 下拉菜单的 className 属性 | string | - | 4.23.0 |
+| ~~popupClassName~~ | 下拉菜单的 className 属性，使用 `classNames.popup` 替换 | string | - | 4.23.0 |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | 5.5.0 |
-| dropdownRender | 自定义下拉框内容 | (originNode: ReactNode, props) => ReactNode | - |  |
-| dropdownStyle | 下拉菜单的样式 | object | - |  |
+| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactNode, props) => ReactNode | - |  |
+| popupRender | 自定义下拉框内容 | (originNode: ReactNode, props) => ReactNode | - |  |
+| ~~dropdownStyle~~ | 下拉菜单的样式，使用 `styles.popup` 替换 | object | - |  |
 | fieldNames | 自定义节点 label、value、children 的字段 | object | { label: `label`, value: `value`, children: `children` } | 4.17.0 |
 | filterTreeNode | 是否根据输入项进行筛选，默认用 treeNodeFilterProp 的值作为要筛选的 TreeNode 的属性值 | boolean \| function(inputValue: string, treeNode: TreeNode) (函数需要返回 bool 值) | function |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  |
@@ -88,7 +89,8 @@ demo:
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
 | virtual | 设置 false 时关闭虚拟滚动 | boolean | true | 4.1.0 |
 | onChange | 选中树节点时调用此函数 | function(value, label, extra) | - |  |
-| onDropdownVisibleChange | 展开下拉菜单的回调 | function(open) | - |  |
+| ~~onDropdownVisibleChange~~ | 展开下拉菜单的回调，使用 `onOpenChange` 替换 | (open: boolean) => void | - |  |
+| onOpenChange | 展开下拉菜单的回调 | (open: boolean) => void | - |  |
 | onSearch | 文本框值变化时的回调 | function(value: string) | - |  |
 | onSelect | 被选中时调用 | function(value, node, extra) | - |  |
 | onTreeExpand | 展示节点时调用 | function(expandedKeys) | - |  |
@@ -115,6 +117,10 @@ demo:
 | selectable      | 是否可选                                           | boolean   | true   |      |
 | title           | 树节点显示的内容                                   | ReactNode | `---`  |      |
 | value           | 默认根据此属性值进行筛选（其值在整个树范围内唯一） | string    | -      |      |
+
+## 语义化DOM（Semantic DOM）
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## 主题变量（Design Token）
 

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -118,7 +118,7 @@ demo:
 | title           | 树节点显示的内容                                   | ReactNode | `---`  |      |
 | value           | 默认根据此属性值进行筛选（其值在整个树范围内唯一） | string    | -      |      |
 
-## 语义化DOM（Semantic DOM）
+## 语义化 DOM（Semantic DOM）
 
 <code src="./demo/_semantic.tsx" simplify="true"></code>
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 🛠 Refactoring

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   🆕 TreeSelect component adds popup semantic node, and deprecated some api        |
| 🇨🇳 Chinese |    🆕 TreeSelect 组件新增 popup 语义节点，并且废弃部分api       |
