### PR TITLE
feat: Configure the aria attribute to the button node of the Modal

### DIFF
--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -104,7 +104,12 @@ export default function useClosable(
      */
     closeIconRender?: (closeIcon: ReactNode) => ReactNode;
   } = EmptyFallbackCloseCollection,
-): [closable: boolean, closeIcon: React.ReactNode, closeBtnIsDisabled: boolean, ariaProps: object] {
+): [
+  closable: boolean,
+  closeIcon: React.ReactNode,
+  closeBtnIsDisabled: boolean,
+  ariaProps: React.AriaAttributes,
+] {
   // Align the `props`, `context` `fallback` to config object first
   const propCloseConfig = useClosableConfig(propCloseCollection);
   const contextCloseConfig = useClosableConfig(contextCloseCollection);

--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import type { DialogProps } from '@rc-component/dialog';
+import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 export type ClosableType = DialogProps['closable'];
 
@@ -93,7 +93,9 @@ interface ClosableCollection {
 
 /** Use same object to support `useMemo` optimization */
 const EmptyFallbackCloseCollection: ClosableCollection = {};
-
+type DataAttributes = {
+  [key: `data-${string}`]: string;
+};
 export default function useClosable(
   propCloseCollection?: ClosableCollection,
   contextCloseCollection?: ClosableCollection | null,
@@ -108,7 +110,7 @@ export default function useClosable(
   closable: boolean,
   closeIcon: React.ReactNode,
   closeBtnIsDisabled: boolean,
-  ariaProps: React.AriaAttributes,
+  ariaOrDataProps: React.AriaAttributes & DataAttributes,
 ] {
   // Align the `props`, `context` `fallback` to config object first
   const propCloseConfig = useClosableConfig(propCloseCollection);
@@ -164,22 +166,22 @@ export default function useClosable(
 
     let mergedCloseIcon: ReactNode = closeIcon;
     // Wrap the closeIcon with aria props
-    const ariaProps = pickAttrs(mergedClosableConfig, true);
+    const ariaOrDataProps = pickAttrs(mergedClosableConfig, true);
     if (mergedCloseIcon !== null && mergedCloseIcon !== undefined) {
       // Wrap the closeIcon if needed
       if (closeIconRender) {
         mergedCloseIcon = closeIconRender(closeIcon);
       }
 
-      if (Object.keys(ariaProps).length) {
+      if (Object.keys(ariaOrDataProps).length) {
         mergedCloseIcon = React.isValidElement(mergedCloseIcon) ? (
-          React.cloneElement(mergedCloseIcon, ariaProps)
+          React.cloneElement(mergedCloseIcon, ariaOrDataProps)
         ) : (
-          <span {...ariaProps}>{mergedCloseIcon}</span>
+          <span {...ariaOrDataProps}>{mergedCloseIcon}</span>
         );
       }
     }
 
-    return [true, mergedCloseIcon, closeBtnIsDisabled, ariaProps];
+    return [true, mergedCloseIcon, closeBtnIsDisabled, ariaOrDataProps];
   }, [mergedClosableConfig, mergedFallbackCloseCollection]);
 }

--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -104,7 +104,7 @@ export default function useClosable(
      */
     closeIconRender?: (closeIcon: ReactNode) => ReactNode;
   } = EmptyFallbackCloseCollection,
-): [closable: boolean, closeIcon: React.ReactNode, closeBtnIsDisabled: boolean] {
+): [closable: boolean, closeIcon: React.ReactNode, closeBtnIsDisabled: boolean, ariaProps: object] {
   // Align the `props`, `context` `fallback` to config object first
   const propCloseConfig = useClosableConfig(propCloseCollection);
   const contextCloseConfig = useClosableConfig(contextCloseCollection);
@@ -151,21 +151,21 @@ export default function useClosable(
   // Calculate the final closeIcon
   return React.useMemo(() => {
     if (mergedClosableConfig === false) {
-      return [false, null, closeBtnIsDisabled];
+      return [false, null, closeBtnIsDisabled, {}];
     }
 
     const { closeIconRender } = mergedFallbackCloseCollection;
     const { closeIcon } = mergedClosableConfig;
 
     let mergedCloseIcon: ReactNode = closeIcon;
+    // Wrap the closeIcon with aria props
+    const ariaProps = pickAttrs(mergedClosableConfig, true);
     if (mergedCloseIcon !== null && mergedCloseIcon !== undefined) {
       // Wrap the closeIcon if needed
       if (closeIconRender) {
         mergedCloseIcon = closeIconRender(closeIcon);
       }
 
-      // Wrap the closeIcon with aria props
-      const ariaProps = pickAttrs(mergedClosableConfig, true);
       if (Object.keys(ariaProps).length) {
         mergedCloseIcon = React.isValidElement(mergedCloseIcon) ? (
           React.cloneElement(mergedCloseIcon, ariaProps)
@@ -175,6 +175,6 @@ export default function useClosable(
       }
     }
 
-    return [true, mergedCloseIcon, closeBtnIsDisabled];
+    return [true, mergedCloseIcon, closeBtnIsDisabled, ariaProps];
   }, [mergedClosableConfig, mergedFallbackCloseCollection]);
 }

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -116,7 +116,7 @@ const Modal: React.FC<ModalProps> = (props) => {
       <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
     ) : null;
 
-  const [mergedClosable, mergedCloseIcon, closeBtnIsDisabled] = useClosable(
+  const [mergedClosable, mergedCloseIcon, closeBtnIsDisabled, ariaProps] = useClosable(
     pickClosable(props),
     pickClosable(modalContext),
     {
@@ -185,7 +185,7 @@ const Modal: React.FC<ModalProps> = (props) => {
           onClose={handleCancel as any}
           closable={
             mergedClosable
-              ? { disabled: closeBtnIsDisabled, closeIcon: mergedCloseIcon }
+              ? { disabled: closeBtnIsDisabled, closeIcon: mergedCloseIcon, ...ariaProps }
               : mergedClosable
           }
           closeIcon={mergedCloseIcon}

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -116,7 +116,7 @@ const Modal: React.FC<ModalProps> = (props) => {
       <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
     ) : null;
 
-  const [mergedClosable, mergedCloseIcon, closeBtnIsDisabled, ariaProps] = useClosable(
+  const [mergedClosable, mergedCloseIcon, closeBtnIsDisabled, ariaOrDataProps] = useClosable(
     pickClosable(props),
     pickClosable(modalContext),
     {
@@ -185,7 +185,7 @@ const Modal: React.FC<ModalProps> = (props) => {
           onClose={handleCancel as any}
           closable={
             mergedClosable
-              ? { disabled: closeBtnIsDisabled, closeIcon: mergedCloseIcon, ...ariaProps }
+              ? { disabled: closeBtnIsDisabled, closeIcon: mergedCloseIcon, ...ariaOrDataProps }
               : mergedClosable
           }
           closeIcon={mergedCloseIcon}

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -319,4 +319,10 @@ describe('Modal', () => {
 
     jest.useRealTimers();
   });
+
+  it('closable have aria', () => {
+    render(<Modal open closable={{ 'aria-label': 'xxx' }} />);
+    const element = document.body.querySelector('.ant-modal-close');
+    expect(element).toHaveAttribute('aria-label', 'xxx');
+  });
 });


### PR DESCRIPTION

### 🤔 This is a ...

- [X] ⭐️ Feature enhancement


### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/49554

### 💡 Background and Solution
FRC https://github.com/ant-design/ant-design/discussions/53197

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Apply the aria - * attribute configured in the closable object to the close button node of the Modal component to achieve accessibility functionality      |
| 🇨🇳 Chinese |     将在closable对象中配置的aria-*属性，应用到Modal组件的关闭button节点上，实现无障碍功能      |
