### PR TITLE
style: change notification closeButton style

### DIFF
--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -196,6 +196,8 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      background: 'none',
+      border: 'none',
 
       '&:hover': {
         color: token.colorIconHover,


### PR DESCRIPTION

### 🤔 This is a ...

- [X] 💄 Component style improvement
- 
### 🔗 Related Issues


### 💡 Background and Solution

底层组件rc-notification的close button 由a标签更换为button，因此修改按钮背景色和边框避免出现样式差异

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     The close button of the notification component，Cancel the background color and border     |
| 🇨🇳 Chinese |      notification 组件的关闭按钮，取消背景色和边框     |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
	- 更新了通知组件关闭按钮的视觉效果，移除默认的背景和边框，提供了更简洁的显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->