### PR TITLE
feat(Menu): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -71,11 +71,7 @@ function useSemanticStyles<StylesType extends object>(
 }
 
 // =========================== Export ===========================
-function fillObjectBySchema<T extends object>(obj: T, schema?: SemanticSchema): T {
-  if (!schema) {
-    return obj;
-  }
-
+function fillObjectBySchema<T extends object>(obj: T, schema: SemanticSchema): T {
   const newObj: any = { ...obj };
 
   Object.keys(schema).forEach((key) => {

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -80,13 +80,10 @@ function fillObjectBySchema<T extends object>(obj: T, schema?: SemanticSchema): 
 
   Object.keys(schema).forEach((key) => {
     if (key !== '_default') {
-      newObj[key] = newObj[key] || {};
-
-      // Loop fill
       const nestSchema = (schema as any)[key] as SemanticSchema;
-      if (nestSchema) {
-        newObj[key] = fillObjectBySchema(newObj[key], nestSchema);
-      }
+      const nextValue = newObj[key] || {};
+
+      newObj[key] = nestSchema ? fillObjectBySchema(nextValue, nestSchema) : nextValue;
     }
   });
 

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -164,7 +164,8 @@ export type CheckboxConfig = ComponentStyleConfig & Pick<CheckboxProps, 'classNa
 
 export type MasonryConfig = ComponentStyleConfig & Pick<MasonryProps, 'classNames' | 'styles'>;
 
-export type MenuConfig = ComponentStyleConfig & Pick<MenuProps, 'expandIcon'>;
+export type MenuConfig = ComponentStyleConfig &
+  Pick<MenuProps, 'expandIcon' | 'classNames' | 'styles'>;
 
 export type TourConfig = ComponentStyleConfig &
   Pick<TourProps, 'closeIcon' | 'classNames' | 'styles'>;

--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 
 import type { DirectionType } from '../config-provider';
+import { MenuProps } from './menu';
 
 export type MenuTheme = 'light' | 'dark';
 
@@ -12,6 +13,8 @@ export interface MenuContextProps {
   firstLevel: boolean;
   /** @internal Safe to remove */
   disableMenuItemTitleTooltip?: boolean;
+  classNames?: MenuProps['classNames'];
+  styles?: MenuProps['styles'];
 }
 
 const MenuContext = createContext<MenuContextProps>({

--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -19,6 +19,7 @@ export interface MenuContextProps {
   styles: Required<
     Record<SemanticName, React.CSSProperties> & {
       subMenu: Required<Record<SubMenuName, React.CSSProperties>>;
+      popup: { root: React.CSSProperties };
     }
   >;
 }

--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
 import type { DirectionType } from '../config-provider';
-import { MenuProps } from './menu';
+import { SemanticName, SubMenuName } from './menu';
 
 export type MenuTheme = 'light' | 'dark';
 
@@ -13,14 +13,22 @@ export interface MenuContextProps {
   firstLevel: boolean;
   /** @internal Safe to remove */
   disableMenuItemTitleTooltip?: boolean;
-  classNames?: MenuProps['classNames'];
-  styles?: MenuProps['styles'];
+  classNames: Required<
+    Record<SemanticName, string> & { subMenu: Required<Record<SubMenuName, string>> }
+  >;
+  styles: Required<
+    Record<SemanticName, React.CSSProperties> & {
+      subMenu: Required<Record<SubMenuName, React.CSSProperties>>;
+    }
+  >;
 }
 
 const MenuContext = createContext<MenuContextProps>({
   prefixCls: '',
   firstLevel: true,
   inlineCollapsed: false,
+  styles: null!,
+  classNames: null!,
 });
 
 export default MenuContext;

--- a/components/menu/MenuContext.tsx
+++ b/components/menu/MenuContext.tsx
@@ -14,7 +14,10 @@ export interface MenuContextProps {
   /** @internal Safe to remove */
   disableMenuItemTitleTooltip?: boolean;
   classNames: Required<
-    Record<SemanticName, string> & { subMenu: Required<Record<SubMenuName, string>> }
+    Record<SemanticName, string> & {
+      popup: { root: string };
+      subMenu: Required<Record<SubMenuName, string>>;
+    }
   >;
   styles: Required<
     Record<SemanticName, React.CSSProperties> & {

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -52,12 +52,12 @@ const MenuItem: GenericComponent = (props) => {
       <span
         className={cls(
           `${prefixCls}-title-content`,
-          firstLevel ? classNames.itemContent : classNames.subMenu.listItemContent,
+          firstLevel ? classNames.itemContent : classNames.subMenu?.listItemContent,
           {
             [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
           },
         )}
-        style={firstLevel ? styles.itemContent : styles.subMenu.listItemContent}
+        style={firstLevel ? styles.itemContent : styles.subMenu?.listItemContent}
       >
         {children}
       </span>
@@ -97,25 +97,25 @@ const MenuItem: GenericComponent = (props) => {
     <Item
       {...omit(props, ['title', 'icon', 'danger'])}
       className={cls(
-        firstLevel ? classNames.item : classNames.subMenu.listItem,
+        firstLevel ? classNames.item : classNames.subMenu?.listItem,
         {
           [`${prefixCls}-item-danger`]: danger,
           [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
         },
         className,
       )}
-      style={firstLevel ? styles.item : styles.subMenu.listItem}
+      style={firstLevel ? styles.item : styles.subMenu?.listItem}
       title={typeof title === 'string' ? title : undefined}
     >
       {cloneElement(icon, (oriProps) => ({
         className: cls(
           oriProps.className,
           `${prefixCls}-item-icon`,
-          firstLevel ? classNames.itemIcon : classNames.subMenu.listItemIcon,
+          firstLevel ? classNames.itemIcon : classNames.subMenu?.listItemIcon,
         ),
         style: {
           ...oriProps.style,
-          ...(firstLevel ? styles.itemIcon : styles.subMenu.listItemIcon),
+          ...(firstLevel ? styles.itemIcon : styles.subMenu?.listItemIcon),
         },
       }))}
       {renderItemChildren(isInlineCollapsed)}

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -52,12 +52,12 @@ const MenuItem: GenericComponent = (props) => {
       <span
         className={cls(
           `${prefixCls}-title-content`,
-          firstLevel ? classNames.itemContent : classNames.subMenu?.itemContent,
+          firstLevel ? classNames.itemContent : classNames.subMenu.itemContent,
           {
             [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
           },
         )}
-        style={firstLevel ? styles.itemContent : styles.subMenu?.itemContent}
+        style={firstLevel ? styles.itemContent : styles.subMenu.itemContent}
       >
         {children}
       </span>
@@ -97,25 +97,25 @@ const MenuItem: GenericComponent = (props) => {
     <Item
       {...omit(props, ['title', 'icon', 'danger'])}
       className={cls(
-        firstLevel ? classNames.item : classNames.subMenu?.item,
+        firstLevel ? classNames.item : classNames.subMenu.item,
         {
           [`${prefixCls}-item-danger`]: danger,
           [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
         },
         className,
       )}
-      style={firstLevel ? styles.item : styles.subMenu?.item}
+      style={firstLevel ? styles.item : styles.subMenu.item}
       title={typeof title === 'string' ? title : undefined}
     >
       {cloneElement(icon, (oriProps) => ({
         className: cls(
           oriProps.className,
           `${prefixCls}-item-icon`,
-          firstLevel ? classNames.itemIcon : classNames.subMenu?.itemIcon,
+          firstLevel ? classNames.itemIcon : classNames.subMenu.itemIcon,
         ),
         style: {
           ...oriProps.style,
-          ...(firstLevel ? styles.itemIcon : styles.subMenu?.itemIcon),
+          ...(firstLevel ? styles.itemIcon : styles.subMenu.itemIcon),
         },
       }))}
       {renderItemChildren(isInlineCollapsed)}

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -48,17 +48,16 @@ const MenuItem: GenericComponent = (props) => {
   } = React.useContext<MenuContextProps>(MenuContext);
   const renderItemChildren = (inlineCollapsed: boolean) => {
     const label = (children as React.ReactNode[])?.[0];
-
     const wrapNode = (
       <span
         className={cls(
           `${prefixCls}-title-content`,
-          firstLevel ? classNames?.itemContent : classNames?.popup?.listItemContent,
+          firstLevel ? classNames.itemContent : classNames.subMenu.listItemContent,
           {
             [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
           },
         )}
-        style={firstLevel ? styles?.itemContent : styles?.popup?.listItemContent}
+        style={firstLevel ? styles.itemContent : styles.subMenu.listItemContent}
       >
         {children}
       </span>
@@ -98,25 +97,25 @@ const MenuItem: GenericComponent = (props) => {
     <Item
       {...omit(props, ['title', 'icon', 'danger'])}
       className={cls(
+        firstLevel ? classNames.item : classNames.subMenu.listItem,
         {
           [`${prefixCls}-item-danger`]: danger,
           [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
         },
         className,
-        firstLevel ? classNames?.item : classNames?.popup?.listItem,
       )}
-      style={firstLevel ? styles?.item : styles?.popup?.listItem}
+      style={firstLevel ? styles.item : styles.subMenu.listItem}
       title={typeof title === 'string' ? title : undefined}
     >
       {cloneElement(icon, (oriProps) => ({
         className: cls(
           oriProps.className,
           `${prefixCls}-item-icon`,
-          firstLevel ? classNames?.itemIcon : classNames?.popup?.listItemIcon,
+          firstLevel ? classNames.itemIcon : classNames.subMenu.listItemIcon,
         ),
         style: {
           ...oriProps.style,
-          ...(firstLevel ? styles?.itemIcon : styles?.popup?.listItemIcon),
+          ...(firstLevel ? styles.itemIcon : styles.subMenu.listItemIcon),
         },
       }))}
       {renderItemChildren(isInlineCollapsed)}

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import toArray from '@rc-component/util/lib/Children/toArray';
-import omit from '@rc-component/util/lib/omit';
-import classNames from 'classnames';
 import type { MenuItemProps as RcMenuItemProps } from '@rc-component/menu';
 import { Item } from '@rc-component/menu';
+import toArray from '@rc-component/util/lib/Children/toArray';
+import omit from '@rc-component/util/lib/omit';
+import cls from 'classnames';
 
 import { cloneElement } from '../_util/reactNode';
 import type { SiderContextProps } from '../layout/Sider';
@@ -43,15 +43,22 @@ const MenuItem: GenericComponent = (props) => {
     direction,
     disableMenuItemTitleTooltip,
     inlineCollapsed: isInlineCollapsed,
+    styles,
+    classNames,
   } = React.useContext<MenuContextProps>(MenuContext);
   const renderItemChildren = (inlineCollapsed: boolean) => {
     const label = (children as React.ReactNode[])?.[0];
 
     const wrapNode = (
       <span
-        className={classNames(`${prefixCls}-title-content`, {
-          [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
-        })}
+        className={cls(
+          `${prefixCls}-title-content`,
+          firstLevel ? classNames?.itemContent : classNames?.popup?.listItemContent,
+          {
+            [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
+          },
+        )}
+        style={firstLevel ? styles?.itemContent : styles?.popup?.listItemContent}
       >
         {children}
       </span>
@@ -90,23 +97,28 @@ const MenuItem: GenericComponent = (props) => {
   let returnNode = (
     <Item
       {...omit(props, ['title', 'icon', 'danger'])}
-      className={classNames(
+      className={cls(
         {
           [`${prefixCls}-item-danger`]: danger,
           [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
         },
         className,
+        firstLevel ? classNames?.item : classNames?.popup?.listItem,
       )}
+      style={firstLevel ? styles?.item : styles?.popup?.listItem}
       title={typeof title === 'string' ? title : undefined}
     >
-      {cloneElement(icon, {
-        className: classNames(
-          React.isValidElement(icon)
-            ? (icon as React.ReactElement<{ className?: string }>).props?.className
-            : '',
+      {cloneElement(icon, (oriProps) => ({
+        className: cls(
+          oriProps.className,
           `${prefixCls}-item-icon`,
+          firstLevel ? classNames?.itemIcon : classNames?.popup?.listItemIcon,
         ),
-      })}
+        style: {
+          ...oriProps.style,
+          ...(firstLevel ? styles?.itemIcon : styles?.popup?.listItemIcon),
+        },
+      }))}
       {renderItemChildren(isInlineCollapsed)}
     </Item>
   );

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -52,12 +52,12 @@ const MenuItem: GenericComponent = (props) => {
       <span
         className={cls(
           `${prefixCls}-title-content`,
-          firstLevel ? classNames.itemContent : classNames.subMenu?.listItemContent,
+          firstLevel ? classNames.itemContent : classNames.subMenu?.itemContent,
           {
             [`${prefixCls}-title-content-with-extra`]: !!extra || extra === 0,
           },
         )}
-        style={firstLevel ? styles.itemContent : styles.subMenu?.listItemContent}
+        style={firstLevel ? styles.itemContent : styles.subMenu?.itemContent}
       >
         {children}
       </span>
@@ -97,25 +97,25 @@ const MenuItem: GenericComponent = (props) => {
     <Item
       {...omit(props, ['title', 'icon', 'danger'])}
       className={cls(
-        firstLevel ? classNames.item : classNames.subMenu?.listItem,
+        firstLevel ? classNames.item : classNames.subMenu?.item,
         {
           [`${prefixCls}-item-danger`]: danger,
           [`${prefixCls}-item-only-child`]: (icon ? childrenLength + 1 : childrenLength) === 1,
         },
         className,
       )}
-      style={firstLevel ? styles.item : styles.subMenu?.listItem}
+      style={firstLevel ? styles.item : styles.subMenu?.item}
       title={typeof title === 'string' ? title : undefined}
     >
       {cloneElement(icon, (oriProps) => ({
         className: cls(
           oriProps.className,
           `${prefixCls}-item-icon`,
-          firstLevel ? classNames.itemIcon : classNames.subMenu?.listItemIcon,
+          firstLevel ? classNames.itemIcon : classNames.subMenu?.itemIcon,
         ),
         style: {
           ...oriProps.style,
-          ...(firstLevel ? styles.itemIcon : styles.subMenu?.listItemIcon),
+          ...(firstLevel ? styles.itemIcon : styles.subMenu?.itemIcon),
         },
       }))}
       {renderItemChildren(isInlineCollapsed)}

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import omit from '@rc-component/util/lib/omit';
-import classNames from 'classnames';
 import { SubMenu as RcSubMenu, useFullPath } from '@rc-component/menu';
+import omit from '@rc-component/util/lib/omit';
+import cls from 'classnames';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
 import { cloneElement } from '../_util/reactNode';
@@ -17,7 +17,7 @@ export interface SubMenuProps extends Omit<SubMenuType, 'ref' | 'key' | 'childre
 const SubMenu: React.FC<SubMenuProps> = (props) => {
   const { popupClassName, icon, title, theme: customTheme } = props;
   const context = React.useContext(MenuContext);
-  const { prefixCls, inlineCollapsed, theme: contextTheme } = context;
+  const { prefixCls, inlineCollapsed, theme: contextTheme, classNames, styles } = context;
 
   const parentPath = useFullPath();
 
@@ -36,14 +36,10 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
     const titleIsSpan = React.isValidElement(title) && title.type === 'span';
     titleNode = (
       <>
-        {cloneElement(icon, {
-          className: classNames(
-            React.isValidElement(icon)
-              ? (icon as React.ReactElement<{ className?: string }>).props?.className
-              : '',
-            `${prefixCls}-item-icon`,
-          ),
-        })}
+        {cloneElement(icon, (oriProps) => ({
+          className: cls(oriProps.className, `${prefixCls}-item-icon`, classNames?.itemIcon),
+          style: { ...oriProps.style, ...styles?.itemIcon },
+        }))}
         {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
       </>
     );
@@ -62,15 +58,25 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
       <RcSubMenu
         {...omit(props, ['icon'])}
         title={titleNode}
-        popupClassName={classNames(
+        classNames={{
+          list: classNames?.popup?.list,
+          listTitle: classNames?.popup?.listTitle,
+        }}
+        styles={{
+          list: styles?.popup?.list,
+          listTitle: styles?.popup?.listTitle,
+        }}
+        popupClassName={cls(
           prefixCls,
           popupClassName,
+          classNames?.popup?.root,
           `${prefixCls}-${customTheme || contextTheme}`,
         )}
         popupStyle={{
           zIndex,
           // fix: https://github.com/ant-design/ant-design/issues/47826#issuecomment-2360737237
           ...props.popupStyle,
+          ...styles?.popup?.root,
         }}
       />
     </MenuContext.Provider>

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -37,8 +37,12 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
     titleNode = (
       <>
         {cloneElement(icon, (oriProps) => ({
-          className: cls(oriProps.className, `${prefixCls}-item-icon`, classNames.itemIcon),
-          style: { ...oriProps.style, ...styles.itemIcon },
+          className: cls(
+            oriProps.className,
+            `${prefixCls}-item-icon`,
+            classNames.subMenu?.listItemIcon,
+          ),
+          style: { ...oriProps.style, ...styles.subMenu?.listItemIcon },
         }))}
         {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
       </>
@@ -59,12 +63,12 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
         {...omit(props, ['icon'])}
         title={titleNode}
         classNames={{
-          list: classNames.subMenu.list,
-          listTitle: classNames.subMenu.listTitle,
+          list: classNames.subMenu?.list,
+          listTitle: classNames.subMenu?.listTitle,
         }}
         styles={{
-          list: styles.subMenu.list,
-          listTitle: styles.subMenu.listTitle,
+          list: styles.subMenu?.list,
+          listTitle: styles.subMenu?.listTitle,
         }}
         popupClassName={cls(
           prefixCls,
@@ -76,7 +80,7 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
           zIndex,
           // fix: https://github.com/ant-design/ant-design/issues/47826#issuecomment-2360737237
           ...props.popupStyle,
-          ...styles.popup,
+          ...styles.popup?.root,
         }}
       />
     </MenuContext.Provider>

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -69,7 +69,7 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
         popupClassName={cls(
           prefixCls,
           popupClassName,
-          classNames.popup,
+          classNames.popup.root,
           `${prefixCls}-${customTheme || contextTheme}`,
         )}
         popupStyle={{

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -37,8 +37,8 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
     titleNode = (
       <>
         {cloneElement(icon, (oriProps) => ({
-          className: cls(oriProps.className, `${prefixCls}-item-icon`, classNames?.itemIcon),
-          style: { ...oriProps.style, ...styles?.itemIcon },
+          className: cls(oriProps.className, `${prefixCls}-item-icon`, classNames.itemIcon),
+          style: { ...oriProps.style, ...styles.itemIcon },
         }))}
         {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
       </>
@@ -59,24 +59,24 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
         {...omit(props, ['icon'])}
         title={titleNode}
         classNames={{
-          list: classNames?.popup?.list,
-          listTitle: classNames?.popup?.listTitle,
+          list: classNames.subMenu.list,
+          listTitle: classNames.subMenu.listTitle,
         }}
         styles={{
-          list: styles?.popup?.list,
-          listTitle: styles?.popup?.listTitle,
+          list: styles.subMenu.list,
+          listTitle: styles.subMenu.listTitle,
         }}
         popupClassName={cls(
           prefixCls,
           popupClassName,
-          classNames?.popup?.root,
+          classNames.popup,
           `${prefixCls}-${customTheme || contextTheme}`,
         )}
         popupStyle={{
           zIndex,
           // fix: https://github.com/ant-design/ant-design/issues/47826#issuecomment-2360737237
           ...props.popupStyle,
-          ...styles?.popup?.root,
+          ...styles.popup,
         }}
       />
     </MenuContext.Provider>

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -37,12 +37,8 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
     titleNode = (
       <>
         {cloneElement(icon, (oriProps) => ({
-          className: cls(
-            oriProps.className,
-            `${prefixCls}-item-icon`,
-            classNames.subMenu?.listItemIcon,
-          ),
-          style: { ...oriProps.style, ...styles.subMenu?.listItemIcon },
+          className: cls(oriProps.className, `${prefixCls}-item-icon`, classNames.itemIcon),
+          style: { ...oriProps.style, ...styles.itemIcon },
         }))}
         {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
       </>
@@ -64,11 +60,11 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
         title={titleNode}
         classNames={{
           list: classNames.subMenu?.list,
-          listTitle: classNames.subMenu?.listTitle,
+          listTitle: classNames.subMenu?.itemTitle,
         }}
         styles={{
           list: styles.subMenu?.list,
-          listTitle: styles.subMenu?.listTitle,
+          listTitle: styles.subMenu?.itemTitle,
         }}
         popupClassName={cls(
           prefixCls,

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -76,7 +76,7 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
           zIndex,
           // fix: https://github.com/ant-design/ant-design/issues/47826#issuecomment-2360737237
           ...props.popupStyle,
-          ...styles.popup?.root,
+          ...styles.popup.root,
         }}
       />
     </MenuContext.Provider>

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -59,12 +59,12 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
         {...omit(props, ['icon'])}
         title={titleNode}
         classNames={{
-          list: classNames.subMenu?.list,
-          listTitle: classNames.subMenu?.itemTitle,
+          list: classNames.subMenu.list,
+          listTitle: classNames.subMenu.itemTitle,
         }}
         styles={{
-          list: styles.subMenu?.list,
-          listTitle: styles.subMenu?.itemTitle,
+          list: styles.subMenu.list,
+          listTitle: styles.subMenu.itemTitle,
         }}
         popupClassName={cls(
           prefixCls,

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1193,4 +1193,75 @@ describe('Menu', () => {
       cursor: 'not-allowed',
     });
   });
+  it('support classNames and styles', () => {
+    const items = [
+      {
+        label: 'Navigation One',
+        key: 'mail',
+        icon: <MailOutlined />,
+      },
+      {
+        key: 'SubMenu',
+        label: 'Navigation One',
+        icon: <MailOutlined />,
+        children: [
+          {
+            key: 'g1',
+            label: 'Item 1',
+            type: 'group',
+            children: [
+              { key: '1', label: 'Option 1' },
+              { key: '2', label: 'Option 2' },
+            ],
+          },
+        ],
+      },
+    ];
+    const testClassNames = {
+      root: 'test-root',
+      item: 'test-item',
+      itemIcon: 'test-item-icon',
+      itemContent: 'test-item-content',
+      popup: {
+        root: 'test-popup-root',
+        list: 'test-list',
+        listTitle: 'test-list-title',
+        listItem: 'test-list-item',
+      },
+    };
+    const testStyles = {
+      root: { fontSize: '12px' },
+      item: { backgroundColor: 'red' },
+      itemIcon: { backgroundColor: 'blue' },
+      itemContent: { backgroundColor: 'green' },
+      popup: {
+        root: { fontSize: '14px' },
+        list: { color: 'red' },
+        listTitle: { color: 'blue' },
+        listItem: { color: 'green' },
+      },
+    };
+    const { container } = render(
+      <Menu
+        selectedKeys={['mail']}
+        mode="horizontal"
+        items={items}
+        openKeys={['SubMenu']}
+        classNames={testClassNames}
+        styles={testStyles}
+      />,
+    );
+    const root = container.querySelector('.ant-menu');
+    const item = container.querySelectorAll('.ant-menu-item')[0];
+    const itemIcon = container.querySelector('.ant-menu-item-icon');
+    const itemContent = container.querySelector('.ant-menu-title-content');
+    expect(root).toHaveClass(testClassNames.root);
+    expect(root).toHaveStyle(testStyles.root);
+    expect(item).toHaveClass(testClassNames.item);
+    expect(item).toHaveStyle(testStyles.item);
+    expect(itemIcon).toHaveClass(testClassNames.itemIcon);
+    expect(itemIcon).toHaveStyle(testStyles.itemIcon);
+    expect(itemContent).toHaveClass(testClassNames.itemContent);
+    expect(itemContent).toHaveStyle(testStyles.itemContent);
+  });
 });

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1310,7 +1310,11 @@ describe('Menu', () => {
       popup: 'test-popup',
     };
     const testStyles = {
-      popup: { color: 'red' },
+      popup: {
+        root: {
+          color: 'red',
+        },
+      },
     };
     render(
       <TriggerMockContext.Provider value={{ popupVisible: true }}>
@@ -1325,6 +1329,6 @@ describe('Menu', () => {
       </TriggerMockContext.Provider>,
     );
     const popup = document.querySelector(`.${testClassNames.popup}`) as HTMLElement;
-    expect(popup).toHaveStyle(testStyles.popup);
+    expect(popup).toHaveStyle(testStyles.popup.root);
   });
 });

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1267,19 +1267,13 @@ describe('Menu', () => {
     expect(itemContent).toHaveClass(testClassNames.itemContent);
     expect(itemContent).toHaveStyle(testStyles.itemContent);
 
-    const subMenuList = document.querySelector(`.${testClassNames.subMenu.list}`) as HTMLElement;
-    const subMenuListItem = document.querySelector(
-      `.${testClassNames.subMenu.listItem}`,
-    ) as HTMLElement;
-    const subMenuListItemIcon = document.querySelector(
-      `.${testClassNames.subMenu.listItemIcon}`,
-    ) as HTMLElement;
+    const subMenuList = document.querySelector(`.${testClassNames.subMenu.list}`);
+    const subMenuListItem = document.querySelector(`.${testClassNames.subMenu.listItem}`);
+    const subMenuListItemIcon = document.querySelector(`.${testClassNames.subMenu.listItemIcon}`);
     const subMenuListItemContent = document.querySelector(
       `.${testClassNames.subMenu.listItemContent}`,
-    ) as HTMLElement;
-    const subMenuListTitle = document.querySelector(
-      `.${testClassNames.subMenu.listTitle}`,
-    ) as HTMLElement;
+    );
+    const subMenuListTitle = document.querySelector(`.${testClassNames.subMenu.listTitle}`);
 
     expect(subMenuList).toHaveStyle(testStyles.subMenu.list);
     expect(subMenuListItem).toHaveStyle(testStyles.subMenu.listItem);

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1224,10 +1224,10 @@ describe('Menu', () => {
       itemContent: 'test-item-content',
       subMenu: {
         list: 'test-sub-menu-list',
-        listItem: 'test-sub-menu-list-item',
-        listItemIcon: 'test-sub-menu-list-item-icon',
-        listItemContent: 'test-sub-menu-list-item-content',
-        listTitle: 'test-sub-menu-list-title',
+        item: 'test-sub-menu-list-item',
+        itemIcon: 'test-sub-menu-list-item-icon',
+        itemContent: 'test-sub-menu-list-item-content',
+        itemTitle: 'test-sub-menu-list-title',
       },
     };
     const testStyles = {
@@ -1237,10 +1237,10 @@ describe('Menu', () => {
       itemContent: { backgroundColor: 'green' },
       subMenu: {
         list: { color: 'blue' },
-        listItem: { color: 'red' },
-        listItemIcon: { color: 'green' },
-        listItemContent: { color: 'blue' },
-        listTitle: { color: 'red' },
+        item: { color: 'red' },
+        itemIcon: { color: 'green' },
+        itemContent: { color: 'blue' },
+        itemTitle: { color: 'red' },
       },
     };
     const { container } = render(
@@ -1268,18 +1268,16 @@ describe('Menu', () => {
     expect(itemContent).toHaveStyle(testStyles.itemContent);
 
     const subMenuList = document.querySelector(`.${testClassNames.subMenu.list}`);
-    const subMenuListItem = document.querySelector(`.${testClassNames.subMenu.listItem}`);
-    const subMenuListItemIcon = document.querySelector(`.${testClassNames.subMenu.listItemIcon}`);
-    const subMenuListItemContent = document.querySelector(
-      `.${testClassNames.subMenu.listItemContent}`,
-    );
-    const subMenuListTitle = document.querySelector(`.${testClassNames.subMenu.listTitle}`);
+    const subMenuListItem = document.querySelector(`.${testClassNames.subMenu.item}`);
+    const subMenuListItemIcon = document.querySelector(`.${testClassNames.subMenu.itemIcon}`);
+    const subMenuListItemContent = document.querySelector(`.${testClassNames.subMenu.itemContent}`);
+    const subMenuListTitle = document.querySelector(`.${testClassNames.subMenu.itemTitle}`);
 
     expect(subMenuList).toHaveStyle(testStyles.subMenu.list);
-    expect(subMenuListItem).toHaveStyle(testStyles.subMenu.listItem);
-    expect(subMenuListItemIcon).toHaveStyle(testStyles.subMenu.listItemIcon);
-    expect(subMenuListItemContent).toHaveStyle(testStyles.subMenu.listItemContent);
-    expect(subMenuListTitle).toHaveStyle(testStyles.subMenu.listTitle);
+    expect(subMenuListItem).toHaveStyle(testStyles.subMenu.item);
+    expect(subMenuListItemIcon).toHaveStyle(testStyles.subMenu.itemIcon);
+    expect(subMenuListItemContent).toHaveStyle(testStyles.subMenu.itemContent);
+    expect(subMenuListTitle).toHaveStyle(testStyles.subMenu.itemTitle);
   });
   it('test classNames for popup', () => {
     const items = [

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1210,7 +1210,7 @@ describe('Menu', () => {
             label: 'Item 1',
             type: 'group',
             children: [
-              { key: '1', label: 'Option 1' },
+              { key: '1', label: 'Option 1', icon: <MailOutlined /> },
               { key: '2', label: 'Option 2' },
             ],
           },
@@ -1222,11 +1222,12 @@ describe('Menu', () => {
       item: 'test-item',
       itemIcon: 'test-item-icon',
       itemContent: 'test-item-content',
-      popup: {
-        root: 'test-popup-root',
-        list: 'test-list',
-        listTitle: 'test-list-title',
-        listItem: 'test-list-item',
+      subMenu: {
+        list: 'test-sub-menu-list',
+        listItem: 'test-sub-menu-list-item',
+        listItemIcon: 'test-sub-menu-list-item-icon',
+        listItemContent: 'test-sub-menu-list-item-content',
+        listTitle: 'test-sub-menu-list-title',
       },
     };
     const testStyles = {
@@ -1234,17 +1235,18 @@ describe('Menu', () => {
       item: { backgroundColor: 'red' },
       itemIcon: { backgroundColor: 'blue' },
       itemContent: { backgroundColor: 'green' },
-      popup: {
-        root: { fontSize: '14px' },
-        list: { color: 'red' },
-        listTitle: { color: 'blue' },
-        listItem: { color: 'green' },
+      subMenu: {
+        list: { color: 'blue' },
+        listItem: { color: 'red' },
+        listItemIcon: { color: 'green' },
+        listItemContent: { color: 'blue' },
+        listTitle: { color: 'red' },
       },
     };
     const { container } = render(
       <Menu
         selectedKeys={['mail']}
-        mode="horizontal"
+        mode="inline"
         items={items}
         openKeys={['SubMenu']}
         classNames={testClassNames}
@@ -1255,6 +1257,7 @@ describe('Menu', () => {
     const item = container.querySelectorAll('.ant-menu-item')[0];
     const itemIcon = container.querySelector('.ant-menu-item-icon');
     const itemContent = container.querySelector('.ant-menu-title-content');
+
     expect(root).toHaveClass(testClassNames.root);
     expect(root).toHaveStyle(testStyles.root);
     expect(item).toHaveClass(testClassNames.item);
@@ -1263,5 +1266,65 @@ describe('Menu', () => {
     expect(itemIcon).toHaveStyle(testStyles.itemIcon);
     expect(itemContent).toHaveClass(testClassNames.itemContent);
     expect(itemContent).toHaveStyle(testStyles.itemContent);
+
+    const subMenuList = document.querySelector(`.${testClassNames.subMenu.list}`) as HTMLElement;
+    const subMenuListItem = document.querySelector(
+      `.${testClassNames.subMenu.listItem}`,
+    ) as HTMLElement;
+    const subMenuListItemIcon = document.querySelector(
+      `.${testClassNames.subMenu.listItemIcon}`,
+    ) as HTMLElement;
+    const subMenuListItemContent = document.querySelector(
+      `.${testClassNames.subMenu.listItemContent}`,
+    ) as HTMLElement;
+    const subMenuListTitle = document.querySelector(
+      `.${testClassNames.subMenu.listTitle}`,
+    ) as HTMLElement;
+
+    expect(subMenuList).toHaveStyle(testStyles.subMenu.list);
+    expect(subMenuListItem).toHaveStyle(testStyles.subMenu.listItem);
+    expect(subMenuListItemIcon).toHaveStyle(testStyles.subMenu.listItemIcon);
+    expect(subMenuListItemContent).toHaveStyle(testStyles.subMenu.listItemContent);
+    expect(subMenuListTitle).toHaveStyle(testStyles.subMenu.listTitle);
+  });
+  it('test classNames for popup', () => {
+    const items = [
+      {
+        key: 'SubMenu',
+        label: 'Navigation One',
+        icon: <MailOutlined />,
+        children: [
+          {
+            key: 'g1',
+            label: 'Item 1',
+            type: 'group',
+            children: [
+              { key: '1', label: 'Option 1', icon: <MailOutlined /> },
+              { key: '2', label: 'Option 2' },
+            ],
+          },
+        ],
+      },
+    ];
+    const testClassNames = {
+      popup: 'test-popup',
+    };
+    const testStyles = {
+      popup: { color: 'red' },
+    };
+    render(
+      <TriggerMockContext.Provider value={{ popupVisible: true }}>
+        <Menu
+          selectedKeys={['mail']}
+          mode="vertical"
+          items={items}
+          openKeys={['SubMenu']}
+          classNames={testClassNames}
+          styles={testStyles}
+        />
+      </TriggerMockContext.Provider>,
+    );
+    const popup = document.querySelector(`.${testClassNames.popup}`) as HTMLElement;
+    expect(popup).toHaveStyle(testStyles.popup);
   });
 });

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -13,24 +13,28 @@ const locales = {
     item: '条目元素',
     itemContent: '条目内容元素',
     itemIcon: '图标元素',
+    itemTitle: '菜单标题元素(horizontal 模式不生效)',
+    list: '菜单列表元素(horizontal 模式不生效)',
     popup: '弹出菜单(inline 模式不生效)',
-    'subMenu.listTitle': '子菜单标题元素',
+    'subMenu.itemTitle': '子菜单标题元素',
     'subMenu.list': '子菜单列表元素',
-    'subMenu.listItem': '子菜单单项元素',
-    'subMenu.listItemIcon': '子菜单条目图标元素',
-    'subMenu.listItemContent': '子菜单条目内容元素',
+    'subMenu.item': '子菜单单项元素',
+    'subMenu.itemIcon': '子菜单条目图标元素',
+    'subMenu.itemContent': '子菜单条目内容元素',
   },
   en: {
     root: 'Root element',
     item: 'Item element',
     itemContent: 'Item content element',
     itemIcon: 'Icon element',
+    itemTitle: 'Item title(horizontal mode has no effect)',
+    list: 'Item list element(horizontal mode has no effect)',
     popup: 'Popup element(inline mode has no effect)',
-    'subMenu.listTitle': 'subMenu list title',
-    'subMenu.list': 'Submenu list element',
-    'subMenu.listItem': 'Submenu list item element',
-    'subMenu.listItemIcon': 'Submenu list item icon element',
-    'subMenu.listItemContent': 'Submenu list item content element',
+    'subMenu.itemTitle': 'subMenu item title',
+    'subMenu.list': 'Submenu element',
+    'subMenu.item': 'Submenu item element',
+    'subMenu.itemIcon': 'Submenu item icon element',
+    'subMenu.itemContent': 'Submenu item content element',
   },
 };
 const items: MenuItem[] = [
@@ -121,17 +125,22 @@ const App: React.FC = () => {
       { name: 'itemIcon', desc: locale.itemIcon },
       { name: 'itemContent', desc: locale.itemContent },
     ];
-    const subMenu = [
-      { name: 'subMenu.listTitle', desc: locale['subMenu.listTitle'] },
+    const subMenuLocale = [
+      { name: 'subMenu.itemTitle', desc: locale['subMenu.itemTitle'] },
       { name: 'subMenu.list', desc: locale['subMenu.list'] },
-      { name: 'subMenu.listItem', desc: locale['subMenu.listItem'] },
-      { name: 'subMenu.listItemIcon', desc: locale['subMenu.listItemIcon'] },
-      { name: 'subMenu.listItemContent', desc: locale['subMenu.listItemContent'] },
+      { name: 'subMenu.item', desc: locale['subMenu.item'] },
+      { name: 'subMenu.itemIcon', desc: locale['subMenu.itemIcon'] },
+      { name: 'subMenu.itemContent', desc: locale['subMenu.itemContent'] },
+    ];
+    const groupLocale = [
+      { name: 'itemTitle', desc: locale.itemTitle },
+      { name: 'list', desc: locale.list },
     ];
 
-    const additionalLocale = mode !== 'inline' ? [{ name: 'popup', desc: locale.popup }] : [];
+    const additionalPopupLocale = mode !== 'inline' ? [{ name: 'popup', desc: locale.popup }] : [];
+    const additionalGroupLocale = mode !== 'horizontal' ? groupLocale : [];
 
-    return [...baseLocale, ...additionalLocale, ...subMenu];
+    return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale];
   }, [mode]);
 
   const itemList = React.useMemo(() => {

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -57,10 +57,22 @@ const items: MenuItem[] = [
   },
 ];
 
+const groupItem = [
+  {
+    key: 'grp',
+    label: 'Group',
+    type: 'group',
+    children: [
+      { key: '13', label: 'Option 13' },
+      { key: '14', label: 'Option 14' },
+    ],
+  },
+];
+
 type ModeType = 'horizontal' | 'vertical' | 'inline';
 
 const Block = (props: any) => {
-  const { mode, setMode } = props;
+  const { mode, setMode, item } = props;
   const divRef = React.useRef<HTMLDivElement>(null);
   const [current, setCurrent] = React.useState('mail');
 
@@ -79,8 +91,11 @@ const Block = (props: any) => {
         onClick={onClick}
         selectedKeys={[current]}
         mode={mode}
-        items={items}
+        items={item}
         styles={{
+          root: {
+            width: mode === 'horizontal' ? 400 : 230,
+          },
           popup: {
             zIndex: 1,
           },
@@ -117,9 +132,13 @@ const App: React.FC = () => {
     return [...baseLocale, ...additionalLocale, ...subMenu];
   }, [mode]);
 
+  const itemList = React.useMemo(() => {
+    return mode === 'horizontal' ? items : [...items, ...groupItem];
+  }, [mode]);
+
   return (
     <SemanticPreview componentName="Menu" semantics={semantics}>
-      <Block mode={mode} setMode={setMode} />
+      <Block mode={mode} setMode={setMode} item={itemList} />
     </SemanticPreview>
   );
 };

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MailOutlined } from '@ant-design/icons';
-import { Menu, MenuProps, Segmented } from 'antd';
+import { Flex, Menu, MenuProps, Segmented } from 'antd';
 
 import SemanticPreview from '../../../.dumi/components/SemanticPreview';
 import useLocale from '../../../.dumi/hooks/useLocale';
@@ -88,29 +88,33 @@ const Block: React.FC<
   };
 
   return (
-    <div ref={divRef}>
+    <Flex vertical gap="middle" ref={divRef} align="center">
       <Segmented<ModeType>
         options={['horizontal', 'vertical', 'inline']}
         onChange={(value) => setMode(value)}
       />
-      <Menu
-        onClick={onClick}
-        selectedKeys={[current]}
-        mode={mode}
-        items={item}
-        styles={{
-          root: {
-            width: mode === 'horizontal' ? 400 : 230,
-          },
-          popup: {
-            zIndex: 1,
-          },
-        }}
-        {...props}
-        openKeys={['SubMenu']}
-        getPopupContainer={() => divRef.current!}
-      />
-    </div>
+      <div style={{ height: 360 }}>
+        <Menu
+          onClick={onClick}
+          selectedKeys={[current]}
+          mode={mode}
+          items={item}
+          styles={{
+            root: {
+              width: mode === 'horizontal' ? 310 : 230,
+            },
+            popup: {
+              root: {
+                zIndex: 1,
+              },
+            },
+          }}
+          {...props}
+          openKeys={['SubMenu']}
+          getPopupContainer={() => divRef.current!}
+        />
+      </div>
+    </Flex>
   );
 };
 

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -13,24 +13,24 @@ const locales = {
     item: '条目元素',
     itemContent: '条目内容元素',
     itemIcon: '图标元素',
-    'popup.root': '弹出菜单元素(inline 模式不生效)',
-    'popup.list': '弹出菜单列表元素',
-    'popup.listItem': '弹出菜单单项元素',
-    'popup.listItemIcon': '弹出菜单条目图标元素',
-    'popup.listItemContent': '弹出菜单条目内容元素',
-    'popup.listTitle': '弹出菜单标题元素',
+    popup: '弹出菜单(inline 模式不生效)',
+    'subMenu.listTitle': '子菜单标题元素',
+    'subMenu.list': '子菜单列表元素',
+    'subMenu.listItem': '子菜单单项元素',
+    'subMenu.listItemIcon': '子菜单条目图标元素',
+    'subMenu.listItemContent': '子菜单条目内容元素',
   },
   en: {
     root: 'Root element',
     item: 'Item element',
     itemContent: 'Item content element',
     itemIcon: 'Icon element',
-    'popup.root': 'Popup element(Inline mode has no effect)',
-    'popup.list': 'Popup list element',
-    'popup.listItem': 'Popup item element',
-    'popup.listItemIcon': 'Popup item icon element',
-    'popup.listItemContent': 'Popup item content element',
-    'popup.listTitle': 'Popup title element',
+    popup: 'Popup element(inline mode has no effect)',
+    'subMenu.listTitle': 'subMenu list title',
+    'subMenu.list': 'Submenu list element',
+    'subMenu.listItem': 'Submenu list item element',
+    'subMenu.listItemIcon': 'Submenu list item icon element',
+    'subMenu.listItemContent': 'Submenu list item content element',
   },
 };
 const items: MenuItem[] = [
@@ -58,10 +58,11 @@ const items: MenuItem[] = [
 ];
 
 type ModeType = 'horizontal' | 'vertical' | 'inline';
-const Block: React.FC = (props: any) => {
+
+const Block = (props: any) => {
+  const { mode, setMode } = props;
   const divRef = React.useRef<HTMLDivElement>(null);
   const [current, setCurrent] = React.useState('mail');
-  const [mode, setMode] = React.useState<ModeType>('horizontal');
 
   const onClick: MenuProps['onClick'] = (e) => {
     console.log('click ', e);
@@ -81,9 +82,7 @@ const Block: React.FC = (props: any) => {
         items={items}
         styles={{
           popup: {
-            root: {
-              zIndex: 1,
-            },
+            zIndex: 1,
           },
         }}
         {...props}
@@ -96,23 +95,31 @@ const Block: React.FC = (props: any) => {
 
 const App: React.FC = () => {
   const [locale] = useLocale(locales);
+  const [mode, setMode] = React.useState<ModeType>('horizontal');
+
+  const semantics = React.useMemo(() => {
+    const baseLocale = [
+      { name: 'root', desc: locale.root },
+      { name: 'item', desc: locale.item },
+      { name: 'itemIcon', desc: locale.itemIcon },
+      { name: 'itemContent', desc: locale.itemContent },
+    ];
+    const subMenu = [
+      { name: 'subMenu.listTitle', desc: locale['subMenu.listTitle'] },
+      { name: 'subMenu.list', desc: locale['subMenu.list'] },
+      { name: 'subMenu.listItem', desc: locale['subMenu.listItem'] },
+      { name: 'subMenu.listItemIcon', desc: locale['subMenu.listItemIcon'] },
+      { name: 'subMenu.listItemContent', desc: locale['subMenu.listItemContent'] },
+    ];
+
+    const additionalLocale = mode !== 'inline' ? [{ name: 'popup', desc: locale.popup }] : [];
+
+    return [...baseLocale, ...additionalLocale, ...subMenu];
+  }, [mode]);
+
   return (
-    <SemanticPreview
-      componentName="Menu"
-      semantics={[
-        { name: 'root', desc: locale.root },
-        { name: 'item', desc: locale.item },
-        { name: 'itemIcon', desc: locale.itemIcon },
-        { name: 'itemContent', desc: locale.itemContent },
-        { name: 'popup.root', desc: locale['popup.root'] },
-        { name: 'popup.listTitle', desc: locale['popup.listTitle'] },
-        { name: 'popup.list', desc: locale['popup.list'] },
-        { name: 'popup.listItem', desc: locale['popup.listItem'] },
-        { name: 'popup.listItemIcon', desc: locale['popup.listItemIcon'] },
-        { name: 'popup.listItemContent', desc: locale['popup.listItemContent'] },
-      ]}
-    >
-      <Block />
+    <SemanticPreview componentName="Menu" semantics={semantics}>
+      <Block mode={mode} setMode={setMode} />
     </SemanticPreview>
   );
 };

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { MailOutlined } from '@ant-design/icons';
+import { Menu, MenuProps, Segmented } from 'antd';
+
+import SemanticPreview from '../../../.dumi/components/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+type MenuItem = Required<MenuProps>['items'][number];
+
+const locales = {
+  cn: {
+    root: '根元素',
+    item: '条目元素',
+    itemContent: '条目内容元素',
+    itemIcon: '图标元素',
+    'popup.root': '弹出菜单元素(inline 模式不生效)',
+    'popup.list': '弹出菜单列表元素',
+    'popup.listItem': '弹出菜单单项元素',
+    'popup.listItemIcon': '弹出菜单条目图标元素',
+    'popup.listItemContent': '弹出菜单条目内容元素',
+    'popup.listTitle': '弹出菜单标题元素',
+  },
+  en: {
+    root: 'Root element',
+    item: 'Item element',
+    itemContent: 'Item content element',
+    itemIcon: 'Icon element',
+    'popup.root': 'Popup element(Inline mode has no effect)',
+    'popup.list': 'Popup list element',
+    'popup.listItem': 'Popup item element',
+    'popup.listItemIcon': 'Popup item icon element',
+    'popup.listItemContent': 'Popup item content element',
+    'popup.listTitle': 'Popup title element',
+  },
+};
+const items: MenuItem[] = [
+  {
+    label: 'Navigation One',
+    key: 'mail',
+    icon: <MailOutlined />,
+  },
+  {
+    key: 'SubMenu',
+    label: 'Navigation One',
+    icon: <MailOutlined />,
+    children: [
+      {
+        key: 'g1',
+        label: 'Item 1',
+        type: 'group',
+        children: [
+          { key: '1', label: 'Option 1', icon: <MailOutlined /> },
+          { key: '2', label: 'Option 2' },
+        ],
+      },
+    ],
+  },
+];
+
+type ModeType = 'horizontal' | 'vertical' | 'inline';
+const Block: React.FC = (props: any) => {
+  const divRef = React.useRef<HTMLDivElement>(null);
+  const [current, setCurrent] = React.useState('mail');
+  const [mode, setMode] = React.useState<ModeType>('horizontal');
+
+  const onClick: MenuProps['onClick'] = (e) => {
+    console.log('click ', e);
+    setCurrent(e.key);
+  };
+
+  return (
+    <div ref={divRef}>
+      <Segmented<ModeType>
+        options={['horizontal', 'vertical', 'inline']}
+        onChange={(value) => setMode(value)}
+      />
+      <Menu
+        onClick={onClick}
+        selectedKeys={[current]}
+        mode={mode}
+        items={items}
+        styles={{
+          popup: {
+            root: {
+              zIndex: 1,
+            },
+          },
+        }}
+        {...props}
+        openKeys={['SubMenu']}
+        getPopupContainer={() => divRef.current}
+      />
+    </div>
+  );
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      componentName="Menu"
+      semantics={[
+        { name: 'root', desc: locale.root },
+        { name: 'item', desc: locale.item },
+        { name: 'itemIcon', desc: locale.itemIcon },
+        { name: 'itemContent', desc: locale.itemContent },
+        { name: 'popup.root', desc: locale['popup.root'] },
+        { name: 'popup.listTitle', desc: locale['popup.listTitle'] },
+        { name: 'popup.list', desc: locale['popup.list'] },
+        { name: 'popup.listItem', desc: locale['popup.listItem'] },
+        { name: 'popup.listItemIcon', desc: locale['popup.listItemIcon'] },
+        { name: 'popup.listItemContent', desc: locale['popup.listItemContent'] },
+      ]}
+    >
+      <Block />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -57,7 +57,7 @@ const items: MenuItem[] = [
   },
 ];
 
-const groupItem = [
+const groupItem: MenuItem[] = [
   {
     key: 'grp',
     label: 'Group',
@@ -71,7 +71,9 @@ const groupItem = [
 
 type ModeType = 'horizontal' | 'vertical' | 'inline';
 
-const Block = (props: any) => {
+const Block: React.FC<
+  MenuProps & { item: MenuItem[]; setMode: React.Dispatch<React.SetStateAction<ModeType>> }
+> = (props) => {
   const { mode, setMode, item } = props;
   const divRef = React.useRef<HTMLDivElement>(null);
   const [current, setCurrent] = React.useState('mail');
@@ -102,7 +104,7 @@ const Block = (props: any) => {
         }}
         {...props}
         openKeys={['SubMenu']}
-        getPopupContainer={() => divRef.current}
+        getPopupContainer={() => divRef.current!}
       />
     </div>
   );

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -147,6 +147,10 @@ Menu will render fully item in flex layout and then collapse it. You need tell f
 </div>
 ```
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## Design Token
 
 <ComponentTokenTable component="Menu"></ComponentTokenTable>

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -147,6 +147,10 @@ Menu 初始化时会先全部渲染，然后根据宽度裁剪内容。当处于
 </div>
 ```
 
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
+
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="Menu"></ComponentTokenTable>

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -35,10 +35,18 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
   divider: Divider,
 };
 
-export type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemContent' | 'popup';
-export type SubMenuName = 'listItem' | 'listTitle' | 'list' | 'listItemContent' | 'listItemIcon';
+export type SemanticName =
+  | 'root'
+  | 'itemTitle'
+  | 'list'
+  | 'item'
+  | 'itemIcon'
+  | 'itemContent'
+  | 'popup';
+export type SubMenuName = 'item' | 'itemTitle' | 'list' | 'itemContent' | 'itemIcon';
 
-export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalComponents'> {
+export interface MenuProps
+  extends Omit<RcMenuProps, 'items' | '_internalComponents' | 'classNames' | 'styles'> {
   theme?: MenuTheme;
   inlineIndent?: number;
 
@@ -221,6 +229,14 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
             `${prefixCls}-${theme}`,
             overflowedIndicatorPopupClassName,
           )}
+          classNames={{
+            list: mergedClassNames.list,
+            listTitle: mergedClassNames.itemTitle,
+          }}
+          styles={{
+            list: mergedStyles.list,
+            listTitle: mergedStyles.itemTitle,
+          }}
           mode={mergedMode}
           selectable={mergedSelectable}
           onClick={onItemClick}

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -35,8 +35,14 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
   divider: Divider,
 };
 
-type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemContent';
-type PopupName = 'root' | 'listItem' | 'listTitle' | 'list' | 'listItemContent' | 'listItemIcon';
+export type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemContent' | 'popup';
+export type SubMenuName =
+  | 'root'
+  | 'listItem'
+  | 'listTitle'
+  | 'list'
+  | 'listItemContent'
+  | 'listItemIcon';
 
 export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalComponents'> {
   theme?: MenuTheme;
@@ -52,12 +58,12 @@ export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalCompone
   items?: ItemType[];
   classNames?: Partial<
     Record<SemanticName, string> & {
-      popup?: Partial<Record<PopupName, string>>;
+      subMenu?: Partial<Record<SubMenuName, string>>;
     }
   >;
   styles?: Partial<
     Record<SemanticName, React.CSSProperties> & {
-      popup?: Partial<Record<PopupName, React.CSSProperties>>;
+      subMenu?: Partial<Record<SubMenuName, React.CSSProperties>>;
     }
   >;
 }
@@ -106,11 +112,11 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     [contextClassNames, classNames],
     [contextStyles, styles],
     {
-      popup: {
+      subMenu: {
         _default: 'root',
       },
     },
-  );
+  ) as [MenuContextProps['classNames'], MenuContextProps['styles']];
 
   const rootPrefixCls = getPrefixCls();
 
@@ -225,7 +231,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           onClick={onItemClick}
           {...passedProps}
           inlineCollapsed={mergedInlineCollapsed}
-          style={{ ...mergedStyles?.root, ...contextStyle, ...style }}
+          style={{ ...mergedStyles.root, ...contextStyle, ...style }}
           className={menuClassName}
           prefixCls={prefixCls}
           direction={direction}
@@ -238,7 +244,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
             overrideObj.rootClassName,
             cssVarCls,
             rootCls,
-            classNames?.root,
+            mergedClassNames.root,
           )}
           _internalComponents={MENU_COMPONENTS}
         />

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -36,13 +36,7 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
 };
 
 export type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemContent' | 'popup';
-export type SubMenuName =
-  | 'root'
-  | 'listItem'
-  | 'listTitle'
-  | 'list'
-  | 'listItemContent'
-  | 'listItemIcon';
+export type SubMenuName = 'listItem' | 'listTitle' | 'list' | 'listItemContent' | 'listItemIcon';
 
 export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalComponents'> {
   theme?: MenuTheme;

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -64,6 +64,7 @@ export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalCompone
   styles?: Partial<
     Record<SemanticName, React.CSSProperties> & {
       subMenu?: Partial<Record<SubMenuName, React.CSSProperties>>;
+      popup?: { root?: React.CSSProperties };
     }
   >;
 }

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -35,14 +35,8 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
   divider: Divider,
 };
 
-export type SemanticName =
-  | 'root'
-  | 'itemTitle'
-  | 'list'
-  | 'item'
-  | 'itemIcon'
-  | 'itemContent'
-  | 'popup';
+export type SemanticName = 'root' | 'itemTitle' | 'list' | 'item' | 'itemIcon' | 'itemContent';
+
 export type SubMenuName = 'item' | 'itemTitle' | 'list' | 'itemContent' | 'itemIcon';
 
 export interface MenuProps
@@ -60,6 +54,7 @@ export interface MenuProps
   items?: ItemType[];
   classNames?: Partial<
     Record<SemanticName, string> & {
+      popup?: string | { root?: string };
       subMenu?: Partial<Record<SubMenuName, string>>;
     }
   >;

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -110,6 +110,9 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     [contextClassNames, classNames],
     [contextStyles, styles],
     {
+      popup: {
+        _default: 'root',
+      },
       subMenu: {
         _default: 'root',
       },

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { forwardRef } from 'react';
 import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import omit from '@rc-component/util/lib/omit';
-import classNames from 'classnames';
 import type { MenuProps as RcMenuProps, MenuRef as RcMenuRef } from '@rc-component/menu';
 import RcMenu from '@rc-component/menu';
+import useEvent from '@rc-component/util/lib/hooks/useEvent';
+import omit from '@rc-component/util/lib/omit';
+import cls from 'classnames';
 
+import useMergeSemantic from '../_util/hooks/useMergeSemantic';
 import initCollapseMotion from '../_util/motion';
 import { cloneElement } from '../_util/reactNode';
 import type { GetProp } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type { SiderContextProps } from '../layout/Sider';
 import type { ItemType } from './interface';
@@ -33,6 +35,9 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
   divider: Divider,
 };
 
+type SemanticName = 'root' | 'item' | 'itemIcon' | 'itemContent';
+type PopupName = 'root' | 'listItem' | 'listTitle' | 'list' | 'listItemContent' | 'listItemIcon';
+
 export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalComponents'> {
   theme?: MenuTheme;
   inlineIndent?: number;
@@ -45,6 +50,16 @@ export interface MenuProps extends Omit<RcMenuProps, 'items' | '_internalCompone
   _internalDisableMenuItemTitleTooltip?: boolean;
 
   items?: ItemType[];
+  classNames?: Partial<
+    Record<SemanticName, string> & {
+      popup?: Partial<Record<PopupName, string>>;
+    }
+  >;
+  styles?: Partial<
+    Record<SemanticName, React.CSSProperties> & {
+      popup?: Partial<Record<PopupName, React.CSSProperties>>;
+    }
+  >;
 }
 
 type InternalMenuProps = MenuProps &
@@ -55,10 +70,6 @@ type InternalMenuProps = MenuProps &
 const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   const override = React.useContext(OverrideContext);
   const overrideObj = override || {};
-
-  const { getPrefixCls, getPopupContainer, direction, menu } = React.useContext(ConfigContext);
-
-  const rootPrefixCls = getPrefixCls();
 
   const {
     prefixCls: customizePrefixCls,
@@ -74,8 +85,34 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     selectable,
     onClick,
     overflowedIndicatorPopupClassName,
+    classNames,
+    styles,
     ...restProps
   } = props;
+
+  const { menu } = React.useContext(ConfigContext);
+
+  const {
+    getPrefixCls,
+    getPopupContainer,
+    direction,
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('menu');
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic(
+    [contextClassNames, classNames],
+    [contextStyles, styles],
+    {
+      popup: {
+        _default: 'root',
+      },
+    },
+  );
+
+  const rootPrefixCls = getPrefixCls();
 
   const passedProps = omit(restProps, ['collapsedWidth']);
 
@@ -119,7 +156,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   const prefixCls = getPrefixCls('menu', customizePrefixCls || overrideObj.prefixCls);
   const rootCls = useCSSVarCls(prefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls, rootCls, !override);
-  const menuClassName = classNames(`${prefixCls}-${theme}`, menu?.className, className);
+  const menuClassName = cls(`${prefixCls}-${theme}`, contextClassName, className);
 
   // ====================== ExpandIcon ========================
   const mergedExpandIcon = React.useMemo<MenuProps['expandIcon']>(() => {
@@ -134,7 +171,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     }
     const mergedIcon = expandIcon ?? overrideObj?.expandIcon ?? menu?.expandIcon;
     return cloneElement(mergedIcon, {
-      className: classNames(
+      className: cls(
         `${prefixCls}-submenu-expand-icon`,
         React.isValidElement<any>(mergedIcon)
           ? (
@@ -157,8 +194,18 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
       theme,
       mode: mergedMode,
       disableMenuItemTitleTooltip: _internalDisableMenuItemTitleTooltip,
+      classNames: mergedClassNames,
+      styles: mergedStyles,
     }),
-    [prefixCls, mergedInlineCollapsed, direction, _internalDisableMenuItemTitleTooltip, theme],
+    [
+      prefixCls,
+      mergedInlineCollapsed,
+      direction,
+      _internalDisableMenuItemTitleTooltip,
+      theme,
+      mergedClassNames,
+      mergedStyles,
+    ],
   );
 
   // ========================= Render ==========================
@@ -168,7 +215,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
         <RcMenu
           getPopupContainer={getPopupContainer}
           overflowedIndicator={<EllipsisOutlined />}
-          overflowedIndicatorPopupClassName={classNames(
+          overflowedIndicatorPopupClassName={cls(
             prefixCls,
             `${prefixCls}-${theme}`,
             overflowedIndicatorPopupClassName,
@@ -178,19 +225,20 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           onClick={onItemClick}
           {...passedProps}
           inlineCollapsed={mergedInlineCollapsed}
-          style={{ ...menu?.style, ...style }}
+          style={{ ...mergedStyles?.root, ...contextStyle, ...style }}
           className={menuClassName}
           prefixCls={prefixCls}
           direction={direction}
           defaultMotions={defaultMotions}
           expandIcon={mergedExpandIcon}
           ref={ref}
-          rootClassName={classNames(
+          rootClassName={cls(
             rootClassName,
             hashId,
             overrideObj.rootClassName,
             cssVarCls,
             rootCls,
+            classNames?.root,
           )}
           _internalComponents={MENU_COMPONENTS}
         />

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@rc-component/input": "~1.0.1",
     "@rc-component/input-number": "~1.0.0",
     "@rc-component/mentions": "~1.2.0",
-    "@rc-component/menu": "~1.1.0",
+    "@rc-component/menu": "~1.1.2",
     "@rc-component/motion": "~1.1.4",
     "@rc-component/mutate-observer": "^2.0.0",
     "@rc-component/pagination": "~1.1.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@rc-component/input": "~1.0.1",
     "@rc-component/input-number": "~1.0.0",
     "@rc-component/mentions": "~1.2.0",
-    "@rc-component/menu": "~1.1.2",
+    "@rc-component/menu": "~1.1.3",
     "@rc-component/motion": "~1.1.4",
     "@rc-component/mutate-observer": "^2.0.0",
     "@rc-component/pagination": "~1.1.1",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 💡 Background and Solution

wait for https://github.com/react-component/menu/pull/770

https://github.com/react-component/menu/pull/775


合并后记得去评论

close:https://github.com/ant-design/ant-design/pull/50626


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        feat: ConfigProvider support classNames and styles for menu    |
| 🇨🇳 Chinese |     feat: ConfigProvider support classNames and styles for menu       |
