### PR TITLE
chore: lock nwsapi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,13 +354,13 @@
   },
   "pnpm":{
     "overrides": {
-      "nwsapi":"2.2.16"
+      "nwsapi":"2.2.19"
     }
   },
   "overrides": {
-    "nwsapi": "2.2.16"
+    "nwsapi": "2.2.19"
   },
   "resolutions": {
-    "nwsapi": "2.2.16"
+    "nwsapi": "2.2.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -351,5 +351,16 @@
   "title": "Ant Design",
   "tnpm": {
     "mode": "npm"
+  },
+  "pnpm":{
+    "overrides": {
+      "nwsapi":"2.2.16"
+    }
+  },
+  "overrides": {
+    "nwsapi": "2.2.16"
+  },
+  "resolutions": {
+    "nwsapi": "2.2.16"
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] ❓ Other (about what?)

### 🔗 Related Issues

![image](https://github.com/user-attachments/assets/636baf74-83f4-4fe6-8cf8-a23c03a8533a)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     --      |
| 🇨🇳 Chinese |    --       |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- 更新依赖管理配置，确保关键依赖 `nwsapi` 版本统一为 2.2.19，提高项目一致性和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->