### PR TITLE
chore: update lint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,7 +126,7 @@ export default antfu(
       'react/no-array-index-key': 'off',
       'react-dom/no-missing-iframe-sandbox': 'off',
       'no-restricted-globals': 'off',
-      'react/no-use-context': 'on',
+      'react/no-use-context': 'warn',
     },
     settings: {
       polyfills: ['Promise', 'URL', 'URLSearchParams'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,7 @@ export default antfu(
       /* turn off React 19 only rules */
       'react/no-forward-ref': 'off',
       'react/no-context-provider': 'off',
+      'react/no-use-context': 'off',
     },
   },
   compat.configs['flat/recommended'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,6 +126,7 @@ export default antfu(
       'react/no-array-index-key': 'off',
       'react-dom/no-missing-iframe-sandbox': 'off',
       'no-restricted-globals': 'off',
+      'react/no-use-context': 'on',
     },
     settings: {
       polyfills: ['Promise', 'URL', 'URLSearchParams'],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore: update lint rules |
| 🇨🇳 Chinese | chore: update lint rules |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 优化了 ESLint 配置，增强了代码质量管理。此次调整仅涉及开发环境，不影响应用的用户界面或功能体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->