### PR TITLE
chore: make StackBlitz demos work

### DIFF
--- a/.dumi/theme/builtins/Previewer/CodeBlockButton.tsx
+++ b/.dumi/theme/builtins/Previewer/CodeBlockButton.tsx
@@ -47,7 +47,7 @@ const CodeBlockButton: React.FC<CodeBlockButtonProps> = ({ title, dependencies =
 
   const codeBlockPrefillConfig = {
     title: `${title} - antd@${dependencies.antd}`,
-    js: `import '@ant-design/v5-patch-for-react-19';\n${
+    js: `${
       /import React(\D*)from 'react';/.test(jsx) ? '' : `import React from 'react';\n`
     }import { createRoot } from 'react-dom/client';\n${jsx.replace(
       /export default/,

--- a/.dumi/theme/builtins/Previewer/CodeBlockButton.tsx
+++ b/.dumi/theme/builtins/Previewer/CodeBlockButton.tsx
@@ -47,7 +47,7 @@ const CodeBlockButton: React.FC<CodeBlockButtonProps> = ({ title, dependencies =
 
   const codeBlockPrefillConfig = {
     title: `${title} - antd@${dependencies.antd}`,
-    js: `${
+    js: `import '@ant-design/v5-patch-for-react-19';\n${
       /import React(\D*)from 'react';/.test(jsx) ? '' : `import React from 'react';\n`
     }import { createRoot } from 'react-dom/client';\n${jsx.replace(
       /export default/,

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -321,7 +321,6 @@ createRoot(document.getElementById('container')).render(<Demo />);
   const stackblitzPrefillConfig: Project = {
     title: `${localizedTitle} - antd@${dependencies.antd}`,
     template: 'create-react-app',
-    // dependencies,
     dependencies:{
       ...dependencies,
       react: '^19.0.0',

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -211,7 +211,6 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   );
 
   dependencies['@ant-design/icons'] = 'latest';
-  dependencies['@ant-design/v5-patch-for-react-19']='latest'
 
   if (suffix === 'tsx') {
     dependencies['@types/react'] = '^18.0.0';
@@ -280,7 +279,6 @@ ${parsedSourceCode}
 
   const indexJsContent = `import React from 'react';
 import { createRoot } from 'react-dom/client';
-import '@ant-design/v5-patch-for-react-19';
 import Demo from './demo';
 
 createRoot(document.getElementById('container')).render(<Demo />);
@@ -330,11 +328,12 @@ createRoot(document.getElementById('container')).render(<Demo />);
       'react-dom': '^19.0.0',
       '@types/react' :'^19.0.0',
       '@types/react-dom' : '^19.0.0',
+      '@ant-design/v5-patch-for-react-19':'latest'
     },
     description: '',
     files: {
       'index.css': indexCssContent,
-      [`index.${suffix}`]: indexJsContent,
+      [`index.${suffix}`]: `import '@ant-design/v5-patch-for-react-19';\n${indexJsContent}`,
       [`demo.${suffix}`]: demoJsContent,
       'index.html': html,
     },

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -211,6 +211,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   );
 
   dependencies['@ant-design/icons'] = 'latest';
+  dependencies['@ant-design/v5-patch-for-react-19']='latest'
 
   if (suffix === 'tsx') {
     dependencies['@types/react'] = '^18.0.0';
@@ -279,6 +280,7 @@ ${parsedSourceCode}
 
   const indexJsContent = `import React from 'react';
 import { createRoot } from 'react-dom/client';
+import '@ant-design/v5-patch-for-react-19';
 import Demo from './demo';
 
 createRoot(document.getElementById('container')).render(<Demo />);
@@ -321,7 +323,14 @@ createRoot(document.getElementById('container')).render(<Demo />);
   const stackblitzPrefillConfig: Project = {
     title: `${localizedTitle} - antd@${dependencies.antd}`,
     template: 'create-react-app',
-    dependencies,
+    // dependencies,
+    dependencies:{
+      ...dependencies,
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      '@types/react' :'^19.0.0',
+      '@types/react-dom' : '^19.0.0',
+    },
     description: '',
     files: {
       'index.css': indexCssContent,

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -325,9 +325,9 @@ createRoot(document.getElementById('container')).render(<Demo />);
       ...dependencies,
       react: '^19.0.0',
       'react-dom': '^19.0.0',
-      '@types/react' :'^19.0.0',
-      '@types/react-dom' : '^19.0.0',
-      '@ant-design/v5-patch-for-react-19':'latest'
+      '@types/react': '^19.0.0',
+      '@types/react-dom': '^19.0.0',
+      '@ant-design/v5-patch-for-react-19': '^1.0.3'
     },
     description: '',
     files: {


### PR DESCRIPTION


### 🤔 This is a ...

- [X] 🐞 Bug fix


### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/52868

### 💡 Background and Solution
组件demo，在 Stackblitz 中打开失败，不能正常演示
调整传递的react依赖版本为19，并且对添加兼容react 19的工具引入使用

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue of component demo failing to open StackBlitz     |
| 🇨🇳 Chinese |      修复组件demo打开Stackblitz失败问题     |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了代码预览配置，现在StackBlitz预览项目支持React 19及其相关依赖和类型声明，确保在最新React环境中的兼容性和展示效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->