### PR TITLE
feat: enhance SemanticPreview with info icon and improved layout

### DIFF
--- a/.dumi/components/SemanticPreview.tsx
+++ b/.dumi/components/SemanticPreview.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Col, ConfigProvider, Flex, Popover, Row, Tag, theme, Typography } from 'antd';
 import { createStyles, css } from 'antd-style';
 import classnames from 'classnames';
+import { InfoCircleOutlined } from '@ant-design/icons';
 
 const MARK_BORDER_SIZE = 2;
 
@@ -146,13 +147,26 @@ const SemanticPreview: React.FC<SemanticPreviewProps> = (props) => {
         <Col span={8}>
           <ul className={classnames(styles.listWrap)}>
             {semantics.map<React.ReactNode>((semantic) => (
-              <Popover
+              <li
                 key={semantic.name}
-                content={
-                  <Typography style={{ fontSize: 12, minWidth: 300 }}>
-                    <pre dir="ltr">
-                      <code dir="ltr">
-                        {`<${componentName}
+                className={classnames(styles.listItem)}
+                onMouseEnter={() => setHoverSemantic(semantic.name)}
+                onMouseLeave={() => setHoverSemantic(null)}
+              >
+                <Flex vertical gap="small">
+                  <Flex gap="small" align="center" justify="space-between">
+                    <Flex gap="small" align="center">
+                      <Typography.Title level={5} style={{ margin: 0 }}>
+                        {semantic.name}
+                      </Typography.Title>
+                      {semantic.version && <Tag color="blue">{semantic.version}</Tag>}
+                    </Flex>
+                    <Popover
+                      content={
+                        <Typography style={{ fontSize: 12, minWidth: 300 }}>
+                          <pre dir="ltr">
+                            <code dir="ltr">
+                              {`<${componentName}
   classNames={{
     ${semantic.name}: 'my-${componentName.toLowerCase()}',
   }}
@@ -162,29 +176,21 @@ const SemanticPreview: React.FC<SemanticPreviewProps> = (props) => {
 >
   ...
 </${componentName}>`}
-                      </code>
-                    </pre>
-                  </Typography>
-                }
-              >
-                <li
-                  className={classnames(styles.listItem)}
-                  onMouseEnter={() => setHoverSemantic(semantic.name)}
-                  onMouseLeave={() => setHoverSemantic(null)}
-                >
-                  <Flex vertical gap="small">
-                    <Flex gap="small" align="center">
-                      <Typography.Title level={5} style={{ margin: 0 }}>
-                        {semantic.name}
-                      </Typography.Title>
-                      {semantic.version && <Tag color="blue">{semantic.version}</Tag>}
-                    </Flex>
-                    <Typography.Paragraph style={{ margin: 0, fontSize: token.fontSizeSM }}>
-                      {semantic.desc}
-                    </Typography.Paragraph>
+                            </code>
+                          </pre>
+                        </Typography>
+                      }
+                    >
+                      <InfoCircleOutlined
+                        style={{ cursor: 'pointer', color: token.colorTextSecondary }}
+                      />
+                    </Popover>
                   </Flex>
-                </li>
-              </Popover>
+                  <Typography.Paragraph style={{ margin: 0, fontSize: token.fontSizeSM }}>
+                    {semantic.desc}
+                  </Typography.Paragraph>
+                </Flex>
+              </li>
             ))}
           </ul>
         </Col>


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📽️ Demo improvement

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

优化一下交互，之前整个热区hover会完全遮挡下方，影响用户体验

![image](https://github.com/user-attachments/assets/80c21e0a-3b6f-4753-8ce1-b8b69581dd38)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |    --       |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 当鼠标悬停在信息图标上时，会显示组件使用提示代码，帮助用户快速参考示例。
- **重构**
	- 优化了语义信息的展示布局，调整后组件描述始终清晰可见，交互体验更直观。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->