### PR TITLE
feat: V6 abandons copy-to-clipboard dependency

### DIFF
--- a/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
@@ -3,7 +3,6 @@ import React, { useRef } from 'react';
 import { CheckOutlined, SketchOutlined } from '@ant-design/icons';
 import { App } from 'antd';
 import { createStyles } from 'antd-style';
-// import copy from 'copy-to-clipboard';
 import copy from '../../../../components/_util/copy';
 import { nodeToGroup } from 'html2sketch';
 

--- a/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
@@ -3,7 +3,8 @@ import React, { useRef } from 'react';
 import { CheckOutlined, SketchOutlined } from '@ant-design/icons';
 import { App } from 'antd';
 import { createStyles } from 'antd-style';
-import copy from 'copy-to-clipboard';
+// import copy from 'copy-to-clipboard';
+import copy from '../../../../components/_util/copy';
 import { nodeToGroup } from 'html2sketch';
 
 import type { AntdPreviewerProps } from './Previewer';

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -1,0 +1,93 @@
+import copy from '../copy';
+
+describe('Test copy', () => {
+  beforeEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        clipboard: {
+          writeText: jest.fn(),
+          write: jest.fn(),
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    jest.spyOn(global.console, 'warn');
+
+    document.execCommand = jest.fn();
+
+    global.ClipboardItem = class {
+      static supports(): boolean {
+        return true;
+      }
+      constructor(data: Record<string, string | Blob>) {
+        this._data = data;
+        this.types = Object.keys(data);
+      }
+      private _data: Record<string, string | Blob>;
+      public types: string[];
+      public presentationStyle: PresentationStyle = 'unspecified';
+      async getType(): Promise<string> {
+        return this.types[0];
+      }
+
+      async getBlob(type?: string): Promise<Blob> {
+        const mimeType = type || this.types[0];
+        return new Blob([this._data[mimeType]], { type: mimeType });
+      }
+    };
+  });
+
+  test('format!=text/html use navigator.clipboard.writeText', async () => {
+    const mockWriteText = jest.fn().mockImplementation(() => Promise.resolve());
+
+    global.navigator.clipboard.writeText = mockWriteText;
+
+    const result = copy('Test Text', {});
+
+    expect(result).toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Test Text');
+  });
+
+  it('format=text/html ,use navigator.clipboard.write', async () => {
+    const mockWrite = jest.fn().mockImplementation(() => Promise.resolve());
+    navigator.clipboard.write = mockWrite;
+    const result = copy('<div>Text</div>', {
+      format: 'text/html',
+    });
+
+    expect(navigator.clipboard.write).toHaveBeenCalledWith([
+      expect.objectContaining({
+        types: ['text/html', 'text/plain'],
+      }),
+    ]);
+    expect(result).toBe(true);
+  });
+
+  test('use function fallbackCopy success', async () => {
+    delete (global.navigator as any).clipboard;
+
+    const execCommandSpy = jest.spyOn(document, 'execCommand').mockReturnValue(true);
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+
+    const result = await copy('Test Text', {});
+
+    expect(createElementSpy).toHaveBeenCalled();
+    expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    expect(result).toBe(true);
+
+    expect(console.warn).toHaveBeenLastCalledWith('copy success');
+
+    execCommandSpy.mockRestore();
+    createElementSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    delete (global as any).navigator;
+    delete (document as any).execCommand;
+    delete (global as any).ClipboardItem;
+    jest.restoreAllMocks();
+  });
+});

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -13,7 +13,6 @@ describe('Test copy', () => {
       writable: true,
     });
 
-    jest.spyOn(global.console, 'warn');
     jest.spyOn(global.console, 'error');
 
     (global as any).ClipboardItem = class {
@@ -68,7 +67,9 @@ describe('Test copy', () => {
     const mockWrite = jest.fn().mockImplementation(() => Promise.resolve());
     navigator.clipboard.write = mockWrite;
     const result = copy(0 as any);
-    expect(console.warn).toHaveBeenLastCalledWith('The clipboard content must be of string type');
+    expect((console.error as any).mock.lastCall[0]).toContain(
+      'The clipboard content must be of string type',
+    );
     expect(result).toBe(false);
   });
 

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -17,7 +17,7 @@ describe('Test copy', () => {
 
     document.execCommand = jest.fn();
 
-    global.ClipboardItem = class {
+    (global as any).ClipboardItem = class {
       static supports(): boolean {
         return true;
       }
@@ -39,7 +39,7 @@ describe('Test copy', () => {
     };
   });
 
-  test('format!=text/html use navigator.clipboard.writeText', async () => {
+  it('format!=text/html use navigator.clipboard.writeText', async () => {
     const mockWriteText = jest.fn().mockImplementation(() => Promise.resolve());
 
     global.navigator.clipboard.writeText = mockWriteText;
@@ -65,7 +65,7 @@ describe('Test copy', () => {
     expect(result).toBe(true);
   });
 
-  test('use function fallbackCopy success', async () => {
+  it('use function fallbackCopy success', async () => {
     delete (global.navigator as any).clipboard;
 
     const execCommandSpy = jest.spyOn(document, 'execCommand').mockReturnValue(true);
@@ -81,6 +81,21 @@ describe('Test copy', () => {
     expect(console.warn).toHaveBeenLastCalledWith('copy success');
 
     execCommandSpy.mockRestore();
+    createElementSpy.mockRestore();
+  });
+
+  it('use function fallbackCopy fail', async () => {
+    delete (global.navigator as any).clipboard;
+    delete (document as any).execCommand;
+
+    const createElementSpy = jest.spyOn(document, 'createElement');
+
+    const result = await copy('Test Text', {});
+
+    expect(createElementSpy).toHaveBeenCalled();
+    expect(result).toBe(false);
+    expect((console.warn as any).mock.lastCall[0]).toContain('copy error');
+
     createElementSpy.mockRestore();
   });
 

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -1,25 +1,27 @@
+import warning from './warning';
+
 function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
   const format = config?.format;
 
   if (typeof text !== 'string') {
-    console.warn('The clipboard content must be of string type');
-
+    warning(false, 'The clipboard content must be of string type', '');
     return false;
   }
-  const isHtmlFormat = format === 'text/html';
+
   try {
-    if (isHtmlFormat) {
+    if (format === 'text/html') {
       const item = new ClipboardItem({
         [format]: new Blob([text], { type: format }),
         'text/plain': new Blob([text], { type: 'text/plain' }),
       });
       navigator.clipboard.write([item]);
-      return true;
+    } else {
+      navigator.clipboard.writeText(text);
     }
-    navigator.clipboard.writeText(text);
+
     return true;
   } catch (err) {
-    console.error('Clipboard API failed:', err);
+    warning(false, 'Clipboard API failed:', String(err));
   }
 }
 

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -1,0 +1,76 @@
+function fallbackCopy(text: string, debug?: any) {
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed'; // 避免滚动跳动
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    // 扩展选中范围 (兼容 iOS)
+    if (textarea.setSelectionRange) {
+      const range = document.createRange();
+      range.selectNodeContents(textarea);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      textarea.setSelectionRange(0, 999999);
+    }
+
+    const result = document.execCommand('copy');
+    document.body.removeChild(textarea);
+
+    if (debug) {
+      console.warn(`copy ${result ? 'success' : 'error'}`);
+    }
+    return result;
+  } catch (err) {
+    if (debug) console.warn('copy error:', err);
+    return false;
+  }
+}
+
+export default (
+  text: string,
+  config?: { debug?: boolean; format?: 'text/plain' | 'text/html' },
+) => {
+  const debug = config?.debug || true;
+  const format = config?.format;
+
+  if (typeof text !== 'string') {
+    if (debug) {
+      console.warn('剪贴板内容必须是字符串类型');
+    }
+    return false;
+  }
+
+  if (navigator.clipboard?.writeText) {
+    if (format === 'text/html') {
+      const item = new ClipboardItem({
+        [format]: new Blob([text], { type: format }),
+        'text/plain': new Blob([text], { type: 'text/plain' }),
+      });
+
+      navigator.clipboard
+        .write([item])
+        .then(() => {
+          if (debug) console.warn('copy success');
+        })
+        .catch((err) => {
+          if (debug) console.warn('copy failed:', err);
+        });
+      return true;
+    }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        if (debug) console.warn('copy success');
+      })
+      .catch((err) => {
+        if (debug) console.warn('copy failed:', err);
+        fallbackCopy(text, debug);
+      });
+    return true;
+  }
+
+  return fallbackCopy(text, debug);
+};

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -1,72 +1,26 @@
-function fallbackCopy(text: string, debug?: any) {
-  try {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    if (textarea.setSelectionRange) {
-      const range = document.createRange();
-      range.selectNodeContents(textarea);
-      const selection = window.getSelection() as Selection;
-      selection.removeAllRanges();
-      selection.addRange(range);
-      textarea.setSelectionRange(0, 999999);
-    }
-
-    const result = document.execCommand('copy');
-    document.body.removeChild(textarea);
-
-    if (debug) {
-      console.warn(`copy ${result ? 'success' : 'error'}`);
-    }
-    return result;
-  } catch (err) {
-    if (debug) console.warn('copy error:', err);
-    return false;
-  }
-}
-
-function copy(text: string, config?: { debug?: boolean; format?: 'text/plain' | 'text/html' }) {
-  const debug = config?.debug || true;
+function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
   const format = config?.format;
 
   if (typeof text !== 'string') {
-    if (debug) {
-      console.warn('The clipboard content must be of string type');
-    }
+    console.warn('The clipboard content must be of string type');
+
     return false;
   }
   const isHtmlFormat = format === 'text/html';
   try {
     if (isHtmlFormat) {
-      if (navigator.clipboard?.write) {
-        const item = new ClipboardItem({
-          [format]: new Blob([text], { type: format }),
-          'text/plain': new Blob([text], { type: 'text/plain' }),
-        });
-
-        navigator.clipboard.write([item]).then(() => {
-          if (debug) console.warn('copy success');
-        });
-
-        return true;
-      }
-      return fallbackCopy(text, debug);
-    } else {
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(text).then(() => {
-          if (debug) console.warn('copy success');
-        });
-        return true;
-      }
-      return fallbackCopy(text, debug);
+      const item = new ClipboardItem({
+        [format]: new Blob([text], { type: format }),
+        'text/plain': new Blob([text], { type: 'text/plain' }),
+      });
+      navigator.clipboard.write([item]);
+      return true;
     }
+    navigator.clipboard.writeText(text);
+    return true;
   } catch (err) {
-    if (debug) console.error('Clipboard API failed:', err);
+    console.error('Clipboard API failed:', err);
   }
-  return fallbackCopy(text, debug);
 }
 
 export default copy;

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -258,7 +258,6 @@ describe('Typography copy', () => {
       const copyBtn = wrapper.querySelectorAll('.ant-typography-copy')[0];
       fireEvent.click(copyBtn);
       expect(spy.mock.calls[0][0]).toEqual(originText);
-
       await waitFakeTimer();
       spy.mockReset();
       fireEvent.click(copyBtn);
@@ -369,6 +368,7 @@ describe('Typography copy', () => {
 
     // Check copy content
     expect(spy.mock.calls[0][0]).toBe(`${bamboo}${little}`);
+
     spy.mockRestore();
   });
 });

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { LikeOutlined, SmileOutlined } from '@ant-design/icons';
 
-import copyObj from '../../_util/copy';
+import * as copyObj from '../../_util/copy';
 import { fireEvent, render, renderHook, waitFakeTimer, waitFor } from '../../../tests/utils';
 import Base from '../Base';
 import useCopyClick from '../hooks/useCopyClick';
 
-jest.mock('../../_util/copy');
 describe('Typography copy', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -239,7 +238,7 @@ describe('Typography copy', () => {
 
     it('copy to clipboard', async () => {
       jest.useFakeTimers();
-      // const spy = jest.spyOn(copyObj, 'default');
+      const spy = jest.spyOn(copyObj, 'default');
       const originText = 'origin text.';
       const nextText = 'next text.';
       const Test = () => {
@@ -258,18 +257,18 @@ describe('Typography copy', () => {
       const { container: wrapper } = render(<Test />);
       const copyBtn = wrapper.querySelectorAll('.ant-typography-copy')[0];
       fireEvent.click(copyBtn);
-      expect((copyObj as any).mock.cells[0][0]).toEqual(originText);
+      expect(spy.mock.calls[0][0]).toEqual(originText);
+
       await waitFakeTimer();
-      // spy.mockReset();
+      spy.mockReset();
       fireEvent.click(copyBtn);
-      // expect(spy.mock.calls[0][0]).toEqual(nextText);
-      expect((copyObj as any).mock.cells[0][0]).toEqual(nextText);
+      expect(spy.mock.calls[0][0]).toEqual(nextText);
       jest.useRealTimers();
-      // spy.mockReset();
+      spy.mockReset();
     });
 
     it('copy by async', async () => {
-      // const spy = jest.spyOn(copyObj, 'default');
+      const spy = jest.spyOn(copyObj, 'default');
       const { container: wrapper } = render(
         <Base
           component="p"
@@ -283,8 +282,8 @@ describe('Typography copy', () => {
       fireEvent.click(wrapper.querySelectorAll('.ant-typography-copy')[0]);
       expect(wrapper.querySelectorAll('.anticon-loading')[0]).toBeTruthy();
       await waitFakeTimer();
-      expect((copyObj as any).mock.calls[0][0]).toEqual('Request text');
-      // spy.mockReset();
+      expect(spy.mock.calls[0][0]).toEqual('Request text');
+      spy.mockReset();
       expect(wrapper.querySelectorAll('.anticon-loading')[0]).toBeFalsy();
     });
 
@@ -302,7 +301,7 @@ describe('Typography copy', () => {
   });
 
   it('not block copy text change', () => {
-    // const spy = jest.spyOn(copyObj, 'default');
+    const spy = jest.spyOn(copyObj, 'default');
 
     const renderDemo = (text: string) => (
       <Base copyable={{ text }} component="p">
@@ -314,10 +313,9 @@ describe('Typography copy', () => {
     rerender(renderDemo('Light'));
 
     fireEvent.click(container.querySelector('.ant-typography-copy')!);
+    expect(spy.mock.calls[0][0]).toBe('Light');
 
-    expect((copyObj as any).mock.calls[0][0]).toBe('Light');
-
-    // spy.mockRestore();
+    spy.mockRestore();
   });
 
   it('dynamic set editable', () => {
@@ -356,7 +354,7 @@ describe('Typography copy', () => {
   });
 
   it('copy array children', () => {
-    // const spy = jest.spyOn(copyObj, 'default');
+    const spy = jest.spyOn(copyObj, 'default');
 
     const bamboo = 'bamboo';
     const little = 'little';
@@ -370,8 +368,7 @@ describe('Typography copy', () => {
     fireEvent.click(container.querySelector('.ant-typography-copy')!);
 
     // Check copy content
-    expect((copyObj as any).mock.calls[0][0]).toBe(`${bamboo}${little}`);
-
-    // spy.mockRestore();
+    expect(spy.mock.calls[0][0]).toBe(`${bamboo}${little}`);
+    spy.mockRestore();
   });
 });

--- a/components/typography/__tests__/copy.test.tsx
+++ b/components/typography/__tests__/copy.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { LikeOutlined, SmileOutlined } from '@ant-design/icons';
-import * as copyObj from 'copy-to-clipboard';
 
+import copyObj from '../../_util/copy';
 import { fireEvent, render, renderHook, waitFakeTimer, waitFor } from '../../../tests/utils';
 import Base from '../Base';
 import useCopyClick from '../hooks/useCopyClick';
 
+jest.mock('../../_util/copy');
 describe('Typography copy', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -238,7 +239,7 @@ describe('Typography copy', () => {
 
     it('copy to clipboard', async () => {
       jest.useFakeTimers();
-      const spy = jest.spyOn(copyObj, 'default');
+      // const spy = jest.spyOn(copyObj, 'default');
       const originText = 'origin text.';
       const nextText = 'next text.';
       const Test = () => {
@@ -257,17 +258,18 @@ describe('Typography copy', () => {
       const { container: wrapper } = render(<Test />);
       const copyBtn = wrapper.querySelectorAll('.ant-typography-copy')[0];
       fireEvent.click(copyBtn);
-      expect(spy.mock.calls[0][0]).toEqual(originText);
+      expect((copyObj as any).mock.cells[0][0]).toEqual(originText);
       await waitFakeTimer();
-      spy.mockReset();
+      // spy.mockReset();
       fireEvent.click(copyBtn);
-      expect(spy.mock.calls[0][0]).toEqual(nextText);
+      // expect(spy.mock.calls[0][0]).toEqual(nextText);
+      expect((copyObj as any).mock.cells[0][0]).toEqual(nextText);
       jest.useRealTimers();
-      spy.mockReset();
+      // spy.mockReset();
     });
 
     it('copy by async', async () => {
-      const spy = jest.spyOn(copyObj, 'default');
+      // const spy = jest.spyOn(copyObj, 'default');
       const { container: wrapper } = render(
         <Base
           component="p"
@@ -281,8 +283,8 @@ describe('Typography copy', () => {
       fireEvent.click(wrapper.querySelectorAll('.ant-typography-copy')[0]);
       expect(wrapper.querySelectorAll('.anticon-loading')[0]).toBeTruthy();
       await waitFakeTimer();
-      expect(spy.mock.calls[0][0]).toEqual('Request text');
-      spy.mockReset();
+      expect((copyObj as any).mock.calls[0][0]).toEqual('Request text');
+      // spy.mockReset();
       expect(wrapper.querySelectorAll('.anticon-loading')[0]).toBeFalsy();
     });
 
@@ -300,7 +302,7 @@ describe('Typography copy', () => {
   });
 
   it('not block copy text change', () => {
-    const spy = jest.spyOn(copyObj, 'default');
+    // const spy = jest.spyOn(copyObj, 'default');
 
     const renderDemo = (text: string) => (
       <Base copyable={{ text }} component="p">
@@ -312,9 +314,10 @@ describe('Typography copy', () => {
     rerender(renderDemo('Light'));
 
     fireEvent.click(container.querySelector('.ant-typography-copy')!);
-    expect(spy.mock.calls[0][0]).toBe('Light');
 
-    spy.mockRestore();
+    expect((copyObj as any).mock.calls[0][0]).toBe('Light');
+
+    // spy.mockRestore();
   });
 
   it('dynamic set editable', () => {
@@ -353,7 +356,7 @@ describe('Typography copy', () => {
   });
 
   it('copy array children', () => {
-    const spy = jest.spyOn(copyObj, 'default');
+    // const spy = jest.spyOn(copyObj, 'default');
 
     const bamboo = 'bamboo';
     const little = 'little';
@@ -367,8 +370,8 @@ describe('Typography copy', () => {
     fireEvent.click(container.querySelector('.ant-typography-copy')!);
 
     // Check copy content
-    expect(spy.mock.calls[0][0]).toBe(`${bamboo}${little}`);
+    expect((copyObj as any).mock.calls[0][0]).toBe(`${bamboo}${little}`);
 
-    spy.mockRestore();
+    // spy.mockRestore();
   });
 });

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -3,8 +3,8 @@ import { CheckOutlined, HighlightOutlined, LikeOutlined, SmileOutlined } from '@
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import { resetWarned } from '@rc-component/util/lib/warning';
 import userEvent from '@testing-library/user-event';
-import copy from 'copy-to-clipboard';
 
+import copy from '../../_util/copy';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer, waitFor } from '../../../tests/utils';
@@ -15,7 +15,7 @@ import Text from '../Text';
 import type { TitleProps } from '../Title';
 import Title from '../Title';
 
-jest.mock('copy-to-clipboard');
+jest.mock('../../_util/copy');
 
 describe('Typography', () => {
   mountTest(Paragraph);
@@ -144,9 +144,9 @@ describe('Typography', () => {
           // Click to copy
           fireEvent.click(container.querySelector('.ant-typography-copy')!);
           await waitFakeTimer(1);
+          expect((copy as any).mock.lastCall[0]).toEqual(target);
+          expect((copy as any).mock.lastCall[1].format).toEqual(format);
 
-          expect((copy as any).lastStr).toEqual(target);
-          expect((copy as any).lastOptions.format).toEqual(format);
           expect(onCopy).toHaveBeenCalled();
 
           let copiedIcon = '.anticon-check';

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -144,6 +144,7 @@ describe('Typography', () => {
           // Click to copy
           fireEvent.click(container.querySelector('.ant-typography-copy')!);
           await waitFakeTimer(1);
+
           expect((copy as any).mock.lastCall[0]).toEqual(target);
           expect((copy as any).mock.lastCall[1].format).toEqual(format);
 

--- a/components/typography/hooks/useCopyClick.ts
+++ b/components/typography/hooks/useCopyClick.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import copy from 'copy-to-clipboard';
+// import copy from 'copy-to-clipboard';
+import copy from '../../_util/copy';
 
 import toList from '../../_util/toList';
 import type { CopyConfig } from '../Base';

--- a/components/typography/hooks/useCopyClick.ts
+++ b/components/typography/hooks/useCopyClick.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import useEvent from '@rc-component/util/lib/hooks/useEvent';
-// import copy from 'copy-to-clipboard';
-import copy from '../../_util/copy';
 
+import copy from '../../_util/copy';
 import toList from '../../_util/toList';
 import type { CopyConfig } from '../Base';
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@rc-component/trigger": "~3.1.0",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.5.1",
-    "copy-to-clipboard": "^3.3.3",
     "dayjs": "^1.11.11",
     "rc-checkbox": "~3.5.0",
     "rc-notification": "~5.6.3",


### PR DESCRIPTION

### 🤔 This is a ...

- [X] 📦 Bundle size optimization


### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/53383

### 💡 Background and Solution


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Dependency removal of copy to clipboard package to reduce build size    |
| 🇨🇳 Chinese |      依赖移除copy-to-clipboard包，降低构建体积，copy能力用原生api实现     |
