### PR TITLE
chore: Use filled variant to replace the bordered={false} for tag

### DIFF
--- a/.dumi/hooks/useMenu.tsx
+++ b/.dumi/hooks/useMenu.tsx
@@ -67,7 +67,7 @@ const MenuItemLabelWithTag: React.FC<MenuItemLabelProps> = (props) => {
           {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
         </Flex>
         {tag && (
-          <Tag bordered={false} className={classnames(styles.tag)} color={getTagColor(tag)}>
+          <Tag variant="filled" className={classnames(styles.tag)} color={getTagColor(tag)}>
             {tag.replace(/VERSION/i, version)}
           </Tag>
         )}

--- a/.dumi/theme/builtins/Badge/index.tsx
+++ b/.dumi/theme/builtins/Badge/index.tsx
@@ -15,7 +15,7 @@ const colorMap = {
 
 export default ({ type = 'info', ...props }: BadgeProps) => (
   <Tag
-    bordered={false}
+    variant="filled"
     color={colorMap[type]}
     {...props}
     style={{ verticalAlign: 'top', ...props.style }}

--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1114,11 +1114,7 @@ exports[`renders components/tag/demo/disabled.tsx extend context correctly 1`] =
 </div>
 `;
 
-exports[`renders components/tag/demo/disabled.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: Tag] \`bordered={false}\` is deprecated. Please use \`variant="filled"\` instead.",
-]
-`;
+exports[`renders components/tag/demo/disabled.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/tag/demo/draggable.tsx extend context correctly 1`] = `
 Array [

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -396,4 +396,8 @@ describe('Tag', () => {
 
     expect(document.head.innerHTML).toContain('--ant-tag-solid-text-color:#000;');
   });
+  it('legacy bordered={false}', () => {
+    const { container } = render(<Tag bordered={false}>Tag</Tag>);
+    expect(container.querySelector('.ant-tag-filled')).toBeTruthy();
+  });
 });

--- a/components/tag/demo/disabled.tsx
+++ b/components/tag/demo/disabled.tsx
@@ -85,13 +85,13 @@ const App: React.FC = () => {
       </Flex>
 
       <Flex gap="small" wrap>
-        <Tag disabled bordered={false}>
+        <Tag disabled variant="filled">
           Borderless Basic
         </Tag>
-        <Tag disabled bordered={false} color="success" icon={<CheckCircleOutlined />}>
+        <Tag disabled variant="filled" color="success" icon={<CheckCircleOutlined />}>
           Borderless with Icon
         </Tag>
-        <Tag disabled bordered={false} closable onClose={() => handleClose('Borderless Closable')}>
+        <Tag disabled variant="filled" closable onClose={() => handleClose('Borderless Closable')}>
           Borderless Closable
         </Tag>
       </Flex>

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -57,7 +57,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
       color,
       variant,
       onClose,
-      bordered = true,
+      bordered,
       disabled: customDisabled,
       href,
       target,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ❓ Other (about what?)


### 💡 Background and Solution
替换废弃 api，以消除警告
![image](https://github.com/user-attachments/assets/fb250b5e-bead-4416-87a6-e3f55a40dc94)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
