### PR TITLE
fix: Inserting the panel outside the popup node causes style loss.

### DIFF
--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -168,6 +168,22 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
             },
           }}
           allowClear={mergedAllowClear}
+          panelRender={(originPanel: React.ReactNode) => {
+            const panelRender = restProps?.panelRender;
+            if (typeof panelRender === 'function') {
+              return panelRender(
+                <div
+                  style={{
+                    position: 'initial',
+                  }}
+                  className={classNames(hashId, cssVarCls, rootCls, `${prefixCls}-dropdown`)}
+                >
+                  {originPanel}
+                </div>,
+              );
+            }
+            return originPanel;
+          }}
         />
       </ContextIsolator>,
     );

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -213,6 +213,22 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
             }}
             allowClear={mergedAllowClear}
             removeIcon={removeIcon}
+            panelRender={(originPanel: React.ReactNode) => {
+              const panelRender = restProps?.panelRender;
+              if (typeof panelRender === 'function') {
+                return panelRender(
+                  <div
+                    style={{
+                      position: 'initial',
+                    }}
+                    className={classNames(hashId, cssVarCls, rootCls, `${prefixCls}-dropdown`)}
+                  >
+                    {originPanel}
+                  </div>,
+                );
+              }
+              return originPanel;
+            }}
           />
         </ContextIsolator>,
       );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - #53408

### 💡 Background and Solution

> - picker的不在ant-picker-dropdown下的时候，样式会丢失。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Inserting the panel outside the popup node causes style loss      |
| 🇨🇳 Chinese |    panel插入到popup节点以外导致样式丢失        |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
	- 日期选择组件现支持自定义面板渲染。用户可以根据需求自定义面板的显示效果，若未提供定制方案，组件将继续显示默认面板。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->