### PR TITLE
fix: Input.TextArea Bounces to 2-row-height at Initial Render #53486

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -149,12 +149,16 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
     }
   };
 
+  // resolve Input.TextArea Bounces to 2-row-height at Initial Render
+  const rows = rest.autoSize ? 1 : rest.rows;
+
   // ==================== Render ====================
   return wrapSharedCSSVar(
     wrapCSSVar(
       <RcTextArea
         autoComplete={contextAutoComplete}
         {...rest}
+        rows={rows}
         style={{ ...contextStyle, ...style }}
         styles={{ ...contextStyles, ...styles }}
         disabled={mergedDisabled}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       fix: Input.TextArea Bounces to 2-row-height at Initial Render    |
| 🇨🇳 Chinese |       解决Input.TextArea在autoSize时默认弹跳问题    |
