### PR TITLE
feat(Form.Item): Open ColorPicker when clicking the label of Form.Item

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -985,7 +985,7 @@ Last version of the Dragon Year, Happy Chinese New Year! 🐲
   - 🐞 Fix Form's `setFieldsValue` should tread same as `setFields`.
 - 🐞 Fix Table that internationalization of table columns fails when searching. [#48126](https://github.com/ant-design/ant-design/pull/48126) [@LingJinT](https://github.com/LingJinT)
 - 🐞 Fix Upload that `onChange` should be triggered when `fileList.length` is larger than `maxCount`. [#47747](https://github.com/ant-design/ant-design/pull/47747) [@Zhou-Bill](https://github.com/Zhou-Bill)
-- 🐞 Fix Carousel several <a href="https://github.com/ant-design/react-slick/pull/110" data-hovercard-type="pull_request" data-hovercard-url="/ant-design/react-slick/pull/110/hovercard">bugs</a> by upgrading react-slick changes and renewing TS type. [#48093](https://github.com/ant-design/ant-design/pull/48093)
+- 🐞 Fix Carousel several [bugs](https://github.com/ant-design/react-slick/pull/110) by upgrading react-slick changes and renewing TS type. [#48093](https://github.com/ant-design/ant-design/pull/48093)
 - 🐞 Fix ColorPicker that displayed cleared color not change after `value` changed. [#47816](https://github.com/ant-design/ant-design/pull/47816) [@MadCcc](https://github.com/MadCcc)
 - 🐞 Make Badge consistent with Tag that apply `colorInfo` token in processing. [#47695](https://github.com/ant-design/ant-design/pull/47695) [@pfdgithub](https://github.com/pfdgithub)
 - 🇮🇸 Add missing form translations in is_IS. [#48104](https://github.com/ant-design/ant-design/pull/48104) [@LonelySnowman](https://github.com/LonelySnowman)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -988,7 +988,7 @@ tag: vVERSION
   - 🐞 修复 Form 的 `setFieldsValue` 和 `setFields` 的行为应该相同。
 - 🐞 修复 Table 表格列在搜索情况下，国际化失效的问题。[#48126](https://github.com/ant-design/ant-design/pull/48126) [@LingJinT](https://github.com/LingJinT)
 - 🐞 修复 Upload 当文件数量超出限制时，删除不起作用，无法触发 `onChange` 的问题。[#47747](https://github.com/ant-design/ant-design/pull/47747) [@Zhou-Bill](https://github.com/Zhou-Bill)
-- 🐞 Carousel 组件同步上游 react-slick 改动，修复一系列<a href="https://github.com/ant-design/react-slick/pull/110" data-hovercard-type="pull_request" data-hovercard-url="/ant-design/react-slick/pull/110/hovercard">问题</a>，并更新到最新 TS 定义。[#48093](https://github.com/ant-design/ant-design/pull/48093)
+- 🐞 Carousel 组件同步上游 react-slick 改动，修复一系列[问题](https://github.com/ant-design/react-slick/pull/110)，并更新到最新 TS 定义。[#48093](https://github.com/ant-design/ant-design/pull/48093)
 - 🐞 修复 ColorPicker 展示的清除颜色在受控 `value` 变化后不会改变的问题。[#47816](https://github.com/ant-design/ant-design/pull/47816) [@MadCcc](https://github.com/MadCcc)
 - 🐞 Badge 与 Tag 组件保持一致，processing 状态使用 `colorInfo` token 。[#47695](https://github.com/ant-design/ant-design/pull/47695) [@pfdgithub](https://github.com/pfdgithub)
 - 🇮🇸 添加冰岛语缺失的 From 翻译。[#48104](https://github.com/ant-design/ant-design/pull/48104) [@LonelySnowman](https://github.com/LonelySnowman)

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -11,7 +11,7 @@ import { ConfigContext } from '../config-provider/context';
 import DisabledContext from '../config-provider/DisabledContext';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
-import { FormItemInputContext } from '../form/context';
+import { FormItemPopupContext, FormItemInputContext } from '../form/context';
 import type { PopoverProps } from '../popover';
 import Popover from '../popover';
 import { useCompactItemContext } from '../space/Compact';
@@ -65,6 +65,8 @@ const ColorPicker: CompoundedComponent = (props) => {
   } = props;
 
   const { getPrefixCls, direction, colorPicker } = useContext<ConfigConsumerProps>(ConfigContext);
+  const { popupOpen: popupOpenContext, setPopupOpen: setPopupOpenContext } =
+    useContext(FormItemPopupContext);
   const contextDisabled = useContext(DisabledContext);
   const mergedDisabled = disabled ?? contextDisabled;
 
@@ -78,6 +80,8 @@ const ColorPicker: CompoundedComponent = (props) => {
     defaultValue: defaultFormat,
     onChange: onFormatChange,
   });
+
+  const mergedOpen = popupOpen || popupOpenContext;
 
   const prefixCls = getPrefixCls('color-picker', customizePrefixCls);
 
@@ -204,7 +208,7 @@ const ColorPicker: CompoundedComponent = (props) => {
   }
 
   const popoverProps: PopoverProps = {
-    open: popupOpen,
+    open: mergedOpen,
     trigger,
     placement,
     arrow,
@@ -225,6 +229,7 @@ const ColorPicker: CompoundedComponent = (props) => {
       onOpenChange={(visible) => {
         if (!visible || !mergedDisabled) {
           setPopupOpen(visible);
+          !visible && setPopupOpenContext(false);
         }
       }}
       content={
@@ -258,8 +263,8 @@ const ColorPicker: CompoundedComponent = (props) => {
     >
       {children || (
         <ColorTrigger
-          activeIndex={popupOpen ? activeIndex : -1}
-          open={popupOpen}
+          activeIndex={mergedOpen ? activeIndex : -1}
+          open={mergedOpen}
           className={mergedCls}
           style={mergedStyle}
           prefixCls={prefixCls}

--- a/components/descriptions/index.en-US.md
+++ b/components/descriptions/index.en-US.md
@@ -83,7 +83,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | bordered | Whether to display the border | boolean | false |  |
 | colon | Change default props `colon` value of Descriptions.Item. Indicates whether the colon after the label is displayed | boolean | true |  |
-| column | The number of `DescriptionItems` in a row,could be a number or a object like `{ xs: 8, sm: 16, md: 24}`,(Only set `bordered={true}` to take effect) | number \| [Record<Breakpoint, number>](https://github.com/ant-design/ant-design/blob/84ca0d23ae52e4f0940f20b0e22eabe743f90dca/components/descriptions/index.tsx#L111C21-L111C56) | 3 |  |
+| column | The number of `DescriptionItems` in a row, could be an object (like `{ xs: 8, sm: 16, md: 24}`, but must have `bordered={true}`) or a number | number \| [Record<Breakpoint, number>](https://github.com/ant-design/ant-design/blob/84ca0d23ae52e4f0940f20b0e22eabe743f90dca/components/descriptions/index.tsx#L111C21-L111C56) | 3 |  |
 | ~~contentStyle~~ | Customize content style, Please use `styles={{ content: {} }}` instead | CSSProperties | - | 4.10.0 |
 | extra | The action area of the description list, placed at the top-right | ReactNode | - | 4.5.0 |
 | items | Describe the contents of the list item | [DescriptionsItem](#descriptionitem)[] | - | 5.8.0 |

--- a/components/form/FormItem/PopupProvider.tsx
+++ b/components/form/FormItem/PopupProvider.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { FormItemPopupContext } from '../context';
+
+interface PopupProviderProps {
+  children?: React.ReactNode;
+}
+
+export default function PopupProvider({ children }: PopupProviderProps) {
+  const [popupOpen, setPopupOpen] = React.useState(false);
+
+  const value = React.useMemo(
+    () => ({
+      popupOpen,
+      setPopupOpen,
+    }),
+    [popupOpen],
+  );
+
+  return <FormItemPopupContext.Provider value={value}>{children}</FormItemPopupContext.Provider>;
+}

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -21,6 +21,7 @@ import useFrameState from '../hooks/useFrameState';
 import useItemRef from '../hooks/useItemRef';
 import useStyle from '../style';
 import { getFieldId, toArray } from '../util';
+import PopupProvider from './PopupProvider';
 import type { ItemHolderProps } from './ItemHolder';
 import ItemHolder from './ItemHolder';
 import StatusProvider from './StatusProvider';
@@ -283,8 +284,12 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
     );
   }
 
+  function popupDecorator(children: React.ReactNode): React.ReactNode {
+    return <PopupProvider>{children}</PopupProvider>;
+  }
+
   if (!hasName && !isRenderProps && !dependencies) {
-    return wrapCSSVar(renderLayout(mergedChildren) as JSX.Element);
+    return wrapCSSVar(popupDecorator(renderLayout(mergedChildren)) as JSX.Element);
   }
 
   let variables: Record<string, string> = {};
@@ -442,7 +447,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
           childNode = mergedChildren as React.ReactNode;
         }
 
-        return renderLayout(childNode, fieldId, isRequired);
+        return popupDecorator(renderLayout(childNode, fieldId, isRequired));
       }}
     </Field>,
   );

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -9,7 +9,7 @@ import defaultLocale from '../locale/en_US';
 import type { TooltipProps } from '../tooltip';
 import Tooltip from '../tooltip';
 import type { FormContextProps } from './context';
-import { FormContext } from './context';
+import { FormContext, FormItemPopupContext } from './context';
 import type { RequiredMark } from './Form';
 import type { FormLabelAlign } from './interface';
 
@@ -60,6 +60,12 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
   vertical,
 }) => {
   const [formLocale] = useLocale('Form');
+
+  const { setPopupOpen } = React.useContext(FormItemPopupContext);
+
+  const onClick = () => {
+    setPopupOpen(true);
+  };
 
   const {
     labelAlign: contextLabelAlign,
@@ -163,6 +169,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
         htmlFor={htmlFor}
         className={labelClassName}
         title={typeof label === 'string' ? label : ''}
+        onClick={onClick}
       >
         {labelChildren}
       </label>

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -100,3 +100,13 @@ export const NoFormStyle: React.FC<NoFormStyleProps> = ({ children, status, over
 };
 
 export const VariantContext = React.createContext<Variant | undefined>(undefined);
+
+interface FormItemPopupContextProps {
+  popupOpen?: boolean;
+  setPopupOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const FormItemPopupContext = React.createContext<FormItemPopupContextProps>({
+  popupOpen: false,
+  setPopupOpen: () => {},
+});

--- a/docs/blog/config-provider-style.en-US.md
+++ b/docs/blog/config-provider-style.en-US.md
@@ -78,7 +78,7 @@ const useButtonStyle = createStyles(({ css }, prefixCls: string) => {
 });
 
 const GeekProvider: React.FC<Readonly<React.PropsWithChildren>> = (props) => {
-  const { getPrefixCls } = React.use(ConfigProvider.ConfigContext);
+  const { getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
   const btnPrefixCls = getPrefixCls('btn');
   const { styles } = useButtonStyle(btnPrefixCls);
   return <ConfigProvider button={{ className: styles.btn }}>{props.children}</ConfigProvider>;
@@ -94,10 +94,12 @@ It's also easy to extend for scenarios that need to inherit `className`:
 ```tsx
 import React from 'react';
 import { ConfigProvider } from 'antd';
+import classNames from 'classnames';
 
 const GeekProvider: React.FC<Readonly<React.PropsWithChildren>> = (props) => {
-  const { button } = React.useContext(ConfigProvider.ConfigContext);
-  const { styles } = useButtonStyle();
+  const { button, getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
+  const btnPrefixCls = getPrefixCls('btn');
+  const { styles } = useButtonStyle(btnPrefixCls);
   return (
     <ConfigProvider button={{ className: classNames(button?.className, styles.btn) }}>
       {props.children}

--- a/docs/blog/config-provider-style.zh-CN.md
+++ b/docs/blog/config-provider-style.zh-CN.md
@@ -78,7 +78,7 @@ const useButtonStyle = createStyles(({ css }, prefixCls: string) => {
 });
 
 const GeekProvider: React.FC<Readonly<React.PropsWithChildren>> = (props) => {
-  const { getPrefixCls } = React.use(ConfigProvider.ConfigContext);
+  const { getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
   const btnPrefixCls = getPrefixCls('btn');
   const { styles } = useButtonStyle(btnPrefixCls);
   return <ConfigProvider button={{ className: styles.btn }}>{props.children}</ConfigProvider>;
@@ -94,10 +94,12 @@ export default GeekProvider;
 ```tsx
 import React from 'react';
 import { ConfigProvider } from 'antd';
+import classNames from 'classnames';
 
 const GeekProvider: React.FC<Readonly<React.PropsWithChildren>> = (props) => {
-  const { button } = React.useContext(ConfigProvider.ConfigContext);
-  const { styles } = useButtonStyle();
+  const { button, getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
+  const btnPrefixCls = getPrefixCls('btn');
+  const { styles } = useButtonStyle(btnPrefixCls);
   return (
     <ConfigProvider button={{ className: classNames(button?.className, styles.btn) }}>
       {props.children}

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -45,7 +45,7 @@ export default App;
 
 ## Component Token
 
-## Alert
+### Alert
 
 <!-- prettier-ignore -->
 | Less variables | Component Token | Note |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/ant-design/issues/52623
### 💡 Background and Solution

- Solution: create a new state which helps to open/close the ColorPicker when click the label
- UI/interaction changes:
![Screen Recording 2025-04-16 at 00 50 12](https://github.com/user-attachments/assets/fec8e4d6-9751-4a5e-87a0-ec31b8056ef7)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add focus behavior of ColorPicker when click the label.      |
| 🇨🇳 Chinese |     Add focus behavior of ColorPicker when click the label.      |
