### PR TITLE
fix: Input.TextArea Bounces to 2-row-height at Initial Render #53486

### DIFF
--- a/components/input/style/textarea.ts
+++ b/components/input/style/textarea.ts
@@ -35,11 +35,6 @@ const genTextAreaStyle: GenerateStyle<InputToken> = (token) => {
       position: 'relative',
 
       '&-show-count': {
-        // https://github.com/ant-design/ant-design/issues/33049
-        [`> ${componentCls}`]: {
-          height: '100%',
-        },
-
         [`${componentCls}-data-count`]: {
           position: 'absolute',
           bottom: token.calc(token.fontSize).mul(token.lineHeight).mul(-1).equal(),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx
- fix #53486
- close https://github.com/ant-design/ant-design/pull/53513


### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.
- 问题原因: 开启`autoSize`时，`textarea`样式`height: 100%`导致外层元素高度为2行高度[MDN textarea](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Reference/Elements/textarea#rows)，同时由于内部计算的高度与之不同，结合`textarea`过渡动画会出现该问题。
- 解决方法: 去掉`height: 100%`; 开启`showCount`时，最外层布局为`inline-flex`，`textarea`还存在`height: auto`样式, 无法应用过渡动画，不会出现该issue问题。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input.TextArea bounces to 2-row-height at initial render.      |
| 🇨🇳 Chinese |    修复 Input.TextArea 初始化时渲染高度闪烁问题。       |
