### PR TITLE
fix: adjust icon position for rtl

### DIFF
--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -17,6 +17,18 @@ import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useStyle from './style';
 
+export const icons = {
+  rotateLeft: <RotateLeftOutlined />,
+  rotateRight: <RotateRightOutlined />,
+  zoomIn: <ZoomInOutlined />,
+  zoomOut: <ZoomOutOutlined />,
+  close: <CloseOutlined />,
+  left: <LeftOutlined />,
+  right: <RightOutlined />,
+  flipX: <SwapOutlined />,
+  flipY: <SwapOutlined rotate={90} />,
+};
+
 const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
   previewPrefixCls: customizePrefixCls,
   preview,
@@ -35,17 +47,11 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
     typeof preview === 'object' ? preview.zIndex : undefined,
   );
 
-  const icons = React.useMemo(
+  const memoizedIcons = React.useMemo(
     () => ({
-      rotateLeft: <RotateLeftOutlined />,
-      rotateRight: <RotateRightOutlined />,
-      zoomIn: <ZoomInOutlined />,
-      zoomOut: <ZoomOutOutlined />,
-      close: <CloseOutlined />,
+      ...icons,
       left: direction === 'rtl' ? <RightOutlined /> : <LeftOutlined />,
       right: direction === 'rtl' ? <LeftOutlined /> : <RightOutlined />,
-      flipX: <SwapOutlined />,
-      flipY: <SwapOutlined rotate={90} />,
     }),
     [direction],
   );
@@ -75,7 +81,7 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
     <RcImage.PreviewGroup
       preview={mergedPreview}
       previewPrefixCls={previewPrefixCls}
-      icons={icons}
+      icons={memoizedIcons}
       {...otherProps}
     />,
   );

--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -17,24 +17,12 @@ import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useStyle from './style';
 
-export const icons = {
-  rotateLeft: <RotateLeftOutlined />,
-  rotateRight: <RotateRightOutlined />,
-  zoomIn: <ZoomInOutlined />,
-  zoomOut: <ZoomOutOutlined />,
-  close: <CloseOutlined />,
-  left: <LeftOutlined />,
-  right: <RightOutlined />,
-  flipX: <SwapOutlined />,
-  flipY: <SwapOutlined rotate={90} />,
-};
-
 const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
   previewPrefixCls: customizePrefixCls,
   preview,
   ...otherProps
 }) => {
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('image', customizePrefixCls);
   const previewPrefixCls = `${prefixCls}-preview`;
   const rootPrefixCls = getPrefixCls();
@@ -45,6 +33,21 @@ const InternalPreviewGroup: React.FC<GroupConsumerProps> = ({
   const [zIndex] = useZIndex(
     'ImagePreview',
     typeof preview === 'object' ? preview.zIndex : undefined,
+  );
+
+  const icons = React.useMemo(
+    () => ({
+      rotateLeft: <RotateLeftOutlined />,
+      rotateRight: <RotateRightOutlined />,
+      zoomIn: <ZoomInOutlined />,
+      zoomOut: <ZoomOutOutlined />,
+      close: <CloseOutlined />,
+      left: direction === 'rtl' ? <RightOutlined /> : <LeftOutlined />,
+      right: direction === 'rtl' ? <LeftOutlined /> : <RightOutlined />,
+      flipX: <SwapOutlined />,
+      flipY: <SwapOutlined rotate={90} />,
+    }),
+    [direction],
   );
 
   const mergedPreview = React.useMemo<GroupConsumerProps['preview']>(() => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #53523 
fix #53528 

### 💡 Background and Solution

![image](https://github.com/user-attachments/assets/8034ad47-ce3c-4ef8-96c5-4a3a3c10e4eb)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Image.PreviewGroup` left/right navigation icons not displaying correctly in RTL mode. |
| 🇨🇳 Chinese | 修复 `Image.PreviewGroup` 在 RTL 模式下，左右切换图标方向不正确的问题。 |