### PR TITLE
fix: DatePicker.Panel style fails when mounted on an external element

### DIFF
--- a/components/date-picker/__tests__/other.test.tsx
+++ b/components/date-picker/__tests__/other.test.tsx
@@ -83,7 +83,7 @@ describe('Override locale setting of the ConfigProvider', () => {
 });
 
 describe('The panel should work properly', () => {
-  it('use cssVar panelRender', () => {
+  it('Use cssVar panelRender', () => {
     const customRender = (panel: any) => {
       return (
         <Menu
@@ -113,7 +113,7 @@ describe('The panel should work properly', () => {
 
     expect(container.querySelector('.ant-picker-panel-layout')).toHaveClass('ant-picker-css-var');
   });
-  it('use panelRender', () => {
+  it('Use panelRender', () => {
     const customRender = (panel: any) => {
       return (
         <Menu
@@ -144,5 +144,35 @@ describe('The panel should work properly', () => {
     expect(container.querySelector('.ant-picker-panel-layout')).not.toHaveClass(
       'ant-picker-css-var',
     );
+  });
+  it('Use cssVar panelRender in RangePicker', () => {
+    const customRender = (panel: any) => {
+      return (
+        <Menu
+          items={[
+            {
+              key: 'custom-date',
+              label: (
+                <Popover content={panel} trigger="click" open>
+                  <div>Custom Date</div>
+                </Popover>
+              ),
+            },
+          ]}
+        />
+      );
+    };
+
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          cssVar: true,
+        }}
+      >
+        <DatePicker.RangePicker open panelRender={customRender} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker-panel-layout')).toHaveClass('ant-picker-css-var');
   });
 });

--- a/components/date-picker/__tests__/other.test.tsx
+++ b/components/date-picker/__tests__/other.test.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 
 import React from 'react';
+import { Menu, Popover } from 'antd';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import DatePicker from '..';
@@ -78,5 +79,70 @@ describe('Override locale setting of the ConfigProvider', () => {
     );
     expect(container.querySelectorAll('input')[0]?.placeholder).toEqual('開始日期');
     expect(container.querySelectorAll('input')[1]?.placeholder).toEqual('結束日期');
+  });
+});
+
+describe('The panel should work properly', () => {
+  it('use cssVar panelRender', () => {
+    const customRender = (panel: any) => {
+      return (
+        <Menu
+          items={[
+            {
+              key: 'custom-date',
+              label: (
+                <Popover content={panel} trigger="click" open>
+                  <div>Custom Date</div>
+                </Popover>
+              ),
+            },
+          ]}
+        />
+      );
+    };
+
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          cssVar: true,
+        }}
+      >
+        <DatePicker open panelRender={customRender} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker-panel-layout')).toHaveClass('ant-picker-css-var');
+  });
+  it('use panelRender', () => {
+    const customRender = (panel: any) => {
+      return (
+        <Menu
+          items={[
+            {
+              key: 'custom-date',
+              label: (
+                <Popover content={panel} trigger="click" open>
+                  <div>Custom Date</div>
+                </Popover>
+              ),
+            },
+          ]}
+        />
+      );
+    };
+
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          cssVar: false,
+        }}
+      >
+        <DatePicker open panelRender={customRender} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker-panel-layout')).not.toHaveClass(
+      'ant-picker-css-var',
+    );
   });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -27,6 +27,7 @@ import { getRangePlaceholder, useIcons } from '../util';
 import { TIME } from './constant';
 import type { RangePickerProps } from './interface';
 import useComponents from './useComponents';
+import useCssVarPanelRender from './useCssVarPanelRender';
 
 const generateRangePicker = <DateType extends AnyObject = AnyObject>(
   generateConfig: GenerateConfig<DateType>,
@@ -109,26 +110,11 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     const [zIndex] = useZIndex('DatePicker', props.popupStyle?.zIndex as number);
 
     // ============================ panelRender ============================
-    const cssVarPanelRender = React.useCallback(
-      (panelNode: React.ReactNode) => {
-        const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
-        return panelRender
-          ? panelRender(
-              wrapCSSVar(
-                React.cloneElement(sourcePanelNode, {
-                  className: classNames(
-                    sourcePanelNode.props.className,
-                    hashId,
-                    rootCls,
-                    cssVarCls,
-                  ),
-                }),
-              ),
-            )
-          : panelNode;
-      },
-      [hashId, rootCls, cssVarCls],
-    );
+    const cssVarPanelRender = useCssVarPanelRender({
+      panelRender,
+      wrapCSSVar,
+      cssVarCls: classNames(hashId, rootCls, cssVarCls),
+    });
 
     return wrapCSSVar(
       <ContextIsolator space>

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -111,9 +111,6 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     // ============================ panelRender ============================
     const cssVarPanelRender = React.useCallback(
       (panelNode: React.ReactNode) => {
-        if (!React.isValidElement(panelNode)) {
-          return;
-        }
         const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
         return panelRender
           ? panelRender(

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -51,6 +51,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
       rootClassName,
       variant: customVariant,
       picker,
+      panelRender,
       ...restProps
     } = props;
 
@@ -107,6 +108,31 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     // ============================ zIndex ============================
     const [zIndex] = useZIndex('DatePicker', props.popupStyle?.zIndex as number);
 
+    // ============================ panelRender ============================
+    const cssVarPanelRender = React.useCallback(
+      (panelNode: React.ReactNode) => {
+        if (!React.isValidElement(panelNode)) {
+          return;
+        }
+        const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
+        return panelRender
+          ? panelRender(
+              wrapCSSVar(
+                React.cloneElement(sourcePanelNode, {
+                  className: classNames(
+                    sourcePanelNode.props.className,
+                    hashId,
+                    rootCls,
+                    cssVarCls,
+                  ),
+                }),
+              ),
+            )
+          : panelNode;
+      },
+      [hashId, rootCls, cssVarCls],
+    );
+
     return wrapCSSVar(
       <ContextIsolator space>
         <RCRangePicker<DateType>
@@ -126,6 +152,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
           superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
           transitionName={`${rootPrefixCls}-slide-up`}
           picker={picker}
+          panelRender={cssVarPanelRender}
           {...restProps}
           className={classNames(
             {

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -38,6 +38,7 @@ import {
 } from './constant';
 import type { GenericTimePickerProps, PickerProps, PickerPropsWithMultiple } from './interface';
 import useComponents from './useComponents';
+import useCssVarPanelRender from './useCssVarPanelRender';
 
 const generatePicker = <DateType extends AnyObject = AnyObject>(
   generateConfig: GenerateConfig<DateType>,
@@ -156,26 +157,11 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
       const [zIndex] = useZIndex('DatePicker', props.popupStyle?.zIndex as number);
 
       // ============================ panelRender ============================
-      const cssVarPanelRender = React.useCallback(
-        (panelNode: React.ReactNode) => {
-          const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
-          return panelRender
-            ? panelRender(
-                wrapCSSVar(
-                  React.cloneElement(sourcePanelNode, {
-                    className: classNames(
-                      sourcePanelNode.props.className,
-                      hashId,
-                      rootCls,
-                      cssVarCls,
-                    ),
-                  }),
-                ),
-              )
-            : panelNode;
-        },
-        [hashId, rootCls, cssVarCls],
-      );
+      const cssVarPanelRender = useCssVarPanelRender({
+        panelRender,
+        wrapCSSVar,
+        cssVarCls: classNames(hashId, rootCls, cssVarCls),
+      });
 
       return wrapCSSVar(
         <ContextIsolator space>

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -65,6 +65,7 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
         status: customStatus,
         variant: customVariant,
         onCalendarChange,
+        panelRender,
         ...restProps
       } = props;
 
@@ -154,6 +155,31 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
       // ============================ zIndex ============================
       const [zIndex] = useZIndex('DatePicker', props.popupStyle?.zIndex as number);
 
+      // ============================ panelRender ============================
+      const cssVarPanelRender = React.useCallback(
+        (panelNode: React.ReactNode) => {
+          if (!React.isValidElement(panelNode)) {
+            return;
+          }
+          const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
+          return panelRender
+            ? panelRender(
+                wrapCSSVar(
+                  React.cloneElement(sourcePanelNode, {
+                    className: classNames(
+                      sourcePanelNode.props.className,
+                      hashId,
+                      rootCls,
+                      cssVarCls,
+                    ),
+                  }),
+                ),
+              )
+            : panelNode;
+        },
+        [hashId, rootCls, cssVarCls],
+      );
+
       return wrapCSSVar(
         <ContextIsolator space>
           <RCPicker<DateType>
@@ -167,6 +193,7 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
             superNextIcon={<span className={`${prefixCls}-super-next-icon`} />}
             transitionName={`${rootPrefixCls}-slide-up`}
             picker={picker}
+            panelRender={cssVarPanelRender}
             onCalendarChange={onInternalCalendarChange}
             {...additionalProps}
             {...restProps}

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -158,9 +158,6 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
       // ============================ panelRender ============================
       const cssVarPanelRender = React.useCallback(
         (panelNode: React.ReactNode) => {
-          if (!React.isValidElement(panelNode)) {
-            return;
-          }
           const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
           return panelRender
             ? panelRender(

--- a/components/date-picker/generatePicker/useCssVarPanelRender.ts
+++ b/components/date-picker/generatePicker/useCssVarPanelRender.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { DatePickerProps } from '..';
+
+export default function useCssVarPanelRender({
+  panelRender,
+  wrapCSSVar,
+  cssVarCls,
+}: {
+  panelRender: DatePickerProps['panelRender'];
+  wrapCSSVar: (node: React.ReactElement) => React.ReactElement;
+  cssVarCls: string;
+}) {
+  return (panelNode: React.ReactNode) => {
+    const sourcePanelNode = panelNode as React.ReactElement<HTMLDivElement>;
+    return panelRender
+      ? panelRender(
+          wrapCSSVar(
+            React.cloneElement(sourcePanelNode, {
+              className: classNames(sourcePanelNode.props.className, cssVarCls),
+            }),
+          ),
+        )
+      : panelNode;
+  };
+}

--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -503,6 +503,12 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           },
         },
       },
+      [`${componentCls}-panel-layout`]: {
+        display: 'flex',
+        flexWrap: 'nowrap',
+        alignItems: 'stretch',
+        ...genPanelStyle(token),
+      },
     },
 
     // Follow code may reuse in other components


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/53408

### 💡 Background and Solution

当 DatePicker.Panel 被挂载在其他元素内部时样式失效

<img width="187" alt="image" src="https://github.com/user-attachments/assets/2a8fad76-5996-43cf-b5ce-c819bad9cdfa" />


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix DatePicker.Panel style fails when mounted on an external element     |
| 🇨🇳 Chinese |     修复 DatePicker 时间面板 挂载在其他元素时样式失效问题      |
