### PR TITLE
refactor: deprecated destroyPopupOnHide API

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -259,7 +259,7 @@ describe('Dropdown', () => {
     errorSpy.mockRestore();
   });
 
-  it('legacy dropdownRender', () => {
+  it('legacy dropdownRender & legacy destroyPopupOnHide', () => {
     resetWarned();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const dropdownRender = jest.fn((menu) => (
@@ -272,6 +272,7 @@ describe('Dropdown', () => {
     const { container } = render(
       <Dropdown
         open
+        destroyPopupOnHide
         dropdownRender={dropdownRender}
         menu={{
           items: [
@@ -288,6 +289,9 @@ describe('Dropdown', () => {
 
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Dropdown] `dropdownRender` is deprecated. Please use `popupRender` instead.',
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Dropdown] `destroyPopupOnHide` is deprecated. Please use `destroyOnClose` instead.',
     );
 
     expect(dropdownRender).toHaveBeenCalled();

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -94,7 +94,7 @@ const DropdownButton: CompoundedComponent = (props) => {
     mouseLeaveDelay,
     overlayClassName,
     overlayStyle,
-    destroyPopupOnHide: mergedDestroyOnClose,
+    destroyOnClose: mergedDestroyOnClose,
     popupRender: mergedPopupRender,
   };
 

--- a/components/dropdown/dropdown-button.tsx
+++ b/components/dropdown/dropdown-button.tsx
@@ -67,6 +67,7 @@ const DropdownButton: CompoundedComponent = (props) => {
     mouseLeaveDelay,
     overlayClassName,
     overlayStyle,
+    destroyOnClose,
     destroyPopupOnHide,
     dropdownRender,
     popupRender,
@@ -77,6 +78,8 @@ const DropdownButton: CompoundedComponent = (props) => {
   const buttonPrefixCls = `${prefixCls}-button`;
 
   const mergedPopupRender = popupRender || dropdownRender;
+
+  const mergedDestroyOnClose = destroyOnClose ?? destroyPopupOnHide;
 
   const dropdownProps: DropdownProps = {
     menu,
@@ -91,7 +94,7 @@ const DropdownButton: CompoundedComponent = (props) => {
     mouseLeaveDelay,
     overlayClassName,
     overlayStyle,
-    destroyPopupOnHide,
+    destroyPopupOnHide: mergedDestroyOnClose,
     popupRender: mergedPopupRender,
   };
 

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -55,7 +55,12 @@ export interface DropdownProps {
   onOpenChange?: (open: boolean, info: { source: 'trigger' | 'menu' }) => void;
   open?: boolean;
   disabled?: boolean;
+  /** @deprecated Please use `destroyOnClose` instead */
   destroyPopupOnHide?: boolean;
+  /**
+   * @since 5.25.0
+   */
+  destroyOnClose?: boolean;
   align?: AlignType;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   prefixCls?: string;
@@ -129,6 +134,7 @@ const Dropdown: CompoundedComponent = (props) => {
       onVisibleChange: 'onOpenChange',
       overlay: 'menu',
       dropdownRender: 'popupRender',
+      destroyPopupOnHide: 'destroyOnClose',
     };
 
     Object.entries(deprecatedProps).forEach(([deprecatedName, newName]) => {

--- a/components/dropdown/index.en-US.md
+++ b/components/dropdown/index.en-US.md
@@ -48,7 +48,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | autoAdjustOverflow | Whether to adjust dropdown placement automatically when dropdown is off screen | boolean | true | 5.2.0 |
 | autoFocus | Focus element in `overlay` when opened | boolean | false | 4.21.0 |
 | disabled | Whether the dropdown menu is disabled | boolean | - |  |
-| destroyPopupOnHide | Whether destroy dropdown when hidden | boolean | false |  |
+| ~~destroyPopupOnHide~~ | Whether destroy dropdown when hidden, use `destroyOnClose` instead | boolean | false |  |
+| destroyOnClose | Whether destroy dropdown when hidden | boolean | false | 5.25.0 |
 | ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (menus: ReactNode) => ReactNode | - | 4.24.0 |
 | popupRender | Customize popup content | (menus: ReactNode) => ReactNode | - | 5.25.0 |
 | getPopupContainer | To set the container of the dropdown menu. The default is to create a div element in body, but you can reset it to the scrolling area and make a relative reposition. [Example on CodePen](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | (triggerNode: HTMLElement) => HTMLElement | () => document.body |  |

--- a/components/dropdown/index.zh-CN.md
+++ b/components/dropdown/index.zh-CN.md
@@ -52,7 +52,8 @@ demo:
 | autoAdjustOverflow | 下拉框被遮挡时自动调整位置 | boolean | true | 5.2.0 |
 | autoFocus | 打开后自动聚焦下拉框 | boolean | false | 4.21.0 |
 | disabled | 菜单是否禁用 | boolean | - |  |
-| destroyPopupOnHide | 关闭后是否销毁 Dropdown | boolean | false |  |
+| ~~destroyPopupOnHide~~ | 关闭后是否销毁 Dropdown，使用 `destroyOnClose` 替换 | boolean | false |  |
+| destroyOnClose | 关闭后是否销毁 Dropdown | boolean | false | 5.25.0 |
 | ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (menus: ReactNode) => ReactNode | - | 4.24.0 |
 | popupRender | 自定义弹出框内容 | (menus: ReactNode) => ReactNode | - | 5.25.0 |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | (triggerNode: HTMLElement) => HTMLElement | () => document.body |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

- #53727

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 无需纳入 ChangeLog，这个 PR 作废，最终的修改在 #53739 里面 |
| 🇨🇳 Chinese | 无需纳入 ChangeLog，这个 PR 作废，最终的修改在 #53739 里面 |