### PR TITLE
fix: Input OTP breaks with type number and mask

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -30339,43 +30339,80 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>
@@ -30409,43 +30446,80 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>
@@ -30479,43 +30553,80 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -12614,43 +12614,80 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-success ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>
@@ -12684,43 +12721,80 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-warning ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>
@@ -12754,43 +12828,80 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
           >
             <div
               class="ant-otp"
+              role="group"
             >
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
-              <input
-                class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
-                size="1"
-                type="text"
-                value=""
-              />
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 1"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 2"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 3"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 4"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 5"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-otp-input-wrapper"
+                role="presentation"
+              >
+                <input
+                  aria-label="OTP Input 6"
+                  class="ant-input ant-input-outlined ant-input-status-error ant-otp-input"
+                  size="1"
+                  type="text"
+                  value=""
+                />
+              </span>
             </div>
           </div>
         </div>

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import raf from 'rc-util/lib/raf';
 
+import { ConfigContext } from '../../config-provider';
 import Input from '../Input';
 import type { InputProps, InputRef } from '../Input';
 
@@ -14,17 +16,19 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
 }
 
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { value, onChange, onActiveChange, index, mask, ...restProps } = props;
-
-  const internalValue = value && typeof mask === 'string' ? mask : value;
-
-  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    onChange(index, e.target.value);
-  };
+  const { className, value, onChange, onActiveChange, index, mask, ...restProps } = props;
+  const { getPrefixCls } = React.useContext(ConfigContext);
+  const prefixCls = getPrefixCls('otp');
+  const maskValue = typeof mask === 'string' ? mask : value;
 
   // ========================== Ref ===========================
   const inputRef = React.useRef<InputRef>(null);
   React.useImperativeHandle(ref, () => inputRef.current!);
+
+  // ========================= Input ==========================
+  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    onChange(index, e.target.value);
+  };
 
   // ========================= Focus ==========================
   const syncSelection = () => {
@@ -61,18 +65,31 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
 
   // ========================= Render =========================
   return (
-    <Input
-      type={mask === true ? 'password' : 'text'}
-      {...restProps}
-      ref={inputRef}
-      value={internalValue}
-      onInput={onInternalChange}
-      onFocus={syncSelection}
-      onKeyDown={onInternalKeyDown}
-      onKeyUp={onInternalKeyUp}
-      onMouseDown={syncSelection}
-      onMouseUp={syncSelection}
-    />
+    <span className={`${prefixCls}-input-wrapper`} role="presentation">
+      {/* mask value */}
+      {mask && value !== '' && value !== undefined && (
+        <span className={`${prefixCls}-mask-icon`} aria-hidden="true">
+          {maskValue}
+        </span>
+      )}
+
+      <Input
+        aria-label={`OTP Input ${index + 1}`}
+        type={mask === true ? 'password' : 'text'}
+        {...restProps}
+        ref={inputRef}
+        value={value}
+        onInput={onInternalChange}
+        onFocus={syncSelection}
+        onKeyDown={onInternalKeyDown}
+        onKeyUp={onInternalKeyUp}
+        onMouseDown={syncSelection}
+        onMouseUp={syncSelection}
+        className={classNames(className, {
+          [`${prefixCls}-mask-input`]: mask,
+        })}
+      />
+    </span>
   );
 });
 

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -258,6 +258,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
         cssVarCls,
         hashId,
       )}
+      role="group"
     >
       <FormItemInputContext.Provider value={proxyFormContext}>
         {Array.from({ length }).map((_, index) => {

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10292,43 +10292,80 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10337,49 +10374,86 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10388,55 +10462,104 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 7"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 8"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10445,43 +10568,80 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10490,43 +10650,80 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10535,13 +10732,20 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10549,12 +10753,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10562,12 +10772,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10575,12 +10791,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10588,12 +10810,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10601,12 +10829,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -10615,13 +10849,20 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10631,12 +10872,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10646,12 +10893,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10661,12 +10914,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10676,12 +10935,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -10691,12 +10956,18 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
 </div>
 `;

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3642,43 +3642,80 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3687,49 +3724,86 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
-      disabled=""
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-disabled ant-input-outlined ant-otp-input"
+        disabled=""
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3738,55 +3812,104 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 7"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 8"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3795,43 +3918,80 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-filled ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-filled ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3840,43 +4000,80 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3885,13 +4082,20 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3899,12 +4103,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3912,12 +4122,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3925,12 +4141,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3938,12 +4160,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3951,12 +4179,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         /
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
   <h5
     class="ant-typography"
@@ -3965,13 +4199,20 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
   </h5>
   <div
     class="ant-otp"
+    role="group"
   >
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 1"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3981,12 +4222,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 2"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -3996,12 +4243,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 3"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -4011,12 +4264,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 4"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -4026,12 +4285,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 5"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
     <span
       class="ant-otp-separator"
     >
@@ -4041,12 +4306,18 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         —
       </span>
     </span>
-    <input
-      class="ant-input ant-input-outlined ant-otp-input"
-      size="1"
-      type="text"
-      value=""
-    />
+    <span
+      class="ant-otp-input-wrapper"
+      role="presentation"
+    >
+      <input
+        aria-label="OTP Input 6"
+        class="ant-input ant-input-outlined ant-otp-input"
+        size="1"
+        type="text"
+        value=""
+      />
+    </span>
   </div>
 </div>
 `;

--- a/components/input/__tests__/__snapshots__/otp.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/otp.test.tsx.snap
@@ -3,42 +3,79 @@
 exports[`Input.OTP rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-otp ant-otp-rtl"
+  role="group"
 >
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
-  <input
-    class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
-    size="1"
-    type="text"
-    value=""
-  />
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 1"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 2"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 3"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 4"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 5"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
+  <span
+    class="ant-otp-input-wrapper"
+    role="presentation"
+  >
+    <input
+      aria-label="OTP Input 6"
+      class="ant-input ant-input-rtl ant-input-outlined ant-otp-input"
+      size="1"
+      type="text"
+      value=""
+    />
+  </span>
 </div>
 `;

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -145,11 +145,11 @@ describe('Input.OTP', () => {
 
     // support string
     rerender(<OTP defaultValue="bamboo" mask="*" />);
-    expect(getText(container)).toBe('******');
+    expect(getText(container)).toBe('bamboo');
 
     // support emoji
     rerender(<OTP defaultValue="bamboo" mask="🔒" />);
-    expect(getText(container)).toBe('🔒🔒🔒🔒🔒🔒');
+    expect(getText(container)).toBe('bamboo');
   });
 
   it('should throw Error when mask.length > 1', () => {

--- a/components/input/style/otp.ts
+++ b/components/input/style/otp.ts
@@ -14,6 +14,29 @@ const genOTPStyle: GenerateStyle<InputToken> = (token) => {
       flexWrap: 'nowrap',
       columnGap: paddingXS,
 
+      [`${componentCls}-input-wrapper`]: {
+        position: 'relative',
+        [`${componentCls}-mask-icon`]: {
+          position: 'absolute',
+          zIndex: '1',
+          top: '50%',
+          right: '50%',
+          transform: 'translate(50%, -50%)',
+          pointerEvents: 'none',
+        },
+        [`${componentCls}-mask-input`]: {
+          color: 'transparent',
+          caretColor: 'var(--ant-color-text)',
+        },
+        [`${componentCls}-mask-input[type=number]::-webkit-inner-spin-button`]: {
+          '-webkit-appearance': 'none',
+          margin: 0,
+        },
+        [`${componentCls}-mask-input[type=number]`]: {
+          '-moz-appearance': 'textfield',
+        },
+      },
+
       '&-rtl': {
         direction: 'rtl',
       },


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a bugfix for Input.OTP, it breaks when mask is used with type number field.

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Input.OTP breaks in UI, when set with type as number and mask.
> - For example : https://codesandbox.io/p/sandbox/otp-antd-5-24-6-forked-23m9n3

https://github.com/user-attachments/assets/4cbf9d86-9405-4b0e-b5ed-75ddbd8fb5d0

### 💡 Background and Solution

> - Mask doesnt work on number field, so i have handled it using css based approach
> - Type will be single source of truth, in the new approach we are not changing its type dynamically

Demo of fix :

https://github.com/user-attachments/assets/2e3761eb-f9b0-43e5-b202-e8a5da078c07

Code :

<img width="694" alt="Screenshot 2025-04-05 at 5 15 14 PM" src="https://github.com/user-attachments/assets/80f7b740-87c6-4a0a-9935-27bcafd2b240" />


### 📝 Change Log

> - None