### PR TITLE
fix label-wrap when not required

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9150,6 +9150,45 @@ exports[`renders components/form/demo/layout-can-wrap.tsx extend context correct
       >
         <label
           class="ant-form-item-no-colon"
+          for="wrap_password1"
+          title="A super long label text"
+        >
+          A super long label text
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+        style="flex: 1 1 auto;"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="wrap_password1"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+        style="flex: 0 0 110px;"
+      >
+        <label
+          class="ant-form-item-no-colon"
           title=" "
         >
         </label>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -5499,6 +5499,45 @@ exports[`renders components/form/demo/layout-can-wrap.tsx correctly 1`] = `
       >
         <label
           class="ant-form-item-no-colon"
+          for="wrap_password1"
+          title="A super long label text"
+        >
+          A super long label text
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+        style="flex:1 1 auto"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <input
+              class="ant-input ant-input-outlined"
+              id="wrap_password1"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label ant-form-item-label-left ant-form-item-label-wrap"
+        style="flex:0 0 110px"
+      >
+        <label
+          class="ant-form-item-no-colon"
           title=" "
         >
         </label>

--- a/components/form/demo/layout-can-wrap.tsx
+++ b/components/form/demo/layout-can-wrap.tsx
@@ -19,6 +19,10 @@ const App: React.FC = () => (
       <Input />
     </Form.Item>
 
+    <Form.Item label="A super long label text" name="password1">
+      <Input />
+    </Form.Item>
+
     <Form.Item label=" ">
       <Button type="primary" htmlType="submit">
         Submit

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -244,6 +244,10 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
           overflow: 'unset',
           lineHeight: token.lineHeight,
           whiteSpace: 'unset',
+
+          '> label': {
+            verticalAlign: 'middle',
+          },
         },
 
         '> label': {

--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -247,6 +247,7 @@ const genFormItemStyle: GenerateStyle<FormToken> = (token) => {
 
           '> label': {
             verticalAlign: 'middle',
+            textWrap: 'balance',
           },
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### This is a fix for label wrap when not required and label is not middle align with input

<img width="476" alt="Pasted image 20250417103701" src="https://github.com/user-attachments/assets/fd82569c-d22c-45cc-b95a-532d97c8d8ff" />

reproduce demo: https://codesandbox.io/p/sandbox/biao-dan-biao-qian-ke-huan-xing-antd-5-24-7-forked-3sl8sg?file=%2Fdemo.tsx%3A20%2C17

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix for label wrap when not required and label is not middle align with input  |
| 🇨🇳 Chinese |  修复非必选的label换行不对齐的问题 |
