### PR TITLE
fix: Fixed the issue of incorrect onResizeEnd call in lazy mode

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -14,7 +14,7 @@ export interface SplitBarProps {
   startCollapsible: boolean;
   endCollapsible: boolean;
   onOffsetStart: (index: number) => void;
-  onOffsetUpdate: (index: number, offsetX: number, offsetY: number) => void;
+  onOffsetUpdate: (index: number, offsetX: number, offsetY: number, lazyEnd?: boolean) => void;
   onOffsetEnd: VoidFunction;
   onCollapse: (index: number, type: 'start' | 'end') => void;
   vertical: boolean;
@@ -93,7 +93,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   });
 
   const handleLazyEnd = useEvent(() => {
-    onOffsetUpdate(index, constrainedOffsetX, constrainedOffsetY);
+    onOffsetUpdate(index, constrainedOffsetX, constrainedOffsetY, true);
     setConstrainedOffset(0);
   });
 
@@ -114,9 +114,10 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       const onMouseUp = () => {
         if (lazy) {
           handleLazyEnd();
+        } else {
+          onOffsetEnd();
         }
         setStartPos(null);
-        onOffsetEnd();
       };
 
       const handleTouchMove = (e: TouchEvent) => {

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -111,10 +111,11 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
 
   const onInternalResizeUpdate = useEvent((index: number, offset: number, lazyEnd?: boolean) => {
     const nextSizes = onOffsetUpdate(index, offset);
-    onResize?.(nextSizes);
 
     if (lazyEnd) {
       onResizeEnd?.(nextSizes);
+    } else {
+      onResize?.(nextSizes);
     }
   });
 

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -109,9 +109,13 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     onResizeStart?.(itemPxSizes);
   });
 
-  const onInternalResizeUpdate = useEvent((index: number, offset: number) => {
+  const onInternalResizeUpdate = useEvent((index: number, offset: number, lazyEnd?: boolean) => {
     const nextSizes = onOffsetUpdate(index, offset);
     onResize?.(nextSizes);
+
+    if (lazyEnd) {
+      onResizeEnd?.(nextSizes);
+    }
   });
 
   const onInternalResizeEnd = useEvent(() => {
@@ -189,12 +193,12 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
                 startCollapsible={resizableInfo.startCollapsible}
                 endCollapsible={resizableInfo.endCollapsible}
                 onOffsetStart={onInternalResizeStart}
-                onOffsetUpdate={(index, offsetX, offsetY) => {
+                onOffsetUpdate={(index, offsetX, offsetY, lazyEnd) => {
                   let offset = isVertical ? offsetY : offsetX;
                   if (reverse) {
                     offset = -offset;
                   }
-                  onInternalResizeUpdate(index, offset);
+                  onInternalResizeUpdate(index, offset, lazyEnd);
                 }}
                 onOffsetEnd={onInternalResizeEnd}
                 onCollapse={onInternalCollapse}

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -49,6 +49,7 @@ describe('Splitter', () => {
     containerSize = 100;
     errSpy.mockReset();
     resetWarned();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {

--- a/components/splitter/__tests__/lazy.test.tsx
+++ b/components/splitter/__tests__/lazy.test.tsx
@@ -41,6 +41,7 @@ describe('Splitter lazy', () => {
     containerSize = 100;
     errSpy.mockReset();
     resetWarned();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {

--- a/components/splitter/__tests__/lazy.test.tsx
+++ b/components/splitter/__tests__/lazy.test.tsx
@@ -116,12 +116,12 @@ describe('Splitter lazy', () => {
 
     // Right
     mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, 1000);
-    expect(onResize).toHaveBeenCalledWith([70, 30]);
+    expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
 
     // Left
     onResize.mockReset();
     mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, -1000);
-    expect(onResize).toHaveBeenCalledWith([30, 70]);
+    expect(onResizeEnd).toHaveBeenCalledWith([30, 70]);
   });
 
   it('should work with touch events when lazy', async () => {
@@ -152,12 +152,12 @@ describe('Splitter lazy', () => {
 
     // Right
     mockTouchDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, 1000);
-    expect(onResize).toHaveBeenCalledWith([70, 30]);
+    expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
 
     // Left
     onResize.mockReset();
     mockTouchDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, -1000);
-    expect(onResize).toHaveBeenCalledWith([30, 70]);
+    expect(onResizeEnd).toHaveBeenCalledWith([30, 70]);
   });
 
   it('should work with vertical splitter', async () => {
@@ -189,21 +189,21 @@ describe('Splitter lazy', () => {
 
     // Drag Down
     mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, 1000);
-    expect(onResize).toHaveBeenCalledWith([70, 30]);
+    expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
 
     // Drag Up
     onResize.mockReset();
     mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, -1000);
-    expect(onResize).toHaveBeenCalledWith([30, 70]);
+    expect(onResizeEnd).toHaveBeenCalledWith([30, 70]);
 
     // Touch Drag Down
     onResize.mockReset();
     mockTouchDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, 1000);
-    expect(onResize).toHaveBeenCalledWith([70, 30]);
+    expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
 
     // Touch Drag Up
     onResize.mockReset();
     mockTouchDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, -1000);
-    expect(onResize).toHaveBeenCalledWith([30, 70]);
+    expect(onResizeEnd).toHaveBeenCalledWith([30, 70]);
   });
 });

--- a/components/splitter/__tests__/ssr.test.tsx
+++ b/components/splitter/__tests__/ssr.test.tsx
@@ -18,7 +18,7 @@ describe('Splitter.SSR', () => {
   it('px value', () => {
     const str = renderToString(
       <Splitter>
-        <Splitter.Panel key="1" size={23} />
+        <Splitter.Panel key="1" defaultSize={23} />
         <Splitter.Panel key="2" />
       </Splitter>,
     );
@@ -40,7 +40,7 @@ describe('Splitter.SSR', () => {
   it('ptg value', () => {
     const str = renderToString(
       <Splitter>
-        <Splitter.Panel key="1" size="33%" />
+        <Splitter.Panel key="1" defaultSize="33%" />
         <Splitter.Panel key="2" />
       </Splitter>,
     );


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

 - fix https://github.com/ant-design/ant-design/issues/53554

### 💡 Background and Solution

lazy 模式下 onResizeEnd 调用时机不对
onResize 在 lazy 模式下好像也不应该调用 ，lazy 模式下 onResize 和 onResizeEnd 是同时的

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix: Fixed the issue of incorrect onResizeEnd call in lazy mode      |
| 🇨🇳 Chinese |    修复 lazy 模式下 onResizeEnd 回调参数不是最新值    |
