### PR TITLE
The collapsible icon of the Spliter component remain displayed when hover=none device

### DIFF
--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -185,6 +185,10 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
           alignItems: 'center',
           justifyContent: 'center',
 
+          '@media(hover:none)': {
+            opacity: 1,
+          },
+
           // Hover
           '&:hover': {
             background: controlItemBgActive,


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 💄 Component style improvement


### 🔗 Related Issues



### 💡 Background and Solution



### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    The collapsible icon of the Spliter component remain displayed when hover=none device      |
| 🇨🇳 Chinese |    Splitter组件的折叠icon在hover=none设备情况下一直显示      |