### PR TITLE
config: update .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
 
+.team-maintain_pattern: &team-maintain_pattern
+  - "rc-*"
+  - "@rc-component*"
+  - "@ant-design*"
+
 version: 2
 updates:
   - package-ecosystem: npm
@@ -16,19 +21,17 @@ updates:
       team-maintain:
         dependency-type: production
         patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
+          - *team-maintain_pattern
         update-types: [patch]
       dependencies:
         dependency-type: production
         exclude-patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
+          - *team-maintain_pattern
         update-types: [major, minor]
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - *team-maintain_pattern
         update-types: [major]
     ignore:
       - dependency-name: "@ant-design/cssinjs"
@@ -47,9 +50,7 @@ updates:
       team-maintain:
         dependency-type: production
         patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
+          - *team-maintain_pattern
         update-types: [minor]
 
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,17 +10,12 @@ updates:
     schedule:
       interval: daily
     groups:
-      rc-component-patch:
-        dependency-type: production
-        patterns:
-        - "rc-*"
-        - "@rc-component*"
-        update-types: [patch]
       dependencies:
         dependency-type: production
         exclude-patterns:
-        - "rc-*"
-        - "@rc-component*"
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
         update-types: [major, minor]
       dev-dependencies:
         dependency-type: development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,6 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
 
-.team-maintain_pattern: &team-maintain_pattern
-  - "rc-*"
-  - "@rc-component*"
-  - "@ant-design*"
-
 version: 2
 updates:
   - package-ecosystem: npm
@@ -21,17 +16,19 @@ updates:
       team-maintain:
         dependency-type: production
         patterns:
-          - *team-maintain_pattern
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
         update-types: [patch]
       dependencies:
         dependency-type: production
         exclude-patterns:
-          - *team-maintain_pattern
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
         update-types: [major, minor]
       dev-dependencies:
         dependency-type: development
-        exclude-patterns:
-          - *team-maintain_pattern
         update-types: [major]
     ignore:
       - dependency-name: "@ant-design/cssinjs"
@@ -50,7 +47,9 @@ updates:
       team-maintain:
         dependency-type: production
         patterns:
-          - *team-maintain_pattern
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
         update-types: [minor]
 
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,20 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    target-branch: master
     directory: /
     schedule:
       interval: daily
+      time: "05:00"
+      timezone: Asia/Shanghai
     groups:
+      team-maintain:
+        dependency-type: production
+        patterns:
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
+        update-types: [patch]
       dependencies:
         dependency-type: production
         exclude-patterns:
@@ -24,6 +34,24 @@ updates:
       - dependency-name: "@ant-design/cssinjs"
       - dependency-name: dayjs
         versions: [1.x]
+
+# feature branch
+  - package-ecosystem: npm
+    target-branch: feature
+    directory: /
+    schedule:
+      interval: daily
+      time: "13:00"
+      timezone: Asia/Shanghai
+    groups:
+      team-maintain:
+        dependency-type: production
+        patterns:
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
+        update-types: [minor]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Similar https://github.com/ant-design/ant-design/pull/53586

上次在 #53586 更新的是 https://github.com/renovatebot/renovate 机器人的配置，其实不然。我发现基本上都是 https://github.com/apps/dependabot 机器人在工作。renovate 似乎都没启用。

起初我想把之前 https://github.com/ant-design/ant-design/pull/45593 用到的 ncu([npm-check-updates](https://github.com/raineorshine/npm-check-updates)) 都改成 dependabot，因为 dependabot 创建的 PR 会走 CI/CD 流程，这样方便升级后及时通过 ci 发现问题。 （其实 ncu 创建的 PR 也可以设置 token 让其触发 CI，因为安全原因考虑不开启

 dependabot 有一个问题是只能设置 `update-types` 方式为 `major` 、`minor` 以及 `patch`。 并不能像 ncu 设置 `target: () => "semver"` 方式。 导致 rc 有些库用的 `^` 标识的版本无法正常提.  antd 自己的 pkg 范围其实已经手动维护的很到位了。都不太需要严格区分

dependabot 的[ yaml 配置也不支持别名和锚点](https://github.com/dependabot/dependabot-core/issues/1582)，写起来重复的内容一大坨

---

最后结论是 dependabot 和 ncu 相辅相成

1. 通过 `target-branch`  区分目标分支
   1. antd 团队维护的包在 `master` 分支只更新 `patch`,  在 `feature` 分支更新 `minor` 和 `major`
2. 另外调整了一下时间，feature 的更新应该在开发者活跃的时候进行， 小更新则不太需要关注


前面说的 `target-branch` 不确定是否能正常工作，我也通过文档获取的，需要更多的讨论
