### PR TITLE
chore: lock countup.js@2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,13 +356,16 @@
   },
   "pnpm": {
     "overrides": {
+      "countup.js": "2.8.0",
       "nwsapi": "2.2.20"
     }
   },
   "overrides": {
+    "countup.js": "2.8.0",
     "nwsapi": "2.2.20"
   },
   "resolutions": {
+    "countup.js": "2.8.0",
     "nwsapi": "2.2.20"
   }
 }


### PR DESCRIPTION


### 🤔 This is a ...
- [x] ❓ Other (about what?)

### 💡 Background and Solution
先锁一下以解决 ci lint warning，后续观察上游库的相应情况再做其他考虑~
https://github.com/inorganik/countUp.js/pull/341

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           -|
| 🇨🇳 Chinese |      -     |
