### PR TITLE
fix(Tabs): remove active text shadow

### DIFF
--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -143,7 +143,6 @@ export interface TabsToken extends FullToken<'Tabs'> {
   tabsCardPadding: string;
   dropdownEdgeChildVerticalPadding: number;
   tabsNavWrapPseudoWidth: number;
-  tabsActiveTextShadow: string;
   tabsDropdownHeight: number | string;
   tabsDropdownWidth: number | string;
   tabsHorizontalItemMargin: string;
@@ -756,7 +755,6 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
 
       [`&${tabCls}-active ${tabCls}-btn`]: {
         color: itemSelectedColor,
-        textShadow: token.tabsActiveTextShadow,
       },
 
       [`&${tabCls}-focus ${tabCls}-btn`]: {
@@ -1104,7 +1102,6 @@ export default genStyleHooks(
       // `cardPadding` is empty by default, so we could calculate with dynamic `cardHeight`
       tabsCardPadding: token.cardPadding,
       dropdownEdgeChildVerticalPadding: token.paddingXXS,
-      tabsActiveTextShadow: '0 0 0.25px currentcolor',
       tabsDropdownHeight: 200,
       tabsDropdownWidth: 120,
       tabsHorizontalItemMargin: `0 0 0 ${unit(token.horizontalItemGutter)}`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

Tabs 用 text-shadow 实现了一个伪加粗效果（目的是不改变宽度）：
![image](https://github.com/user-attachments/assets/7bf3d5ce-c139-4093-94a1-2d6a11d925a2)

这种实现有几个问题：

1. 与真实的字体加粗相比，这种加粗比较机械，字形不美观
2. 操作系统的字体微调对 text-shadow 不生效，导致在低分辨率屏幕下会模糊或者缺失细节
3. 无法通过控制阴影大小，实现与真实字体加粗相近的粗细，因为这是由字体文件控制的，不一定是等比例的加粗
4. 苹方等字体已经内置了加粗不加宽的解决方案，未来应该是一种趋势，加粗实现应该交还给字体

此 PR 去掉了加粗效果，仅用颜色区分激活态：

![image](https://github.com/user-attachments/assets/2e641618-b0fd-47e3-99bb-e61b8429213e)

市面上不加粗激活 Tab 的例子：

Google 搜索标签页

![image](https://github.com/user-attachments/assets/1ecf53c8-a516-48df-a5de-9adf0895c54f)

讨论过程

![image](https://github.com/user-attachments/assets/3dede88c-eeb9-42fa-872c-8da48259d611)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Tabs): remove active text shadow |
| 🇨🇳 Chinese | fix(Tabs): 移除激活态文字阴影 |
