### PR TITLE
config: Update .github/dependabot.yml again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,12 @@ updates:
         update-types: [major, minor]
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - "rc-*"
+          - "@rc-component*"
+          - "@ant-design*"
         update-types: [major]
     ignore:
-      - dependency-name: "@ant-design/cssinjs"
       - dependency-name: dayjs
         versions: [1.x]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    target-branch: master
     directory: /
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,6 @@ updates:
       time: "05:00"
       timezone: Asia/Shanghai
     groups:
-      team-maintain:
-        dependency-type: production
-        patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
-        update-types: [patch]
       dependencies:
         dependency-type: production
         exclude-patterns:
@@ -34,23 +27,6 @@ updates:
       - dependency-name: "@ant-design/cssinjs"
       - dependency-name: dayjs
         versions: [1.x]
-
-# feature branch
-  - package-ecosystem: npm
-    target-branch: feature
-    directory: /
-    schedule:
-      interval: daily
-      time: "13:00"
-      timezone: Asia/Shanghai
-    groups:
-      team-maintain:
-        dependency-type: production
-        patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
-        update-types: [minor]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,11 @@ updates:
         dependency-type: development
         update-types: [major]
     ignore:
-      - dependency-name: dayjs
-        versions: [1.x]
       - dependency-name: "rc-*"
       - dependency-name: "@rc-component*"
       - dependency-name: "@ant-design*"
-        versions: ["*"]
+      - dependency-name: dayjs
+        versions: [1.x]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,17 @@ updates:
     groups:
       dependencies:
         dependency-type: production
-        exclude-patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
         update-types: [major, minor]
       dev-dependencies:
         dependency-type: development
-        exclude-patterns:
-          - "rc-*"
-          - "@rc-component*"
-          - "@ant-design*"
         update-types: [major]
     ignore:
       - dependency-name: dayjs
         versions: [1.x]
+      - dependency-name: "rc-*"
+      - dependency-name: "@rc-component*"
+      - dependency-name: "@ant-design*"
+        versions: ["*"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
配置文件没配置好，机器人给 PR 制造了太多噪音了😡 

最后的规则应该是：

1. 所有除了 `rc-*` 和 `@rc-component*` 和 `@ant-design*` 的 **生产依赖** 只升级 `major` 和 `minor`
2. 所有除了 `rc-*` 和 `@rc-component*` 和 `@ant-design*` 的 **开发依赖** 只升级 `major`
3. dayjs 忽略 1.x 版本升级 （原有的）
