### PR TITLE
chore: remove unnecessary console warning

### DIFF
--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -306,7 +306,7 @@ const Header: React.FC = () => {
       className={styles.versionSelect}
       defaultValue={pkg.version}
       onChange={handleVersionChange}
-      dropdownStyle={getDropdownStyle}
+      styles={{ popup: getDropdownStyle }}
       popupMatchSelectWidth={false}
       getPopupContainer={(trigger) => trigger.parentNode}
       options={versionOptions}

--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -728,7 +728,7 @@ exports[`renders components/auto-complete/demo/basic.tsx extend context correctl
 
 exports[`renders components/auto-complete/demo/certain-category.tsx extend context correctly 1`] = `
 <div
-  class="ant-select ant-select-lg ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+  class="ant-select ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
   style="width: 250px;"
 >
   <div
@@ -1096,11 +1096,7 @@ exports[`renders components/auto-complete/demo/certain-category.tsx extend conte
 </div>
 `;
 
-exports[`renders components/auto-complete/demo/certain-category.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: AutoComplete] You need to control style self instead of setting \`size\` when using customize input.",
-]
-`;
+exports[`renders components/auto-complete/demo/certain-category.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/auto-complete/demo/custom.tsx extend context correctly 1`] = `
 <div
@@ -2899,7 +2895,7 @@ exports[`renders components/auto-complete/demo/status.tsx extend context correct
 
 exports[`renders components/auto-complete/demo/uncertain-category.tsx extend context correctly 1`] = `
 <div
-  class="ant-select ant-select-lg ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+  class="ant-select ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
   style="width: 300px;"
 >
   <div
@@ -2986,11 +2982,7 @@ exports[`renders components/auto-complete/demo/uncertain-category.tsx extend con
 </div>
 `;
 
-exports[`renders components/auto-complete/demo/uncertain-category.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: AutoComplete] You need to control style self instead of setting \`size\` when using customize input.",
-]
-`;
+exports[`renders components/auto-complete/demo/uncertain-category.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/auto-complete/demo/variant.tsx extend context correctly 1`] = `
 <div

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
@@ -445,7 +445,7 @@ Array [
 
 exports[`renders components/auto-complete/demo/certain-category.tsx correctly 1`] = `
 <div
-  class="ant-select ant-select-lg ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+  class="ant-select ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
   style="width:250px"
 >
   <div
@@ -1669,7 +1669,7 @@ exports[`renders components/auto-complete/demo/status.tsx correctly 1`] = `
 
 exports[`renders components/auto-complete/demo/uncertain-category.tsx correctly 1`] = `
 <div
-  class="ant-select ant-select-lg ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
+  class="ant-select ant-select-outlined ant-select-auto-complete ant-select-single ant-select-customize-input ant-select-show-search"
   style="width:300px"
 >
   <div

--- a/components/auto-complete/demo/certain-category.tsx
+++ b/components/auto-complete/demo/certain-category.tsx
@@ -44,7 +44,6 @@ const App: React.FC = () => (
     popupMatchSelectWidth={500}
     style={{ width: 250 }}
     options={options}
-    size="large"
   >
     <Input.Search size="large" placeholder="input here" />
   </AutoComplete>

--- a/components/auto-complete/demo/uncertain-category.tsx
+++ b/components/auto-complete/demo/uncertain-category.tsx
@@ -53,7 +53,6 @@ const App: React.FC = () => {
       options={options}
       onSelect={onSelect}
       onSearch={handleSearch}
-      size="large"
     >
       <Input.Search size="large" placeholder="input here" enterButton />
     </AutoComplete>

--- a/components/tree-select/demo/component-token.tsx
+++ b/components/tree-select/demo/component-token.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
         showSearch
         style={{ width: '100%' }}
         value={value}
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { maxHeight: 400, overflow: 'auto' } }}
         placeholder="Please select"
         allowClear
         treeDefaultExpandAll


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [x] ❓ Other (about what?)

### 💡 Background and Solution

修复`dropdownStyle`造成的控制台warning
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/1825f334-5619-4d28-b286-fb1cb7e8a805" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   --        |
| 🇨🇳 Chinese |   --        |
