### PR TITLE
feat(Divider): unify orientation attribute usage

### DIFF
--- a/.dumi/theme/builtins/ResourceArticles/index.tsx
+++ b/.dumi/theme/builtins/ResourceArticles/index.tsx
@@ -79,7 +79,7 @@ const ArticleList: React.FC<ArticleListProps> = ({ name, data = [], authors = []
                 <a href={author?.href} target="_blank" rel="noreferrer">
                   <Avatar size="small" src={author?.avatar} />
                 </a>
-                <Divider type="vertical" />
+                <Divider vertical />
                 <a href={article.href} target="_blank" rel="noreferrer">
                   {article?.title}
                 </a>

--- a/components/badge/demo/colorful.tsx
+++ b/components/badge/demo/colorful.tsx
@@ -19,13 +19,13 @@ const colors = [
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Presets</Divider>
+    <Divider titlePlacement="left">Presets</Divider>
     <Space vertical>
       {colors.map((color) => (
         <Badge key={color} color={color} text={color} />
       ))}
     </Space>
-    <Divider orientation="left">Custom</Divider>
+    <Divider titlePlacement="left">Custom</Divider>
     <Space vertical>
       <Badge color="#f50" text="#f50" />
       <Badge color="rgb(45, 183, 245)" text="rgb(45, 183, 245)" />

--- a/components/badge/demo/colorful.tsx
+++ b/components/badge/demo/colorful.tsx
@@ -19,13 +19,13 @@ const colors = [
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Presets</Divider>
+    <Divider titlePlacement="start">Presets</Divider>
     <Space vertical>
       {colors.map((color) => (
         <Badge key={color} color={color} text={color} />
       ))}
     </Space>
-    <Divider titlePlacement="left">Custom</Divider>
+    <Divider titlePlacement="start">Custom</Divider>
     <Space vertical>
       <Badge color="#f50" text="#f50" />
       <Badge color="rgb(45, 183, 245)" text="rgb(45, 183, 245)" />

--- a/components/button/demo/debug-icon.tsx
+++ b/components/button/demo/debug-icon.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
         <Radio.Button value="default">Default</Radio.Button>
         <Radio.Button value="small">Small</Radio.Button>
       </Radio.Group>
-      <Divider orientation="left" plain>
+      <Divider titlePlacement="left" plain>
         Preview
       </Divider>
       <ConfigProvider componentSize={size}>

--- a/components/button/demo/debug-icon.tsx
+++ b/components/button/demo/debug-icon.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
         <Radio.Button value="default">Default</Radio.Button>
         <Radio.Button value="small">Small</Radio.Button>
       </Radio.Group>
-      <Divider titlePlacement="left" plain>
+      <Divider titlePlacement="start" plain>
         Preview
       </Divider>
       <ConfigProvider componentSize={size}>

--- a/components/button/demo/icon-position.tsx
+++ b/components/button/demo/icon-position.tsx
@@ -13,7 +13,7 @@ const App: React.FC = () => {
           <Radio.Button value="end">end</Radio.Button>
         </Radio.Group>
       </Space>
-      <Divider orientation="left" plain>
+      <Divider titlePlacement="left" plain>
         Preview
       </Divider>
       <Flex gap="small" vertical>

--- a/components/button/demo/icon-position.tsx
+++ b/components/button/demo/icon-position.tsx
@@ -13,7 +13,7 @@ const App: React.FC = () => {
           <Radio.Button value="end">end</Radio.Button>
         </Radio.Group>
       </Space>
-      <Divider titlePlacement="left" plain>
+      <Divider titlePlacement="start" plain>
         Preview
       </Divider>
       <Flex gap="small" vertical>

--- a/components/button/demo/size.tsx
+++ b/components/button/demo/size.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => {
         <Radio.Button value="default">Default</Radio.Button>
         <Radio.Button value="small">Small</Radio.Button>
       </Radio.Group>
-      <Divider titlePlacement="left" plain>
+      <Divider titlePlacement="start" plain>
         Preview
       </Divider>
       <Flex gap="small" align="flex-start" vertical>

--- a/components/button/demo/size.tsx
+++ b/components/button/demo/size.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => {
         <Radio.Button value="default">Default</Radio.Button>
         <Radio.Button value="small">Small</Radio.Button>
       </Radio.Group>
-      <Divider orientation="left" plain>
+      <Divider titlePlacement="left" plain>
         Preview
       </Divider>
       <Flex gap="small" align="flex-start" vertical>

--- a/components/collapse/demo/size.tsx
+++ b/components/collapse/demo/size.tsx
@@ -9,16 +9,16 @@ const text = `
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Default Size</Divider>
+    <Divider titlePlacement="left">Default Size</Divider>
     <Collapse
       items={[{ key: '1', label: 'This is default size panel header', children: <p>{text}</p> }]}
     />
-    <Divider orientation="left">Small Size</Divider>
+    <Divider titlePlacement="left">Small Size</Divider>
     <Collapse
       size="small"
       items={[{ key: '1', label: 'This is small size panel header', children: <p>{text}</p> }]}
     />
-    <Divider orientation="left">Large Size</Divider>
+    <Divider titlePlacement="left">Large Size</Divider>
     <Collapse
       size="large"
       items={[{ key: '1', label: 'This is large size panel header', children: <p>{text}</p> }]}

--- a/components/collapse/demo/size.tsx
+++ b/components/collapse/demo/size.tsx
@@ -9,16 +9,16 @@ const text = `
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Default Size</Divider>
+    <Divider titlePlacement="start">Default Size</Divider>
     <Collapse
       items={[{ key: '1', label: 'This is default size panel header', children: <p>{text}</p> }]}
     />
-    <Divider titlePlacement="left">Small Size</Divider>
+    <Divider titlePlacement="start">Small Size</Divider>
     <Collapse
       size="small"
       items={[{ key: '1', label: 'This is small size panel header', children: <p>{text}</p> }]}
     />
-    <Divider titlePlacement="left">Large Size</Divider>
+    <Divider titlePlacement="start">Large Size</Divider>
     <Collapse
       size="large"
       items={[{ key: '1', label: 'This is large size panel header', children: <p>{text}</p> }]}

--- a/components/color-picker/demo/panel-render.tsx
+++ b/components/color-picker/demo/panel-render.tsx
@@ -27,7 +27,7 @@ const HorizontalLayoutDemo = () => {
       <Col span={12}>
         <Presets />
       </Col>
-      <Divider type="vertical" style={{ height: 'auto' }} />
+      <Divider vertical style={{ height: 'auto' }} />
       <Col flex="auto">
         <Picker />
       </Col>

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -163,7 +163,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
     <div className="direction-components">
       <Row>
         <Col span={24}>
-          <Divider titlePlacement="left">Cascader example</Divider>
+          <Divider titlePlacement="start">Cascader example</Divider>
           <Cascader
             suffixIcon={<SearchIcon />}
             options={cascaderOptions}
@@ -185,7 +185,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={12}>
-          <Divider titlePlacement="left">Switch example</Divider>
+          <Divider titlePlacement="start">Switch example</Divider>
           &nbsp;&nbsp;
           <Switch defaultChecked />
           &nbsp;&nbsp;
@@ -194,7 +194,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <Switch size="small" loading />
         </Col>
         <Col span={12}>
-          <Divider titlePlacement="left">Radio Group example</Divider>
+          <Divider titlePlacement="start">Radio Group example</Divider>
           <Radio.Group defaultValue="c" buttonStyle="solid">
             <Radio.Button value="a">تهران</Radio.Button>
             <Radio.Button value="b" disabled>
@@ -208,7 +208,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={12}>
-          <Divider titlePlacement="left">Button example</Divider>
+          <Divider titlePlacement="start">Button example</Divider>
           <div className="button-demo">
             <Button type="primary" icon={<DownloadOutlined />} />
             <Button type="primary" shape="circle" icon={<DownloadOutlined />} />
@@ -239,7 +239,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           </div>
         </Col>
         <Col span={12}>
-          <Divider titlePlacement="left">Tree example</Divider>
+          <Divider titlePlacement="start">Tree example</Divider>
           <Tree
             showLine
             checkable
@@ -262,7 +262,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={24}>
-          <Divider titlePlacement="left">Input (Input Group) example</Divider>
+          <Divider titlePlacement="start">Input (Input Group) example</Divider>
           <InputGroup size="large">
             <Row gutter={8}>
               <Col span={5}>
@@ -297,7 +297,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={12}>
-              <Divider titlePlacement="left">Select example</Divider>
+              <Divider titlePlacement="start">Select example</Divider>
               <Space wrap>
                 <Select mode="multiple" defaultValue="مورچه" style={{ width: 120 }}>
                   <Option value="jack">Jack</Option>
@@ -321,7 +321,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               </Space>
             </Col>
             <Col span={12}>
-              <Divider titlePlacement="left">TreeSelect example</Divider>
+              <Divider titlePlacement="start">TreeSelect example</Divider>
               <TreeSelect
                 showSearch
                 style={{ width: '100%' }}
@@ -349,7 +349,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={24}>
-              <Divider titlePlacement="left">Modal example</Divider>
+              <Divider titlePlacement="start">Modal example</Divider>
               <Button type="primary" onClick={showModal}>
                 Open Modal
               </Button>
@@ -363,7 +363,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={24}>
-              <Divider titlePlacement="left">Steps example</Divider>
+              <Divider titlePlacement="start">Steps example</Divider>
               <Steps
                 progressDot
                 current={currentStep}
@@ -406,7 +406,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={12}>
-              <Divider titlePlacement="left">Rate example</Divider>
+              <Divider titlePlacement="start">Rate example</Divider>
               <Rate defaultValue={2.5} />
               <br />
               <strong>* Note:</strong> Half star not implemented in RTL direction, it will be
@@ -417,7 +417,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               implement rtl support.
             </Col>
             <Col span={12}>
-              <Divider titlePlacement="left">Badge example</Divider>
+              <Divider titlePlacement="start">Badge example</Divider>
               <Badge count={badgeCount}>
                 <a href="#" className="head-example" />
               </Badge>
@@ -443,14 +443,14 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={24}>
-          <Divider titlePlacement="left">Pagination example</Divider>
+          <Divider titlePlacement="start">Pagination example</Divider>
           <Pagination showSizeChanger defaultCurrent={3} total={500} />
         </Col>
       </Row>
       <br />
       <Row>
         <Col span={24}>
-          <Divider titlePlacement="left">Grid System example</Divider>
+          <Divider titlePlacement="start">Grid System example</Divider>
           <div className="grid-demo">
             <div className="code-box-demo">
               <p>

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -163,7 +163,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
     <div className="direction-components">
       <Row>
         <Col span={24}>
-          <Divider orientation="left">Cascader example</Divider>
+          <Divider titlePlacement="left">Cascader example</Divider>
           <Cascader
             suffixIcon={<SearchIcon />}
             options={cascaderOptions}
@@ -185,7 +185,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={12}>
-          <Divider orientation="left">Switch example</Divider>
+          <Divider titlePlacement="left">Switch example</Divider>
           &nbsp;&nbsp;
           <Switch defaultChecked />
           &nbsp;&nbsp;
@@ -194,7 +194,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <Switch size="small" loading />
         </Col>
         <Col span={12}>
-          <Divider orientation="left">Radio Group example</Divider>
+          <Divider titlePlacement="left">Radio Group example</Divider>
           <Radio.Group defaultValue="c" buttonStyle="solid">
             <Radio.Button value="a">تهران</Radio.Button>
             <Radio.Button value="b" disabled>
@@ -208,7 +208,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={12}>
-          <Divider orientation="left">Button example</Divider>
+          <Divider titlePlacement="left">Button example</Divider>
           <div className="button-demo">
             <Button type="primary" icon={<DownloadOutlined />} />
             <Button type="primary" shape="circle" icon={<DownloadOutlined />} />
@@ -239,7 +239,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           </div>
         </Col>
         <Col span={12}>
-          <Divider orientation="left">Tree example</Divider>
+          <Divider titlePlacement="left">Tree example</Divider>
           <Tree
             showLine
             checkable
@@ -262,7 +262,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={24}>
-          <Divider orientation="left">Input (Input Group) example</Divider>
+          <Divider titlePlacement="left">Input (Input Group) example</Divider>
           <InputGroup size="large">
             <Row gutter={8}>
               <Col span={5}>
@@ -297,7 +297,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={12}>
-              <Divider orientation="left">Select example</Divider>
+              <Divider titlePlacement="left">Select example</Divider>
               <Space wrap>
                 <Select mode="multiple" defaultValue="مورچه" style={{ width: 120 }}>
                   <Option value="jack">Jack</Option>
@@ -321,7 +321,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               </Space>
             </Col>
             <Col span={12}>
-              <Divider orientation="left">TreeSelect example</Divider>
+              <Divider titlePlacement="left">TreeSelect example</Divider>
               <TreeSelect
                 showSearch
                 style={{ width: '100%' }}
@@ -349,7 +349,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={24}>
-              <Divider orientation="left">Modal example</Divider>
+              <Divider titlePlacement="left">Modal example</Divider>
               <Button type="primary" onClick={showModal}>
                 Open Modal
               </Button>
@@ -363,7 +363,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={24}>
-              <Divider orientation="left">Steps example</Divider>
+              <Divider titlePlacement="left">Steps example</Divider>
               <Steps
                 progressDot
                 current={currentStep}
@@ -406,7 +406,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <br />
           <Row>
             <Col span={12}>
-              <Divider orientation="left">Rate example</Divider>
+              <Divider titlePlacement="left">Rate example</Divider>
               <Rate defaultValue={2.5} />
               <br />
               <strong>* Note:</strong> Half star not implemented in RTL direction, it will be
@@ -417,7 +417,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               implement rtl support.
             </Col>
             <Col span={12}>
-              <Divider orientation="left">Badge example</Divider>
+              <Divider titlePlacement="left">Badge example</Divider>
               <Badge count={badgeCount}>
                 <a href="#" className="head-example" />
               </Badge>
@@ -443,14 +443,14 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <br />
       <Row>
         <Col span={24}>
-          <Divider orientation="left">Pagination example</Divider>
+          <Divider titlePlacement="left">Pagination example</Divider>
           <Pagination showSizeChanger defaultCurrent={3} total={500} />
         </Col>
       </Row>
       <br />
       <Row>
         <Col span={24}>
-          <Divider orientation="left">Grid System example</Divider>
+          <Divider titlePlacement="left">Grid System example</Divider>
           <div className="grid-demo">
             <div className="code-box-demo">
               <p>

--- a/components/config-provider/demo/locale.tsx
+++ b/components/config-provider/demo/locale.tsx
@@ -188,7 +188,7 @@ const Page: React.FC = () => {
         />
       </Space>
       <Upload listType="picture-card" fileList={fileList} />
-      <Divider titlePlacement="left">Tour</Divider>
+      <Divider titlePlacement="start">Tour</Divider>
       <Button type="primary" onClick={() => setTourOpen(true)}>
         Begin Tour
       </Button>

--- a/components/config-provider/demo/locale.tsx
+++ b/components/config-provider/demo/locale.tsx
@@ -188,7 +188,7 @@ const Page: React.FC = () => {
         />
       </Space>
       <Upload listType="picture-card" fileList={fileList} />
-      <Divider orientation="left">Tour</Divider>
+      <Divider titlePlacement="left">Tour</Divider>
       <Button type="primary" onClick={() => setTourOpen(true)}>
         Begin Tour
       </Button>

--- a/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -73,7 +73,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start: 0;"
     >
-      Left Text with 0 titlePlacementMargin
+      Left Text with 0 orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -93,7 +93,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end: 50px;"
     >
-      Right Text with 50px titlePlacementMargin
+      Right Text with 50px orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -105,7 +105,11 @@ Array [
 ]
 `;
 
-exports[`renders components/divider/demo/component-token.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/divider/demo/component-token.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: Divider] \`orientationMargin\` is deprecated. Please use \`styles.content.margin\` instead.",
+]
+`;
 
 exports[`renders components/divider/demo/customize-style.tsx extend context correctly 1`] = `
 Array [
@@ -463,7 +467,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start: 0;"
     >
-      Left Text with 0 titlePlacementMargin
+      Left Text with 0 orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -483,7 +487,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end: 50px;"
     >
-      Right Text with 50px titlePlacementMargin
+      Right Text with 50px orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -495,4 +499,8 @@ Array [
 ]
 `;
 
-exports[`renders components/divider/demo/with-text.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/divider/demo/with-text.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: Divider] \`orientationMargin\` is deprecated. Please use \`styles.content.margin\` instead.",
+]
+`;

--- a/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -73,7 +73,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start: 0;"
     >
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -93,7 +93,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end: 50px;"
     >
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -463,7 +463,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start: 0;"
     >
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -483,7 +483,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end: 50px;"
     >
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"

--- a/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -63,7 +63,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-no-default-orientation-margin-start"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
     role="separator"
   >
     <div
@@ -71,9 +71,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-start: 0;"
+      style="margin: 0px;"
     >
-      Left Text with 0 orientationMargin
+      Left Text margin with 0
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -83,7 +83,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end ant-divider-no-default-orientation-margin-end"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end"
     role="separator"
   >
     <div
@@ -91,9 +91,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-end: 50px;"
+      style="margin: 0px 50px;"
     >
-      Right Text with 50px orientationMargin
+      Right Text margin with 50px
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -105,11 +105,7 @@ Array [
 ]
 `;
 
-exports[`renders components/divider/demo/component-token.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: Divider] \`orientationMargin\` is deprecated. Please use \`styles.content.margin\` instead.",
-]
-`;
+exports[`renders components/divider/demo/component-token.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/divider/demo/customize-style.tsx extend context correctly 1`] = `
 Array [
@@ -457,7 +453,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-no-default-orientation-margin-start"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
     role="separator"
   >
     <div
@@ -465,9 +461,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-start: 0;"
+      style="margin: 0px;"
     >
-      Left Text with 0 orientationMargin
+      Left Text margin with 0
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -477,7 +473,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end ant-divider-no-default-orientation-margin-end"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end"
     role="separator"
   >
     <div
@@ -485,9 +481,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-end: 50px;"
+      style="margin: 0px 50px;"
     >
-      Right Text with 50px orientationMargin
+      Right Text margin with 50px
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -499,8 +495,4 @@ Array [
 ]
 `;
 
-exports[`renders components/divider/demo/with-text.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: Divider] \`orientationMargin\` is deprecated. Please use \`styles.content.margin\` instead.",
-]
-`;
+exports[`renders components/divider/demo/with-text.tsx extend context correctly 2`] = `[]`;

--- a/components/divider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo.test.ts.snap
@@ -63,7 +63,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-no-default-orientation-margin-start"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
     role="separator"
   >
     <div
@@ -71,9 +71,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-start:0"
+      style="margin:0"
     >
-      Left Text with 0 orientationMargin
+      Left Text margin with 0
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -83,7 +83,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end ant-divider-no-default-orientation-margin-end"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end"
     role="separator"
   >
     <div
@@ -91,9 +91,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-end:50px"
+      style="margin:0 50px"
     >
-      Right Text with 50px orientationMargin
+      Right Text margin with 50px
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -439,7 +439,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-no-default-orientation-margin-start"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
     role="separator"
   >
     <div
@@ -447,9 +447,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-start:0"
+      style="margin:0"
     >
-      Left Text with 0 orientationMargin
+      Left Text margin with 0
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -459,7 +459,7 @@ Array [
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista probare, quae sunt a te dicta? Refert tamen, quo modo.
   </p>,
   <div
-    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end ant-divider-no-default-orientation-margin-end"
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-end"
     role="separator"
   >
     <div
@@ -467,9 +467,9 @@ Array [
     />
     <span
       class="ant-divider-inner-text"
-      style="margin-inline-end:50px"
+      style="margin:0 50px"
     >
-      Right Text with 50px orientationMargin
+      Right Text margin with 50px
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"

--- a/components/divider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo.test.ts.snap
@@ -73,7 +73,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start:0"
     >
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -93,7 +93,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end:50px"
     >
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -449,7 +449,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start:0"
     >
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -469,7 +469,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end:50px"
     >
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"

--- a/components/divider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/divider/__tests__/__snapshots__/demo.test.ts.snap
@@ -73,7 +73,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start:0"
     >
-      Left Text with 0 titlePlacementMargin
+      Left Text with 0 orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -93,7 +93,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end:50px"
     >
-      Right Text with 50px titlePlacementMargin
+      Right Text with 50px orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -449,7 +449,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-start:0"
     >
-      Left Text with 0 titlePlacementMargin
+      Left Text with 0 orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"
@@ -469,7 +469,7 @@ Array [
       class="ant-divider-inner-text"
       style="margin-inline-end:50px"
     >
-      Right Text with 50px titlePlacementMargin
+      Right Text with 50px orientationMargin
     </span>
     <div
       class="ant-divider-rail ant-divider-rail-end"

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -19,7 +19,7 @@ describe('Divider', () => {
     errSpy.mockRestore();
   });
 
-  it('support string orientationMargin', () => {
+  it('support string titlePlacementMargin', () => {
     const { container } = render(
       <Divider titlePlacement="right" titlePlacementMargin="10">
         test test test

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -19,9 +19,9 @@ describe('Divider', () => {
     errSpy.mockRestore();
   });
 
-  it('support string titlePlacementMargin', () => {
+  it('support string orientationMargin', () => {
     const { container } = render(
-      <Divider titlePlacement="end" titlePlacementMargin="10">
+      <Divider titlePlacement="end" orientationMargin="10">
         test test test
       </Divider>,
     );
@@ -77,7 +77,7 @@ describe('Divider', () => {
           vertical?: boolean,
           type?: Orientation,
           titlePlacement?: TitlePlacement,
-          titlePlacementMargin?: number,
+          orientationMargin?: number,
         ],
         expected: string,
       ]
@@ -97,7 +97,7 @@ describe('Divider', () => {
           vertical={params[1]}
           type={params[2]}
           titlePlacement={params[3]}
-          {...(params[4] && { titlePlacementMargin: params[4] })}
+          {...(params[4] && { orientationMargin: params[4] })}
         >
           Bamboo
         </Divider>,

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { ConfigProvider } from 'antd';
 
 import Divider from '..';
+import type { Orientation } from '../../_util/hooks/useOrientation';
 import mountTest from '../../../tests/shared/mountTest';
 import { render } from '../../../tests/utils';
+import type { TitlePlacement } from '../index';
 
 describe('Divider', () => {
   mountTest(Divider);
@@ -19,7 +21,7 @@ describe('Divider', () => {
 
   it('support string orientationMargin', () => {
     const { container } = render(
-      <Divider orientation="right" orientationMargin="10">
+      <Divider titlePlacement="right" titlePlacementMargin="10">
         test test test
       </Divider>,
     );
@@ -66,65 +68,48 @@ describe('Divider', () => {
     expect(container.querySelector<HTMLSpanElement>('.ant-divider-sm')).toBeTruthy();
   });
 
-  describe('orientation attribute', () => {
-    it('orientation=center result: titlePlacement=center ', () => {
-      const { container } = render(<Divider orientation="center">Bamboo</Divider>);
-      expect(
-        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-center'),
-      ).not.toBeNull();
-    });
-
-    it('orientation=vertical  type=horizontal, result orientation=vertical', () => {
-      const { container } = render(<Divider orientation="vertical" type="horizontal" />);
-      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
-    });
-
-    it('type=vertical orientation=undefined, result orientation=vertical', () => {
-      const { container } = render(<Divider type="vertical" />);
-      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
-    });
-
-    it('orientation=center titlePlacement=left, result titlePlacement=left', () => {
+  describe('orientation and placement attribute', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const testCases: Array<
+      [
+        params: [
+          orientation?: Orientation | TitlePlacement,
+          vertical?: boolean,
+          type?: Orientation,
+          titlePlacement?: TitlePlacement,
+          titlePlacementMargin?: number,
+        ],
+        expected: string,
+      ]
+    > = [
+      [['right'], '.ant-divider-with-text-end'],
+      [['vertical', undefined, 'horizontal'], '.ant-divider-vertical'],
+      [[undefined, undefined, 'vertical'], '.ant-divider-vertical'],
+      [['center', undefined, undefined, 'left'], '.ant-divider-with-text-start'],
+      [['horizontal', true, undefined], '.ant-divider-horizontal'],
+      [[undefined, true, 'horizontal'], '.ant-divider-vertical'],
+      [['center', undefined, 'horizontal', 'left', 20], '.ant-divider-with-text-start'],
+    ];
+    it.each(testCases)('with args %j should have %s node', (params, expected) => {
       const { container } = render(
-        <Divider orientation="center" titlePlacement="left">
-          test title
-        </Divider>,
-      );
-      expect(
-        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-start'),
-      ).not.toBeNull();
-    });
-
-    it('vertical=true orientation=horizontal, result orientation=horizontal', () => {
-      const { container } = render(
-        <Divider vertical orientation="horizontal" type="horizontal">
-          test title
-        </Divider>,
-      );
-      expect(container.querySelector<HTMLSpanElement>('.ant-divider-horizontal')).not.toBeNull();
-    });
-
-    it('vertical=true orientation=undefined  type=horizontal, result orientation=vertical', () => {
-      const { container } = render(<Divider vertical type="horizontal" />);
-      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
-    });
-  });
-
-  describe('titlePlacement attribute', () => {
-    it('orientation=center titlePlacement=left, result: titlePlacement=left margin=20px ', () => {
-      const { container } = render(
-        <Divider placementMargin={20} titlePlacement="left" orientation="center">
+        <Divider
+          orientation={params[0] as Orientation}
+          vertical={params[1]}
+          type={params[2]}
+          titlePlacement={params[3]}
+          {...(params[4] && { titlePlacementMargin: params[4] })}
+        >
           Bamboo
         </Divider>,
-      ); //
-      expect(
-        container
-          .querySelector<HTMLSpanElement>('.ant-divider-inner-text')
-          ?.style.getPropertyValue('margin-inline-start'),
-      ).toBe('20px');
-      expect(
-        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-start'),
-      ).not.toBeNull();
+      );
+      expect(container.querySelector<HTMLSpanElement>(expected)).not.toBeNull();
+      if (params[4]) {
+        expect(
+          container
+            .querySelector<HTMLSpanElement>('.ant-divider-inner-text')
+            ?.style.getPropertyValue('margin-inline-start'),
+        ).toBe('20px');
+      }
     });
   });
 });

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -65,4 +65,66 @@ describe('Divider', () => {
     rerender(<Divider type="vertical" size="small" />);
     expect(container.querySelector<HTMLSpanElement>('.ant-divider-sm')).toBeTruthy();
   });
+
+  describe('orientation attribute', () => {
+    it('orientation=center result: titlePlacement=center ', () => {
+      const { container } = render(<Divider orientation="center">Bamboo</Divider>);
+      expect(
+        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-center'),
+      ).not.toBeNull();
+    });
+
+    it('orientation=vertical  type=horizontal, result orientation=vertical', () => {
+      const { container } = render(<Divider orientation="vertical" type="horizontal" />);
+      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
+    });
+
+    it('type=vertical orientation=undefined, result orientation=vertical', () => {
+      const { container } = render(<Divider type="vertical" />);
+      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
+    });
+
+    it('orientation=center titlePlacement=left, result titlePlacement=left', () => {
+      const { container } = render(
+        <Divider orientation="center" titlePlacement="left">
+          test title
+        </Divider>,
+      );
+      expect(
+        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-start'),
+      ).not.toBeNull();
+    });
+
+    it('vertical=true orientation=horizontal, result orientation=horizontal', () => {
+      const { container } = render(
+        <Divider vertical orientation="horizontal" type="horizontal">
+          test title
+        </Divider>,
+      );
+      expect(container.querySelector<HTMLSpanElement>('.ant-divider-horizontal')).not.toBeNull();
+    });
+
+    it('vertical=true orientation=undefined  type=horizontal, result orientation=vertical', () => {
+      const { container } = render(<Divider vertical type="horizontal" />);
+      expect(container.querySelector<HTMLSpanElement>('.ant-divider-vertical')).not.toBeNull();
+    });
+  });
+
+  describe('titlePlacement attribute', () => {
+    it('orientation=center titlePlacement=left, result: titlePlacement=left margin=20px ', () => {
+      const { container } = render(
+        <Divider placementMargin={20} titlePlacement="left" orientation="center">
+          Bamboo
+        </Divider>,
+      ); //
+      expect(
+        container
+          .querySelector<HTMLSpanElement>('.ant-divider-inner-text')
+          ?.style.getPropertyValue('margin-inline-start'),
+      ).toBe('20px');
+      expect(
+        container.querySelector<HTMLSpanElement>('.ant-divider-with-text-start'),
+      ).not.toBeNull();
+    });
+  });
 });

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -21,7 +21,7 @@ describe('Divider', () => {
 
   it('support string titlePlacementMargin', () => {
     const { container } = render(
-      <Divider titlePlacement="right" titlePlacementMargin="10">
+      <Divider titlePlacement="end" titlePlacementMargin="10">
         test test test
       </Divider>,
     );

--- a/components/divider/demo/_semantic.tsx
+++ b/components/divider/demo/_semantic.tsx
@@ -35,23 +35,23 @@ const Block: React.FC<DividerProps> = (props) => {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi
         ista probare, quae sunt a te dicta? Refert tamen, quo modo.
       </p>
-      <Divider orientation="left" variant="dotted" {...props}>
+      <Divider titlePlacement="left" variant="dotted" {...props}>
         Dotted
       </Divider>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi
         ista probare, quae sunt a te dicta? Refert tamen, quo modo.
       </p>
-      <Divider orientation="right" variant="dashed" {...props}>
+      <Divider titlePlacement="right" variant="dashed" {...props}>
         Dashed
       </Divider>
       <>
         These
-        <Divider type="vertical" {...props} />
+        <Divider orientation="vertical" {...props} />
         are
-        <Divider type="vertical" {...props} />
+        <Divider orientation="vertical" {...props} />
         vertical
-        <Divider type="vertical" {...props} />
+        <Divider orientation="vertical" {...props} />
         Dividers
       </>
     </div>

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -28,24 +28,24 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left">Left Text</Divider>
+    <Divider titlePlacement="start">Left Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right">Right Text</Divider>
+    <Divider titlePlacement="end">Right Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left" titlePlacementMargin="0">
+    <Divider titlePlacement="start" titlePlacementMargin="0">
       Left Text with 0 titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right" titlePlacementMargin={50}>
+    <Divider titlePlacement="end" titlePlacementMargin={50}>
       Right Text with 50px titlePlacementMargin
     </Divider>
     <p>

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -38,14 +38,14 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left" placementMargin="0">
+    <Divider titlePlacement="left" titlePlacementMargin="0">
       Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right" placementMargin={50}>
+    <Divider titlePlacement="right" titlePlacementMargin={50}>
       Right Text with 50px orientationMargin
     </Divider>
     <p>

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -38,15 +38,15 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" orientationMargin="0">
-      Left Text with 0 orientationMargin
+    <Divider titlePlacement="start" styles={{ content: { margin: '0' } }}>
+      Left Text margin with 0
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="end" orientationMargin={50}>
-      Right Text with 50px orientationMargin
+    <Divider titlePlacement="end" styles={{ content: { margin: '0 50px' } }}>
+      Right Text margin with 50px
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => (
         Divider: {
           verticalMarginInline: 16,
           textPaddingInline: 16,
-          orientationMargin: 0.2,
+          titlePlacementMargin: 0.2,
         },
       },
     }}
@@ -39,14 +39,14 @@ const App: React.FC = () => (
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
     <Divider titlePlacement="left" titlePlacementMargin="0">
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
     <Divider titlePlacement="right" titlePlacementMargin={50}>
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -28,24 +28,24 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="left">Left Text</Divider>
+    <Divider titlePlacement="left">Left Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="right">Right Text</Divider>
+    <Divider titlePlacement="right">Right Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="left" orientationMargin="0">
+    <Divider titlePlacement="left" placementMargin="0">
       Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="right" orientationMargin={50}>
+    <Divider titlePlacement="right" placementMargin={50}>
       Right Text with 50px orientationMargin
     </Divider>
     <p>

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" styles={{ content: { margin: '0' } }}>
+    <Divider titlePlacement="start" styles={{ content: { margin: 0 } }}>
       Left Text margin with 0
     </Divider>
     <p>

--- a/components/divider/demo/component-token.tsx
+++ b/components/divider/demo/component-token.tsx
@@ -14,7 +14,7 @@ const App: React.FC = () => (
         Divider: {
           verticalMarginInline: 16,
           textPaddingInline: 16,
-          titlePlacementMargin: 0.2,
+          orientationMargin: 0.2,
         },
       },
     }}
@@ -38,15 +38,15 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" titlePlacementMargin="0">
-      Left Text with 0 titlePlacementMargin
+    <Divider titlePlacement="start" orientationMargin="0">
+      Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="end" titlePlacementMargin={50}>
-      Right Text with 50px titlePlacementMargin
+    <Divider titlePlacement="end" orientationMargin={50}>
+      Right Text with 50px orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/demo/customize-style.tsx
+++ b/components/divider/demo/customize-style.tsx
@@ -8,11 +8,11 @@ const App: React.FC = () => (
     <Divider style={{ borderColor: '#7cb305' }} dashed>
       Text
     </Divider>
-    <Divider type="vertical" style={{ height: 60, borderColor: '#7cb305' }} />
-    <Divider type="vertical" style={{ height: 60, borderColor: '#7cb305' }} dashed />
+    <Divider vertical style={{ height: 60, borderColor: '#7cb305' }} />
+    <Divider vertical style={{ height: 60, borderColor: '#7cb305' }} dashed />
 
     <div style={{ display: 'flex', flexDirection: 'column', height: 50, boxShadow: '0 0 1px red' }}>
-      <Divider style={{ background: 'rgba(0,255,0,0.05)' }} orientation="left">
+      <Divider style={{ background: 'rgba(0,255,0,0.05)' }} titlePlacement="left">
         Text
       </Divider>
     </div>

--- a/components/divider/demo/customize-style.tsx
+++ b/components/divider/demo/customize-style.tsx
@@ -12,7 +12,7 @@ const App: React.FC = () => (
     <Divider vertical style={{ height: 60, borderColor: '#7cb305' }} dashed />
 
     <div style={{ display: 'flex', flexDirection: 'column', height: 50, boxShadow: '0 0 1px red' }}>
-      <Divider style={{ background: 'rgba(0,255,0,0.05)' }} titlePlacement="left">
+      <Divider style={{ background: 'rgba(0,255,0,0.05)' }} titlePlacement="start">
         Text
       </Divider>
     </div>

--- a/components/divider/demo/plain.tsx
+++ b/components/divider/demo/plain.tsx
@@ -7,19 +7,21 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider plain>Text</Divider>
+    <Divider plain orientation="center">
+      Text
+    </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="left" plain>
+    <Divider titlePlacement="left" plain>
       Left Text
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="right" plain>
+    <Divider titlePlacement="right" plain>
       Right Text
     </Divider>
     <p>

--- a/components/divider/demo/plain.tsx
+++ b/components/divider/demo/plain.tsx
@@ -7,9 +7,7 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider plain orientation="center">
-      Text
-    </Divider>
+    <Divider plain>Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.

--- a/components/divider/demo/plain.tsx
+++ b/components/divider/demo/plain.tsx
@@ -12,14 +12,14 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left" plain>
+    <Divider titlePlacement="start" plain>
       Left Text
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right" plain>
+    <Divider titlePlacement="end" plain>
       Right Text
     </Divider>
     <p>

--- a/components/divider/demo/vertical.md
+++ b/components/divider/demo/vertical.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-使用 `type="vertical"` 设置为行内的垂直分割线。
+使用 `orientation="vertical"` 或者 `vertical=true` 设置为行内的垂直分割线。
 
 ## en-US
 
-Use `type="vertical"` to make the divider vertical.
+Use `orientation="vertical"` or `vertical=true` to make the divider vertical.

--- a/components/divider/demo/vertical.md
+++ b/components/divider/demo/vertical.md
@@ -1,6 +1,6 @@
 ## zh-CN
 
-使用 `orientation="vertical"` 或者 `vertical=true` 设置为行内的垂直分割线。
+使用 `orientation="vertical"` 或者 `vertical` 设置为行内的垂直分割线。
 
 ## en-US
 

--- a/components/divider/demo/vertical.md
+++ b/components/divider/demo/vertical.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Use `orientation="vertical"` or `vertical=true` to make the divider vertical.
+Use `orientation="vertical"` or `vertical` to make the divider vertical.

--- a/components/divider/demo/vertical.tsx
+++ b/components/divider/demo/vertical.tsx
@@ -4,9 +4,9 @@ import { Divider } from 'antd';
 const App: React.FC = () => (
   <>
     Text
-    <Divider type="vertical" />
+    <Divider orientation="vertical" />
     <a href="#">Link</a>
-    <Divider type="vertical" />
+    <Divider vertical />
     <a href="#">Link</a>
   </>
 );

--- a/components/divider/demo/with-text.md
+++ b/components/divider/demo/with-text.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-分割线中带有文字，可以用 `orientation` 指定文字位置。
+分割线中带有文字，可以用 `titlePlacement` 指定文字位置。
 
 ## en-US
 
-Divider with inner title, set `orientation="left/right"` to align it.
+Divider with inner title, set `titlePlacement="left/right"` to align it.

--- a/components/divider/demo/with-text.md
+++ b/components/divider/demo/with-text.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Divider with inner title, set `titlePlacement` to align it.
+Divider with inner title, set `titlePlacement="start/end"` to align it.

--- a/components/divider/demo/with-text.md
+++ b/components/divider/demo/with-text.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Divider with inner title, set `titlePlacement="left/right"` to align it.
+Divider with inner title, set `titlePlacement` to align it.

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" styles={{ content: { margin: '0' } }}>
+    <Divider titlePlacement="start" styles={{ content: { margin: 0 } }}>
       Left Text margin with 0
     </Divider>
     <p>

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -22,15 +22,15 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" titlePlacementMargin="0">
-      Left Text with 0 titlePlacementMargin
+    <Divider titlePlacement="start" orientationMargin="0">
+      Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="end" titlePlacementMargin={50}>
-      Right Text with 50px titlePlacementMargin
+    <Divider titlePlacement="end" orientationMargin={50}>
+      Right Text with 50px orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -12,24 +12,24 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left">Left Text</Divider>
+    <Divider titlePlacement="start">Left Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right">Right Text</Divider>
+    <Divider titlePlacement="end">Right Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left" titlePlacementMargin="0">
+    <Divider titlePlacement="start" titlePlacementMargin="0">
       Left Text with 0 titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right" titlePlacementMargin={50}>
+    <Divider titlePlacement="end" titlePlacementMargin={50}>
       Right Text with 50px titlePlacementMargin
     </Divider>
     <p>

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -22,14 +22,14 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="left" placementMargin="0">
+    <Divider titlePlacement="left" titlePlacementMargin="0">
       Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="right" placementMargin={50}>
+    <Divider titlePlacement="right" titlePlacementMargin={50}>
       Right Text with 50px orientationMargin
     </Divider>
     <p>

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -12,24 +12,24 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="left">Left Text</Divider>
+    <Divider titlePlacement="left">Left Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="right">Right Text</Divider>
+    <Divider titlePlacement="right">Right Text</Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="left" orientationMargin="0">
+    <Divider titlePlacement="left" placementMargin="0">
       Left Text with 0 orientationMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider orientation="right" orientationMargin={50}>
+    <Divider titlePlacement="right" placementMargin={50}>
       Right Text with 50px orientationMargin
     </Divider>
     <p>

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -23,14 +23,14 @@ const App: React.FC = () => (
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
     <Divider titlePlacement="left" titlePlacementMargin="0">
-      Left Text with 0 orientationMargin
+      Left Text with 0 titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
     <Divider titlePlacement="right" titlePlacementMargin={50}>
-      Right Text with 50px orientationMargin
+      Right Text with 50px titlePlacementMargin
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/demo/with-text.tsx
+++ b/components/divider/demo/with-text.tsx
@@ -22,15 +22,15 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="start" orientationMargin="0">
-      Left Text with 0 orientationMargin
+    <Divider titlePlacement="start" styles={{ content: { margin: '0' } }}>
+      Left Text margin with 0
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider titlePlacement="end" orientationMargin={50}>
-      Right Text with 50px orientationMargin
+    <Divider titlePlacement="end" styles={{ content: { margin: '0 50px' } }}>
+      Right Text margin with 50px
     </Divider>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -43,7 +43,6 @@ Common props ref：[Common props](/docs/react/common-props)
 | style | The style object of container | CSSProperties | - |  |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `middle` \| `large` | - | 5.25.0 |
 | titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| titlePlacementMargin | The margin-left/right between the title and its closest border, while the `titlePlacement` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
 | ~~type~~ | The direction type of divider | `horizontal` \| `vertical` | `horizontal` |  |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | vertical | Orientation, Simultaneously configure with `orientation` and prioritize `orientation` | boolean | false | - |

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -42,8 +42,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `middle` \| `large` | - | 5.25.0 |
-| titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| ~~type~~ | The direction type of divider | `horizontal` \| `vertical` | `horizontal` |  |
+| titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | - |
+| ~~type~~ | The direction type of divider | `horizontal` \| `vertical` | `horizontal` | - |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | vertical | Orientation, Simultaneously configure with `orientation` and prioritize `orientation` | boolean | false | - |
 

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -37,14 +37,16 @@ Common props ref：[Common props](/docs/react/common-props)
 | children | The wrapped title | ReactNode | - |  |
 | className | The className of container | string | - |  |
 | dashed | Whether line is dashed | boolean | false |  |
-| variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | - |
-| placementMargin | The margin-left/right between the title and its closest border, while the `orientation` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
+| ~~orientationMargin~~ | The margin-left/right between the title and its closest border, while the `titlePlacement` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `middle` \| `large` | - | 5.25.0 |
 | titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| vertical | Orientation, Simultaneously configure with orientation and prioritize orientation | boolean | false | 6.x |
+| titlePlacementMargin | The margin-left/right between the title and its closest border, while the `titlePlacement` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
+| ~~type~~ | The direction type of divider | `horizontal` \| `vertical` | `horizontal` |  |
+| variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
+| vertical | Orientation, Simultaneously configure with `orientation` and prioritize `orientation` | boolean | false | - |
 
 ## Semantic DOM
 

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -38,12 +38,13 @@ Common props ref：[Common props](/docs/react/common-props)
 | className | The className of container | string | - |  |
 | dashed | Whether line is dashed | boolean | false |  |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
-| orientation | The position of title inside divider | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| orientationMargin | The margin-left/right between the title and its closest border, while the `orientation` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
+| orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | 6.x |
+| placementMargin | The margin-left/right between the title and its closest border, while the `orientation` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `middle` \| `large` | - | 5.25.0 |
-| type | The direction type of divider | `horizontal` \| `vertical` | `horizontal` |  |
+| titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
+| vertical | Orientation, Simultaneously configure with orientation and prioritize orientation | boolean | false | 6.x |
 
 ## Semantic DOM
 

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -38,7 +38,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | className | The className of container | string | - |  |
 | dashed | Whether line is dashed | boolean | false |  |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
-| orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | 6.x |
+| orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | - |
 | placementMargin | The margin-left/right between the title and its closest border, while the `orientation` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cls from 'classnames';
 
 import useMergeSemantic from '../_util/hooks/useMergeSemantic';
-import  useOrientation  from '../_util/hooks/useOrientation';
+import useOrientation from '../_util/hooks/useOrientation';
 import type { Orientation } from '../_util/hooks/useOrientation';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
@@ -12,7 +12,7 @@ import useStyle from './style';
 
 type SemanticName = 'root' | 'rail' | 'content';
 
-type TitlePlacement =
+export type TitlePlacement =
   | 'left'
   | 'right'
   | 'center'
@@ -112,9 +112,7 @@ const Divider: React.FC<DividerProps> = (props) => {
 
   const hasMarginEnd = mergedTitlePlacement === 'end' && mergedPlacementMargin != null;
 
-  const [mergedOrientation,mergedVertical] = useOrientation(orientation, vertical ,
-    type,
-  );
+  const [mergedOrientation, mergedVertical] = useOrientation(orientation, vertical, type);
 
   const classString = cls(
     prefixCls,
@@ -181,7 +179,7 @@ const Divider: React.FC<DividerProps> = (props) => {
       {...restProps}
       role="separator"
     >
-      {children && !mergedVertical&&(
+      {children && !mergedVertical && (
         <>
           <div
             className={cls(railCls, `${railCls}-start`, mergedClassNames.rail)}

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -26,9 +26,8 @@ export interface DividerProps {
   orientation?: Orientation;
   vertical?: boolean;
   titlePlacement?: TitlePlacement;
-  /** @deprecated please use `titlePlacementMargin` */
+  /** @deprecated */
   orientationMargin?: string | number;
-  titlePlacementMargin?: string | number;
   className?: string;
   rootClassName?: string;
   children?: React.ReactNode;
@@ -63,7 +62,6 @@ const Divider: React.FC<DividerProps> = (props) => {
     vertical,
     titlePlacement,
     orientationMargin,
-    titlePlacementMargin,
     className,
     rootClassName,
     children,
@@ -104,13 +102,9 @@ const Divider: React.FC<DividerProps> = (props) => {
     return placement;
   }, [direction, orientation]);
 
-  const mergedPlacementMargin = React.useMemo(
-    () => titlePlacementMargin ?? orientationMargin,
-    [titlePlacementMargin, orientationMargin],
-  );
-  const hasMarginStart = mergedTitlePlacement === 'start' && mergedPlacementMargin != null;
+  const hasMarginStart = mergedTitlePlacement === 'start' && orientationMargin != null;
 
-  const hasMarginEnd = mergedTitlePlacement === 'end' && mergedPlacementMargin != null;
+  const hasMarginEnd = mergedTitlePlacement === 'end' && orientationMargin != null;
 
   const [mergedOrientation, mergedVertical] = useOrientation(orientation, vertical, type);
 
@@ -139,14 +133,14 @@ const Divider: React.FC<DividerProps> = (props) => {
   );
 
   const memoizedPlacementMargin = React.useMemo<string | number>(() => {
-    if (typeof mergedPlacementMargin === 'number') {
-      return mergedPlacementMargin;
+    if (typeof orientationMargin === 'number') {
+      return orientationMargin;
     }
-    if (/^\d+$/.test(mergedPlacementMargin!)) {
-      return Number(mergedPlacementMargin);
+    if (/^\d+$/.test(orientationMargin!)) {
+      return Number(orientationMargin);
     }
-    return mergedPlacementMargin!;
-  }, [mergedPlacementMargin]);
+    return orientationMargin!;
+  }, [orientationMargin]);
 
   const innerStyle: React.CSSProperties = {
     marginInlineStart: hasMarginStart ? memoizedPlacementMargin : undefined,
@@ -164,7 +158,7 @@ const Divider: React.FC<DividerProps> = (props) => {
       '"orientation" is used for direction, please use titlePlacement replace this',
     );
     warning.deprecated(!type, 'type', 'orientation');
-    warning.deprecated(!orientationMargin, 'orientationMargin', 'titlePlacementMargin');
+    warning.deprecated(!orientationMargin, 'orientationMargin', 'styles.content.margin');
   }
 
   return (

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -155,7 +155,7 @@ const Divider: React.FC<DividerProps> = (props) => {
     warning(
       !validTitlePlacement,
       'usage',
-      '"orientation" is used for direction, please use titlePlacement replace this',
+      '`orientation` is used for direction, please use `titlePlacement` replace this',
     );
     [
       ['type', 'orientation'],

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -187,7 +187,7 @@ const Divider: React.FC<DividerProps> = (props) => {
           />
           <span
             className={cls(`${prefixCls}-inner-text`, mergedClassNames.content)}
-            style={innerStyle}
+            style={{ ...innerStyle, ...mergedStyles.content }}
           >
             {children}
           </span>

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -26,7 +26,7 @@ export interface DividerProps {
   orientation?: Orientation;
   vertical?: boolean;
   titlePlacement?: TitlePlacement;
-  /** @deprecated */
+  /** @deprecated please use `styles.content.margin` */
   orientationMargin?: string | number;
   className?: string;
   rootClassName?: string;

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -157,8 +157,12 @@ const Divider: React.FC<DividerProps> = (props) => {
       'usage',
       '"orientation" is used for direction, please use titlePlacement replace this',
     );
-    warning.deprecated(!type, 'type', 'orientation');
-    warning.deprecated(!orientationMargin, 'orientationMargin', 'styles.content.margin');
+    [
+      ['type', 'orientation'],
+      ['orientationMargin', 'styles.content.margin'],
+    ].forEach(([deprecatedName, newName]) => {
+      warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
+    });
   }
 
   return (

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -2,27 +2,38 @@ import * as React from 'react';
 import cls from 'classnames';
 
 import useMergeSemantic from '../_util/hooks/useMergeSemantic';
+import  useOrientation  from '../_util/hooks/useOrientation';
+import type { Orientation } from '../_util/hooks/useOrientation';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
-import useSize from '../config-provider/hooks/useSize';
-import { SizeType } from '../config-provider/SizeContext';
 import useStyle from './style';
 
 type SemanticName = 'root' | 'rail' | 'content';
 
+type TitlePlacement =
+  | 'left'
+  | 'right'
+  | 'center'
+  | 'start' // 👈 5.24.0+
+  | 'end'; // 👈 5.24.0+
+const titlePlacementList = ['left', 'right', 'center', 'start', 'end'];
 export interface DividerProps {
   prefixCls?: string;
-  type?: 'horizontal' | 'vertical';
   /**
-   * @default center
+   * @deprecated please use orientation
+   * @default horizontal
    */
-  orientation?:
-    | 'left'
-    | 'right'
-    | 'center'
-    | 'start' // 👈 5.24.0+
-    | 'end'; // 👈 5.24.0+
+  type?: Orientation;
+  /**
+   * @default horizontal
+   * @since 6.x
+   */
+  orientation?: Orientation | TitlePlacement;
+  vertical?: boolean;
+  titlePlacement?: TitlePlacement;
+  /** @deprecated please use placementMargin */
   orientationMargin?: string | number;
+  placementMargin?: string | number;
   className?: string;
   rootClassName?: string;
   children?: React.ReactNode;
@@ -33,13 +44,10 @@ export interface DividerProps {
    */
   variant?: 'dashed' | 'dotted' | 'solid';
   style?: React.CSSProperties;
-  size?: SizeType;
   plain?: boolean;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
-
-const sizeClassNameMap: Record<string, string> = { small: 'sm', middle: 'md' };
 
 const Divider: React.FC<DividerProps> = (props) => {
   const {
@@ -54,8 +62,11 @@ const Divider: React.FC<DividerProps> = (props) => {
   const {
     prefixCls: customizePrefixCls,
     type = 'horizontal',
-    orientation = 'center',
+    orientation,
+    vertical,
+    titlePlacement,
     orientationMargin,
+    placementMargin,
     className,
     rootClassName,
     children,
@@ -68,6 +79,7 @@ const Divider: React.FC<DividerProps> = (props) => {
     styles,
     ...restProps
   } = props;
+  const warning = devUseWarning('Divider');
   const prefixCls = getPrefixCls('divider', customizePrefixCls);
   const railCls = `${prefixCls}-rail`;
   const [mergedClassNames, mergedStyles] = useMergeSemantic(
@@ -77,34 +89,47 @@ const Divider: React.FC<DividerProps> = (props) => {
 
   const [hashId, cssVarCls] = useStyle(prefixCls);
 
-  const sizeFullName = useSize(customSize);
-  const sizeCls = sizeClassNameMap[sizeFullName];
-
   const hasChildren = !!children;
 
-  const mergedOrientation = React.useMemo<'start' | 'end' | 'center'>(() => {
-    if (orientation === 'left') {
+  const mergedTitlePlacement = React.useMemo<'start' | 'end' | 'center'>(() => {
+    const haveTitlePlacement = titlePlacementList.includes(orientation || '');
+    warning(
+      haveTitlePlacement,
+      'deprecated',
+      '"orientation" is used for direction, please use titlePlacement replace this',
+    );
+    const placement =
+      titlePlacement ?? (haveTitlePlacement ? (orientation as TitlePlacement) : 'center');
+    if (placement === 'left') {
       return direction === 'rtl' ? 'end' : 'start';
     }
-    if (orientation === 'right') {
+    if (placement === 'right') {
       return direction === 'rtl' ? 'start' : 'end';
     }
-    return orientation;
+    return placement;
   }, [direction, orientation]);
 
-  const hasMarginStart = mergedOrientation === 'start' && orientationMargin != null;
+  const mergedPlacementMargin = React.useMemo(
+    () => placementMargin ?? orientationMargin,
+    [placementMargin, orientationMargin],
+  );
+  const hasMarginStart = mergedTitlePlacement === 'start' && mergedPlacementMargin != null;
 
-  const hasMarginEnd = mergedOrientation === 'end' && orientationMargin != null;
+  const hasMarginEnd = mergedTitlePlacement === 'end' && mergedPlacementMargin != null;
+
+  const [mergedOrientation,mergedVertical] = useOrientation(orientation, vertical ,
+    type,
+  );
 
   const classString = cls(
     prefixCls,
     dividerClassName,
     hashId,
     cssVarCls,
-    `${prefixCls}-${type}`,
+    `${prefixCls}-${mergedOrientation}`,
     {
       [`${prefixCls}-with-text`]: hasChildren,
-      [`${prefixCls}-with-text-${mergedOrientation}`]: hasChildren,
+      [`${prefixCls}-with-text-${mergedTitlePlacement}`]: hasChildren,
       [`${prefixCls}-dashed`]: !!dashed,
       [`${prefixCls}-${variant}`]: variant !== 'solid',
       [`${prefixCls}-plain`]: !!plain,
@@ -120,28 +145,25 @@ const Divider: React.FC<DividerProps> = (props) => {
     mergedClassNames.root,
   );
 
-  const memoizedOrientationMargin = React.useMemo<string | number>(() => {
-    if (typeof orientationMargin === 'number') {
-      return orientationMargin;
+  const memoizedPlacementMargin = React.useMemo<string | number>(() => {
+    if (typeof mergedPlacementMargin === 'number') {
+      return mergedPlacementMargin;
     }
-    if (/^\d+$/.test(orientationMargin!)) {
-      return Number(orientationMargin);
+    if (/^\d+$/.test(mergedPlacementMargin!)) {
+      return Number(mergedPlacementMargin);
     }
-    return orientationMargin!;
-  }, [orientationMargin]);
+    return mergedPlacementMargin!;
+  }, [mergedPlacementMargin]);
 
   const innerStyle: React.CSSProperties = {
-    marginInlineStart: hasMarginStart ? memoizedOrientationMargin : undefined,
-    marginInlineEnd: hasMarginEnd ? memoizedOrientationMargin : undefined,
-    ...mergedStyles.content,
+    marginInlineStart: hasMarginStart ? memoizedPlacementMargin : undefined,
+    marginInlineEnd: hasMarginEnd ? memoizedPlacementMargin : undefined,
   };
 
   // Warning children not work in vertical mode
   if (process.env.NODE_ENV !== 'production') {
-    const warning = devUseWarning('Divider');
-
     warning(
-      !children || type !== 'vertical',
+      !children || !mergedVertical,
       'usage',
       '`children` not working in `vertical` mode.',
     );
@@ -159,7 +181,7 @@ const Divider: React.FC<DividerProps> = (props) => {
       {...restProps}
       role="separator"
     >
-      {children && type !== 'vertical' && (
+      {children && !mergedVertical&&(
         <>
           <div
             className={cls(railCls, `${railCls}-start`, mergedClassNames.rail)}

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -6,6 +6,8 @@ import  useOrientation  from '../_util/hooks/useOrientation';
 import type { Orientation } from '../_util/hooks/useOrientation';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
+import useSize from '../config-provider/hooks/useSize';
+import { SizeType } from '../config-provider/SizeContext';
 import useStyle from './style';
 
 type SemanticName = 'root' | 'rail' | 'content';
@@ -44,11 +46,13 @@ export interface DividerProps {
    */
   variant?: 'dashed' | 'dotted' | 'solid';
   style?: React.CSSProperties;
+  size?: SizeType;
   plain?: boolean;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
+const sizeClassNameMap: Record<string, string> = { small: 'sm', middle: 'md' };
 const Divider: React.FC<DividerProps> = (props) => {
   const {
     getPrefixCls,
@@ -88,6 +92,9 @@ const Divider: React.FC<DividerProps> = (props) => {
   );
 
   const [hashId, cssVarCls] = useStyle(prefixCls);
+
+  const sizeFullName = useSize(customSize);
+  const sizeCls = sizeClassNameMap[sizeFullName];
 
   const hasChildren = !!children;
 

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -21,21 +21,14 @@ type TitlePlacement =
 const titlePlacementList = ['left', 'right', 'center', 'start', 'end'];
 export interface DividerProps {
   prefixCls?: string;
-  /**
-   * @deprecated please use orientation
-   * @default horizontal
-   */
+  /**  @deprecated please use `orientation`*/
   type?: Orientation;
-  /**
-   * @default horizontal
-   * @since 6.x
-   */
-  orientation?: Orientation | TitlePlacement;
+  orientation?: Orientation;
   vertical?: boolean;
   titlePlacement?: TitlePlacement;
-  /** @deprecated please use placementMargin */
+  /** @deprecated please use `titlePlacementMargin` */
   orientationMargin?: string | number;
-  placementMargin?: string | number;
+  titlePlacementMargin?: string | number;
   className?: string;
   rootClassName?: string;
   children?: React.ReactNode;
@@ -65,12 +58,12 @@ const Divider: React.FC<DividerProps> = (props) => {
 
   const {
     prefixCls: customizePrefixCls,
-    type = 'horizontal',
+    type,
     orientation,
     vertical,
     titlePlacement,
     orientationMargin,
-    placementMargin,
+    titlePlacementMargin,
     className,
     rootClassName,
     children,
@@ -83,7 +76,7 @@ const Divider: React.FC<DividerProps> = (props) => {
     styles,
     ...restProps
   } = props;
-  const warning = devUseWarning('Divider');
+
   const prefixCls = getPrefixCls('divider', customizePrefixCls);
   const railCls = `${prefixCls}-rail`;
   const [mergedClassNames, mergedStyles] = useMergeSemantic(
@@ -98,15 +91,10 @@ const Divider: React.FC<DividerProps> = (props) => {
 
   const hasChildren = !!children;
 
+  const validTitlePlacement = titlePlacementList.includes(orientation || '');
   const mergedTitlePlacement = React.useMemo<'start' | 'end' | 'center'>(() => {
-    const haveTitlePlacement = titlePlacementList.includes(orientation || '');
-    warning(
-      !haveTitlePlacement,
-      'deprecated',
-      '"orientation" is used for direction, please use titlePlacement replace this',
-    );
     const placement =
-      titlePlacement ?? (haveTitlePlacement ? (orientation as TitlePlacement) : 'center');
+      titlePlacement ?? (validTitlePlacement ? (orientation as TitlePlacement) : 'center');
     if (placement === 'left') {
       return direction === 'rtl' ? 'end' : 'start';
     }
@@ -117,8 +105,8 @@ const Divider: React.FC<DividerProps> = (props) => {
   }, [direction, orientation]);
 
   const mergedPlacementMargin = React.useMemo(
-    () => placementMargin ?? orientationMargin,
-    [placementMargin, orientationMargin],
+    () => titlePlacementMargin ?? orientationMargin,
+    [titlePlacementMargin, orientationMargin],
   );
   const hasMarginStart = mergedTitlePlacement === 'start' && mergedPlacementMargin != null;
 
@@ -167,13 +155,18 @@ const Divider: React.FC<DividerProps> = (props) => {
     marginInlineEnd: hasMarginEnd ? memoizedPlacementMargin : undefined,
   };
 
-  // Warning children not work in vertical mode
+  // =================== Warning =====================
   if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning('Divider');
+
+    warning(!children || !mergedVertical, 'usage', '`children` not working in `vertical` mode.');
     warning(
-      !children || !mergedVertical,
+      !validTitlePlacement,
       'usage',
-      '`children` not working in `vertical` mode.',
+      '"orientation" is used for direction, please use titlePlacement replace this',
     );
+    warning.deprecated(!type, 'type', 'orientation');
+    warning.deprecated(!orientationMargin, 'orientationMargin', 'titlePlacementMargin');
   }
 
   return (

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -101,7 +101,7 @@ const Divider: React.FC<DividerProps> = (props) => {
   const mergedTitlePlacement = React.useMemo<'start' | 'end' | 'center'>(() => {
     const haveTitlePlacement = titlePlacementList.includes(orientation || '');
     warning(
-      haveTitlePlacement,
+      !haveTitlePlacement,
       'deprecated',
       '"orientation" is used for direction, please use titlePlacement replace this',
     );

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -39,7 +39,7 @@ group:
 | className | 分割线样式类 | string | - |  |
 | dashed | 是否虚线 | boolean | false |  |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
-| orientation | 水平或垂直类型 | `horizontal` \| `vertical` | `horizontal` | 6.x |
+| orientation | 水平或垂直类型 | `horizontal` \| `vertical` | `horizontal` | - |
 | placementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -39,14 +39,14 @@ group:
 | className | 分割线样式类 | string | - |  |
 | dashed | 是否虚线 | boolean | false |  |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
-| orientation | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` | 6.x |
+| orientation | 水平或垂直类型 | `horizontal` \| `vertical` | `horizontal` | 6.x |
 | placementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
 | titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
 | type | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
-| vertical | 是否垂直，和orientation同时配置以orientation优先 | boolean | false | 6.x |
+| vertical | 是否垂直，和 orientation 同时配置以 orientation 优先 | boolean | false | 6.x |
 
 ## Semantic DOM
 

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -39,12 +39,14 @@ group:
 | className | 分割线样式类 | string | - |  |
 | dashed | 是否虚线 | boolean | false |  |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
-| orientation | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| orientationMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 不能为 `center`。如果传入 `string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
+| orientation | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` | 6.x |
+| placementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
+| titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
 | type | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
+| vertical | 是否垂直，和orientation同时配置以orientation优先 | boolean | false | 6.x |
 
 ## Semantic DOM
 

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -38,15 +38,16 @@ group:
 | children | 嵌套的标题 | ReactNode | - |  |
 | className | 分割线样式类 | string | - |  |
 | dashed | 是否虚线 | boolean | false |  |
-| variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | orientation | 水平或垂直类型 | `horizontal` \| `vertical` | `horizontal` | - |
-| placementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `orientation` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
+| ~~orientationMargin~~ | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `titlePlacement` 不能为 `center`。如果传入 `string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
 | titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| type | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
-| vertical | 是否垂直，和 orientation 同时配置以 orientation 优先 | boolean | false | 6.x |
+| titlePlacementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `titlePlacement` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
+| ~~type~~ | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
+| variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
+| vertical | 是否垂直，和 orientation 同时配置以 orientation 优先 | boolean | false | - |
 
 ## Semantic DOM
 

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -44,7 +44,6 @@ group:
 | style | 分割线样式对象 | CSSProperties | - |  |
 | size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
 | titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| titlePlacementMargin | 标题和最近 left/right 边框之间的距离，去除了分割线，同时 `titlePlacement` 不能为 `center`。如果传入`string` 类型的数字且不带单位，默认单位是 px | string \| number | - |  |
 | ~~type~~ | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | vertical | 是否垂直，和 orientation 同时配置以 orientation 优先 | boolean | false | - |

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -43,8 +43,8 @@ group:
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
-| titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | `start` `end`: 5.24.0 |
-| ~~type~~ | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` |  |
+| titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | - |
+| ~~type~~ | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` | - |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |
 | vertical | 是否垂直，和 orientation 同时配置以 orientation 优先 | boolean | false | - |
 

--- a/components/divider/style/index.ts
+++ b/components/divider/style/index.ts
@@ -14,10 +14,16 @@ export interface ComponentToken {
    */
   textPaddingInline: CSSProperties['paddingInline'];
   /**
+   * @deprecated Please use `titlePlacementMargin`
    * @desc 文本与边缘距离，取值 0 ～ 1
    * @descEN Distance between text and edge, which should be a number between 0 and 1.
    */
-  orientationMargin: number;
+  orientationMargin?: number;
+  /**
+   * @desc 文本与边缘距离，取值 0 ～ 1
+   * @descEN Distance between text and edge, which should be a number between 0 and 1.
+   */
+  titlePlacementMargin: number;
   /**
    * @desc 纵向分割线的横向外间距
    * @descEN Horizontal margin of vertical Divider
@@ -71,10 +77,12 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
     lineWidth,
     textPaddingInline,
     orientationMargin,
+    titlePlacementMargin,
     verticalMarginInline,
   } = token;
   const railCls = `${componentCls}-rail`;
 
+  const mergedTitlePlacementMargin = titlePlacementMargin ?? orientationMargin;
   return {
     [componentCls]: {
       ...resetComponent(token),
@@ -126,116 +134,116 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
 
       [`&-horizontal${componentCls}-with-text-start`]: {
         [`${railCls}-start`]: {
-          width: `calc(${orientationMargin} * 100%)`,
+          width: `calc(${mergedTitlePlacementMargin} * 100%)`,
         },
         [`${railCls}-end`]: {
-          width: `calc(100% - ${orientationMargin} * 100%)`,
+          width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
         },
-      },
 
-      [`&-horizontal${componentCls}-with-text-end`]: {
-        [`${railCls}-start`]: {
-          width: `calc(100% - ${orientationMargin} * 100%)`,
-        },
-        [`${railCls}-end`]: {
-          width: `calc(${orientationMargin} * 100%)`,
-        },
-      },
-
-      [`${componentCls}-inner-text`]: {
-        display: 'inline-block',
-        paddingBlock: 0,
-        paddingInline: textPaddingInline,
-      },
-
-      '&-dashed': {
-        background: 'none',
-        borderColor: colorSplit,
-        borderStyle: 'dashed',
-        borderWidth: `${unit(lineWidth)} 0 0`,
-        [railCls]: {
-          borderBlockStart: `${unit(lineWidth)} dashed ${colorSplit}`,
-        },
-      },
-
-      [`&-horizontal${componentCls}-with-text${componentCls}-dashed`]: {
-        [`${railCls}-start, ${railCls}-end`]: {
-          borderStyle: 'dashed none none',
-        },
-      },
-
-      [`&-vertical${componentCls}-dashed`]: {
-        borderInlineStartWidth: lineWidth,
-        borderInlineEnd: 0,
-        borderBlockStart: 0,
-        borderBlockEnd: 0,
-      },
-
-      '&-dotted': {
-        background: 'none',
-        borderColor: colorSplit,
-        borderStyle: 'dotted',
-        borderWidth: `${unit(lineWidth)} 0 0`,
-        [railCls]: {
-          borderBlockStart: `${unit(lineWidth)} dotted ${colorSplit}`,
-        },
-      },
-
-      [`&-horizontal${componentCls}-with-text${componentCls}-dotted`]: {
-        '&::before, &::after': {
-          borderStyle: 'dotted none none',
-        },
-      },
-
-      [`&-vertical${componentCls}-dotted`]: {
-        borderInlineStartWidth: lineWidth,
-        borderInlineEnd: 0,
-        borderBlockStart: 0,
-        borderBlockEnd: 0,
-      },
-
-      [`&-plain${componentCls}-with-text`]: {
-        color: token.colorText,
-        fontWeight: 'normal',
-        fontSize: token.fontSize,
-      },
-
-      [`&-horizontal${componentCls}-with-text-start${componentCls}-no-default-orientation-margin-start`]:
-        {
+        [`&-horizontal${componentCls}-with-text-end`]: {
           [`${railCls}-start`]: {
-            width: 0,
+            width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
           },
-
           [`${railCls}-end`]: {
-            width: '100%',
-          },
-
-          [`${componentCls}-inner-text`]: {
-            paddingInlineStart: sizePaddingEdgeHorizontal,
+            width: `calc(${mergedTitlePlacementMargin} * 100%)`,
           },
         },
 
-      [`&-horizontal${componentCls}-with-text-end${componentCls}-no-default-orientation-margin-end`]:
-        {
-          [`${railCls}-start`]: {
-            width: '100%',
-          },
+        [`${componentCls}-inner-text`]: {
+          display: 'inline-block',
+          paddingBlock: 0,
+          paddingInline: textPaddingInline,
+        },
 
-          [`${railCls}-end`]: {
-            width: 0,
-          },
-
-          [`${componentCls}-inner-text`]: {
-            paddingInlineEnd: sizePaddingEdgeHorizontal,
+        '&-dashed': {
+          background: 'none',
+          borderColor: colorSplit,
+          borderStyle: 'dashed',
+          borderWidth: `${unit(lineWidth)} 0 0`,
+          [railCls]: {
+            borderBlockStart: `${unit(lineWidth)} dashed ${colorSplit}`,
           },
         },
+
+        [`&-horizontal${componentCls}-with-text${componentCls}-dashed`]: {
+          [`${railCls}-start, ${railCls}-end`]: {
+            borderStyle: 'dashed none none',
+          },
+        },
+
+        [`&-vertical${componentCls}-dashed`]: {
+          borderInlineStartWidth: lineWidth,
+          borderInlineEnd: 0,
+          borderBlockStart: 0,
+          borderBlockEnd: 0,
+        },
+
+        '&-dotted': {
+          background: 'none',
+          borderColor: colorSplit,
+          borderStyle: 'dotted',
+          borderWidth: `${unit(lineWidth)} 0 0`,
+          [railCls]: {
+            borderBlockStart: `${unit(lineWidth)} dotted ${colorSplit}`,
+          },
+        },
+
+        [`&-horizontal${componentCls}-with-text${componentCls}-dotted`]: {
+          '&::before, &::after': {
+            borderStyle: 'dotted none none',
+          },
+        },
+
+        [`&-vertical${componentCls}-dotted`]: {
+          borderInlineStartWidth: lineWidth,
+          borderInlineEnd: 0,
+          borderBlockStart: 0,
+          borderBlockEnd: 0,
+        },
+
+        [`&-plain${componentCls}-with-text`]: {
+          color: token.colorText,
+          fontWeight: 'normal',
+          fontSize: token.fontSize,
+        },
+
+        [`&-horizontal${componentCls}-with-text-start${componentCls}-no-default-orientation-margin-start`]:
+          {
+            [`${railCls}-start`]: {
+              width: 0,
+            },
+
+            [`${railCls}-end`]: {
+              width: '100%',
+            },
+
+            [`${componentCls}-inner-text`]: {
+              paddingInlineStart: sizePaddingEdgeHorizontal,
+            },
+          },
+
+        [`&-horizontal${componentCls}-with-text-end${componentCls}-no-default-orientation-margin-end`]:
+          {
+            [`${railCls}-start`]: {
+              width: '100%',
+            },
+
+            [`${railCls}-end`]: {
+              width: 0,
+            },
+
+            [`${componentCls}-inner-text`]: {
+              paddingInlineEnd: sizePaddingEdgeHorizontal,
+            },
+          },
+      },
     },
   };
 };
 
 export const prepareComponentToken: GetDefaultToken<'Divider'> = (token) => ({
   textPaddingInline: '1em',
-  orientationMargin: 0.05,
+  titlePlacementMargin: 0.05,
   verticalMarginInline: token.marginXS,
 });
 
@@ -252,7 +260,7 @@ export default genStyleHooks(
   prepareComponentToken,
   {
     unitless: {
-      orientationMargin: true,
+      titlePlacementMargin: true,
     },
   },
 );

--- a/components/divider/style/index.ts
+++ b/components/divider/style/index.ts
@@ -139,104 +139,104 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
         [`${railCls}-end`]: {
           width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
         },
-
-        [`&-horizontal${componentCls}-with-text-end`]: {
-          [`${railCls}-start`]: {
-            width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
-          },
-          [`${railCls}-end`]: {
-            width: `calc(${mergedTitlePlacementMargin} * 100%)`,
-          },
-        },
-
-        [`${componentCls}-inner-text`]: {
-          display: 'inline-block',
-          paddingBlock: 0,
-          paddingInline: textPaddingInline,
-        },
-
-        '&-dashed': {
-          background: 'none',
-          borderColor: colorSplit,
-          borderStyle: 'dashed',
-          borderWidth: `${unit(lineWidth)} 0 0`,
-          [railCls]: {
-            borderBlockStart: `${unit(lineWidth)} dashed ${colorSplit}`,
-          },
-        },
-
-        [`&-horizontal${componentCls}-with-text${componentCls}-dashed`]: {
-          [`${railCls}-start, ${railCls}-end`]: {
-            borderStyle: 'dashed none none',
-          },
-        },
-
-        [`&-vertical${componentCls}-dashed`]: {
-          borderInlineStartWidth: lineWidth,
-          borderInlineEnd: 0,
-          borderBlockStart: 0,
-          borderBlockEnd: 0,
-        },
-
-        '&-dotted': {
-          background: 'none',
-          borderColor: colorSplit,
-          borderStyle: 'dotted',
-          borderWidth: `${unit(lineWidth)} 0 0`,
-          [railCls]: {
-            borderBlockStart: `${unit(lineWidth)} dotted ${colorSplit}`,
-          },
-        },
-
-        [`&-horizontal${componentCls}-with-text${componentCls}-dotted`]: {
-          '&::before, &::after': {
-            borderStyle: 'dotted none none',
-          },
-        },
-
-        [`&-vertical${componentCls}-dotted`]: {
-          borderInlineStartWidth: lineWidth,
-          borderInlineEnd: 0,
-          borderBlockStart: 0,
-          borderBlockEnd: 0,
-        },
-
-        [`&-plain${componentCls}-with-text`]: {
-          color: token.colorText,
-          fontWeight: 'normal',
-          fontSize: token.fontSize,
-        },
-
-        [`&-horizontal${componentCls}-with-text-start${componentCls}-no-default-orientation-margin-start`]:
-          {
-            [`${railCls}-start`]: {
-              width: 0,
-            },
-
-            [`${railCls}-end`]: {
-              width: '100%',
-            },
-
-            [`${componentCls}-inner-text`]: {
-              paddingInlineStart: sizePaddingEdgeHorizontal,
-            },
-          },
-
-        [`&-horizontal${componentCls}-with-text-end${componentCls}-no-default-orientation-margin-end`]:
-          {
-            [`${railCls}-start`]: {
-              width: '100%',
-            },
-
-            [`${railCls}-end`]: {
-              width: 0,
-            },
-
-            [`${componentCls}-inner-text`]: {
-              paddingInlineEnd: sizePaddingEdgeHorizontal,
-            },
-          },
       },
+
+      [`&-horizontal${componentCls}-with-text-end`]: {
+        [`${railCls}-start`]: {
+          width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
+        },
+        [`${railCls}-end`]: {
+          width: `calc(${mergedTitlePlacementMargin} * 100%)`,
+        },
+      },
+
+      [`${componentCls}-inner-text`]: {
+        display: 'inline-block',
+        paddingBlock: 0,
+        paddingInline: textPaddingInline,
+      },
+
+      '&-dashed': {
+        background: 'none',
+        borderColor: colorSplit,
+        borderStyle: 'dashed',
+        borderWidth: `${unit(lineWidth)} 0 0`,
+        [railCls]: {
+          borderBlockStart: `${unit(lineWidth)} dashed ${colorSplit}`,
+        },
+      },
+
+      [`&-horizontal${componentCls}-with-text${componentCls}-dashed`]: {
+        [`${railCls}-start, ${railCls}-end`]: {
+          borderStyle: 'dashed none none',
+        },
+      },
+
+      [`&-vertical${componentCls}-dashed`]: {
+        borderInlineStartWidth: lineWidth,
+        borderInlineEnd: 0,
+        borderBlockStart: 0,
+        borderBlockEnd: 0,
+      },
+
+      '&-dotted': {
+        background: 'none',
+        borderColor: colorSplit,
+        borderStyle: 'dotted',
+        borderWidth: `${unit(lineWidth)} 0 0`,
+        [railCls]: {
+          borderBlockStart: `${unit(lineWidth)} dotted ${colorSplit}`,
+        },
+      },
+
+      [`&-horizontal${componentCls}-with-text${componentCls}-dotted`]: {
+        '&::before, &::after': {
+          borderStyle: 'dotted none none',
+        },
+      },
+
+      [`&-vertical${componentCls}-dotted`]: {
+        borderInlineStartWidth: lineWidth,
+        borderInlineEnd: 0,
+        borderBlockStart: 0,
+        borderBlockEnd: 0,
+      },
+
+      [`&-plain${componentCls}-with-text`]: {
+        color: token.colorText,
+        fontWeight: 'normal',
+        fontSize: token.fontSize,
+      },
+
+      [`&-horizontal${componentCls}-with-text-start${componentCls}-no-default-orientation-margin-start`]:
+        {
+          [`${railCls}-start`]: {
+            width: 0,
+          },
+
+          [`${railCls}-end`]: {
+            width: '100%',
+          },
+
+          [`${componentCls}-inner-text`]: {
+            paddingInlineStart: sizePaddingEdgeHorizontal,
+          },
+        },
+
+      [`&-horizontal${componentCls}-with-text-end${componentCls}-no-default-orientation-margin-end`]:
+        {
+          [`${railCls}-start`]: {
+            width: '100%',
+          },
+
+          [`${railCls}-end`]: {
+            width: 0,
+          },
+
+          [`${componentCls}-inner-text`]: {
+            paddingInlineEnd: sizePaddingEdgeHorizontal,
+          },
+        },
     },
   };
 };

--- a/components/divider/style/index.ts
+++ b/components/divider/style/index.ts
@@ -14,16 +14,11 @@ export interface ComponentToken {
    */
   textPaddingInline: CSSProperties['paddingInline'];
   /**
-   * @deprecated Please use `titlePlacementMargin`
+   * @deprecated
    * @desc 文本与边缘距离，取值 0 ～ 1
    * @descEN Distance between text and edge, which should be a number between 0 and 1.
    */
   orientationMargin?: number;
-  /**
-   * @desc 文本与边缘距离，取值 0 ～ 1
-   * @descEN Distance between text and edge, which should be a number between 0 and 1.
-   */
-  titlePlacementMargin: number;
   /**
    * @desc 纵向分割线的横向外间距
    * @descEN Horizontal margin of vertical Divider
@@ -77,12 +72,10 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
     lineWidth,
     textPaddingInline,
     orientationMargin,
-    titlePlacementMargin,
     verticalMarginInline,
   } = token;
   const railCls = `${componentCls}-rail`;
 
-  const mergedTitlePlacementMargin = titlePlacementMargin ?? orientationMargin;
   return {
     [componentCls]: {
       ...resetComponent(token),
@@ -134,19 +127,19 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
 
       [`&-horizontal${componentCls}-with-text-start`]: {
         [`${railCls}-start`]: {
-          width: `calc(${mergedTitlePlacementMargin} * 100%)`,
+          width: `calc(${orientationMargin} * 100%)`,
         },
         [`${railCls}-end`]: {
-          width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
+          width: `calc(100% - ${orientationMargin} * 100%)`,
         },
       },
 
       [`&-horizontal${componentCls}-with-text-end`]: {
         [`${railCls}-start`]: {
-          width: `calc(100% - ${mergedTitlePlacementMargin} * 100%)`,
+          width: `calc(100% - ${orientationMargin} * 100%)`,
         },
         [`${railCls}-end`]: {
-          width: `calc(${mergedTitlePlacementMargin} * 100%)`,
+          width: `calc(${orientationMargin} * 100%)`,
         },
       },
 
@@ -243,7 +236,7 @@ const genSharedDividerStyle: GenerateStyle<DividerToken> = (token): CSSObject =>
 
 export const prepareComponentToken: GetDefaultToken<'Divider'> = (token) => ({
   textPaddingInline: '1em',
-  titlePlacementMargin: 0.05,
+  orientationMargin: 0.05,
   verticalMarginInline: token.marginXS,
 });
 
@@ -260,7 +253,7 @@ export default genStyleHooks(
   prepareComponentToken,
   {
     unitless: {
-      titlePlacementMargin: true,
+      orientationMargin: true,
     },
   },
 );

--- a/components/divider/style/index.ts
+++ b/components/divider/style/index.ts
@@ -14,7 +14,6 @@ export interface ComponentToken {
    */
   textPaddingInline: CSSProperties['paddingInline'];
   /**
-   * @deprecated
    * @desc 文本与边缘距离，取值 0 ～ 1
    * @descEN Distance between text and edge, which should be a number between 0 and 1.
    */

--- a/components/grid/demo/flex-align.tsx
+++ b/components/grid/demo/flex-align.tsx
@@ -7,7 +7,7 @@ const DemoBox: React.FC<React.PropsWithChildren<{ value: number }>> = (props) =>
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Align Top</Divider>
+    <Divider titlePlacement="left">Align Top</Divider>
     <Row justify="center" align="top">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>
@@ -23,7 +23,7 @@ const App: React.FC = () => (
       </Col>
     </Row>
 
-    <Divider orientation="left">Align Middle</Divider>
+    <Divider titlePlacement="left">Align Middle</Divider>
     <Row justify="space-around" align="middle">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>
@@ -39,7 +39,7 @@ const App: React.FC = () => (
       </Col>
     </Row>
 
-    <Divider orientation="left">Align Bottom</Divider>
+    <Divider titlePlacement="left">Align Bottom</Divider>
     <Row justify="space-between" align="bottom">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>

--- a/components/grid/demo/flex-align.tsx
+++ b/components/grid/demo/flex-align.tsx
@@ -7,7 +7,7 @@ const DemoBox: React.FC<React.PropsWithChildren<{ value: number }>> = (props) =>
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Align Top</Divider>
+    <Divider titlePlacement="start">Align Top</Divider>
     <Row justify="center" align="top">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>
@@ -23,7 +23,7 @@ const App: React.FC = () => (
       </Col>
     </Row>
 
-    <Divider titlePlacement="left">Align Middle</Divider>
+    <Divider titlePlacement="start">Align Middle</Divider>
     <Row justify="space-around" align="middle">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>
@@ -39,7 +39,7 @@ const App: React.FC = () => (
       </Col>
     </Row>
 
-    <Divider titlePlacement="left">Align Bottom</Divider>
+    <Divider titlePlacement="start">Align Bottom</Divider>
     <Row justify="space-between" align="bottom">
       <Col span={4}>
         <DemoBox value={100}>col-4</DemoBox>

--- a/components/grid/demo/flex-order.tsx
+++ b/components/grid/demo/flex-order.tsx
@@ -3,7 +3,7 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Normal</Divider>
+    <Divider titlePlacement="left">Normal</Divider>
     <Row>
       <Col span={6} order={4}>
         1 col-order-4
@@ -18,7 +18,7 @@ const App: React.FC = () => (
         4 col-order-1
       </Col>
     </Row>
-    <Divider orientation="left">Responsive</Divider>
+    <Divider titlePlacement="left">Responsive</Divider>
     <Row>
       <Col span={6} xs={{ order: 1 }} sm={{ order: 2 }} md={{ order: 3 }} lg={{ order: 4 }}>
         1 col-order-responsive

--- a/components/grid/demo/flex-order.tsx
+++ b/components/grid/demo/flex-order.tsx
@@ -3,7 +3,7 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Normal</Divider>
+    <Divider titlePlacement="start">Normal</Divider>
     <Row>
       <Col span={6} order={4}>
         1 col-order-4
@@ -18,7 +18,7 @@ const App: React.FC = () => (
         4 col-order-1
       </Col>
     </Row>
-    <Divider titlePlacement="left">Responsive</Divider>
+    <Divider titlePlacement="start">Responsive</Divider>
     <Row>
       <Col span={6} xs={{ order: 1 }} sm={{ order: 2 }} md={{ order: 3 }} lg={{ order: 4 }}>
         1 col-order-responsive

--- a/components/grid/demo/flex-stretch.tsx
+++ b/components/grid/demo/flex-stretch.tsx
@@ -3,17 +3,17 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Percentage columns</Divider>
+    <Divider titlePlacement="left">Percentage columns</Divider>
     <Row>
       <Col flex={2}>2 / 5</Col>
       <Col flex={3}>3 / 5</Col>
     </Row>
-    <Divider orientation="left">Fill rest</Divider>
+    <Divider titlePlacement="left">Fill rest</Divider>
     <Row>
       <Col flex="100px">100px</Col>
       <Col flex="auto">Fill Rest</Col>
     </Row>
-    <Divider orientation="left">Raw flex style</Divider>
+    <Divider titlePlacement="left">Raw flex style</Divider>
     <Row>
       <Col flex="1 1 200px">1 1 200px</Col>
       <Col flex="0 1 300px">0 1 300px</Col>

--- a/components/grid/demo/flex-stretch.tsx
+++ b/components/grid/demo/flex-stretch.tsx
@@ -3,17 +3,17 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Percentage columns</Divider>
+    <Divider titlePlacement="start">Percentage columns</Divider>
     <Row>
       <Col flex={2}>2 / 5</Col>
       <Col flex={3}>3 / 5</Col>
     </Row>
-    <Divider titlePlacement="left">Fill rest</Divider>
+    <Divider titlePlacement="start">Fill rest</Divider>
     <Row>
       <Col flex="100px">100px</Col>
       <Col flex="auto">Fill Rest</Col>
     </Row>
-    <Divider titlePlacement="left">Raw flex style</Divider>
+    <Divider titlePlacement="start">Raw flex style</Divider>
     <Row>
       <Col flex="1 1 200px">1 1 200px</Col>
       <Col flex="0 1 300px">0 1 300px</Col>

--- a/components/grid/demo/flex.tsx
+++ b/components/grid/demo/flex.tsx
@@ -3,7 +3,7 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">sub-element align left</Divider>
+    <Divider titlePlacement="start">sub-element align left</Divider>
     <Row justify="start">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -11,7 +11,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider titlePlacement="left">sub-element align center</Divider>
+    <Divider titlePlacement="start">sub-element align center</Divider>
     <Row justify="center">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -19,7 +19,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider titlePlacement="left">sub-element align right</Divider>
+    <Divider titlePlacement="start">sub-element align right</Divider>
     <Row justify="end">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -27,7 +27,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider titlePlacement="left">sub-element monospaced arrangement</Divider>
+    <Divider titlePlacement="start">sub-element monospaced arrangement</Divider>
     <Row justify="space-between">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -35,7 +35,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider titlePlacement="left">sub-element align full</Divider>
+    <Divider titlePlacement="start">sub-element align full</Divider>
     <Row justify="space-around">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -43,7 +43,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider titlePlacement="left">sub-element align evenly</Divider>
+    <Divider titlePlacement="start">sub-element align evenly</Divider>
     <Row justify="space-evenly">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>

--- a/components/grid/demo/flex.tsx
+++ b/components/grid/demo/flex.tsx
@@ -3,7 +3,7 @@ import { Col, Divider, Row } from 'antd';
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">sub-element align left</Divider>
+    <Divider titlePlacement="left">sub-element align left</Divider>
     <Row justify="start">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -11,7 +11,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider orientation="left">sub-element align center</Divider>
+    <Divider titlePlacement="left">sub-element align center</Divider>
     <Row justify="center">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -19,7 +19,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider orientation="left">sub-element align right</Divider>
+    <Divider titlePlacement="left">sub-element align right</Divider>
     <Row justify="end">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -27,7 +27,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider orientation="left">sub-element monospaced arrangement</Divider>
+    <Divider titlePlacement="left">sub-element monospaced arrangement</Divider>
     <Row justify="space-between">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -35,7 +35,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider orientation="left">sub-element align full</Divider>
+    <Divider titlePlacement="left">sub-element align full</Divider>
     <Row justify="space-around">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>
@@ -43,7 +43,7 @@ const App: React.FC = () => (
       <Col span={4}>col-4</Col>
     </Row>
 
-    <Divider orientation="left">sub-element align evenly</Divider>
+    <Divider titlePlacement="left">sub-element align evenly</Divider>
     <Row justify="space-evenly">
       <Col span={4}>col-4</Col>
       <Col span={4}>col-4</Col>

--- a/components/grid/demo/gutter.tsx
+++ b/components/grid/demo/gutter.tsx
@@ -5,7 +5,7 @@ const style: React.CSSProperties = { background: '#0092ff', padding: '8px 0' };
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Horizontal</Divider>
+    <Divider titlePlacement="start">Horizontal</Divider>
     <Row gutter={16}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>
@@ -20,7 +20,7 @@ const App: React.FC = () => (
         <div style={style}>col-6</div>
       </Col>
     </Row>
-    <Divider titlePlacement="left">Responsive</Divider>
+    <Divider titlePlacement="start">Responsive</Divider>
     <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 32 }}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>
@@ -35,7 +35,7 @@ const App: React.FC = () => (
         <div style={style}>col-6</div>
       </Col>
     </Row>
-    <Divider titlePlacement="left">Vertical</Divider>
+    <Divider titlePlacement="start">Vertical</Divider>
     <Row gutter={[16, 24]}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>

--- a/components/grid/demo/gutter.tsx
+++ b/components/grid/demo/gutter.tsx
@@ -5,7 +5,7 @@ const style: React.CSSProperties = { background: '#0092ff', padding: '8px 0' };
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Horizontal</Divider>
+    <Divider titlePlacement="left">Horizontal</Divider>
     <Row gutter={16}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>
@@ -20,7 +20,7 @@ const App: React.FC = () => (
         <div style={style}>col-6</div>
       </Col>
     </Row>
-    <Divider orientation="left">Responsive</Divider>
+    <Divider titlePlacement="left">Responsive</Divider>
     <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 32 }}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>
@@ -35,7 +35,7 @@ const App: React.FC = () => (
         <div style={style}>col-6</div>
       </Col>
     </Row>
-    <Divider orientation="left">Vertical</Divider>
+    <Divider titlePlacement="left">Vertical</Divider>
     <Row gutter={[16, 24]}>
       <Col className="gutter-row" span={6}>
         <div style={style}>col-6</div>

--- a/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -461,7 +461,7 @@ exports[`List.pagination should change page size work 2`] = `
             class="ant-select-selection-search"
           >
             <input
-              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+              aria-activedescendant="rc_select_TEST_OR_SSR_list_2"
               aria-autocomplete="list"
               aria-controls="rc_select_TEST_OR_SSR_list"
               aria-expanded="true"
@@ -506,7 +506,7 @@ exports[`List.pagination should change page size work 2`] = `
                 >
                   <div
                     aria-selected="false"
-                    class="ant-select-item ant-select-item-option ant-select-item-option-active"
+                    class="ant-select-item ant-select-item-option"
                     id="rc_select_TEST_OR_SSR_list_0"
                     role="option"
                     title="10 / page"
@@ -544,7 +544,7 @@ exports[`List.pagination should change page size work 2`] = `
                   </div>
                   <div
                     aria-selected="true"
-                    class="ant-select-item ant-select-item-option ant-select-item-option-selected"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
                     id="rc_select_TEST_OR_SSR_list_2"
                     role="option"
                     title="50 / page"

--- a/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -461,7 +461,7 @@ exports[`List.pagination should change page size work 2`] = `
             class="ant-select-selection-search"
           >
             <input
-              aria-activedescendant="rc_select_TEST_OR_SSR_list_2"
+              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
               aria-autocomplete="list"
               aria-controls="rc_select_TEST_OR_SSR_list"
               aria-expanded="true"
@@ -506,7 +506,7 @@ exports[`List.pagination should change page size work 2`] = `
                 >
                   <div
                     aria-selected="false"
-                    class="ant-select-item ant-select-item-option"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active"
                     id="rc_select_TEST_OR_SSR_list_0"
                     role="option"
                     title="10 / page"
@@ -544,7 +544,7 @@ exports[`List.pagination should change page size work 2`] = `
                   </div>
                   <div
                     aria-selected="true"
-                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-selected"
                     id="rc_select_TEST_OR_SSR_list_2"
                     role="option"
                     title="50 / page"

--- a/components/list/demo/component-token.tsx
+++ b/components/list/demo/component-token.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => (
       },
     }}
   >
-    <Divider orientation="left">Default Size</Divider>
+    <Divider titlePlacement="left">Default Size</Divider>
     <List
       header={<div>Header</div>}
       footer={<div>Footer</div>}
@@ -55,7 +55,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider orientation="left">Small Size</Divider>
+    <Divider titlePlacement="left">Small Size</Divider>
     <List
       size="small"
       header={<div>Header</div>}
@@ -64,7 +64,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider orientation="left">Large Size</Divider>
+    <Divider titlePlacement="left">Large Size</Divider>
     <List
       size="large"
       header={<div>Header</div>}
@@ -73,7 +73,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider orientation="left">Meta</Divider>
+    <Divider titlePlacement="left">Meta</Divider>
     <List
       itemLayout="horizontal"
       dataSource={data1}
@@ -87,7 +87,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider orientation="left">Vertical</Divider>
+    <Divider titlePlacement="left">Vertical</Divider>
     <List
       itemLayout="vertical"
       dataSource={data1}
@@ -101,7 +101,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider orientation="left">Empty Text</Divider>
+    <Divider titlePlacement="left">Empty Text</Divider>
     <List />
   </ConfigProvider>
 );

--- a/components/list/demo/component-token.tsx
+++ b/components/list/demo/component-token.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => (
       },
     }}
   >
-    <Divider titlePlacement="left">Default Size</Divider>
+    <Divider titlePlacement="start">Default Size</Divider>
     <List
       header={<div>Header</div>}
       footer={<div>Footer</div>}
@@ -55,7 +55,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider titlePlacement="left">Small Size</Divider>
+    <Divider titlePlacement="start">Small Size</Divider>
     <List
       size="small"
       header={<div>Header</div>}
@@ -64,7 +64,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider titlePlacement="left">Large Size</Divider>
+    <Divider titlePlacement="start">Large Size</Divider>
     <List
       size="large"
       header={<div>Header</div>}
@@ -73,7 +73,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider titlePlacement="left">Meta</Divider>
+    <Divider titlePlacement="start">Meta</Divider>
     <List
       itemLayout="horizontal"
       dataSource={data1}
@@ -87,7 +87,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider titlePlacement="left">Vertical</Divider>
+    <Divider titlePlacement="start">Vertical</Divider>
     <List
       itemLayout="vertical"
       dataSource={data1}
@@ -101,7 +101,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider titlePlacement="left">Empty Text</Divider>
+    <Divider titlePlacement="start">Empty Text</Divider>
     <List />
   </ConfigProvider>
 );

--- a/components/list/demo/simple.tsx
+++ b/components/list/demo/simple.tsx
@@ -11,7 +11,7 @@ const data = [
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Default Size</Divider>
+    <Divider titlePlacement="left">Default Size</Divider>
     <List
       header={<div>Header</div>}
       footer={<div>Footer</div>}
@@ -23,7 +23,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider orientation="left">Small Size</Divider>
+    <Divider titlePlacement="left">Small Size</Divider>
     <List
       size="small"
       header={<div>Header</div>}
@@ -32,7 +32,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider orientation="left">Large Size</Divider>
+    <Divider titlePlacement="left">Large Size</Divider>
     <List
       size="large"
       header={<div>Header</div>}

--- a/components/list/demo/simple.tsx
+++ b/components/list/demo/simple.tsx
@@ -11,7 +11,7 @@ const data = [
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Default Size</Divider>
+    <Divider titlePlacement="start">Default Size</Divider>
     <List
       header={<div>Header</div>}
       footer={<div>Footer</div>}
@@ -23,7 +23,7 @@ const App: React.FC = () => (
         </List.Item>
       )}
     />
-    <Divider titlePlacement="left">Small Size</Divider>
+    <Divider titlePlacement="start">Small Size</Divider>
     <List
       size="small"
       header={<div>Header</div>}
@@ -32,7 +32,7 @@ const App: React.FC = () => (
       dataSource={data}
       renderItem={(item) => <List.Item>{item}</List.Item>}
     />
-    <Divider titlePlacement="left">Large Size</Divider>
+    <Divider titlePlacement="start">Large Size</Divider>
     <List
       size="large"
       header={<div>Header</div>}

--- a/components/menu/demo/switch-mode.tsx
+++ b/components/menu/demo/switch-mode.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
   return (
     <>
       <Switch onChange={changeMode} /> Change Mode
-      <Divider type="vertical" />
+      <Divider vertical />
       <Switch onChange={changeTheme} /> Change Style
       <br />
       <br />

--- a/components/skeleton/demo/_semantic_element.tsx
+++ b/components/skeleton/demo/_semantic_element.tsx
@@ -50,7 +50,7 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ element, setElement, ..
         value={element}
         onChange={(value: string) => setElement(value)}
       />
-      <Divider orientation="left" plain>
+      <Divider titlePlacement="left" plain>
         Preview
       </Divider>
       <Element {...rest} />

--- a/components/skeleton/demo/_semantic_element.tsx
+++ b/components/skeleton/demo/_semantic_element.tsx
@@ -50,7 +50,7 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ element, setElement, ..
         value={element}
         onChange={(value: string) => setElement(value)}
       />
-      <Divider titlePlacement="left" plain>
+      <Divider titlePlacement="start" plain>
         Preview
       </Divider>
       <Element {...rest} />

--- a/components/space/demo/split.tsx
+++ b/components/space/demo/split.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Divider, Space, Typography } from 'antd';
 
 const App: React.FC = () => (
-  <Space split={<Divider type="vertical" />}>
+  <Space split={<Divider vertical />}>
     <Typography.Link>Link</Typography.Link>
     <Typography.Link>Link</Typography.Link>
     <Typography.Link>Link</Typography.Link>

--- a/components/tag/demo/colorful.tsx
+++ b/components/tag/demo/colorful.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => (
   <>
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider titlePlacement="left">Presets ({variant})</Divider>
+        <Divider titlePlacement="start">Presets ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {presets.map((color) => (
             <Tag key={color} color={color} variant={variant}>
@@ -33,7 +33,7 @@ const App: React.FC = () => (
     ))}
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider titlePlacement="left">Custom ({variant})</Divider>
+        <Divider titlePlacement="start">Custom ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {customs.map((color) => (
             <Tag key={color} color={color} variant={variant}>

--- a/components/tag/demo/colorful.tsx
+++ b/components/tag/demo/colorful.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => (
   <>
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider orientation="left">Presets ({variant})</Divider>
+        <Divider titlePlacement="left">Presets ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {presets.map((color) => (
             <Tag key={color} color={color} variant={variant}>
@@ -33,7 +33,7 @@ const App: React.FC = () => (
     ))}
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider orientation="left">Custom ({variant})</Divider>
+        <Divider titlePlacement="left">Custom ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {customs.map((color) => (
             <Tag key={color} color={color} variant={variant}>

--- a/components/tag/demo/status.tsx
+++ b/components/tag/demo/status.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => (
   <>
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider orientation="left">Status ({variant})</Divider>
+        <Divider titlePlacement="left">Status ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {presets.map(({ status, icon }) => (
             <Tag key={status} color={status} icon={icon} variant={variant}>

--- a/components/tag/demo/status.tsx
+++ b/components/tag/demo/status.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => (
   <>
     {variants.map((variant) => (
       <div key={variant}>
-        <Divider titlePlacement="left">Status ({variant})</Divider>
+        <Divider titlePlacement="start">Status ({variant})</Divider>
         <Flex gap="small" align="center" wrap>
           {presets.map(({ status, icon }) => (
             <Tag key={status} color={status} icon={icon} variant={variant}>

--- a/components/tooltip/demo/colorful.tsx
+++ b/components/tooltip/demo/colorful.tsx
@@ -21,7 +21,7 @@ const customColors = ['#f50', '#2db7f5', '#87d068', '#108ee9'];
 
 const App: React.FC = () => (
   <>
-    <Divider titlePlacement="left">Presets</Divider>
+    <Divider titlePlacement="start">Presets</Divider>
     <Space wrap>
       {colors.map((color) => (
         <Tooltip title="prompt text" color={color} key={color}>
@@ -29,7 +29,7 @@ const App: React.FC = () => (
         </Tooltip>
       ))}
     </Space>
-    <Divider titlePlacement="left">Custom</Divider>
+    <Divider titlePlacement="start">Custom</Divider>
     <Space wrap>
       {customColors.map((color) => (
         <Tooltip title="prompt text" color={color} key={color}>

--- a/components/tooltip/demo/colorful.tsx
+++ b/components/tooltip/demo/colorful.tsx
@@ -21,7 +21,7 @@ const customColors = ['#f50', '#2db7f5', '#87d068', '#108ee9'];
 
 const App: React.FC = () => (
   <>
-    <Divider orientation="left">Presets</Divider>
+    <Divider titlePlacement="left">Presets</Divider>
     <Space wrap>
       {colors.map((color) => (
         <Tooltip title="prompt text" color={color} key={color}>
@@ -29,7 +29,7 @@ const App: React.FC = () => (
         </Tooltip>
       ))}
     </Space>
-    <Divider orientation="left">Custom</Divider>
+    <Divider titlePlacement="left">Custom</Divider>
     <Space wrap>
       {customColors.map((color) => (
         <Tooltip title="prompt text" color={color} key={color}>

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -313,7 +313,7 @@ export default App;
 | --- | --- | --- |
 | --- | --- | --- |
 | `@divider-text-padding` | `textPaddingInline` | - |
-| `@divider-orientation-margin` | `titlePlacementMargin` | - |
+| `@divider-orientation-margin` | `orientationMargin` | - |
 | `@divider-color` | `colorSplit` | Global Token |
 | `@divider-vertical-gutter` | `verticalMarginInline` | - |
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -313,7 +313,7 @@ export default App;
 | --- | --- | --- |
 | --- | --- | --- |
 | `@divider-text-padding` | `textPaddingInline` | - |
-| `@divider-orientation-margin` | `orientationMargin` | - |
+| `@divider-orientation-margin` | `titlePlacementMargin` | - |
 | `@divider-color` | `colorSplit` | Global Token |
 | `@divider-vertical-gutter` | `verticalMarginInline` | - |
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -312,7 +312,7 @@ export default App;
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
 | `@divider-text-padding` | `textPaddingInline` | - |
-| `@divider-orientation-margin` | `orientationMargin` | - |
+| `@divider-orientation-margin` | `titlePlacementMargin` | - |
 | `@divider-color` | `colorSplit` | 全局 Token |
 | `@divider-vertical-gutter` | `verticalMarginInline` | - |
 

--- a/docs/react/migrate-less-variables.zh-CN.md
+++ b/docs/react/migrate-less-variables.zh-CN.md
@@ -312,7 +312,7 @@ export default App;
 | less 变量 | Component Token | 备注 |
 | --- | --- | --- |
 | `@divider-text-padding` | `textPaddingInline` | - |
-| `@divider-orientation-margin` | `titlePlacementMargin` | - |
+| `@divider-orientation-margin` | `orientationMargin` | - |
 | `@divider-color` | `colorSplit` | 全局 Token |
 | `@divider-vertical-gutter` | `verticalMarginInline` | - |
 


### PR DESCRIPTION

### 🤔 This is a ...

- [X] 🆕 New feature



### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

FRC #53328 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Use the "orientation" attribute uniformly for layout configuration of Divider components. The original "orientation" of the Diver component has been changed to "titlePlacement".Diviter  add vertical attribute     |
| 🇨🇳 Chinese |      对Divider组件统一使用“orientation”属性用于布局配置。Divider 组件原本的“orientation”修改为“titlePlacement”。Divider增加vertical 属性     |
