### PR TITLE
INTERNAL: update unstableSetRender to handle optional render parameter

### DIFF
--- a/components/__tests__/unstable.test.ts
+++ b/components/__tests__/unstable.test.ts
@@ -43,10 +43,7 @@ describe('unstable', () => {
   });
 
   it('unstableSetRender without param', async () => {
-    if (ReactDOM.version.startsWith('19')) {
-      const currentRender = unstableSetRender();
-
-      expect(currentRender).toBeInstanceOf(Function);
-    }
+    const currentRender = unstableSetRender();
+    expect(currentRender).toBeInstanceOf(Function);
   });
 });

--- a/components/__tests__/unstable.test.ts
+++ b/components/__tests__/unstable.test.ts
@@ -41,4 +41,12 @@ describe('unstable', () => {
       expect(document.querySelector('.ant-modal')).toBeTruthy();
     }
   });
+
+  it('unstableSetRender without param', async () => {
+    if (ReactDOM.version.startsWith('19')) {
+      const currentRender = unstableSetRender();
+
+      expect(currentRender).toBeInstanceOf(Function);
+    }
+  });
 });

--- a/components/config-provider/UnstableContext.tsx
+++ b/components/config-provider/UnstableContext.tsx
@@ -37,8 +37,11 @@ let unstableRender: RenderType = defaultReactRender;
  * This is internal usage only compatible with React 19.
  * And will be removed in next major version.
  */
-export function unstableSetRender(render: RenderType) {
-  unstableRender = render;
+export function unstableSetRender(render?: RenderType) {
+  if (render) {
+    unstableRender = render;
+  }
+  return unstableRender;
 }
 
 export function getReactRender() {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -683,7 +683,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 };
 
 const ConfigProvider: React.FC<ConfigProviderProps> & {
-  /** @internal internal Usage. do not use in your production; */
+  /** @private internal Usage. do not use in your production; */
   __getReactRender: typeof getReactRender; // 👈 TODO: Remove in v6
   /** @private internal Usage. do not use in your production */
   ConfigContext: typeof ConfigContext;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -78,6 +78,7 @@ import PropWarning from './PropWarning';
 import type { SizeType } from './SizeContext';
 import SizeContext, { SizeContextProvider } from './SizeContext';
 import useStyle from './style';
+import { getReactRender } from './UnstableContext';
 
 export type { Variant };
 
@@ -682,6 +683,8 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 };
 
 const ConfigProvider: React.FC<ConfigProviderProps> & {
+  /** @internal internal Usage. do not use in your production; */
+  __getReactRender: typeof getReactRender; // 👈 TODO: Remove in v6
   /** @private internal Usage. do not use in your production */
   ConfigContext: typeof ConfigContext;
   /** @deprecated Please use `ConfigProvider.useConfig().componentSize` instead */
@@ -698,6 +701,7 @@ ConfigProvider.ConfigContext = ConfigContext;
 ConfigProvider.SizeContext = SizeContext;
 ConfigProvider.config = setGlobalConfig;
 ConfigProvider.useConfig = useConfig;
+ConfigProvider.__getReactRender = getReactRender;
 
 Object.defineProperty(ConfigProvider, 'SizeContext', {
   get: () => {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -78,7 +78,6 @@ import PropWarning from './PropWarning';
 import type { SizeType } from './SizeContext';
 import SizeContext, { SizeContextProvider } from './SizeContext';
 import useStyle from './style';
-import { getReactRender } from './UnstableContext';
 
 export type { Variant };
 
@@ -683,8 +682,6 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 };
 
 const ConfigProvider: React.FC<ConfigProviderProps> & {
-  /** @private internal Usage. do not use in your production; */
-  __getReactRender: typeof getReactRender; // 👈 TODO: Remove in v6
   /** @private internal Usage. do not use in your production */
   ConfigContext: typeof ConfigContext;
   /** @deprecated Please use `ConfigProvider.useConfig().componentSize` instead */
@@ -701,7 +698,6 @@ ConfigProvider.ConfigContext = ConfigContext;
 ConfigProvider.SizeContext = SizeContext;
 ConfigProvider.config = setGlobalConfig;
 ConfigProvider.useConfig = useConfig;
-ConfigProvider.__getReactRender = getReactRender;
 
 Object.defineProperty(ConfigProvider, 'SizeContext', {
   get: () => {


### PR DESCRIPTION
…r internal usage

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

https://github.com/ant-design/happy-work-theme/issues/47

快乐主题在 React 19 无法正常工作，官网打开快乐主题就能复现。


解决方案： 需要将补丁方法放在 CP 上，允许其他需要兼容的包使用。 

在 V6 中应该被删除

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      --     |
| 🇨🇳 Chinese |      changelog 不需要体现     |
