### PR TITLE
feat(Modal): config global okButtonProps & cancelButtonProps

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -177,7 +177,16 @@ export type DescriptionsConfig = ComponentStyleConfig &
 export type EmptyConfig = ComponentStyleConfig & Pick<EmptyProps, 'classNames' | 'styles'>;
 
 export type ModalConfig = ComponentStyleConfig &
-  Pick<ModalProps, 'classNames' | 'styles' | 'closeIcon' | 'closable' | 'centered'>;
+  Pick<
+    ModalProps,
+    | 'classNames'
+    | 'styles'
+    | 'closeIcon'
+    | 'closable'
+    | 'centered'
+    | 'okButtonProps'
+    | 'cancelButtonProps'
+  >;
 
 export type TabsConfig = ComponentStyleConfig &
   Pick<

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -10,6 +10,7 @@ import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';
 import ConfigProvider from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import { useLocale } from '../locale';
 import useToken from '../theme/useToken';
 import CancelBtn from './components/ConfirmCancelBtn';
@@ -182,7 +183,12 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
     closable = false,
     onConfirm,
     styles,
+    okButtonProps,
+    cancelButtonProps,
   } = props;
+
+  const { cancelButtonProps: contextCancelButtonProps, okButtonProps: contextOkButtonProps } =
+    useComponentConfig('modal');
 
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Modal');
@@ -247,7 +253,12 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
       zIndex={mergedZIndex}
       closable={closable}
     >
-      <ConfirmContent {...props} confirmPrefixCls={confirmPrefixCls} />
+      <ConfirmContent
+        {...props}
+        confirmPrefixCls={confirmPrefixCls}
+        okButtonProps={{ ...contextOkButtonProps, ...okButtonProps }}
+        cancelButtonProps={{ ...contextCancelButtonProps, ...cancelButtonProps }}
+      />
     </Modal>
   );
 };

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -63,6 +63,8 @@ const Modal: React.FC<ModalProps> = (props) => {
     mousePosition: customizeMousePosition,
     onOk,
     onCancel,
+    okButtonProps,
+    cancelButtonProps,
     ...restProps
   } = props;
 
@@ -75,6 +77,8 @@ const Modal: React.FC<ModalProps> = (props) => {
     classNames: contextClassNames,
     styles: contextStyles,
     centered: contextCentered,
+    cancelButtonProps: contextCancelButtonProps,
+    okButtonProps: contextOkButtonProps,
   } = useComponentConfig('modal');
   const { modal: modalContext } = React.useContext(ConfigContext);
 
@@ -113,7 +117,13 @@ const Modal: React.FC<ModalProps> = (props) => {
 
   const dialogFooter =
     footer !== null && !loading ? (
-      <Footer {...props} onOk={handleOk} onCancel={handleCancel} />
+      <Footer
+        {...props}
+        okButtonProps={{ ...contextOkButtonProps, ...okButtonProps }}
+        onOk={handleOk}
+        cancelButtonProps={{ ...contextCancelButtonProps, ...cancelButtonProps }}
+        onCancel={handleCancel}
+      />
     ) : null;
 
   const [mergedClosable, mergedCloseIcon, closeBtnIsDisabled, ariaProps] = useClosable(

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -131,7 +131,7 @@ describe('Modal', () => {
     expect(document.querySelector('.custom-footer')).toBeTruthy();
   });
 
-  it('Should custom footer function second param work', () => {
+  it('should custom footer function second param work', () => {
     const footerFn = jest.fn();
     render(<Modal open footer={footerFn} />);
 
@@ -143,7 +143,7 @@ describe('Modal', () => {
     });
   });
 
-  it('Should custom footer function work', () => {
+  it('should custom footer function work', () => {
     render(
       <Modal
         open
@@ -195,12 +195,12 @@ describe('Modal', () => {
     });
   });
 
-  it('Should support centered prop', () => {
+  it('should support centered prop', () => {
     render(<Modal open centered />);
     expect(document.querySelector('.ant-modal-centered')).toBeTruthy();
   });
 
-  it('Should support centered global config', () => {
+  it('should support centered global config', () => {
     render(
       <ConfigProvider modal={{ centered: true }}>
         <Modal open />
@@ -209,13 +209,49 @@ describe('Modal', () => {
     expect(document.querySelector('.ant-modal-centered')).toBeTruthy();
   });
 
-  it('Should prefer centered prop over centered global config', () => {
+  it('should prefer centered prop over centered global config', () => {
     render(
       <ConfigProvider modal={{ centered: true }}>
         <Modal open centered={false} />
       </ConfigProvider>,
     );
     expect(document.querySelector('.ant-modal-centered')).toBeFalsy();
+  });
+
+  it('should support cancelButtonProps global config', () => {
+    render(
+      <ConfigProvider modal={{ cancelButtonProps: { size: 'small' } }}>
+        <Modal open />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-footer .ant-btn-default.ant-btn-sm')).toBeTruthy();
+  });
+
+  it('should prefer cancelButtonProps prop over cancelButtonProps global config', () => {
+    render(
+      <ConfigProvider modal={{ cancelButtonProps: { size: 'large' } }}>
+        <Modal open cancelButtonProps={{ size: 'small' }} />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-footer .ant-btn-default.ant-btn-sm')).toBeTruthy();
+  });
+
+  it('should support okButtonProps global config', () => {
+    render(
+      <ConfigProvider modal={{ okButtonProps: { size: 'small' } }}>
+        <Modal open />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-footer .ant-btn-primary.ant-btn-sm')).toBeTruthy();
+  });
+
+  it('should prefer okButtonProps prop over okButtonProps global config', () => {
+    render(
+      <ConfigProvider modal={{ okButtonProps: { size: 'large' } }}>
+        <Modal open okButtonProps={{ size: 'small' }} />
+      </ConfigProvider>,
+    );
+    expect(document.querySelector('.ant-modal-footer .ant-btn-primary.ant-btn-sm')).toBeTruthy();
   });
 
   it('should apply custom styles to Modal', () => {
@@ -267,7 +303,7 @@ describe('Modal', () => {
     expect(footerElement.style.color).toBe('yellow');
   });
 
-  it('Should not close modal when confirmLoading is loading', async () => {
+  it('should not close modal when confirmLoading is loading', async () => {
     jest.useFakeTimers();
 
     const Demo: React.FC<ModalProps> = ({ onCancel = () => {}, onOk = () => {} }) => {

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -7,7 +7,8 @@ import { resetWarned } from '@rc-component/util/lib/warning';
 
 import type { ModalFuncProps } from '..';
 import Modal from '..';
-import { act, fireEvent, waitFakeTimer } from '../../../tests/utils';
+import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import App from '../../app';
 import ConfigProvider, { defaultPrefixCls } from '../../config-provider';
 import type { ModalFunc } from '../confirm';
 import destroyFns from '../destroyFns';
@@ -978,5 +979,101 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     $$('.ant-btn')[0].click();
     await waitFakeTimer();
     expect(document.querySelector('.ant-modal-root')).toBeFalsy();
+  });
+
+  it('should support cancelButtonProps global config', () => {
+    const Confirm = () => {
+      const { modal } = App.useApp();
+      React.useEffect(() => {
+        modal.confirm({ onCancel: () => undefined });
+      }, []);
+      return null;
+    };
+
+    render(
+      <ConfigProvider modal={{ cancelButtonProps: { size: 'small' } }}>
+        <App>
+          <Confirm />
+        </App>
+      </ConfigProvider>,
+    );
+
+    expect(
+      document.querySelector('.ant-modal-confirm-btns .ant-btn-default.ant-btn-sm'),
+    ).toBeTruthy();
+  });
+
+  it('should prefer cancelButtonProps prop over cancelButtonProps global config', () => {
+    const Confirm = () => {
+      const { modal } = App.useApp();
+      React.useEffect(() => {
+        modal.confirm({
+          cancelButtonProps: { size: 'small' },
+          onCancel: () => undefined,
+        });
+      }, []);
+      return null;
+    };
+
+    render(
+      <ConfigProvider modal={{ cancelButtonProps: { size: 'large' } }}>
+        <App>
+          <Confirm />
+        </App>
+      </ConfigProvider>,
+    );
+
+    expect(
+      document.querySelector('.ant-modal-confirm-btns .ant-btn-default.ant-btn-sm'),
+    ).toBeTruthy();
+  });
+
+  it('should support okButtonProps global config', () => {
+    const Confirm = () => {
+      const { modal } = App.useApp();
+      React.useEffect(() => {
+        modal.confirm({
+          onOk: () => undefined,
+        });
+      }, []);
+      return null;
+    };
+
+    render(
+      <ConfigProvider modal={{ okButtonProps: { size: 'small' } }}>
+        <App>
+          <Confirm />
+        </App>
+      </ConfigProvider>,
+    );
+
+    expect(
+      document.querySelector('.ant-modal-confirm-btns .ant-btn-primary.ant-btn-sm'),
+    ).toBeTruthy();
+  });
+
+  it('should prefer okButtonProps prop over okButtonProps global config', () => {
+    const Confirm = () => {
+      const { modal } = App.useApp();
+      React.useEffect(() => {
+        modal.confirm({
+          okButtonProps: { size: 'small' },
+          onOk: () => undefined,
+        });
+      }, []);
+      return null;
+    };
+
+    render(
+      <ConfigProvider modal={{ okButtonProps: { size: 'large' } }}>
+        <App>
+          <Confirm />
+        </App>
+      </ConfigProvider>,
+    );
+
+    expect(
+      document.querySelector('.ant-modal-confirm-btns .ant-btn-primary.ant-btn-sm'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
…uttonProps

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

支持全局配置 OK 和 Cancel 按钮的文字及属性。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(Modal): config global okButtonProps & cancelButtonProps |
| 🇨🇳 Chinese | feat(Modal): 配置全局 okButtonProps 和 cancelButtonProps |
