### PR TITLE
fix: correctly adjust tooltip position when it overflows the viewport

### DIFF
--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -38,15 +38,11 @@ export function getOverflowOptions(
     case 'top':
     case 'bottom':
       baseOverflow.shiftX = arrowOffset.arrowOffsetHorizontal * 2 + arrowWidth;
-      baseOverflow.shiftY = true;
-      baseOverflow.adjustY = true;
       break;
 
     case 'left':
     case 'right':
       baseOverflow.shiftY = arrowOffset.arrowOffsetVertical * 2 + arrowWidth;
-      baseOverflow.shiftX = true;
-      baseOverflow.adjustX = true;
       break;
   }
 


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/ant-design/issues/53396
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
我调试的时候发现如果注释了下述代码后，能够正常调整位置，估计是shiftY/X设置为true时内部被格式转换变成了其他数字，所以直接设置为undefined
![image](https://github.com/user-attachments/assets/3190cbbc-d666-41c3-868c-8f44b1aa481b)
下图为修改前后的对照
![image](https://github.com/user-attachments/assets/636eca33-a284-46b0-b887-b2d1eeab64e5)
![image](https://github.com/user-attachments/assets/cacc7068-cb55-44c3-8704-e663da125710)

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     correctly adjust popover position when it overflows the viewport  |
| 🇨🇳 Chinese |   气泡框超出视图时位置自动调整对齐        |
