### PR TITLE
fix<Anchor>: Click the anchor point to refresh the page.

### DIFF
--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -51,20 +51,19 @@ const AnchorLink: React.FC<AnchorLinkProps> = (props) => {
     }
 
     const isExternalLink = href.startsWith('http://') || href.startsWith('https://');
+    // Support external link
     if (isExternalLink) {
-      // Support external link
       if (replace) {
         e.preventDefault();
         window.location.replace(href);
       }
-    } else {
-      e.preventDefault();
-      if (replace) {
-        window.history.replaceState(null, '', href);
-      } else {
-        window.history.pushState(null, '', href);
-      }
+      return;
     }
+    
+    // Handling internal anchor link
+    e.preventDefault();
+    const historyMethod = replace ? 'replaceState' : 'pushState';
+    window.history[historyMethod](null, '', href);
   };
 
   // =================== Warning =====================

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -45,7 +45,10 @@ const AnchorLink: React.FC<AnchorLinkProps> = (props) => {
     onClick?.(e, { title, href });
     scrollTo?.(href);
 
-    if (e.defaultPrevented) return; // Support clicking on an anchor does not record history.
+    // Support clicking on an anchor does not record history.
+    if (e.defaultPrevented) {
+      return;
+    }
 
     const isExternalLink = href.startsWith('http://') || href.startsWith('https://');
     if (isExternalLink) {

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -44,9 +44,11 @@ const AnchorLink: React.FC<AnchorLinkProps> = (props) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     onClick?.(e, { title, href });
     scrollTo?.(href);
+    e.preventDefault();
     if (replace) {
-      e.preventDefault();
-      window.location.replace(href);
+      window.history.replaceState(null, '', href);
+    } else {
+      window.history.pushState(null, '', href);
     }
   };
 

--- a/components/anchor/AnchorLink.tsx
+++ b/components/anchor/AnchorLink.tsx
@@ -44,11 +44,23 @@ const AnchorLink: React.FC<AnchorLinkProps> = (props) => {
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     onClick?.(e, { title, href });
     scrollTo?.(href);
-    e.preventDefault();
-    if (replace) {
-      window.history.replaceState(null, '', href);
+
+    if (e.defaultPrevented) return; // Support clicking on an anchor does not record history.
+
+    const isExternalLink = href.startsWith('http://') || href.startsWith('https://');
+    if (isExternalLink) {
+      // Support external link
+      if (replace) {
+        e.preventDefault();
+        window.location.replace(href);
+      }
     } else {
-      window.history.pushState(null, '', href);
+      e.preventDefault();
+      if (replace) {
+        window.history.replaceState(null, '', href);
+      } else {
+        window.history.pushState(null, '', href);
+      }
     }
   };
 

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -270,24 +270,23 @@ describe('Anchor Render', () => {
 
   it('should not proceed when event is default prevented', () => {
     const hash = getHashUrl();
-    const onClick = jest.fn();
+    const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+    };
     const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const pushStateSpy = jest.spyOn(window.history, 'pushState');
+    const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
     const { container } = render(
-      <Anchor items={[{ key: hash, href: `#${hash}`, title: hash }]} onClick={onClick} />,
+      <Anchor items={[{ key: hash, href: `#${hash}`, title: hash }]} onClick={handleClick} />,
     );
 
     const link = container.querySelector(`a[href="#${hash}"]`)!;
 
-    const mockEvent = {
-      defaultPrevented: true,
-      preventDefault: jest.fn(),
-    } as unknown as React.MouseEvent<HTMLAnchorElement>;
+    fireEvent.click(link);
 
-    fireEvent.click(link, mockEvent);
-
-    expect(onClick).toHaveBeenCalled();
     expect(scrollToSpy).toHaveBeenCalled();
-    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
   });
 
   it('targetOffset prop', async () => {

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -357,8 +357,11 @@ describe('Anchor Render', () => {
     const title = hash;
     const { container } = render(<Anchor replace items={[{ key: hash, href, title }]} />);
 
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
     fireEvent.click(container.querySelector(`a[href="${href}"]`)!);
-    expect(window.location.replace).toHaveBeenCalledWith(href);
+
+    expect(window.history.replaceState).toHaveBeenCalledWith(null, '', href);
   });
 
   it('onChange event', () => {

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -268,6 +268,28 @@ describe('Anchor Render', () => {
     expect(container.querySelector(`a[href="#${hash}_1"]`)).toBeTruthy();
   });
 
+  it('should not proceed when event is default prevented', () => {
+    const hash = getHashUrl();
+    const onClick = jest.fn();
+    const scrollToSpy = jest.spyOn(window, 'scrollTo');
+    const { container } = render(
+      <Anchor items={[{ key: hash, href: `#${hash}`, title: hash }]} onClick={onClick} />,
+    );
+
+    const link = container.querySelector(`a[href="#${hash}"]`)!;
+
+    const mockEvent = {
+      defaultPrevented: true,
+      preventDefault: jest.fn(),
+    } as unknown as React.MouseEvent<HTMLAnchorElement>;
+
+    fireEvent.click(link, mockEvent);
+
+    expect(onClick).toHaveBeenCalled();
+    expect(scrollToSpy).toHaveBeenCalled();
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
   it('targetOffset prop', async () => {
     const hash = getHashUrl();
 
@@ -350,7 +372,7 @@ describe('Anchor Render', () => {
     expect(link).toEqual({ href, title });
   });
 
-  it('replaces item href in browser history', () => {
+  it('replaces item href in browser history (hash href)', () => {
     const hash = getHashUrl();
 
     const href = `#${hash}`;
@@ -362,6 +384,17 @@ describe('Anchor Render', () => {
     fireEvent.click(container.querySelector(`a[href="${href}"]`)!);
 
     expect(window.history.replaceState).toHaveBeenCalledWith(null, '', href);
+  });
+
+  it('replaces item href in browser history (external href)', () => {
+    const hash = getHashUrl();
+
+    const href = `http://www.example.com/#${hash}`;
+    const title = hash;
+    const { container } = render(<Anchor replace items={[{ key: hash, href, title }]} />);
+
+    fireEvent.click(container.querySelector(`a[href="${href}"]`)!);
+    expect(window.location.replace).toHaveBeenCalledWith(href);
   });
 
   it('onChange event', () => {

--- a/components/anchor/demo/legacy-anchor.tsx
+++ b/components/anchor/demo/legacy-anchor.tsx
@@ -4,8 +4,8 @@ import { Anchor } from 'antd';
 const { Link } = Anchor;
 
 const App: React.FC = () => (
-  <Anchor affix={false}>
-    <Link href="#anchor-demo-basic" title="Basic demo" />
+  <Anchor onClick={(e) => {}} affix={false}>
+    <Link href="http://www.example.com/#anchor-demo-basic" title="Basic demo" />
     <Link href="#anchor-demo-static" title="Static demo" />
     <Link href="#api" title="API">
       <Link href="#anchor-props" title="Anchor Props" />

--- a/components/anchor/demo/legacy-anchor.tsx
+++ b/components/anchor/demo/legacy-anchor.tsx
@@ -5,7 +5,7 @@ const { Link } = Anchor;
 
 const App: React.FC = () => (
   <Anchor affix={false}>
-    <Link href="http://www.example.com/#anchor-demo-basic" title="Basic demo" />
+    <Link href="#anchor-demo-basic" title="Basic demo" />
     <Link href="#anchor-demo-static" title="Static demo" />
     <Link href="#api" title="API">
       <Link href="#anchor-props" title="Anchor Props" />

--- a/components/anchor/demo/legacy-anchor.tsx
+++ b/components/anchor/demo/legacy-anchor.tsx
@@ -4,7 +4,7 @@ import { Anchor } from 'antd';
 const { Link } = Anchor;
 
 const App: React.FC = () => (
-  <Anchor onClick={(e) => {}} affix={false}>
+  <Anchor affix={false}>
     <Link href="http://www.example.com/#anchor-demo-basic" title="Basic demo" />
     <Link href="#anchor-demo-static" title="Static demo" />
     <Link href="#api" title="API">


### PR DESCRIPTION
- [ ✔] 🐞 Bug 修复

### 🔗 相关 Issue
https://github.com/ant-design/ant-design/issues/53143

### 💡 需求背景和解决方案

原先使用window.location跳转锚点，会造成页面刷新，修改为window.history.pushState/replaceState实现无刷新路由切换，也是SPA跳转的本质

上述#53143就是因为点击锚点而刷新整个页面，造成页面卡顿，当然Menu组件也有问题（鼠标移动的时候也会大量渲染）

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Click the anchor point to refresh the page     |
| 🇨🇳 中文 |     点击锚点刷新页面     |