### PR TITLE
perf: optimize useState initialization with lazy initialization pattern

### DIFF
--- a/components/calendar/demo/lunar.tsx
+++ b/components/calendar/demo/lunar.tsx
@@ -98,8 +98,8 @@ const useStyle = createStyles(({ token, css, cx }) => {
 const App: React.FC = () => {
   const { styles } = useStyle({ test: true });
 
-  const [selectDate, setSelectDate] = React.useState<Dayjs>(dayjs());
-  const [panelDateDate, setPanelDate] = React.useState<Dayjs>(dayjs());
+  const [selectDate, setSelectDate] = React.useState<Dayjs>(() => dayjs());
+  const [panelDateDate, setPanelDate] = React.useState<Dayjs>(() => dayjs());
 
   const onPanelChange = (value: Dayjs, mode: CalendarProps<Dayjs>['mode']) => {
     console.log(value.format('YYYY-MM-DD'), mode);

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -685,7 +685,7 @@ describe('ColorPicker', () => {
       value,
     )}]`, async () => {
       const Demo = () => {
-        const [color, setColor] = useState<ColorValueType>(generateColor('red'));
+        const [color, setColor] = useState<ColorValueType>(() => generateColor('red'));
         useEffect(() => {
           setColor(value);
         }, []);
@@ -699,7 +699,7 @@ describe('ColorPicker', () => {
 
   it('Controlled string value should work with allowClear correctly', async () => {
     const Demo = (props: any) => {
-      const [color, setColor] = useState<ColorValueType>(generateColor('#FF0000'));
+      const [color, setColor] = useState<ColorValueType>(() => generateColor('#FF0000'));
 
       useEffect(() => {
         if (typeof props.value !== 'undefined') {
@@ -738,7 +738,7 @@ describe('ColorPicker', () => {
 
   it('Controlled value should work with allowClear correctly', async () => {
     const Demo = (props: any) => {
-      const [color, setColor] = useState<ColorValueType>(generateColor('red'));
+      const [color, setColor] = useState<ColorValueType>(() => generateColor('red'));
 
       useEffect(() => {
         if (typeof props.value !== 'undefined') {

--- a/components/color-picker/components/ColorAlphaInput.tsx
+++ b/components/color-picker/components/ColorAlphaInput.tsx
@@ -13,7 +13,9 @@ interface ColorAlphaInputProps {
 
 const ColorAlphaInput: FC<ColorAlphaInputProps> = ({ prefixCls, value, onChange }) => {
   const colorAlphaInputPrefixCls = `${prefixCls}-alpha-input`;
-  const [alphaValue, setAlphaValue] = useState<AggregationColor>(generateColor(value || '#000'));
+  const [alphaValue, setAlphaValue] = useState<AggregationColor>(() =>
+    generateColor(value || '#000'),
+  );
 
   // Update step value
   useEffect(() => {

--- a/components/color-picker/components/ColorHsbInput.tsx
+++ b/components/color-picker/components/ColorHsbInput.tsx
@@ -14,7 +14,7 @@ interface ColorHsbInputProps {
 
 const ColorHsbInput: FC<ColorHsbInputProps> = ({ prefixCls, value, onChange }) => {
   const colorHsbInputPrefixCls = `${prefixCls}-hsb-input`;
-  const [hsbValue, setHsbValue] = useState<AggregationColor>(generateColor(value || '#000'));
+  const [hsbValue, setHsbValue] = useState<AggregationColor>(() => generateColor(value || '#000'));
 
   // Update step value
   useEffect(() => {

--- a/components/color-picker/components/ColorRgbInput.tsx
+++ b/components/color-picker/components/ColorRgbInput.tsx
@@ -14,7 +14,7 @@ interface ColorRgbInputProps {
 
 const ColorRgbInput: FC<ColorRgbInputProps> = ({ prefixCls, value, onChange }) => {
   const colorRgbInputPrefixCls = `${prefixCls}-rgb-input`;
-  const [rgbValue, setRgbValue] = useState<AggregationColor>(generateColor(value || '#000'));
+  const [rgbValue, setRgbValue] = useState<AggregationColor>(() => generateColor(value || '#000'));
 
   // Update step value
   useEffect(() => {

--- a/components/table/demo/row-selection-debug.tsx
+++ b/components/table/demo/row-selection-debug.tsx
@@ -53,7 +53,7 @@ function genData(length: number) {
 }
 
 const App: React.FC = () => {
-  const [data, setData] = useState<DataType[]>(genData(50));
+  const [data, setData] = useState<DataType[]>(() => genData(50));
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
 
   const onSelectChange = (newSelectedRowKeys: React.Key[]) => {

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -401,7 +401,7 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
     onSorterChange,
   } = props;
 
-  const [sortStates, setSortStates] = React.useState<SortState<RecordType>[]>(
+  const [sortStates, setSortStates] = React.useState<SortState<RecordType>[]>(() =>
     collectSortStates<RecordType>(mergedColumns, true),
   );
 

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -129,7 +129,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
   const [container, setContainer] = React.useState<HTMLDivElement | null>();
 
   // Used for nest case like Modal, Drawer
-  const [subElements, setSubElements] = React.useState(new Set<HTMLElement>());
+  const [subElements, setSubElements] = React.useState(() => new Set<HTMLElement>());
 
   // Nest elements should also support watermark
   const targetElements = React.useMemo(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

修复了组件中的ESLint警告，通过使用React useState的懒初始化模式优化了状态初始化。

相关规则 [prefer-use-state-lazy-initialization](https://eslint-react.xyz/docs/rules/hooks-extra-prefer-use-state-lazy-initialization) :

#### Failing
```tsx
import React, { useState } from "react";
 
function MyComponent() {
  const [value, setValue] = useState(generateTodos());
  //                                 ^^^^^^^^^^^^^^^
  //                                 - Don't call a function directly inside the 'useState' call.
 
  return null;
}
 
declare function generateTodos(): string[];
```

#### Passing
```tsx
import React, { useState } from "react";
 
function MyComponent() {
  // 🟢 Good: Use an initializer function to avoid recreating the initial state
  const [value, setValue] = useState(() => generateTodos());
 
  return null;
}
 
declare function generateTodos(): string[];
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Optimize `useState` initialization with lazy pattern.       |
| 🇨🇳 Chinese |      优化 useState 初始化方式以提升渲染性能。     |
