### PR TITLE
feat(Cascader): support `classNames` and `styles` for component and ConfigProvider

### DIFF
--- a/.dumi/components/SelectSemanticTemplate.tsx
+++ b/.dumi/components/SelectSemanticTemplate.tsx
@@ -54,7 +54,6 @@ const Block: React.FC<BlockProps> = ({ component: Component, options, defaultVal
 export interface SelectSemanticTemplateProps {
   component: React.ComponentType<any>;
   componentName: string;
-  defaultValue?: string;
   options?: { value: string; label: string }[];
   height?: number;
   onSearch?: (text: string) => void;

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -18,7 +18,7 @@ import type {
 import Select from '../select';
 
 type SemanticName = 'root' | 'prefix' | 'input';
-type PopupSemantic = 'root' | 'listItem' | 'input' | 'list';
+type PopupSemantic = 'root' | 'listItem' | 'list';
 
 const { Option } = Select;
 

--- a/components/cascader/__tests__/semantic.test.tsx
+++ b/components/cascader/__tests__/semantic.test.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+
+import Cascader from '..';
+import { render } from '../../../tests/utils';
+
+describe('Cascader.typescript', () => {
+  it('options value', () => {
+    const options = [
+      {
+        value: 1,
+        label: 'Zhejiang',
+        children: [
+          {
+            value: 'hangzhou',
+            label: 'Hangzhou',
+            children: [
+              {
+                value: 'xihu',
+                label: 'West Lake',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        value: 'jiangsu',
+        label: 'Jiangsu',
+        children: [
+          {
+            value: 'nanjing',
+            label: 'Nanjing',
+            children: [
+              {
+                value: 'zhonghuamen',
+                label: 'Zhong Hua Men',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const customClassNames = {
+      root: 'custom-root',
+      input: 'custom-input',
+      popup: {
+        root: 'custom-popup',
+        list: 'custom-list',
+        listItem: 'custom-list-item',
+      },
+    };
+    const customStyles = {
+      root: { color: 'red' },
+      input: { color: 'green' },
+      popup: {
+        root: { color: 'purple' },
+        list: { color: 'blue' },
+        listItem: { color: 'yellow' },
+      },
+    };
+
+    const { container } = render(
+      <Cascader
+        open
+        options={options}
+        defaultValue={[1, 'hangzhou']}
+        classNames={customClassNames}
+        styles={customStyles}
+      />,
+    );
+    const root = container.querySelector('.ant-cascader');
+    const input = container.querySelector('.ant-select-selection-search-input');
+    const list = container.querySelector('.ant-cascader-menu');
+    const listItem = container.querySelector('.ant-cascader-menu-item');
+    const popup = container.querySelector('.ant-select-dropdown');
+
+    expect(root).toHaveClass(customClassNames.root);
+    expect(input).toHaveClass(customClassNames.input);
+    expect(list).toHaveClass(customClassNames.popup.list);
+    expect(listItem).toHaveClass(customClassNames.popup.listItem);
+    expect(popup).toHaveClass(customClassNames.popup.root);
+
+    expect(root).toHaveStyle(customStyles.root);
+    expect(input).toHaveStyle(customStyles.input);
+    expect(list).toHaveStyle(customStyles.popup.list);
+    expect(listItem).toHaveStyle(customStyles.popup.listItem);
+    expect(popup).toHaveStyle(customStyles.popup.root);
+  });
+});

--- a/components/cascader/__tests__/semantic.test.tsx
+++ b/components/cascader/__tests__/semantic.test.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import Cascader from '..';
 import { render } from '../../../tests/utils';
 
-describe('Cascader.typescript', () => {
-  it('options value', () => {
+describe('Cascader.Semantic', () => {
+  it('support classNames and styles', () => {
     const options = [
       {
         value: 1,

--- a/components/cascader/demo/_semantic.tsx
+++ b/components/cascader/demo/_semantic.tsx
@@ -11,34 +11,16 @@ interface Option {
 
 const options: Option[] = [
   {
-    value: 'zhejiang',
-    label: 'Zhejiang',
+    value: 'contributors',
+    label: 'contributors',
     children: [
       {
-        value: 'hangzhou',
-        label: 'Hangzhou',
-        children: [
-          {
-            value: 'xihu',
-            label: 'West Lake',
-          },
-        ],
+        value: 'aojunhao123',
+        label: 'aojunhao123',
       },
-    ],
-  },
-  {
-    value: 'jiangsu',
-    label: 'Jiangsu',
-    children: [
       {
-        value: 'nanjing',
-        label: 'Nanjing',
-        children: [
-          {
-            value: 'zhonghuamen',
-            label: 'Zhong Hua Men',
-          },
-        ],
+        value: 'thinkasany',
+        label: 'thinkasany',
       },
     ],
   },
@@ -50,6 +32,7 @@ const App: React.FC = () => {
       open
       component={Cascader}
       componentName="Cascader"
+      defaultValue={['contributors', 'thinkasany']}
       prefix="prefix"
       style={{ width: 200 }}
       options={options}

--- a/components/cascader/demo/_semantic.tsx
+++ b/components/cascader/demo/_semantic.tsx
@@ -1,75 +1,59 @@
 import React from 'react';
 import { Cascader } from 'antd';
-import type { CascaderProps } from 'antd';
 
-import SemanticPreview from '../../../.dumi/components/SemanticPreview';
-import useLocale from '../../../.dumi/hooks/useLocale';
+import TemplateSemanticPreview from '../../../.dumi/components/SelectSemanticTemplate';
 
-const locales = {
-  cn: {
-    root: '根元素',
-    'popup.root': '弹出菜单元素',
-  },
-  en: {
-    root: 'Root element',
-    'popup.root': 'Popup element',
-  },
-};
-const options = [
+interface Option {
+  value: string;
+  label: string;
+  children?: Option[];
+}
+
+const options: Option[] = [
   {
-    value: 'contributors',
-    label: 'contributors',
+    value: 'zhejiang',
+    label: 'Zhejiang',
     children: [
       {
-        value: 'aojunhao123',
-        label: 'aojunhao123',
+        value: 'hangzhou',
+        label: 'Hangzhou',
+        children: [
+          {
+            value: 'xihu',
+            label: 'West Lake',
+          },
+        ],
       },
+    ],
+  },
+  {
+    value: 'jiangsu',
+    label: 'Jiangsu',
+    children: [
       {
-        value: 'thinkasany',
-        label: 'thinkasany',
+        value: 'nanjing',
+        label: 'Nanjing',
+        children: [
+          {
+            value: 'zhonghuamen',
+            label: 'Zhong Hua Men',
+          },
+        ],
       },
     ],
   },
 ];
 
-const Block: React.FC<Readonly<CascaderProps<any, any, any>>> = (props) => {
-  const divRef = React.useRef<HTMLDivElement>(null);
-  const [value, setValue] = React.useState<string[]>(['contributors', 'aojunhao123']);
-  return (
-    <div ref={divRef} style={{ marginBottom: 60 }}>
-      <Cascader
-        {...props}
-        open
-        styles={{
-          popup: {
-            root: {
-              zIndex: 1,
-              height: 70,
-            },
-          },
-        }}
-        getPopupContainer={() => divRef.current!}
-        value={value}
-        onChange={setValue}
-        options={options}
-        placement="bottomLeft"
-      />
-    </div>
-  );
-};
-
 const App: React.FC = () => {
-  const [locale] = useLocale(locales);
   return (
-    <SemanticPreview
+    <TemplateSemanticPreview
+      open
+      component={Cascader}
       componentName="Cascader"
-      semantics={[
-        { name: 'root', desc: locale.root, version: '5.25.0' },
-        { name: 'popup.root', desc: locale['popup.root'], version: '5.25.0' },
-      ]}
-    >
-      <Block />
-    </SemanticPreview>
+      prefix="prefix"
+      style={{ width: 200 }}
+      options={options}
+    />
   );
 };
 

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -52,7 +52,7 @@ export type FieldNamesType = FieldNames;
 export type FilledFieldNamesType = Required<FieldNamesType>;
 
 type SemanticName = 'root' | 'prefix' | 'suffix';
-type PopupSemantic = 'root' | 'listItem' | 'input' | 'list';
+type PopupSemantic = 'root' | 'listItem' | 'list';
 
 const { SHOW_CHILD, SHOW_PARENT } = RcCascader;
 

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -75,7 +75,7 @@ export interface InternalSelectProps<
 }
 
 type SemanticName = 'root' | 'prefix' | 'suffix';
-type PopupSemantic = 'root' | 'listItem' | 'input' | 'list';
+type PopupSemantic = 'root' | 'listItem' | 'list';
 
 export interface SelectProps<
   ValueType = any,

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@ant-design/fast-color": "^3.0.0",
     "@ant-design/icons": "^6.0.0",
     "@ant-design/react-slick": "~1.1.2",
-    "@rc-component/cascader": "~1.1.0",
+    "@rc-component/cascader": "~1.2.0",
     "@rc-component/collapse": "~1.0.1",
     "@rc-component/color-picker": "~3.0.1",
     "@rc-component/dialog": "~1.2.0",


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🆕 New feature


### todo

- [x] wait for https://github.com/react-component/cascader/pull/587/files

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |         feat: ConfigProvider support classNames and styles for Cascader  |
| 🇨🇳 Chinese |   feat: ConfigProvider support classNames and styles for Cascader        |
