### PR TITLE
chore: clean similar function methods

### DIFF
--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -4,7 +4,7 @@ import CSSMotion from 'rc-motion';
 import raf from 'rc-util/lib/raf';
 import { composeRef } from 'rc-util/lib/ref';
 
-import { getReactRender } from '../../config-provider/UnstableContext';
+import { unstableSetRender } from '../../config-provider/UnstableContext';
 import type { UnmountType } from '../../config-provider/UnstableContext';
 import { TARGET_CLS } from './interface';
 import type { ShowWaveEffect } from './interface';
@@ -160,7 +160,7 @@ const showWaveEffect: ShowWaveEffect = (target, info) => {
   holder.style.top = '0px';
   target?.insertBefore(holder, target?.firstChild);
 
-  const reactRender = getReactRender();
+  const reactRender = unstableSetRender();
 
   let unmountCallback: UnmountType | null = null;
 

--- a/components/config-provider/UnstableContext.tsx
+++ b/components/config-provider/UnstableContext.tsx
@@ -43,7 +43,3 @@ export function unstableSetRender(render?: RenderType) {
   }
   return unstableRender;
 }
-
-export function getReactRender() {
-  return unstableRender;
-}

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 
 import { AppConfigContext } from '../app/context';
 import ConfigProvider, { ConfigContext, globalConfig, warnContext } from '../config-provider';
-import { getReactRender } from '../config-provider/UnstableContext';
+import { unstableSetRender } from '../config-provider/UnstableContext';
 import type {
   ArgsProps,
   ConfigOptions,
@@ -132,7 +132,7 @@ function flushNotice() {
 
     // Delay render to avoid sync issue
     act(() => {
-      const reactRender = getReactRender();
+      const reactRender = unstableSetRender();
 
       reactRender(
         <GlobalHolderWrapper

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 
 import warning from '../_util/warning';
 import ConfigProvider, { ConfigContext, globalConfig, warnContext } from '../config-provider';
-import { getReactRender, UnmountType } from '../config-provider/UnstableContext';
+import { unstableSetRender, UnmountType } from '../config-provider/UnstableContext';
 import type { ConfirmDialogProps } from './ConfirmDialog';
 import ConfirmDialog from './ConfirmDialog';
 import destroyFns from './destroyFns';
@@ -104,7 +104,7 @@ export default function confirm(config: ModalFuncProps) {
 
       const dom = <ConfirmDialogWrapper {...props} />;
 
-      const reactRender = getReactRender();
+      const reactRender = unstableSetRender();
 
       reactUnmount = reactRender(
         <ConfigProvider prefixCls={rootPrefixCls} iconPrefixCls={iconPrefixCls} theme={theme}>

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 
 import { AppConfigContext } from '../app/context';
 import ConfigProvider, { ConfigContext, globalConfig, warnContext } from '../config-provider';
-import { getReactRender } from '../config-provider/UnstableContext';
+import { unstableSetRender } from '../config-provider/UnstableContext';
 import type { ArgsProps, GlobalConfigProps, NotificationInstance } from './interface';
 import PurePanel from './PurePanel';
 import useNotification, { useInternalNotification } from './useNotification';
@@ -126,7 +126,7 @@ function flushNotice() {
 
     // Delay render to avoid sync issue
     act(() => {
-      const reactRender = getReactRender();
+      const reactRender = unstableSetRender();
 
       reactRender(
         <GlobalHolderWrapper


### PR DESCRIPTION
对 https://github.com/ant-design/ant-design/pull/53662 部分的补充。 `getReactRender` 部分可以直接移除掉了...

提个 PR 讨论一下是不是可以删除掉。 如果其他人用到了肯定是会 break 的