### PR TITLE
fix(Splitter): use minimum value as fallback when historical value out of bound

### DIFF
--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -527,17 +527,18 @@ describe('Splitter', () => {
       const onResize = jest.fn();
       const onResizeEnd = jest.fn();
 
+      containerSize = 500;
+
       const { container } = render(
         <SplitterDemo
           items={[
             {
-              defaultSize: 10,
+              defaultSize: 300,
               collapsible: true,
-              min: 15,
+              max: 200,
             },
             {
               collapsible: true,
-              min: '80%',
             },
           ]}
           onResize={onResize}
@@ -549,25 +550,67 @@ describe('Splitter', () => {
 
       // Collapse left
       fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-start')!);
-      expect(onResize).toHaveBeenCalledWith([0, 100]);
-      expect(onResizeEnd).toHaveBeenCalledWith([0, 100]);
-      expect(container.querySelector('.ant-splitter-bar-dragger-disabled')).toBeTruthy();
+      expect(onResize).toHaveBeenCalledWith([0, 500]);
+      expect(onResizeEnd).toHaveBeenCalledWith([0, 500]);
 
       // Collapse back
       onResize.mockReset();
       onResizeEnd.mockReset();
       fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-end')!);
-      expect(onResize).toHaveBeenCalledWith([2.5, 97.5]);
-      expect(onResizeEnd).toHaveBeenCalledWith([2.5, 97.5]);
-      expect(container.querySelector('.ant-splitter-bar-dragger-disabled')).toBeFalsy();
+      expect(onResize).toHaveBeenCalledWith([100, 400]);
+      expect(onResizeEnd).toHaveBeenCalledWith([100, 400]);
 
       // Collapse right
       onResize.mockReset();
       onResizeEnd.mockReset();
       fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-end')!);
-      expect(onResize).toHaveBeenCalledWith([100, 0]);
-      expect(onResizeEnd).toHaveBeenCalledWith([100, 0]);
-      expect(container.querySelector('.ant-splitter-bar-dragger-disabled')).toBeTruthy();
+      expect(onResize).toHaveBeenCalledWith([500, 0]);
+      expect(onResizeEnd).toHaveBeenCalledWith([500, 0]);
+    });
+
+    it('collapsible with min', async () => {
+      const onResize = jest.fn();
+      const onResizeEnd = jest.fn();
+
+      containerSize = 440;
+
+      const { container } = render(
+        <SplitterDemo
+          items={[
+            {
+              defaultSize: 100,
+              collapsible: true,
+              min: 150,
+            },
+            {
+              collapsible: true,
+            },
+          ]}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+        />,
+      );
+
+      await resizeSplitter();
+
+      // Collapse left
+      fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-start')!);
+      expect(onResize).toHaveBeenCalledWith([0, 440]);
+      expect(onResizeEnd).toHaveBeenCalledWith([0, 440]);
+
+      // Collapse back
+      onResize.mockReset();
+      onResizeEnd.mockReset();
+      fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-end')!);
+      expect(onResize).toHaveBeenCalledWith([150, 290]);
+      expect(onResizeEnd).toHaveBeenCalledWith([150, 290]);
+
+      // Collapse right
+      onResize.mockReset();
+      onResizeEnd.mockReset();
+      fireEvent.click(container.querySelector('.ant-splitter-bar-collapse-end')!);
+      expect(onResize).toHaveBeenCalledWith([440, 0]);
+      expect(onResizeEnd).toHaveBeenCalledWith([440, 0]);
     });
   });
 

--- a/components/splitter/hooks/useResize.ts
+++ b/components/splitter/hooks/useResize.ts
@@ -143,7 +143,7 @@ export default function useResize(
 
       const limitStart = Math.max(currentSizeMin, totalSize - targetSizeMax);
       const limitEnd = Math.min(currentSizeMax, totalSize - targetSizeMin);
-      const halfOffset = (limitEnd - limitStart) / 2;
+      const halfOffset = targetSizeMin || (limitEnd - limitStart) / 2;
 
       const targetCacheCollapsedSize = cacheCollapsedSize.current[index];
       const currentCacheCollapsedSize = totalSize - targetCacheCollapsedSize;


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 在defaultSize小于min的时候,并且没有进行过resize的情况下,展开应该恢复到min

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix: #53663

### 💡 Background and Solution

再次展开时，如果历史值超出面板设置的范围，优先使用面板自身设置的最小值作为恢复值，如果没设置最小值则将使用安全值兜底

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  use minimum value as fallback when historical value out of bound |
| 🇨🇳 Chinese | 历史值超出范围时使用面板设置的最小值最为兜底值  |
