### PR TITLE
docs: replace Chinese Punctuation Marks within English Documents

### DIFF
--- a/components/config-provider/demo/holderRender.md
+++ b/components/config-provider/demo/holderRender.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Use `holderRender` to set the `Provider` for the static methods `message` 、`modal` 、`notification`.
+Use `holderRender` to set the `Provider` for the static methods `message`,`modal`,`notification`.

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -71,7 +71,7 @@ Some components use dynamic style to support wave effect. You can config `csp` p
 
 ### ConfigProvider.config()
 
-Setting `Modal`、`Message`、`Notification` static config. Not work on hooks.
+Setting `Modal`, `Message`, `Notification` static config. Not work on hooks.
 
 ```tsx
 ConfigProvider.config({

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -573,7 +573,7 @@ type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
 
 ## FAQ
 
-### Why can't Switch、Checkbox bind data?
+### Why can't Switch, Checkbox bind data?
 
 Form.Item default bind value to `value` prop, but Switch or Checkbox value prop is `checked`. You can use `valuePropName` to change bind value prop.
 

--- a/components/mentions/demo/status.md
+++ b/components/mentions/demo/status.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Add status to Mentions with `status`, which could be `error` or `warning`。
+Add status to Mentions with `status`, which could be `error` or `warning`.

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -15,7 +15,7 @@ More layouts with navigation: [Layout](/components/layout).
 
 ## Notes for developers
 
-- Menu is rendered as a `ul` element, so it only supports [`li` and `script-supporting` elements](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) as children nodes。Your customized node should be wrapped by `Menu.Item`.
+- Menu is rendered as a `ul` element, so it only supports [`li` and `script-supporting` elements](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) as children nodes. Your customized node should be wrapped by `Menu.Item`.
 - Menu needs to collect its node structure, so its children should be `Menu.*` or encapsulated HOCs.
 
 ## Examples

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -83,7 +83,7 @@ Methods for global configuration and destruction are also provided:
 - `message.config(options)`
 - `message.destroy()`
 
-> use `message.destroy(key)` to remove a message。
+> use `message.destroy(key)` to remove a message.
 
 #### message.config
 

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -72,7 +72,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### RadioGroup
 
-Radio group can wrap a group of `Radio`。
+Radio group can wrap a group of `Radio`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -41,7 +41,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | delete | Deleted line style | boolean | false |  |
 | disabled | Disabled content | boolean | false |  |
 | editable | If editable. Can control edit state when is object | boolean \| [editable](#editable) | false |  |
-| ellipsis | Display ellipsis when text overflows, can't configure expandable、rows and onExpand by using object. Diff with Typography.Paragraph, Text do not have 100% width style which means it will fix width on the first ellipsis. If you want to have responsive ellipsis, please set width manually | boolean \| [Omit<ellipsis, 'expandable' \| 'rows' \| 'onExpand'>](#ellipsis) | false |  |
+| ellipsis | Display ellipsis when text overflows, can't configure expandable, rows and onExpand by using object. Diff with Typography.Paragraph, Text do not have 100% width style which means it will fix width on the first ellipsis. If you want to have responsive ellipsis, please set width manually | boolean \| [Omit<ellipsis, 'expandable' \| 'rows' \| 'onExpand'>](#ellipsis) | false |  |
 | keyboard | Keyboard style | boolean | false | 4.3.0 |
 | mark | Marked style | boolean | false |  |
 | onClick | Set the handler to handle click event | (event) => void | - |  |

--- a/docs/blog/contributor-development-maintenance-guide.en-US.md
+++ b/docs/blog/contributor-development-maintenance-guide.en-US.md
@@ -61,7 +61,7 @@ Back to the topic, what should we do if we find snapshot test failed after chang
 
    - Local dependency is out of date. This may happen when you pull the latest code, but did not update the local dependency. Deleting `lock` file, `node_modules`, and then reinstalling dependencies could solve this problem.
 
-     solution is as simple as deleting the lock file、node_modules and reinstall dependencies.
+     solution is as simple as deleting the lock file, node_modules and reinstall dependencies.
 
    - Your code not synchronizing baseline code can also result in inconsistent snapshot comparisons. The solution is as simple as pulling the baseline code locally and then rebase your code to the baseline code.
 

--- a/docs/react/introduce.en-US.md
+++ b/docs/react/introduce.en-US.md
@@ -64,7 +64,7 @@ We provide `antd.js` and `antd.min.js` `reset.css` under [dist](https://unpkg.co
 
 > **We strongly discourage loading the entire files** this will add bloat to your application and make it more difficult to receive bugfixes and updates. Antd is intended to be used in conjunction with a build tool, such as [webpack](https://webpack.github.io/), which will make it easy to import only the parts of antd that you are using.
 
-> Note: You should import `react`、`react-dom`、`dayjs` before using `antd.js`.
+> Note: You should import `react`, `react-dom`, `dayjs` before using `antd.js`.
 
 ## Usage
 

--- a/docs/react/migrate-less-variables.en-US.md
+++ b/docs/react/migrate-less-variables.en-US.md
@@ -297,9 +297,9 @@ export default App;
 | --- | --- | --- |
 | `@descriptions-bg` | `labelBg` | - |
 | `@descriptions-title-margin-bottom` | `titleMarginBottom` | - |
-| `@descriptions-default-padding` | `padding`、`paddingLG` | GlobalToken, used as `${token.padding}px ${token.paddingLG}px` |
-| `@descriptions-middle-padding` | `paddingSM`、`paddingLG` | GlobalToken, used as `${token.paddingSM}px ${token.paddingLG}px` |
-| `@descriptions-small-padding` | `paddingXS`、`padding` | GlobalToken, used as `${token.paddingXS}px ${token.padding}px` |
+| `@descriptions-default-padding` | `padding`, `paddingLG` | GlobalToken, used as `${token.padding}px ${token.paddingLG}px` |
+| `@descriptions-middle-padding` | `paddingSM`, `paddingLG` | GlobalToken, used as `${token.paddingSM}px ${token.paddingLG}px` |
+| `@descriptions-small-padding` | `paddingXS`, `padding` | GlobalToken, used as `${token.paddingXS}px ${token.padding}px` |
 | `@descriptions-item-padding-bottom` | `itemPaddingBottom` | - |
 | `@descriptions-item-trailing-colon` | - | Deprecated for style change |
 | `@descriptions-item-label-colon-margin-right` | `colonMarginRight` | - |
@@ -323,7 +323,7 @@ export default App;
 | Less variables | Component Token | Note |
 | --- | --- | --- |
 | `@drawer-bg` | `colorBgElevated` | GlobalToken |
-| `@drawer-header-padding` | `padding`、`paddingLG` | GlobalToken, used as `${padding}px ${paddingLG}px` |
+| `@drawer-header-padding` | `padding`, `paddingLG` | GlobalToken, used as `${padding}px ${paddingLG}px` |
 | `@drawer-title-font-size` | `fontSizeLG` | GlobalToken |
 | `@drawer-title-line-height` | `lineHeightLG` | GlobalToken |
 | `@drawer-body-padding` | `paddingLG` | GlobalToken |

--- a/docs/react/use-with-next.en-US.md
+++ b/docs/react/use-with-next.en-US.md
@@ -80,7 +80,7 @@ export default RootLayout;
 Next.js App Router currently not support using sub-components via `.` like `<Select.Option />` and `<Typography.Text />`. Importing them from path would solve this problem.
 :::
 
-For more detailed information, please refer to [with-nextjs-app-router-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-app-router-inline-style)。
+For more detailed information, please refer to [with-nextjs-app-router-inline-style](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-app-router-inline-style).
 
 ## Using Pages Router
 

--- a/docs/spec/data-entry.en-US.md
+++ b/docs/spec/data-entry.en-US.md
@@ -24,7 +24,7 @@ Input is the basic and common way for data entry, which provides a text editable
 
 It uses a single line for text input with limited length.
 
-> Note: Specific styles can be applied to some text (e.g. numbers, URL). Please refer to [Input](/components/input/)。
+> Note: Specific styles can be applied to some text (e.g. numbers, URL). Please refer to [Input](/components/input/).
 
 ### Textarea
 

--- a/docs/spec/navigation.en-US.md
+++ b/docs/spec/navigation.en-US.md
@@ -34,7 +34,7 @@ Top navigation menu put hyperlinks in a row and present information in a simple 
 
 Vertical navigation is more flexible than horizontal one, menu items are easily extensible downward, and longer labels can be allowed. With help from a scrollbar, unlimited number of menu items can be supported. It is suitable for multi-level, operation intensive and dashboard-like web apps.
 
-- More layouts with navigation: [Layout](/components/layout/)。
+- More layouts with navigation: [Layout](/components/layout/).
 
 ---
 

--- a/docs/spec/reaction.en-US.md
+++ b/docs/spec/reaction.en-US.md
@@ -51,7 +51,7 @@ Live Preview: A Live Preview gives the users a glimpse beforehand of how the app
 
 <br>
 
-Progressive Disclosure: When users are faced with a series of steps, it is often best to provide hints only when they are needed, instead of cluttering the interface by displaying all the hints at once. Learn more cases on [Stay on the Page/Progressive Disclosure](/docs/spec/stay#process-flows)。
+Progressive Disclosure: When users are faced with a series of steps, it is often best to provide hints only when they are needed, instead of cluttering the interface by displaying all the hints at once. Learn more cases on [Stay on the Page/Progressive Disclosure](/docs/spec/stay#process-flows).
 
 <br>
 

--- a/docs/spec/visual.en-US.md
+++ b/docs/spec/visual.en-US.md
@@ -171,7 +171,7 @@ In Ant Design's visualisation system, we have developed a set of layout adaptati
   <img alt="dynamic interaction" src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*QXtKSIMgaOUAAAAAAAAAAABkARQnAQ" />
 </ImagePreview>
 
-Different from the relatively static presentation of traditional data reports, interactive charts do not stop at the level of information display. Users continuously interact with the charts to get deeper analysis and information from the data.。
+Different from the relatively static presentation of traditional data reports, interactive charts do not stop at the level of information display. Users continuously interact with the charts to get deeper analysis and information from the data.
 
 In data visualisation, we break down the interaction actions into three layers, namely "data acquisition", "information processing" and "knowledge flow", according to the user's level of consciousness and the goals corresponding to each level. It matches the motto of "overview first, focus on filtering, and then view the details as needed" in visual information retrieval. It is also in line with the basic logic of human seeking information: first general, then local, and then focus on the point of interest to explore, which is a process from the surface to the inside.
 


### PR DESCRIPTION
The periods (。) and the commas (、) are replaced with ASCII ones.

Used `^(?!.*\p{Script=Han}).*?[。、].*` to search for the candidates.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

None I could find

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

I just hit this:
![image](https://github.com/user-attachments/assets/d8d9080d-ca73-4ec3-b18e-d27686408b34)

...and figured there are more out there.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog                                                  |
| ---------- | -----------------------------------------------------------|
| 🇺🇸 English | Replaced misused punctuation marks from English documents. |
| 🇨🇳 Chinese | 替换了英文文档中误用的标点符号。                              |

The changelog is translated by Google so please feel free to correct.