### PR TITLE
fix: Fixed the issue of multiple calls to onResizeEnd in lazy mode

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -15,7 +15,7 @@ export interface SplitBarProps {
   endCollapsible: boolean;
   onOffsetStart: (index: number) => void;
   onOffsetUpdate: (index: number, offsetX: number, offsetY: number, lazyEnd?: boolean) => void;
-  onOffsetEnd: VoidFunction;
+  onOffsetEnd: (lazyEnd?: boolean) => void;
   onCollapse: (index: number, type: 'start' | 'end') => void;
   vertical: boolean;
   ariaNow: number;
@@ -95,7 +95,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   const handleLazyEnd = useEvent(() => {
     onOffsetUpdate(index, constrainedOffsetX, constrainedOffsetY, true);
     setConstrainedOffset(0);
-    onOffsetEnd();
+    onOffsetEnd(true);
   });
 
   React.useEffect(() => {
@@ -138,9 +138,10 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       const handleTouchEnd = () => {
         if (lazy) {
           handleLazyEnd();
+        } else {
+          onOffsetEnd();
         }
         setStartPos(null);
-        onOffsetEnd();
       };
 
       window.addEventListener('touchmove', handleTouchMove);

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -119,8 +119,11 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     }
   });
 
-  const onInternalResizeEnd = useEvent(() => {
-    onOffsetEnd();
+  const onInternalResizeEnd = useEvent((lazyEnd?: boolean) => {
+    if (lazyEnd) {
+      onOffsetEnd();
+      return;
+    }
     onResizeEnd?.(itemPxSizes);
   });
 

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -155,6 +155,7 @@ describe('Splitter', () => {
       // Right
       mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, 40);
       expect(onResize).toHaveBeenCalledWith([90, 10]);
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
       expect(onResizeEnd).toHaveBeenCalledWith([90, 10]);
 
       // Left
@@ -176,6 +177,7 @@ describe('Splitter', () => {
       // Right
       mockTouchDrag(container.querySelector('.ant-splitter-bar-dragger')!, 40);
       expect(onResize).toHaveBeenCalledWith([90, 10]);
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
       expect(onResizeEnd).toHaveBeenCalledWith([90, 10]);
 
       // Left

--- a/components/splitter/__tests__/lazy.test.tsx
+++ b/components/splitter/__tests__/lazy.test.tsx
@@ -116,6 +116,7 @@ describe('Splitter lazy', () => {
 
     // Right
     mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, onResize, 1000);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
     expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
 
     // Left


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/53700

### 💡 Background and Solution



### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fixed the issue of multiple calls to onResizeEnd in lazy mode      |
| 🇨🇳 Chinese |     修复 lazy 模式下 onResizeEnd 被多次调用问题      |
