### PR TITLE
docs: improve semantic hightlight example for Skeleton

### DIFF
--- a/components/skeleton/demo/_semantic_element.tsx
+++ b/components/skeleton/demo/_semantic_element.tsx
@@ -10,32 +10,32 @@ interface PreviewContentProps {
 }
 
 const COMPONENT_MAP: Record<string, React.ElementType> = {
-  avatar: Skeleton.Avatar,
-  button: Skeleton.Button,
-  input: Skeleton.Input,
-  node: Skeleton.Node,
-  image: Skeleton.Image,
+  Avatar: Skeleton.Avatar,
+  Button: Skeleton.Button,
+  Input: Skeleton.Input,
+  Node: Skeleton.Node,
+  Image: Skeleton.Image,
 };
 
 const OPTIONS = [
   {
-    value: 'avatar',
+    value: 'Avatar',
     label: 'Avatar',
   },
   {
-    value: 'button',
+    value: 'Button',
     label: 'Button',
   },
   {
-    value: 'input',
+    value: 'Input',
     label: 'Input',
   },
   {
-    value: 'image',
+    value: 'Image',
     label: 'Image',
   },
   {
-    value: 'node',
+    value: 'Node',
     label: 'Node',
   },
 ];
@@ -70,12 +70,12 @@ const locales = {
 };
 
 const App: React.FC = () => {
-  const [element, setElement] = useState('avatar');
+  const [element, setElement] = useState('Avatar');
   const [locale] = useLocale(locales);
 
   return (
     <SemanticPreview
-      componentName="Skeleton.Element"
+      componentName={`Skeleton.${element}`}
       semantics={[
         { name: 'root', desc: locale.root, version: '6.0.0' },
         { name: 'content', desc: locale.content, version: '6.0.0' },


### PR DESCRIPTION


### 🤔 This is a ...


- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement


### 💡 Background and Solution
提示 ```Skeleton.Element``` 不够具体，可能会误导错误使用。

### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    docs: improve semantic hightlight example for Skeleton     |
| 🇨🇳 Chinese |     docs：优化 Skeleton   高亮例子     |
