### PR TITLE
fix: The align property of the Space component does not take effect

### DIFF
--- a/components/space/style/index.ts
+++ b/components/space/style/index.ts
@@ -27,16 +27,16 @@ const genSpaceStyle: GenerateStyle<SpaceToken> = (token) => {
       '&-align': {
         flexDirection: 'column',
         '&-center': {
-          alignItems: 'center',
+          justifyContent: 'center',
         },
         '&-start': {
-          alignItems: 'flex-start',
+          justifyContent: 'flex-start',
         },
         '&-end': {
-          alignItems: 'flex-end',
+          justifyContent: 'flex-end',
         },
         '&-baseline': {
-          alignItems: 'baseline',
+          justifyContent: 'baseline',
         },
       },
       [`${componentCls}-item:empty`]: {


### PR DESCRIPTION
The align of the Space component cannot take effect. The reason is that it was previously set as secondary axis alignment instead of the main axis. I have modified it to the main axis.