### PR TITLE
fix: Button组件在低端机器下开启loading状态后无法正确阻止onClick事件

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -194,6 +194,24 @@ describe('Button', () => {
     jest.useRealTimers();
   });
 
+  it('should update loading state correctly when using ref', async () => {
+    jest.useFakeTimers();
+    const { container, rerender } = render(<Button loading={{ delay: 1000 }} />);
+
+    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(1);
+
+    rerender(<Button loading={false} />);
+    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(0);
+
+    jest.useRealTimers();
+  });
+
   it('should not clickable when button is loading', () => {
     const onClick = jest.fn();
     const { container } = render(

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -194,24 +194,6 @@ describe('Button', () => {
     jest.useRealTimers();
   });
 
-  it('should update loading state correctly when using ref', async () => {
-    jest.useFakeTimers();
-    const { container, rerender } = render(<Button loading={{ delay: 1000 }} />);
-
-    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(0);
-
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(1);
-
-    rerender(<Button loading={false} />);
-    expect(container.querySelectorAll('.ant-btn-loading')).toHaveLength(0);
-
-    jest.useRealTimers();
-  });
-
   it('should not clickable when button is loading', () => {
     const onClick = jest.fn();
     const { container } = render(
@@ -221,6 +203,32 @@ describe('Button', () => {
     );
     fireEvent.click(container.firstChild!);
     expect(onClick).not.toHaveBeenCalledWith();
+  });
+
+  it('should prevent multiple clicks after triggering loading state', () => {
+    const onClick = jest.fn();
+    const TestComponent = () => {
+      const [loading, setLoading] = useState(false);
+
+      const handleClick = () => {
+        onClick();
+        setLoading(true);
+      };
+
+      return (
+        <Button loading={loading} onClick={handleClick}>
+          Click Me
+        </Button>
+      );
+    };
+
+    const { container } = render(<TestComponent />);
+
+    fireEvent.click(container.firstChild!);
+    fireEvent.click(container.firstChild!);
+    fireEvent.click(container.firstChild!);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('should support link button', () => {

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -180,6 +180,8 @@ const InternalCompoundedButton = React.forwardRef<
   const loadingOrDelay = useMemo<LoadingConfigType>(() => getLoadingConfig(loading), [loading]);
 
   const [innerLoading, setLoading] = useState<boolean>(loadingOrDelay.loading);
+  // Fix https://github.com/ant-design/ant-design/issues/51325
+  const innerLoadingRef = useRef<boolean>(loadingOrDelay.loading);
 
   const [hasTwoCNChar, setHasTwoCNChar] = useState<boolean>(false);
 
@@ -209,9 +211,11 @@ const InternalCompoundedButton = React.forwardRef<
       delayTimer = setTimeout(() => {
         delayTimer = null;
         setLoading(true);
+        innerLoadingRef.current = true;
       }, loadingOrDelay.delay);
     } else {
       setLoading(loadingOrDelay.loading);
+      innerLoadingRef.current = loadingOrDelay.loading;
     }
 
     function cleanupTimer() {
@@ -251,7 +255,7 @@ const InternalCompoundedButton = React.forwardRef<
   const handleClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) => {
       // FIXME: https://github.com/ant-design/ant-design/issues/30207
-      if (innerLoading || mergedDisabled) {
+      if (innerLoadingRef.current || innerLoading || mergedDisabled) {
         e.preventDefault();
         return;
       }

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -62,11 +62,6 @@ export interface ButtonProps extends BaseButtonProps, MergedHTMLAttributes {
   autoInsertSpace?: boolean;
 }
 
-export type LoadingConfigType = {
-  loading: boolean;
-  delay: number;
-};
-
 type ColorVariantPairType = [color?: ButtonColorType, variant?: ButtonVariantType];
 
 const ButtonTypeMap: Partial<Record<ButtonType, ColorVariantPairType>> = {

--- a/components/button/demo/basic.tsx
+++ b/components/button/demo/basic.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
 import { Button, Flex } from 'antd';
 
-const App: React.FC = () => (
-  <Flex gap="small" wrap>
-    <Button type="primary">Primary Button</Button>
-    <Button>Default Button</Button>
-    <Button type="dashed">Dashed Button</Button>
-    <Button type="text">Text Button</Button>
-    <Button type="link">Link Button</Button>
-  </Flex>
-);
+const App: React.FC = () => {
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  const enterLoading = (index: number) => {
+    console.log('click');
+    setLoading(true);
+
+    setTimeout(() => {
+      setLoading(false);
+    }, 3000);
+  };
+
+  return (
+    <Button
+      type="primary"
+      // disabled={loading}
+      loading={loading}
+      onClick={() => enterLoading(0)}
+    >
+      Click me!
+    </Button>
+  );
+};
 
 export default App;

--- a/components/button/demo/basic.tsx
+++ b/components/button/demo/basic.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
 import { Button, Flex } from 'antd';
 
-const App: React.FC = () => {
-  const [loading, setLoading] = React.useState<boolean>(false);
-
-  const enterLoading = (index: number) => {
-    console.log('click');
-    setLoading(true);
-
-    setTimeout(() => {
-      setLoading(false);
-    }, 3000);
-  };
-
-  return (
-    <Button
-      type="primary"
-      // disabled={loading}
-      loading={loading}
-      onClick={() => enterLoading(0)}
-    >
-      Click me!
-    </Button>
-  );
-};
+const App: React.FC = () => (
+  <Flex gap="small" wrap>
+    <Button type="primary">Primary Button</Button>
+    <Button>Default Button</Button>
+    <Button type="dashed">Dashed Button</Button>
+    <Button type="text">Text Button</Button>
+    <Button type="link">Link Button</Button>
+  </Flex>
+);
 
 export default App;

--- a/components/button/useLoadingState.ts
+++ b/components/button/useLoadingState.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import useForceUpdate from '../_util/hooks/useForceUpdate';
+
+export interface LoadingConfigType {
+  loading: boolean;
+  delay: number;
+}
+
+function getLoadingConfig(loading: boolean | { delay?: number }): LoadingConfigType {
+  if (typeof loading === 'object' && loading) {
+    let delay = loading?.delay;
+    delay = !Number.isNaN(delay) && typeof delay === 'number' ? delay : 0;
+    return {
+      loading: delay <= 0,
+      delay,
+    };
+  }
+
+  return {
+    loading: !!loading,
+    delay: 0,
+  };
+}
+
+export default function useLoadingState(loadingProp: boolean | { delay?: number }) {
+  const forceUpdate = useForceUpdate();
+  const loadingOrDelay = useMemo(() => getLoadingConfig(loadingProp), [loadingProp]);
+  const innerLoading = useRef<boolean>(loadingOrDelay.loading);
+  const getLoading = useCallback(() => innerLoading.current, []);
+
+  useEffect(() => {
+    let delayTimer: ReturnType<typeof setTimeout> | null = null;
+    if (loadingOrDelay.delay > 0) {
+      delayTimer = setTimeout(() => {
+        delayTimer = null;
+        innerLoading.current = true;
+        forceUpdate();
+      }, loadingOrDelay.delay);
+    } else {
+      innerLoading.current = loadingOrDelay.loading;
+      forceUpdate();
+    }
+
+    function cleanupTimer() {
+      if (delayTimer) {
+        clearTimeout(delayTimer);
+        delayTimer = null;
+      }
+    }
+
+    return cleanupTimer;
+  }, [loadingOrDelay, forceUpdate]);
+
+  return {
+    loading: innerLoading.current,
+    getLoading,
+  };
+}

--- a/components/button/useLoadingState.ts
+++ b/components/button/useLoadingState.ts
@@ -25,7 +25,7 @@ function getLoadingConfig(loading: boolean | { delay?: number }): LoadingConfigT
 
 export default function useLoadingState(loadingProp: boolean | { delay?: number }) {
   const forceUpdate = useForceUpdate();
-  const loadingOrDelay = useMemo(() => getLoadingConfig(loadingProp), [loadingProp]);
+  const loadingOrDelay = useMemo(() => getLoadingConfig(loadingProp), [loadingProp, loadingProp?.delay]);
   const innerLoading = useRef<boolean>(loadingOrDelay.loading);
   const getLoading = useCallback(() => innerLoading.current, []);
 

--- a/components/button/useLoadingState.ts
+++ b/components/button/useLoadingState.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import useForceUpdate from '../_util/hooks/useForceUpdate';
-
-export interface LoadingConfigType {
-  loading: boolean;
-  delay: number;
-}
+import { LoadingConfigType } from './button';
 
 function getLoadingConfig(loading: boolean | { delay?: number }): LoadingConfigType {
   if (typeof loading === 'object' && loading) {

--- a/components/button/useLoadingState.ts
+++ b/components/button/useLoadingState.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import useForceUpdate from '../_util/hooks/useForceUpdate';
-import { LoadingConfigType } from './button';
+
+type LoadingConfigType = {
+  loading: boolean;
+  delay: number;
+};
 
 function getLoadingConfig(loading: boolean | { delay?: number }): LoadingConfigType {
   if (typeof loading === 'object' && loading) {
@@ -38,12 +42,12 @@ export default function useLoadingState(loadingProp: boolean | { delay?: number 
       forceUpdate();
     }
 
-    function cleanupTimer() {
+    const cleanupTimer = () => {
       if (delayTimer) {
         clearTimeout(delayTimer);
         delayTimer = null;
       }
-    }
+    };
 
     return cleanupTimer;
   }, [loadingOrDelay, forceUpdate]);


### PR DESCRIPTION
- [x] 🐞 Bug fix

### 🔗 Related Issues

https://github.com/ant-design/ant-design/issues/51325


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix the issue where the Button component fails to correctly prevent the onClick event after enabling the loading state on low-end machines.    |
| 🇨🇳 Chinese |       修复Button组件在低端机器下开启loading状态后无法正确阻止onClick事件     |
