### PR TITLE
fix: fix the issue that ColorHexInput cannot manually input values ​​caused by #53810

### DIFF
--- a/components/color-picker/__tests__/components.test.tsx
+++ b/components/color-picker/__tests__/components.test.tsx
@@ -6,6 +6,7 @@ import ColorHexInput from '../components/ColorHexInput';
 import ColorHsbInput from '../components/ColorHsbInput';
 import ColorRgbInput from '../components/ColorRgbInput';
 import ColorSteppers from '../components/ColorSteppers';
+import { generateColor } from '../util';
 
 describe('ColorPicker Components test', () => {
   beforeEach(() => {
@@ -93,5 +94,64 @@ describe('ColorPicker Components test', () => {
     });
     expect(rgbInputEls[2]?.getAttribute('value')).toEqual('21');
     expect(handleAlphaChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('Should update input value when external value changes', () => {
+    // Create a container to hold the component instance for re-rendering
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    // Create initial color value
+    const initialColor = generateColor('#ff0000');
+
+    // Render component with initial color
+    const { rerender, getByRole } = render(
+      <ColorHexInput prefixCls="test" value={initialColor} onChange={jest.fn()} />,
+      { container },
+    );
+
+    // Get input element
+    const input = getByRole('textbox');
+
+    // Verify initial value is displayed correctly
+    expect(input.getAttribute('value')).toEqual('ff0000');
+
+    // Create new color value
+    const newColor = generateColor('#00ff00');
+
+    // Re-render component with new color value
+    rerender(<ColorHexInput prefixCls="test" value={newColor} onChange={jest.fn()} />);
+
+    // Verify input value has been updated to the new color value
+    expect(input.getAttribute('value')).toEqual('00ff00');
+
+    // Cleanup
+    document.body.removeChild(container);
+  });
+
+  it('Should handle user input correctly and maintain state when value prop does not change', () => {
+    const onChange = jest.fn();
+    const { container } = render(<ColorHexInput prefixCls="test" onChange={onChange} />);
+
+    // Get input element
+    const input = container.querySelector('.test-hex-input input')!;
+
+    // Simulate user input
+    fireEvent.change(input, { target: { value: 'ff5500' } });
+
+    // Verify input value has been updated
+    expect(input.getAttribute('value')).toEqual('ff5500');
+
+    // Verify onChange callback has been called
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Simulate invalid input
+    fireEvent.change(input, { target: { value: 'xyz' } });
+
+    // Verify input value has been updated but formatted as valid hex format
+    expect(input.getAttribute('value')).toEqual('xyz');
+
+    // onChange should not be called because the input is invalid
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/color-picker/components/ColorHexInput.tsx
+++ b/components/color-picker/components/ColorHexInput.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Input from '../../input/Input';
 import type { AggregationColor } from '../color';
@@ -17,14 +17,20 @@ const isHexString = (hex?: string) => hexReg.test(`#${hex}`);
 
 const ColorHexInput: FC<ColorHexInputProps> = ({ prefixCls, value, onChange }) => {
   const colorHexInputPrefixCls = `${prefixCls}-hex-input`;
-  const [internalValue, setInternalValue] = useState('');
+  const [hexValue, setHexValue] = useState(() =>
+    value ? toHexFormat(value.toHexString()) : undefined,
+  );
 
-  const hexValue = value ? toHexFormat(value.toHexString()) : internalValue;
+  // Update step value
+  useEffect(() => {
+    if (value) {
+      setHexValue(toHexFormat(value.toHexString()));
+    }
+  }, [value]);
 
   const handleHexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const originValue = e.target.value;
-    setInternalValue(toHexFormat(originValue));
-
+    setHexValue(toHexFormat(originValue));
     if (isHexString(toHexFormat(originValue, true))) {
       onChange?.(generateColor(originValue));
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues


fix #53810

### 💡 Background and Solution

This commit reverts the changes made in commit 4bc93c34cfc79e07776a62acb2103a71ad70de51 to `ColorHexInput.tsx`.
The previous change replaced the `hexValue` state with a computed property, which caused the input to become unresponsive.

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ColorPicker's hex input field not accepting user input       |
| 🇨🇳 Chinese |    修复 ColorPicker 的十六进制输入框无法输入的问题       |
