### PR TITLE
docs: fix the blank issue on the right side in mobile

### DIFF
--- a/.dumi/theme/common/styles/Reset.tsx
+++ b/.dumi/theme/common/styles/Reset.tsx
@@ -44,13 +44,24 @@ export default () => {
         html {
           direction: initial;
 
+          @supports (overflow-x: clip) {
+            overflow-x: clip;
+          }
+
           &.rtl {
             direction: rtl;
           }
         }
 
         body {
-          overflow-x: hidden;
+          @supports (overflow-x: clip) {
+            overflow-x: clip;
+          }
+
+          @supports not (overflow-x: clip) {
+            overflow-x: hidden;
+          }
+
           color: ${token.colorText};
           font-size: ${token.fontSize}px;
           font-family: ${token.fontFamily};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
- None

### 💡 Background and Solution

#### Background 
- 当前官网在移动端样式会出现右侧空白问题，影响移动端访问体验。如下：
- ![image](https://github.com/user-attachments/assets/188da4ea-d0d5-414b-a2b2-ac32d4a50e2e)
- 问题原因： `body` 设置为 `overflow: hidden` 在移动端存在兼容性问题，大部分浏览器都不能正常工作。(目前发现只有`Firefox` 能正常工作)

#### Solution
- 要在移动端生效需要 `html` 和 `body` 同时设置 `overflow: hidden`([stackoverflow](https://stackoverflow.com/questions/24193272/overflow-xhidden-on-mobile-device-not-working)),但是同时设置导致`sticky`不能按预期工作。使用`overflow: clip`替代可以解决问题。

### Test
- 目前测试了 `Window(Chrome、Edge)` 和 `Android(Chrome、小米)` 暂时未发现问题。
- 需要测试 `Safari、 Safari on iOS` 是否正常运行。 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix the blank issue on the right side in mobile       |
| 🇨🇳 Chinese |     修复移动端官网右侧空白问题      |
