### PR TITLE
fix: Add missing generic parameters to DraggerProps

### DIFF
--- a/components/upload/Dragger.tsx
+++ b/components/upload/Dragger.tsx
@@ -4,7 +4,7 @@ import type { UploadProps } from './interface';
 import type { UploadRef } from './Upload';
 import Upload from './Upload';
 
-export type DraggerProps = UploadProps & { height?: number };
+export type DraggerProps<T = any> = UploadProps<T> & { height?: number };
 
 const Dragger = React.forwardRef<UploadRef, DraggerProps>(
   ({ style, height, hasControlInside = false, ...restProps }, ref) => (

--- a/components/upload/__tests__/type.test.tsx
+++ b/components/upload/__tests__/type.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import type { UploadListProps, UploadProps } from '..';
+import type { DraggerProps, UploadListProps, UploadProps } from '..';
 import Upload from '..';
+import Dragger from '../Dragger';
 import UploadList from '../UploadList';
 
 describe('Upload.typescript', () => {
@@ -230,5 +231,15 @@ describe('Upload.typescript', () => {
       previewIcon: (file) => <div>{JSON.stringify(file.response)}</div>,
     };
     expect(<UploadList {...uploadListProps} />).toBeTruthy();
+  });
+
+  it('DraggerProps type', () => {
+    const draggerProps: DraggerProps<number | string> = {
+      customRequest({ onSuccess }) {
+        onSuccess?.(1234);
+        onSuccess?.('test');
+      },
+    };
+    expect(<Dragger {...draggerProps} />).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #53841 

### 💡 Background and Solution

see #53841 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Add missing generic parameters to DraggerProps       |
| 🇨🇳 Chinese |    为`DraggerProps`添加缺失的泛型参数       |
