### PR TITLE
perf: less render in dev 

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -315,7 +315,7 @@ const Dropdown: CompoundedComponent = (props) => {
   let renderNode = (
     <RcDropdown
       alignPoint={alignPoint}
-      {...omit(props, ['rootClassName'])}
+      {...omit(props, ['rootClassName', 'onOpenChange'])}
       mouseEnterDelay={mouseEnterDelay}
       mouseLeaveDelay={mouseLeaveDelay}
       visible={mergedOpen}

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -93,11 +93,7 @@ export interface AbstractTooltipProps extends LegacyTooltipProps {
   placement?: TooltipPlacement;
   builtinPlacements?: typeof Placements;
   openClassName?: string;
-  arrow?:
-    | boolean
-    | {
-        pointAtCenter?: boolean;
-      };
+  arrow?: boolean | { pointAtCenter?: boolean };
   autoAdjustOverflow?: boolean | AdjustOverflow;
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
   children?: React.ReactNode;
@@ -147,6 +143,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
     overlayClassName,
     styles,
     classNames: tooltipClassNames,
+    onOpenChange,
     ...restProps
   } = props;
 
@@ -206,10 +203,10 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
 
   const noTitle = !title && !overlay && title !== 0; // overlay for old version compatibility
 
-  const onOpenChange = (vis: boolean) => {
+  const onInternalOpenChange = (vis: boolean) => {
     setOpen(noTitle ? false : vis);
-    if (!noTitle) {
-      props.onOpenChange?.(vis);
+    if (!noTitle && onOpenChange) {
+      onOpenChange(vis);
     }
   };
 
@@ -269,9 +266,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
 
   const rootClassNames = classNames(
     overlayClassName,
-    {
-      [`${prefixCls}-rtl`]: direction === 'rtl',
-    },
+    { [`${prefixCls}-rtl`]: direction === 'rtl' },
     colorInfo.className,
     rootClassName,
     hashId,
@@ -316,7 +311,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
       builtinPlacements={tooltipPlacements}
       overlay={memoOverlayWrapper}
       visible={tempOpen}
-      onVisibleChange={onOpenChange}
+      onVisibleChange={onInternalOpenChange}
       afterVisibleChange={afterOpenChange}
       arrowContent={<span className={`${prefixCls}-arrow-content`} />}
       motion={{

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@rc-component/tour": "~2.1.5",
     "@rc-component/tree": "~1.0.1",
     "@rc-component/tree-select": "~1.1.2",
-    "@rc-component/trigger": "~3.1.0",
+    "@rc-component/trigger": "^3.4.0",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.11",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

ref #50443

### 💡 Background and Solution

Dev 模式下，React 会对 `createElement` 和 `cloneElement` 注入额外的代码：

#### Dev

```js
function ReactElement(
  type,
  key,
  self,
  source,
  owner,
  props,
  debugStack,
  debugTask
) {
  self = props.ref;
  type = {
    $$typeof: REACT_ELEMENT_TYPE,
    type: type,
    key: key,
    props: props,
    _owner: owner
  };
  null !== (void 0 !== self ? self : null)
    ? Object.defineProperty(type, "ref", {
        enumerable: !1,
        get: elementRefGetterWithDeprecationWarning
      })
    : Object.defineProperty(type, "ref", { enumerable: !1, value: null });
  type._store = {};
  Object.defineProperty(type._store, "validated", {
    configurable: !1,
    enumerable: !1,
    writable: !0,
    value: 0
  });
  Object.defineProperty(type, "_debugInfo", {
    configurable: !1,
    enumerable: !1,
    writable: !0,
    value: null
  });
  Object.defineProperty(type, "_debugStack", {
    configurable: !1,
    enumerable: !1,
    writable: !0,
    value: debugStack
  });
  Object.defineProperty(type, "_debugTask", {
    configurable: !1,
    enumerable: !1,
    writable: !0,
    value: debugTask
  });
  Object.freeze && (Object.freeze(type.props), Object.freeze(type));
  return type;
}
```

#### Prod

```js
function ReactElement(type, key, self, source, owner, props) {
  self = props.ref;
  return {
    $$typeof: REACT_ELEMENT_TYPE,
    type: type,
    key: key,
    ref: void 0 !== self ? self : null,
    props: props
  };
}
```

所以在 dev 模式下，Tooltip 的嵌套 `createElement` 与 `cloneElement` 会产生大量的 Object `defineProperty` 操作。这会导致浏览器对 Object 对象进行降级，从而影响渲染速度。提升后的 `@rc-component/trigger` 在渲染时会少渲染 2 个 `createElement` 和 1 个 `cloneElement`。加上之前的 babel `target` 升级能进一步提升开发体验：

#### 裸渲染 10000 条 Tooltips 效果

```tsx
const App: React.FC = () => {
  const [show, setShow] = React.useState(false);

  React.useLayoutEffect(() => {
    if (show) {
      console.timeEnd('render');
    }
  }, [show]);

  return (
    <>
      <button
        onClick={() => {
          console.time('render');
          setShow(true);
        }}
      >
        Click
      </button>
      {show &&
        Array.from({ length: 10000 }).map((_, index) => (
          <Tooltip key={index} title="prompt text">
            <span>Tooltip </span>
          </Tooltip>
        ))}
    </>
  );
};
```

| 版本   | 渲染时间 | 提升 | 
| ---------- | --------- |  --- | 
| v5 |     ~4401ms      | 0% | 
| v6 babel target |      ~3520ms     | 20% | 
| v6 babel target + less element |  ~2647ms | 39.8% |

* MAC M1 16GB

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Optimize Tooltip dev render performance(~40%) to enhance developer experience.       |
| 🇨🇳 Chinese |     优化 Tooltip 开发模式下性能（约 ~40%）以提升研发体验。     |
