### PR TITLE
refactor: Rename Steps labelPlacement to titlePlacement

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -26297,7 +26297,7 @@ exports[`ConfigProvider components Statistic prefixCls 1`] = `
 
 exports[`ConfigProvider components Steps configProvider 1`] = `
 <div
-  class="config-steps config-steps-vertical config-steps-label-horizontal config-steps-filled css-var-root"
+  class="config-steps config-steps-vertical config-steps-title-horizontal config-steps-filled css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26340,7 +26340,7 @@ exports[`ConfigProvider components Steps configProvider 1`] = `
 
 exports[`ConfigProvider components Steps configProvider componentDisabled 1`] = `
 <div
-  class="config-steps config-steps-vertical config-steps-label-horizontal config-steps-filled css-var-root"
+  class="config-steps config-steps-vertical config-steps-title-horizontal config-steps-filled css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26383,7 +26383,7 @@ exports[`ConfigProvider components Steps configProvider componentDisabled 1`] = 
 
 exports[`ConfigProvider components Steps configProvider componentSize large 1`] = `
 <div
-  class="config-steps config-steps-vertical config-steps-label-horizontal config-steps-filled config-steps-large css-var-root"
+  class="config-steps config-steps-vertical config-steps-title-horizontal config-steps-filled config-steps-large css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26426,7 +26426,7 @@ exports[`ConfigProvider components Steps configProvider componentSize large 1`] 
 
 exports[`ConfigProvider components Steps configProvider componentSize middle 1`] = `
 <div
-  class="config-steps config-steps-vertical config-steps-label-horizontal config-steps-filled config-steps-middle css-var-root"
+  class="config-steps config-steps-vertical config-steps-title-horizontal config-steps-filled config-steps-middle css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26469,7 +26469,7 @@ exports[`ConfigProvider components Steps configProvider componentSize middle 1`]
 
 exports[`ConfigProvider components Steps configProvider componentSize small 1`] = `
 <div
-  class="config-steps config-steps-vertical config-steps-label-horizontal config-steps-filled config-steps-small css-var-root"
+  class="config-steps config-steps-vertical config-steps-title-horizontal config-steps-filled config-steps-small css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26512,7 +26512,7 @@ exports[`ConfigProvider components Steps configProvider componentSize small 1`] 
 
 exports[`ConfigProvider components Steps normal 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-root"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -26555,7 +26555,7 @@ exports[`ConfigProvider components Steps normal 1`] = `
 
 exports[`ConfigProvider components Steps prefixCls 1`] = `
 <div
-  class="prefix-Steps prefix-Steps-vertical prefix-Steps-label-horizontal prefix-Steps-filled css-var-root"
+  class="prefix-Steps prefix-Steps-vertical prefix-Steps-title-horizontal prefix-Steps-filled css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/steps/demo/clickable.tsx extend context correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -129,7 +129,7 @@ Array [
     role="separator"
   />,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -258,7 +258,7 @@ exports[`renders components/steps/demo/clickable.tsx extend context correctly 2`
 exports[`renders components/steps/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -394,7 +394,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -530,7 +530,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -720,7 +720,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -830,7 +830,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -984,7 +984,7 @@ exports[`renders components/steps/demo/component-token.tsx extend context correc
 
 exports[`renders components/steps/demo/customized-progress-dot.tsx extend context correctly 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -1247,7 +1247,7 @@ exports[`renders components/steps/demo/customized-progress-dot.tsx extend contex
 
 exports[`renders components/steps/demo/error.tsx extend context correctly 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -1397,7 +1397,7 @@ exports[`renders components/steps/demo/error.tsx extend context correctly 2`] = 
 
 exports[`renders components/steps/demo/icon.tsx extend context correctly 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -1640,7 +1640,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset: 0; margin-top: 8px;"
           >
             <div
@@ -1850,7 +1850,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset: 0; margin-top: 8px;"
           >
             <div
@@ -2060,7 +2060,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset: 0; margin-top: 8px;"
           >
             <div
@@ -2270,7 +2270,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset: 0; margin-top: 8px;"
           >
             <div
@@ -2456,7 +2456,7 @@ exports[`renders components/steps/demo/inline-variant.tsx extend context correct
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -2773,7 +2773,7 @@ exports[`renders components/steps/demo/inline-variant.tsx extend context correct
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -3104,7 +3104,7 @@ exports[`renders components/steps/demo/inline-variant.tsx extend context correct
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 2;"
   >
     <div
@@ -3299,455 +3299,12 @@ exports[`renders components/steps/demo/inline-variant.tsx extend context correct
 
 exports[`renders components/steps/demo/inline-variant.tsx extend context correctly 2`] = `[]`;
 
-exports[`renders components/steps/demo/label-placement.tsx extend context correctly 1`] = `
-Array [
-  <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-ellipsis css-var-test-id"
-    style="--steps-items-offset: 0;"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <br />,
-  <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
-    style="--steps-items-offset: 0;"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <svg
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="60"
-            class="ant-steps-item-progress-icon-svg"
-            height="100%"
-            viewBox="0 0 100 100"
-            width="100%"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              Progress
-            </title>
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
-            />
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
-              stroke-dasharray="calc(var(--progress-r) * 2 * 1.8849555921538756) 9999"
-              transform="rotate(-90 50 50)"
-            />
-          </svg>
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <br />,
-  <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
-    style="--steps-items-offset: 0;"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <svg
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="80"
-            class="ant-steps-item-progress-icon-svg"
-            height="100%"
-            viewBox="0 0 100 100"
-            width="100%"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              Progress
-            </title>
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
-            />
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
-              stroke-dasharray="calc(var(--progress-r) * 2 * 2.5132741228718345) 9999"
-              transform="rotate(-90 50 50)"
-            />
-          </svg>
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`renders components/steps/demo/label-placement.tsx extend context correctly 2`] = `[]`;
-
 exports[`renders components/steps/demo/nav.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -3901,7 +3458,7 @@ exports[`renders components/steps/demo/nav.tsx extend context correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -4057,7 +3614,7 @@ exports[`renders components/steps/demo/nav.tsx extend context correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -4234,7 +3791,7 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-panel css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-panel css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -4416,7 +3973,7 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined ant-steps-panel ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined ant-steps-panel ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -4604,7 +4161,7 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 2`] = 
 
 exports[`renders components/steps/demo/progress.tsx extend context correctly 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
   style="--steps-items-offset: 0;"
 >
   <div
@@ -4829,7 +4386,7 @@ Array [
   </div>,
   <br />,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -4987,7 +4544,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -5145,7 +4702,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -5303,7 +4860,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -5471,7 +5028,7 @@ exports[`renders components/steps/demo/progress-dot.tsx extend context correctly
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -5581,7 +5138,7 @@ exports[`renders components/steps/demo/progress-dot.tsx extend context correctly
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -5698,7 +5255,7 @@ exports[`renders components/steps/demo/progress-dot.tsx extend context correctly
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
       style="--steps-items-offset: 0; flex-basis: auto;"
     >
       <div
@@ -5808,7 +5365,7 @@ exports[`renders components/steps/demo/progress-dot.tsx extend context correctly
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
       style="--steps-items-offset: 0; flex-basis: auto;"
     >
       <div
@@ -5928,7 +5485,7 @@ exports[`renders components/steps/demo/simple.tsx extend context correctly 1`] =
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6064,7 +5621,7 @@ exports[`renders components/steps/demo/simple.tsx extend context correctly 1`] =
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6200,7 +5757,7 @@ exports[`renders components/steps/demo/simple.tsx extend context correctly 1`] =
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6336,7 +5893,7 @@ exports[`renders components/steps/demo/simple.tsx extend context correctly 1`] =
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6479,7 +6036,7 @@ exports[`renders components/steps/demo/simple.tsx extend context correctly 2`] =
 exports[`renders components/steps/demo/step-next.tsx extend context correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6654,7 +6211,7 @@ Array [
     </label>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-default css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-default css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -6697,7 +6254,7 @@ Array [
                 class="ant-card-body"
               >
                 <div
-                  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-default css-var-test-id"
+                  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-default css-var-test-id"
                   style="--steps-items-offset: 0;"
                 >
                   <div
@@ -6897,12 +6454,455 @@ Array [
 
 exports[`renders components/steps/demo/steps-in-steps.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/steps/demo/title-placement.tsx extend context correctly 1`] = `
+Array [
+  <div
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-ellipsis css-var-test-id"
+    style="--steps-items-offset: 0;"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+    style="--steps-items-offset: 0;"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <svg
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="60"
+            class="ant-steps-item-progress-icon-svg"
+            height="100%"
+            viewBox="0 0 100 100"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Progress
+            </title>
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
+            />
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
+              stroke-dasharray="calc(var(--progress-r) * 2 * 1.8849555921538756) 9999"
+              transform="rotate(-90 50 50)"
+            />
+          </svg>
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    style="--steps-items-offset: 0;"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <svg
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="80"
+            class="ant-steps-item-progress-icon-svg"
+            height="100%"
+            viewBox="0 0 100 100"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Progress
+            </title>
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
+            />
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
+              stroke-dasharray="calc(var(--progress-r) * 2 * 2.5132741228718345) 9999"
+              transform="rotate(-90 50 50)"
+            />
+          </svg>
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`renders components/steps/demo/title-placement.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/steps/demo/variant-debug.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -7053,7 +7053,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -7204,7 +7204,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -7355,7 +7355,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -7516,7 +7516,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -7674,7 +7674,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -7836,7 +7836,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -7987,7 +7987,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -8139,7 +8139,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -8258,7 +8258,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -8374,7 +8374,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-navigation ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-navigation ant-steps-small css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -8530,7 +8530,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     role="separator"
   />
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -8646,7 +8646,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -8797,7 +8797,7 @@ exports[`renders components/steps/demo/variant-debug.tsx extend context correctl
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset: 0;"
   >
     <div
@@ -8960,7 +8960,7 @@ exports[`renders components/steps/demo/vertical.tsx extend context correctly 1`]
     style="flex: 1;"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div
@@ -9094,7 +9094,7 @@ exports[`renders components/steps/demo/vertical.tsx extend context correctly 1`]
     style="flex: 1;"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
       style="--steps-items-offset: 0;"
     >
       <div

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/steps/demo/clickable.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -129,7 +129,7 @@ Array [
     role="separator"
   />,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -256,7 +256,7 @@ Array [
 exports[`renders components/steps/demo/component-token.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -392,7 +392,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -528,7 +528,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -718,7 +718,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -828,7 +828,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -980,7 +980,7 @@ Array [
 
 exports[`renders components/steps/demo/customized-progress-dot.tsx correctly 1`] = `
 <div
-  class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-dot css-var-test-id"
+  class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-dot css-var-test-id"
   style="--steps-items-offset:0"
 >
   <div
@@ -1133,7 +1133,7 @@ exports[`renders components/steps/demo/customized-progress-dot.tsx correctly 1`]
 
 exports[`renders components/steps/demo/error.tsx correctly 1`] = `
 <div
-  class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+  class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
   style="--steps-items-offset:0"
 >
   <div
@@ -1281,7 +1281,7 @@ exports[`renders components/steps/demo/error.tsx correctly 1`] = `
 
 exports[`renders components/steps/demo/icon.tsx correctly 1`] = `
 <div
-  class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+  class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
   style="--steps-items-offset:0"
 >
   <div
@@ -1522,7 +1522,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset:0;margin-top:8px"
           >
             <div
@@ -1672,7 +1672,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset:0;margin-top:8px"
           >
             <div
@@ -1822,7 +1822,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset:0;margin-top:8px"
           >
             <div
@@ -1972,7 +1972,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
             </div>
           </div>
           <div
-            class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+            class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
             style="--steps-items-offset:0;margin-top:8px"
           >
             <div
@@ -2096,7 +2096,7 @@ exports[`renders components/steps/demo/inline-variant.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -2313,7 +2313,7 @@ exports[`renders components/steps/demo/inline-variant.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -2544,7 +2544,7 @@ exports[`renders components/steps/demo/inline-variant.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-inline ant-steps-dot css-var-test-id"
     style="--steps-items-offset:2"
   >
     <div
@@ -2677,453 +2677,12 @@ exports[`renders components/steps/demo/inline-variant.tsx correctly 1`] = `
 </div>
 `;
 
-exports[`renders components/steps/demo/label-placement.tsx correctly 1`] = `
-Array [
-  <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-ellipsis css-var-test-id"
-    style="--steps-items-offset:0"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <br />,
-  <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-with-progress css-var-test-id"
-    style="--steps-items-offset:0"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <svg
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="60"
-            class="ant-steps-item-progress-icon-svg"
-            height="100%"
-            viewBox="0 0 100 100"
-            width="100%"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              Progress
-            </title>
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
-            />
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
-              stroke-dasharray="calc(var(--progress-r) * 2 * 1.8849555921538756) 9999"
-              transform="rotate(-90 50 50)"
-            />
-          </svg>
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <br />,
-  <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
-    style="--steps-items-offset:0"
-  >
-    <div
-      class="ant-steps-item ant-steps-item-finish"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            aria-label="check"
-            class="anticon anticon-check ant-steps-item-icon-finish"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="check"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Finished
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-process"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <svg
-            aria-valuemax="100"
-            aria-valuemin="0"
-            aria-valuenow="80"
-            class="ant-steps-item-progress-icon-svg"
-            height="100%"
-            viewBox="0 0 100 100"
-            width="100%"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              Progress
-            </title>
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
-            />
-            <circle
-              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
-              stroke-dasharray="calc(var(--progress-r) * 2 * 2.5132741228718345) 9999"
-              transform="rotate(-90 50 50)"
-            />
-          </svg>
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            2
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              In Progress
-            </div>
-            <div
-              class="ant-steps-item-rail ant-steps-item-rail-wait"
-            />
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ant-steps-item ant-steps-item-wait"
-    >
-      <div
-        class="ant-steps-item-wrapper"
-      >
-        <div
-          class="ant-steps-item-icon ant-wave-target"
-        >
-          <span
-            class="ant-steps-item-icon-number"
-          >
-            3
-          </span>
-        </div>
-        <div
-          class="ant-steps-item-section"
-        >
-          <div
-            class="ant-steps-item-header"
-          >
-            <div
-              class="ant-steps-item-title"
-            >
-              Waiting
-            </div>
-          </div>
-          <div
-            class="ant-steps-item-content"
-          >
-            This is a content.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
 exports[`renders components/steps/demo/nav.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -3277,7 +2836,7 @@ exports[`renders components/steps/demo/nav.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-navigation css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -3433,7 +2992,7 @@ exports[`renders components/steps/demo/nav.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-navigation ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -3608,7 +3167,7 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-panel css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-panel css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -3790,7 +3349,7 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined ant-steps-panel ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined ant-steps-panel ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -3976,7 +3535,7 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
 
 exports[`renders components/steps/demo/progress.tsx correctly 1`] = `
 <div
-  class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+  class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
   style="--steps-items-offset:0"
 >
   <div
@@ -4199,7 +3758,7 @@ Array [
   </div>,
   <br />,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -4357,7 +3916,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -4515,7 +4074,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -4673,7 +4232,7 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -4839,7 +4398,7 @@ exports[`renders components/steps/demo/progress-dot.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-filled ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -4949,7 +4508,7 @@ exports[`renders components/steps/demo/progress-dot.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-outlined ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-outlined ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -5066,7 +4625,7 @@ exports[`renders components/steps/demo/progress-dot.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-dot css-var-test-id"
       style="--steps-items-offset:0;flex:auto"
     >
       <div
@@ -5176,7 +4735,7 @@ exports[`renders components/steps/demo/progress-dot.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot css-var-test-id"
       style="--steps-items-offset:0;flex:auto"
     >
       <div
@@ -5294,7 +4853,7 @@ exports[`renders components/steps/demo/simple.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -5430,7 +4989,7 @@ exports[`renders components/steps/demo/simple.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -5566,7 +5125,7 @@ exports[`renders components/steps/demo/simple.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -5702,7 +5261,7 @@ exports[`renders components/steps/demo/simple.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -5843,7 +5402,7 @@ exports[`renders components/steps/demo/simple.tsx correctly 1`] = `
 exports[`renders components/steps/demo/step-next.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6016,7 +5575,7 @@ Array [
     </label>
   </div>,
   <div
-    class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-default css-var-test-id"
+    class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-default css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6059,7 +5618,7 @@ Array [
                 class="ant-card-body"
               >
                 <div
-                  class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled ant-steps-default css-var-test-id"
+                  class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled ant-steps-default css-var-test-id"
                   style="--steps-items-offset:0"
                 >
                   <div
@@ -6257,12 +5816,453 @@ Array [
 ]
 `;
 
+exports[`renders components/steps/demo/title-placement.tsx correctly 1`] = `
+Array [
+  <div
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-ellipsis css-var-test-id"
+    style="--steps-items-offset:0"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-with-progress css-var-test-id"
+    style="--steps-items-offset:0"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <svg
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="60"
+            class="ant-steps-item-progress-icon-svg"
+            height="100%"
+            viewBox="0 0 100 100"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Progress
+            </title>
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
+            />
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
+              stroke-dasharray="calc(var(--progress-r) * 2 * 1.8849555921538756) 9999"
+              transform="rotate(-90 50 50)"
+            />
+          </svg>
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <br />,
+  <div
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-filled ant-steps-with-progress ant-steps-small css-var-test-id"
+    style="--steps-items-offset:0"
+  >
+    <div
+      class="ant-steps-item ant-steps-item-finish"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            aria-label="check"
+            class="anticon anticon-check ant-steps-item-icon-finish"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="check"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Finished
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-process"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <svg
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="80"
+            class="ant-steps-item-progress-icon-svg"
+            height="100%"
+            viewBox="0 0 100 100"
+            width="100%"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Progress
+            </title>
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-rail"
+            />
+            <circle
+              class="ant-steps-item-progress-icon-circle ant-steps-item-progress-icon-circle-ptg"
+              stroke-dasharray="calc(var(--progress-r) * 2 * 2.5132741228718345) 9999"
+              transform="rotate(-90 50 50)"
+            />
+          </svg>
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            2
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              In Progress
+            </div>
+            <div
+              class="ant-steps-item-rail ant-steps-item-rail-wait"
+            />
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-steps-item ant-steps-item-wait"
+    >
+      <div
+        class="ant-steps-item-wrapper"
+      >
+        <div
+          class="ant-steps-item-icon ant-wave-target"
+        >
+          <span
+            class="ant-steps-item-icon-number"
+          >
+            3
+          </span>
+        </div>
+        <div
+          class="ant-steps-item-section"
+        >
+          <div
+            class="ant-steps-item-header"
+          >
+            <div
+              class="ant-steps-item-title"
+            >
+              Waiting
+            </div>
+          </div>
+          <div
+            class="ant-steps-item-content"
+          >
+            This is a content.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-filled css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6413,7 +6413,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6564,7 +6564,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6715,7 +6715,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -6876,7 +6876,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7034,7 +7034,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-with-progress ant-steps-small css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7196,7 +7196,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7347,7 +7347,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-small css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7499,7 +7499,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -7618,7 +7618,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-dot ant-steps-small css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7734,7 +7734,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-outlined ant-steps-navigation ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-outlined ant-steps-navigation ant-steps-small css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -7890,7 +7890,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     role="separator"
   />
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-outlined ant-steps-dot css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-outlined ant-steps-dot css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -8006,7 +8006,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-outlined css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-outlined css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -8157,7 +8157,7 @@ exports[`renders components/steps/demo/variant-debug.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-steps ant-steps-horizontal ant-steps-label-vertical ant-steps-outlined ant-steps-small css-var-test-id"
+    class="ant-steps ant-steps-horizontal ant-steps-title-vertical ant-steps-outlined ant-steps-small css-var-test-id"
     style="--steps-items-offset:0"
   >
     <div
@@ -8318,7 +8318,7 @@ exports[`renders components/steps/demo/vertical.tsx correctly 1`] = `
     style="flex:1"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div
@@ -8452,7 +8452,7 @@ exports[`renders components/steps/demo/vertical.tsx correctly 1`] = `
     style="flex:1"
   >
     <div
-      class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-small css-var-test-id"
+      class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-small css-var-test-id"
       style="--steps-items-offset:0"
     >
       <div

--- a/components/steps/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/steps/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Steps rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled ant-steps-rtl css-var-root"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled ant-steps-rtl css-var-root"
   style="--steps-items-offset: 0;"
 />
 `;
 
 exports[`Steps should render correct 1`] = `
 <div
-  class="ant-steps ant-steps-vertical ant-steps-label-horizontal ant-steps-filled css-var-root"
+  class="ant-steps ant-steps-vertical ant-steps-title-horizontal ant-steps-filled css-var-root"
   style="--steps-items-offset: 0;"
 >
   <div

--- a/components/steps/__tests__/a11y.test.ts
+++ b/components/steps/__tests__/a11y.test.ts
@@ -2,5 +2,5 @@ import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('steps', {
   // we can set aria attribute to fix it
-  skip: ['inline.tsx', 'label-placement.tsx', 'progress.tsx'],
+  skip: ['inline.tsx', 'title-placement.tsx', 'progress.tsx'],
 });

--- a/components/steps/__tests__/index.test.tsx
+++ b/components/steps/__tests__/index.test.tsx
@@ -92,6 +92,7 @@ describe('Steps', () => {
       <Steps
         progressDot
         direction="vertical"
+        labelPlacement="horizontal"
         items={[
           {
             title: 'In Progress',
@@ -111,6 +112,9 @@ describe('Steps', () => {
     );
     expect(errorSpy).toHaveBeenCalledWith(
       'Warning: [antd: Steps] `progressDot` is deprecated. Please use `type="dot"` instead.',
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Steps] `labelPlacement` is deprecated. Please use `titlePlacement` instead.',
     );
     errorSpy.mockRestore();
   });

--- a/components/steps/demo/_semantic.tsx
+++ b/components/steps/demo/_semantic.tsx
@@ -35,7 +35,7 @@ const locales = {
 const sharedProps: StepsProps = {
   current: 1,
   style: { width: '100%' },
-  labelPlacement: 'vertical',
+  titlePlacement: 'vertical',
   items: Array.from({ length: 3 }, (_, index) => ({
     title: `Step ${index + 1}`,
     subTitle: `00:0${index}`,
@@ -46,7 +46,7 @@ const sharedProps: StepsProps = {
 const Block = (props: SemanticPreviewInjectionProps) => (
   <Flex vertical gap="large" style={{ width: '100%' }}>
     <Steps {...sharedProps} {...props} />
-    <Steps {...sharedProps} {...props} type="panel" size="small" labelPlacement="horizontal" />
+    <Steps {...sharedProps} {...props} type="panel" size="small" titlePlacement="horizontal" />
   </Flex>
 );
 

--- a/components/steps/demo/label-placement.md
+++ b/components/steps/demo/label-placement.md
@@ -1,7 +1,0 @@
-## zh-CN
-
-使用 `labelPlacement` 设置标签位置，通过 `percent` 显示进度。
-
-## en-US
-
-Use `labelPlacement` to set the label position and display the progress through `percent`.

--- a/components/steps/demo/title-placement.md
+++ b/components/steps/demo/title-placement.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+使用 `titlePlacement` 设置标签位置，通过 `percent` 显示进度。
+
+## en-US
+
+Use `titlePlacement` to set the label position and display the progress through `percent`.

--- a/components/steps/demo/title-placement.tsx
+++ b/components/steps/demo/title-placement.tsx
@@ -18,11 +18,11 @@ const items = [
 ];
 const App: React.FC = () => (
   <>
-    <Steps current={1} labelPlacement="vertical" items={items} ellipsis />
+    <Steps current={1} titlePlacement="vertical" items={items} ellipsis />
     <br />
-    <Steps current={1} percent={60} labelPlacement="vertical" items={items} />
+    <Steps current={1} percent={60} titlePlacement="vertical" items={items} />
     <br />
-    <Steps current={1} percent={80} size="small" labelPlacement="vertical" items={items} />
+    <Steps current={1} percent={80} size="small" titlePlacement="vertical" items={items} />
   </>
 );
 

--- a/components/steps/demo/variant-debug.tsx
+++ b/components/steps/demo/variant-debug.tsx
@@ -70,8 +70,8 @@ const App: React.FC = () => {
         }}
       >
         <Steps {...sharedProps} type="dot" />
-        <Steps {...sharedProps} labelPlacement="vertical" />
-        <Steps {...sharedProps} labelPlacement="vertical" size="small" />
+        <Steps {...sharedProps} titlePlacement="vertical" />
+        <Steps {...sharedProps} titlePlacement="vertical" size="small" />
       </ConfigProvider>
     </Flex>
   );

--- a/components/steps/index.en-US.md
+++ b/components/steps/index.en-US.md
@@ -21,7 +21,7 @@ When a given task is complicated or has a certain sequence in the series of subt
 <code src="./demo/panel.tsx">Panel Steps</code>
 <code src="./demo/icon.tsx">With icon</code>
 <code src="./demo/step-next.tsx" debug>Switch Step</code>
-<code src="./demo/label-placement.tsx">Label Placement and Progress</code>
+<code src="./demo/title-placement.tsx">Title Placement and Progress</code>
 <code src="./demo/progress-dot.tsx">Dot Style</code>
 <code src="./demo/customized-progress-dot.tsx" debug>Customized Dot Style</code>
 <code src="./demo/nav.tsx">Navigation Steps</code>

--- a/components/steps/index.en-US.md
+++ b/components/steps/index.en-US.md
@@ -48,14 +48,15 @@ The whole of the step bar.
 | ~~direction~~ | To specify the direction of the step bar, `horizontal` or `vertical` | string | `horizontal` |  |
 | iconRender | Custom render icon, please use `items.icon` first | (oriNode, info: { index, active, item }) => ReactNode | - |  |
 | initial | Set the initial step, counting from 0 | number | 0 |  |
-| labelPlacement | Place title and content with `horizontal` or `vertical` direction | string | `horizontal` |  |
+| ~~labelPlacement~~ | Place title and content with `horizontal` or `vertical` direction | string | `horizontal` |  |
 | orientation | To specify the orientation of the step bar, `horizontal` or `vertical` | string | `horizontal` |  |
 | percent | Progress circle percentage of current step in `process` status (only works on basic Steps) | number | - | 4.5.0 |
-| progressDot | Steps with progress dot style, customize the progress dot by setting it to a function. labelPlacement will be `vertical` | boolean \| (iconDot, { index, status, title, content }) => ReactNode | false |  |
+| progressDot | Steps with progress dot style, customize the progress dot by setting it to a function. `titlePlacement` will be `vertical` | boolean \| (iconDot, { index, status, title, content }) => ReactNode | false |  |
 | responsive | Change to vertical direction when screen width smaller than `532px` | boolean | true |  |
 | size | To specify the size of the step bar, `default` and `small` are currently supported | string | `default` |  |
 | status | To specify the status of current step, can be set to one of the following values: `wait` `process` `finish` `error` | string | `process` |  |
 | styles | Semantic DOM style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - |  |
+| titlePlacement | Place title and content with `horizontal` or `vertical` direction | string | `horizontal` |  |
 | type | Type of steps, can be set to one of the following values: `default` `dot` `inline` `navigation` `panel` | string | `default` |  |
 | onChange | Trigger when Step is changed | (current) => void | - |  |
 | items | StepItem content | [StepItem](#stepitem) | [] | 4.24.0 |

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -68,7 +68,9 @@ export interface StepsProps {
   /** @deprecated Please use `orientation` instead. */
   direction?: 'horizontal' | 'vertical';
   orientation?: 'horizontal' | 'vertical';
+  /** @deprecated Please use `titlePlacement` instead. */
   labelPlacement?: 'horizontal' | 'vertical';
+  titlePlacement?: 'horizontal' | 'vertical';
   /** @deprecated Please use `type` and `iconRender` instead. */
   progressDot?: boolean | ProgressDotRender;
   responsive?: boolean;
@@ -114,6 +116,7 @@ const Steps = (props: StepsProps) => {
     responsive = true,
     progressDot,
     labelPlacement,
+    titlePlacement,
     ellipsis,
     offset = 0,
 
@@ -190,7 +193,7 @@ const Steps = (props: StepsProps) => {
     return (responsive && xs) || nextOrientation === 'vertical' ? 'vertical' : 'horizontal';
   }, [xs, direction]);
 
-  const mergedLabelPlacement = React.useMemo<StepsProps['labelPlacement']>(() => {
+  const mergedTitlePlacement = React.useMemo<StepsProps['titlePlacement']>(() => {
     if (isDot || mergedOrientation === 'vertical') {
       return mergedOrientation === 'vertical' ? 'horizontal' : 'vertical';
     }
@@ -198,7 +201,7 @@ const Steps = (props: StepsProps) => {
       return 'horizontal';
     }
 
-    return labelPlacement || 'horizontal';
+    return titlePlacement || labelPlacement || 'horizontal';
   }, []);
 
   // ========================== Percentage ==========================
@@ -341,7 +344,7 @@ const Steps = (props: StepsProps) => {
       styles={mergedStyles}
       // Layout
       orientation={mergedOrientation}
-      labelPlacement={mergedLabelPlacement}
+      titlePlacement={mergedTitlePlacement}
       // Data
       current={current}
       items={mergedItems}

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -323,6 +323,7 @@ const Steps = (props: StepsProps) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Steps');
 
+    warning.deprecated(!labelPlacement, 'labelPlacement', 'titlePlacement');
     warning.deprecated(!progressDot, 'progressDot', 'type="dot"');
     warning.deprecated(!direction, 'direction', 'orientation');
     warning.deprecated(

--- a/components/steps/index.zh-CN.md
+++ b/components/steps/index.zh-CN.md
@@ -49,14 +49,15 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*cFsBQLA0b7UAAA
 | ~~direction~~ | 指定步骤条方向。目前支持水平（`horizontal`）和竖直（`vertical`）两种方向 | string | `horizontal` |  |
 | iconRender | 自定义渲染图标，请优先使用 `items.icon` | (oriNode, info: { index, active, item }) => ReactNode | - |  |
 | initial | 起始序号，从 0 开始记数 | number | 0 |  |
-| labelPlacement | 指定标签放置位置，默认水平放图标右侧，可选 `vertical` 放图标下方 | string | `horizontal` |  |
+| ~~labelPlacement~~ | 指定标签放置位置，默认水平放图标右侧，可选 `vertical` 放图标下方 | string | `horizontal` |  |
 | orientation | 指定步骤条方向。目前支持水平（`horizontal`）和竖直（`vertical`）两种方向 | string | `horizontal` |  |
 | percent | 当前 `process` 步骤显示的进度条进度（只对基本类型的 Steps 生效） | number | - | 4.5.0 |
-| progressDot | 点状步骤条，可以设置为一个 function，labelPlacement 将强制为 `vertical` | boolean \| (iconDot, { index, status, title, content }) => ReactNode | false |  |
+| progressDot | 点状步骤条，可以设置为一个 function，`titlePlacement` 将强制为 `vertical` | boolean \| (iconDot, { index, status, title, content }) => ReactNode | false |  |
 | responsive | 当屏幕宽度小于 `532px` 时自动变为垂直模式 | boolean | true |  |
 | size | 指定大小，目前支持普通（`default`）和迷你（`small`） | string | `default` |  |
 | status | 指定当前步骤的状态，可选 `wait` `process` `finish` `error` | string | `process` |  |
 | styles | 语义化结构 style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - |  |
+| titlePlacement | 指定标签放置位置，默认水平放图标右侧，可选 `vertical` 放图标下方 | string | `horizontal` |  |
 | type | 步骤条类型，可选 `default` `dot` `inline` `navigation` `panel` | string | `default` |  |
 | onChange | 点击切换步骤时触发 | (current) => void | - |  |
 | items | 配置选项卡内容 | [StepItem](#stepitem) | [] | 4.24.0 |

--- a/components/steps/index.zh-CN.md
+++ b/components/steps/index.zh-CN.md
@@ -22,7 +22,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*cFsBQLA0b7UAAA
 <code src="./demo/panel.tsx">面板式步骤</code>
 <code src="./demo/icon.tsx">带图标的步骤条</code>
 <code src="./demo/step-next.tsx" debug>步骤切换</code>
-<code src="./demo/label-placement.tsx">标签放置位置与进度</code>
+<code src="./demo/title-placement.tsx">标签放置位置与进度</code>
 <code src="./demo/progress-dot.tsx">点状步骤条</code>
 <code src="./demo/customized-progress-dot.tsx" debug>自定义点状步骤条</code>
 <code src="./demo/nav.tsx">导航步骤</code>

--- a/components/steps/style/inline.ts
+++ b/components/steps/style/inline.ts
@@ -24,7 +24,7 @@ const genInlineStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
       [itemCls]: {
         // ========================= Variable =========================
         // Item
-        '--steps-label-vertical-row-gap': token.paddingXS,
+        '--steps-title-vertical-row-gap': token.paddingXS,
 
         // Icon
         '--steps-icon-size': inlineDotSize,
@@ -42,7 +42,7 @@ const genInlineStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
 
         // Rail
         '--steps-rail-size': token.lineWidth,
-        '--steps-label-horizontal-rail-gap': '0px',
+        '--steps-title-horizontal-rail-gap': '0px',
 
         // ========================== Styles ==========================
         flex: 1,

--- a/components/steps/style/label-placement.ts
+++ b/components/steps/style/label-placement.ts
@@ -11,14 +11,14 @@ const genLabelPlacementStyle: GenerateStyle<StepsToken, CSSObject> = (token) => 
 
   return {
     // ==================== Horizontal ====================
-    [`${componentCls}-label-horizontal`]: {
-      '--steps-label-horizontal-item-margin': token.margin,
-      '--steps-label-horizontal-rail-margin': token.margin,
+    [`${componentCls}-title-horizontal`]: {
+      '--steps-title-horizontal-item-margin': token.margin,
+      '--steps-title-horizontal-rail-margin': token.margin,
 
       // Horizontal only
       [`&${componentCls}-horizontal`]: {
         [`${itemCls}:not(:first-child)`]: {
-          marginInlineStart: `var(--steps-label-horizontal-item-margin)`,
+          marginInlineStart: `var(--steps-title-horizontal-item-margin)`,
         },
 
         [`${itemCls}:last-child`]: {
@@ -62,14 +62,14 @@ const genLabelPlacementStyle: GenerateStyle<StepsToken, CSSObject> = (token) => 
         '--steps-item-wrapper-padding-top': '0px',
 
         flex: 1,
-        marginInlineStart: `var(--steps-label-horizontal-rail-margin)`,
+        marginInlineStart: `var(--steps-title-horizontal-rail-margin)`,
       },
     },
 
     // ===================== Vertical =====================
-    [`${componentCls}-label-vertical`]: {
-      '--steps-label-vertical-row-gap': token.paddingSM,
-      '--steps-label-horizontal-rail-gap': token.marginXXS,
+    [`${componentCls}-title-vertical`]: {
+      '--steps-title-vertical-row-gap': token.paddingSM,
+      '--steps-title-horizontal-rail-gap': token.marginXXS,
 
       [itemCls]: {
         flex: 1,
@@ -77,7 +77,7 @@ const genLabelPlacementStyle: GenerateStyle<StepsToken, CSSObject> = (token) => 
 
       [`${itemCls}-wrapper`]: {
         flexDirection: 'column',
-        rowGap: `var(--steps-label-vertical-row-gap)`,
+        rowGap: `var(--steps-title-vertical-row-gap)`,
         alignItems: 'center',
       },
 
@@ -106,8 +106,8 @@ const genLabelPlacementStyle: GenerateStyle<StepsToken, CSSObject> = (token) => 
       [`${itemCls}-rail`]: {
         position: 'absolute',
         top: 0,
-        width: `calc(100% - var(--steps-icon-size) - var(--steps-label-horizontal-rail-gap) * 2)`,
-        insetInlineStart: `calc(50% + var(--steps-icon-size) / 2 + var(--steps-label-horizontal-rail-gap))`,
+        width: `calc(100% - var(--steps-icon-size) - var(--steps-title-horizontal-rail-gap) * 2)`,
+        insetInlineStart: `calc(50% + var(--steps-icon-size) / 2 + var(--steps-title-horizontal-rail-gap))`,
       },
 
       // With descriptionMaxWidth

--- a/components/steps/style/small.ts
+++ b/components/steps/style/small.ts
@@ -10,14 +10,14 @@ const genSmallStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
   return {
     [`${componentCls}${componentCls}-small`]: {
       '--steps-icon-size': iconSizeSM,
-      '--steps-label-horizontal-item-margin': token.marginSM,
-      '--steps-label-vertical-row-gap': token.paddingXS,
+      '--steps-title-horizontal-item-margin': token.marginSM,
+      '--steps-title-vertical-row-gap': token.paddingXS,
       '--steps-title-font-size': fontSize,
       '--steps-title-line-height': lineHeight,
-      '--steps-label-horizontal-rail-margin': token.marginXS,
+      '--steps-title-horizontal-rail-margin': token.marginXS,
 
       // Horizontal: label vertical
-      [`&${componentCls}-horizontal${componentCls}-label-vertical`]: getItemWithWidthStyle(
+      [`&${componentCls}-horizontal${componentCls}-title-vertical`]: getItemWithWidthStyle(
         token,
         marginXS,
       ),

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/segmented": "~1.1.0",
     "@rc-component/select": "~1.0.3",
-    "@rc-component/steps": "~1.0.1",
+    "@rc-component/steps": "~1.1.0",
     "@rc-component/switch": "~1.0.0",
     "@rc-component/table": "~1.2.7",
     "@rc-component/tabs": "~1.5.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

#53328

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Replace Steps `labelPlacement` to `titlePlacement` to unify the API.       |
| 🇨🇳 Chinese |     重命名 Steps 的 `labelPlacement` 为 `titlePlacement` 以统一 API。   |
