### PR TITLE
fix: statistic timer cannot display tooltip as a children

### DIFF
--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -96,6 +96,7 @@ const Statistic = React.forwardRef<StatisticRef, StatisticProps>((props, ref) =>
   }));
 
   const restProps = pickAttrs(rest, { aria: true, data: true });
+
   return wrapCSSVar(
     <div
       {...restProps}

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -9,6 +9,10 @@ import StatisticNumber from './Number';
 import useStyle from './style';
 import type { FormatConfig, valueType } from './utils';
 
+export interface StatisticRef {
+  nativeElement: HTMLDivElement;
+}
+
 interface StatisticReactProps extends FormatConfig {
   prefixCls?: string;
   className?: string;
@@ -27,7 +31,7 @@ interface StatisticReactProps extends FormatConfig {
 
 export type StatisticProps = HTMLAriaDataAttributes & StatisticReactProps;
 
-const Statistic = React.forwardRef<HTMLDivElement, StatisticProps>((props, ref) => {
+const Statistic = React.forwardRef<StatisticRef, StatisticProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -85,11 +89,17 @@ const Statistic = React.forwardRef<HTMLDivElement, StatisticProps>((props, ref) 
     cssVarCls,
   );
 
+  const internalRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: internalRef.current!,
+  }));
+
   const restProps = pickAttrs(rest, { aria: true, data: true });
   return wrapCSSVar(
     <div
       {...restProps}
-      ref={ref}
+      ref={internalRef}
       className={cls}
       style={{ ...contextStyle, ...style }}
       onMouseEnter={onMouseEnter}

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -27,7 +27,7 @@ interface StatisticReactProps extends FormatConfig {
 
 export type StatisticProps = HTMLAriaDataAttributes & StatisticReactProps;
 
-const Statistic: React.FC<StatisticProps> = (props) => {
+const Statistic = React.forwardRef<HTMLDivElement, StatisticProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -86,10 +86,10 @@ const Statistic: React.FC<StatisticProps> = (props) => {
   );
 
   const restProps = pickAttrs(rest, { aria: true, data: true });
-
   return wrapCSSVar(
     <div
       {...restProps}
+      ref={ref}
       className={cls}
       style={{ ...contextStyle, ...style }}
       onMouseEnter={onMouseEnter}
@@ -105,7 +105,7 @@ const Statistic: React.FC<StatisticProps> = (props) => {
       </Skeleton>
     </div>,
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Statistic.displayName = 'Statistic';

--- a/components/statistic/Timer.tsx
+++ b/components/statistic/Timer.tsx
@@ -80,7 +80,15 @@ const StatisticTimer: React.FC<StatisticTimerProps> = (props) => {
     cloneElement(node, { title: undefined });
 
   // ======================== Render ========================
-  return <Statistic {...rest} value={value} valueRender={valueRender} formatter={formatter} />;
+  return (
+    <Statistic
+      {...rest}
+      value={value}
+      valueRender={valueRender}
+      formatter={formatter}
+      style={{ display: 'inline-block' }}
+    />
+  );
 };
 
 export default StatisticTimer;

--- a/components/statistic/Timer.tsx
+++ b/components/statistic/Timer.tsx
@@ -80,15 +80,7 @@ const StatisticTimer: React.FC<StatisticTimerProps> = (props) => {
     cloneElement(node, { title: undefined });
 
   // ======================== Render ========================
-  return (
-    <Statistic
-      {...rest}
-      value={value}
-      valueRender={valueRender}
-      formatter={formatter}
-      style={{ display: 'inline-block' }}
-    />
-  );
+  return <Statistic {...rest} value={value} valueRender={valueRender} formatter={formatter} />;
 };
 
 export default StatisticTimer;

--- a/components/statistic/__tests__/index.test.tsx
+++ b/components/statistic/__tests__/index.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Tooltip } from 'antd';
+import { isTooltipOpen } from 'antd/es/tooltip/__tests__/util';
 import dayjs from 'dayjs';
 import { renderToString } from 'react-dom/server';
 
@@ -324,5 +326,31 @@ describe('Statistic', () => {
     it('format should support escape', () => {
       expect(formatTimeStr(1000 * 60 * 60 * 24, 'D [Day]')).toBe('1 Day');
     });
+  });
+
+  it('should works for statistic timer', async () => {
+    const onOpenChange = jest.fn();
+    const ref = React.createRef<any>();
+
+    const { container } = render(
+      <Tooltip title="countdown" onOpenChange={onOpenChange} ref={ref}>
+        <Statistic.Timer type="countdown" value={Date.now() + 1000 * 60 * 2} format="m:s" />
+      </Tooltip>,
+    );
+
+    expect(container.getElementsByClassName('ant-statistic')).toHaveLength(1);
+    const statistic = container.getElementsByClassName('ant-statistic')[0];
+
+    fireEvent.mouseEnter(statistic);
+    await waitFakeTimer();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(isTooltipOpen()).toBeTruthy();
+    expect(container.querySelector('.ant-tooltip-open')).not.toBeNull();
+
+    fireEvent.mouseLeave(statistic);
+    await waitFakeTimer();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(isTooltipOpen()).toBeFalsy();
+    expect(container.querySelector('.ant-tooltip-open')).toBeNull();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix

### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/53872

### 💡 Background and Solution

> - statistic timer cannot display tooltip as a children.

### 📝 Change Log

> - statistic timer cannot display tooltip as a children.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    statistic timer cannot display tooltip as a children       |
| 🇨🇳 Chinese |     statistic timer 组件作为tooltip的childern无法正常展示tooltip文字提示      |
