### PR TITLE
fix: timer finish call back does not trigger when page in background

### DIFF
--- a/components/statistic/Timer.tsx
+++ b/components/statistic/Timer.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useEvent } from 'rc-util';
-import raf from 'rc-util/lib/raf';
 
 import { cloneElement } from '../_util/reactNode';
 import type { StatisticProps } from './Statistic';
@@ -9,6 +8,8 @@ import type { FormatConfig, valueType } from './utils';
 import { formatCounter } from './utils';
 
 export type TimerType = 'countdown' | 'countup';
+
+const UPDATE_INTERVAL = 1000 / 60;
 
 export interface StatisticTimerProps extends FormatConfig, StatisticProps {
   type: TimerType;
@@ -51,21 +52,27 @@ const StatisticTimer: React.FC<StatisticTimerProps> = (props) => {
 
   // Effect trigger
   React.useEffect(() => {
-    let rafId: number;
+    let intervalId: number;
 
-    const clear = () => raf.cancel(rafId!);
-
-    const rafUpdate = () => {
-      rafId = raf(() => {
-        if (update()) {
-          rafUpdate();
-        }
-      });
+    const tick = () => {
+      if (!update()) {
+        window.clearInterval(intervalId);
+      }
     };
 
-    rafUpdate();
+    const startTimer = () => {
+      intervalId = window.setInterval(tick, UPDATE_INTERVAL);
+    };
 
-    return clear;
+    const stopTimer = () => {
+      window.clearInterval(intervalId);
+    };
+
+    startTimer();
+
+    return () => {
+      stopTimer();
+    };
   }, [value, down]);
 
   React.useEffect(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Since the Timer component dispatches update events using raf, the onFinish and onChange callbacks will not be executed when the Timer component is in the background.

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Replace raf with setTimeout so that the callbacks are executed regardless of whether the page is in the foreground or background.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix issue where onFinish and onChange callbacks in timer components would not trigger when the page is in the background by replacing requestAnimationFrame with setInterval. Ensures accurate countdown behavior regardless of tab visibility.     |
| 🇨🇳 Chinese |     修复了 Timer 组件在页面进入后台（如切换标签页）时，onFinish 和 onChange 回调未触发的问题。使用 setInterval 替代 requestAnimationFrame，确保倒计时逻辑在任何情况下都能正常执行。      |
