### PR TITLE
Codingories/fix 53897 input on press enter

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -25,6 +25,7 @@ export interface SearchProps extends InputProps {
   ) => void;
   enterButton?: React.ReactNode;
   loading?: boolean;
+  onPressEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
@@ -43,6 +44,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     onCompositionStart,
     onCompositionEnd,
     variant,
+    onPressEnter: customOnPressEnter,
     ...restProps
   } = props;
 
@@ -85,6 +87,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     if (composedRef.current || loading) {
       return;
     }
+    customOnPressEnter?.(e);
     onSearch(e);
   };
 

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -226,6 +226,5 @@ describe('Input.Search', () => {
     const { container } = render(<Search onPressEnter={onPressEnter} />);
     fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
     expect(onPressEnter).toHaveBeenCalledTimes(1);
-    expect(onPressEnter.mock.calls[0][0]).toHaveProperty('key', 'Enter');
   });
 });

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -219,4 +219,13 @@ describe('Input.Search', () => {
       container.querySelector('.ant-input-affix-wrapper')?.classList.contains('className'),
     ).toBe(false);
   });
+
+  // https://github.com/ant-design/ant-design/issues/53897
+  it('should trigger onPressEnter when press enter', () => {
+    const onPressEnter = jest.fn();
+    const { container } = render(<Search onPressEnter={onPressEnter} />);
+    fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter', keyCode: 13 });
+    expect(onPressEnter).toHaveBeenCalledTimes(1);
+    expect(onPressEnter.mock.calls[0][0]).toHaveProperty('key', 'Enter');
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix https://github.com/ant-design/ant-design/issues/53897

### 💡 Background and Solution

> Input Search component miss the onPressEnter callback
> add onPressEnter to Input Search

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   add onPressEnter callback to Input Search Component       |
| 🇨🇳 Chinese |     给Input.Search补充onPressEnter的回调      |
