### PR TITLE
fix:tooltip does not disappear after modal calling

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -362,7 +362,29 @@ const InternalTooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) 
       // TODO: In the future, destroyTooltipOnHide in rc-tooltip needs to be upgrade to destroyOnHidden
       destroyTooltipOnHide={destroyOnHidden ?? !!destroyTooltipOnHide}
     >
-      {tempOpen ? cloneElement(child, { className: childCls }) : child}
+      {tempOpen
+        ? cloneElement(child, {
+            ...child.props,
+            className: childCls,
+            onClick: (e: React.MouseEvent) => {
+              const trigger = props.trigger || ['hover'];
+              const isHoverTrigger = trigger.includes('hover');
+              const isClickTrigger = trigger.includes('click');
+
+              if (typeof child.props.onClick === 'function') {
+                child.props.onClick(e);
+
+                if (isHoverTrigger) {
+                  onOpenChange(false);
+                }
+
+                if (isHoverTrigger && isClickTrigger) {
+                  onOpenChange(false);
+                }
+              }
+            },
+          })
+        : child}
     </RcTooltip>
   );
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix

### 🔗 Related Issues

> - https://github.com/ant-design/ant-design/issues/53454

### 💡 Background and Solution

> - Tooltip does not disappear after modal calling.

### 📝 Change Log

> - Tooltip does not disappear after modal calling.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Tooltip does not disappear after modal calling       |
| 🇨🇳 Chinese |      弹窗弹出后提示未消失     |
