### PR TITLE
fix: mentions sets the autosize property, and the icon in the bottom right corner supports manual height adjustment

### DIFF
--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -196,7 +196,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           width: '100%',
           border: 'none',
           outline: 'none',
-          resize: 'none',
+          resize: 'vertical',
           backgroundColor: 'transparent',
           ...genPlaceholderStyle(token.colorTextPlaceholder),
         },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix

### 🔗 Related Issues

> - https://github.com/ant-design/ant-design/issues/49935

### 💡 Background and Solution

> - Mentions sets the autosize property, and the icon in the bottom right corner supports manual height adjustment

### 📝 Change Log

> - Mentions sets the autosize property, and the icon in the bottom right corner supports manual height adjustment

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Mentions sets the autosize property, and the icon in the bottom right corner supports manual height adjustment      |
| 🇨🇳 Chinese |     Mentions 设置autosize属性右下角图标支持手动调整高度      |
