### PR TITLE
fix: npm / pnpm build

### DIFF
--- a/components/date-picker/generatePicker/interface.ts
+++ b/components/date-picker/generatePicker/interface.ts
@@ -68,6 +68,15 @@ export type PickerStyles = Partial<Record<SemanticName, React.CSSProperties>> & 
   popup?: Partial<Record<PopupSemantic, React.CSSProperties>>;
 };
 
+export type RequiredSemanticPicker = readonly [
+  classNames: Required<Record<SemanticName, string>> & {
+    popup: Required<Record<PopupSemantic, string>>;
+  },
+  styles: Required<Record<SemanticName, React.CSSProperties>> & {
+    popup: Required<Record<PopupSemantic, React.CSSProperties>>;
+  },
+];
+
 type InjectDefaultProps<Props> = Omit<
   Props,
   'locale' | 'generateConfig' | 'hideHeader' | 'classNames' | 'styles'

--- a/components/date-picker/hooks/useMergedPickerSemantic.ts
+++ b/components/date-picker/hooks/useMergedPickerSemantic.ts
@@ -4,7 +4,11 @@ import cls from 'classnames';
 
 import useMergeSemantic from '../../_util/hooks/useMergeSemantic';
 import { useComponentConfig } from '../../config-provider/context';
-import type { PickerClassNames, PickerStyles } from '../generatePicker/interface';
+import type {
+  PickerClassNames,
+  PickerStyles,
+  RequiredSemanticPicker,
+} from '../generatePicker/interface';
 
 const useMergedPickerSemantic = (
   pickerType: 'timePicker' | 'datePicker',
@@ -48,7 +52,7 @@ const useMergedPickerSemantic = (
     };
 
     // Return
-    return [filledClassNames, filledStyles] as const;
+    return [filledClassNames, filledStyles] as RequiredSemanticPicker;
   }, [mergedClassNames, mergedStyles, popupClassName, popupStyle]);
 };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

```
components/date-picker/hooks/useMergedPickerSemantic.ts(8,7): 
error TS2742: The inferred type of 'useMergedPickerSemantic' cannot be named without a reference to 
'.pnpm/csstype@3.1.3/node_modules/csstype'. 
This is likely not portable. A type annotation is necessary. 
TypeScript: 1 declaration error
TypeScript: emit failed
```

TypeScript 推断出的 useMergedPickerSemantic 返回类型引用了外部依赖（csstype），导致类型声明文件生成时不够“可移植”。需要为 useMergedPickerSemantic 显式添加返回类型注解

![image](https://github.com/user-attachments/assets/36bd123d-bd00-4dde-a33f-88ed43295f7e)


找了一个 mac 用户 也是这样子。

![1610ccee66f3af265a8eaaac1702b2f9](https://github.com/user-attachments/assets/4de2e539-fcc8-41af-96bb-69ca0acede6b)



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -     |
