### PR TITLE
fix: update rc-virtual-list and fix scrollbar color in dark theme

### DIFF
--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -199,9 +199,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     [componentCls]: {
       ...resetComponent(token),
       position: 'relative',
-      // https://github.com/ant-design/ant-design/issues/47486
-      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
-      // So we need to define the style of the scrollbar color separately.
+      // Fix https://github.com/ant-design/ant-design/issues/46177
       ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
       '*': {
         outline: 'none',

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -199,6 +199,10 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     [componentCls]: {
       ...resetComponent(token),
       position: 'relative',
+      // https://github.com/ant-design/ant-design/issues/47486
+      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
+      // So we need to define the style of the scrollbar color separately.
+      ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
       '*': {
         outline: 'none',
       },

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -199,7 +199,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
     [componentCls]: {
       ...resetComponent(token),
       position: 'relative',
-      // Fix https://github.com/ant-design/ant-design/issues/46177
+      // fix https://github.com/ant-design/ant-design/issues/46177
       ['--rc-virtual-list-scrollbar-bg' as const]: token.colorSplit,
       '*': {
         outline: 'none',

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -200,7 +200,7 @@ const genBaseStyle: GenerateStyle<ListToken> = (token) => {
       ...resetComponent(token),
       position: 'relative',
       // Fix https://github.com/ant-design/ant-design/issues/46177
-      ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
+      ['--rc-virtual-list-scrollbar-bg' as const]: token.colorSplit,
       '*': {
         outline: 'none',
       },

--- a/components/table/style/index.ts
+++ b/components/table/style/index.ts
@@ -265,9 +265,7 @@ const genTableStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       clear: 'both',
       maxWidth: '100%',
-      // https://github.com/ant-design/ant-design/issues/47486
-      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
-      // So we need to define the style of the scrollbar color separately.
+      // fix https://github.com/ant-design/ant-design/issues/46177
       ['--rc-virtual-list-scrollbar-bg' as any]: token.tableScrollBg,
       ...clearFix(),
 

--- a/components/table/style/index.ts
+++ b/components/table/style/index.ts
@@ -265,6 +265,10 @@ const genTableStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       clear: 'both',
       maxWidth: '100%',
+      // https://github.com/ant-design/ant-design/issues/47486
+      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
+      // So we need to define the style of the scrollbar color separately.
+      ['--rc-virtual-list-scrollbar-bg' as any]: token.tableScrollBg,
       ...clearFix(),
 
       [componentCls]: {

--- a/components/table/style/index.ts
+++ b/components/table/style/index.ts
@@ -266,7 +266,7 @@ const genTableStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       clear: 'both',
       maxWidth: '100%',
       // fix https://github.com/ant-design/ant-design/issues/46177
-      ['--rc-virtual-list-scrollbar-bg' as any]: token.tableScrollBg,
+      ['--rc-virtual-list-scrollbar-bg' as const]: token.tableScrollBg,
       ...clearFix(),
 
       [componentCls]: {

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -124,9 +124,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
   return {
     [treeCls]: {
       ...resetComponent(token),
-      // https://github.com/ant-design/ant-design/issues/47486
-      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
-      // So we need to define the style of the scrollbar color separately.
+      // fix https://github.com/ant-design/ant-design/issues/50316
       ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
       background: token.colorBgContainer,
       borderRadius: token.borderRadius,

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -125,7 +125,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
     [treeCls]: {
       ...resetComponent(token),
       // fix https://github.com/ant-design/ant-design/issues/50316
-      ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
+      ['--rc-virtual-list-scrollbar-bg' as const]: token.colorSplit,
       background: token.colorBgContainer,
       borderRadius: token.borderRadius,
       transition: `background-color ${token.motionDurationSlow}`,

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -124,6 +124,10 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
   return {
     [treeCls]: {
       ...resetComponent(token),
+      // https://github.com/ant-design/ant-design/issues/47486
+      // From testing, it seems that the virtual scrollbar in rc-virtual-list will not be styled by scrollbar-color.
+      // So we need to define the style of the scrollbar color separately.
+      ['--rc-virtual-list-scrollbar-bg' as any]: token.colorSplit,
       background: token.colorBgContainer,
       borderRadius: token.borderRadius,
       transition: `background-color ${token.motionDurationSlow}`,

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "puppeteer": "^24.7.1",
     "rc-footer": "^0.6.8",
     "rc-tween-one": "^3.0.6",
-    "rc-virtual-list": "^3.17.0",
+    "rc-virtual-list": "3.19.1-0",
     "react": "^19.1.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-countup": "^6.5.3",
@@ -360,7 +360,8 @@
     }
   },
   "overrides": {
-    "nwsapi": "2.2.20"
+    "nwsapi": "2.2.20",
+    "rc-virtual-list": "3.19.1-0"
   },
   "resolutions": {
     "nwsapi": "2.2.20"

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "puppeteer": "^24.7.1",
     "rc-footer": "^0.6.8",
     "rc-tween-one": "^3.0.6",
-    "rc-virtual-list": "3.19.1-0",
+    "rc-virtual-list": "^3.19.1",
     "react": "^19.1.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-countup": "^6.5.3",
@@ -360,8 +360,7 @@
     }
   },
   "overrides": {
-    "nwsapi": "2.2.20",
-    "rc-virtual-list": "3.19.1-0"
+    "nwsapi": "2.2.20"
   },
   "resolutions": {
     "nwsapi": "2.2.20"


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/50316
close https://github.com/ant-design/ant-design/issues/47565
close https://github.com/ant-design/ant-design/issues/46177

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

解法在 https://github.com/react-component/virtual-list/pull/323

| Before ❌ | After ✅ |
| --- | --- |
| <img width="417" alt="图片" src="https://github.com/user-attachments/assets/ab3814e2-ff9f-453e-92f8-e06a6d683192" /> | <img width="427" alt="图片" src="https://github.com/user-attachments/assets/87c52083-7ae8-41e7-9f68-8a6e1eee890d" /> |
| [线上链接](https://ant.design/components/tree-cn?theme=dark#tree-demo-virtual-scroll) | [修复后的链接](https://fix-scrollbar-color-in-dark.ant-design.pages.dev/components/tree-cn?theme=dark#tree-demo-virtual-scroll) |

Select 因为滚动条在一个浮层背景上，效果还可以，符合预期。本次修复不动。

<img width="435" alt="图片" src="https://github.com/user-attachments/assets/5b77eb7a-9058-4c0d-b486-a0a19106a617" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tree/List/Table virtual scrollbar visibility in dark themes.          |
| 🇨🇳 Chinese | 修复 Tree/List/Table 等组件的虚拟滚动条样式在暗色主题下难以识别的问题。          |
