### PR TITLE
fix[#54146]: DirectoryTree drop indicator overflow bug

### DIFF
--- a/components/tree/style/directory.ts
+++ b/components/tree/style/directory.ts
@@ -16,6 +16,10 @@ export const genDirectoryStyle = ({
     [`${treeCls}-node-content-wrapper`]: {
       position: 'static',
 
+      [`&:has(${treeCls}-drop-indicator)`]: {
+        position: 'relative',
+      },
+
       [`> *:not(${treeCls}-drop-indicator)`]: {
         position: 'relative',
       },
@@ -44,6 +48,9 @@ export const genDirectoryStyle = ({
 
     // ============= Selected =============
     '&-selected': {
+      background: directoryNodeSelectedBg,
+      borderRadius,
+
       [`${treeCls}-switcher, ${treeCls}-draggable-icon`]: {
         color: directoryNodeSelectedColor,
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> fix #54146 

### 💡 Background and Solution

Update the DirectoryTree style, set the position to relative when there is an indicator under antd-tree-node-content-wrapper, and update the background color of the node-content-wrapper

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix issue #54146  Indicator overflow when dragging nodes in the DirectoryTree component       |
| 🇨🇳 Chinese |     修复issue #54146  DirectoryTree组件拖拽节点时指示器溢出问题   |
