### PR TITLE
fix[ant-design#42120] use fontWeightStrong token for Typography.Text strong

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -228,7 +228,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
 
         [`&:not(${treeNodeCls}-disabled).filter-node ${treeCls}-title`]: {
           color: token.colorPrimary,
-          fontWeight: 500,
+          fontWeight: token.fontWeightStrong,
         },
 
         '&-draggable': {

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -118,7 +118,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
   },
 
   strong: {
-    fontWeight: 600,
+    fontWeight: token.fontWeightStrong,
   },
 
   // list


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #42120

### 💡 Background and Solution

fontWeight was hard coded for Typography.Text strong and Tree titles.
This fix replaces the hard coded value with the `fontWeightStrong` token .

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Typography.Text strong  font-weight now uses the `fontWeightStrong` token.|
| 🇨🇳 Chinese | Typography.Text 强字体粗细现在使用 `fontWeightStrong` 标记 |
