### PR TITLE
fix: incorrect warning of FloatButton.Group shape

### DIFF
--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -85,7 +85,7 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
     const warning = devUseWarning('FloatButton');
 
     warning(
-      !(shape === 'circle' && description),
+      !(mergedShape === 'circle' && description),
       'usage',
       'supported only when `shape` is `square`. Due to narrow space for text, short sentence is recommended.',
     );


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

```ts
<FloatButton.Group shape="square" content="Test" icon={<QuestionCircleOutlined />} style={{ insetInlineEnd: 94 }}  trigger="hover">
  <FloatButton icon={<QuestionCircleOutlined />} />
</FloatButton.Group>
```

this code will always trigger a warning in development even though the shape is square.
> Warning: [antd: FloatButton] supported only when `shape` is `square`. Due to narrow space for text, short sentence is recommended.

### 💡 Background and Solution

incorrect warning of FloatButton.Group shape

### 📝 Change Log

> * fix incorrect warning of FloatButton.Group shape

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix incorrect warning of FloatButton.Group shape        |
| 🇨🇳 Chinese |           |
