### PR TITLE
docs(Tree): add missing props from rc-tree

### DIFF
--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -82,10 +82,15 @@ Common props ref：[Common props](/docs/react/common-props)
 | onDragOver | Callback function for when the onDragOver event occurs | function({event, node}) | - |  |
 | onDragStart | Callback function for when the onDragStart event occurs | function({event, node}) | - |  |
 | onDrop | Callback function for when the onDrop event occurs | function({event, node, dragNode, dragNodesKeys}) | - |  |
+| onDoubleClick | Callback function for when the user double clicks a treeNode | function(event, node) | - |  |
 | onExpand | Callback function for when a treeNode is expanded or collapsed | function(expandedKeys, {expanded: boolean, node}) | - |  |
 | onLoad | Callback function for when a treeNode is loaded | function(loadedKeys, {event, node}) | - |  |
+| onMouseEnter | Callback function for when the mouse enters a treeNode | function({event, node}) | - |  |
+| onMouseLeave | Callback function for when the mouse leaves a treeNode | function({event, node}) | - |  |
 | onRightClick | Callback function for when the user right clicks a treeNode | function({event, node}) | - |  |
 | onSelect | Callback function for when the user clicks a treeNode | function(selectedKeys, e:{selected: boolean, selectedNodes, node, event}) | - |  |
+| onScroll | Callback function for when the tree container scrolls | function(event) | - |  |
+| dropIndicatorRender | Customize the drop indicator when dragging | (props: {dropPosition, dropLevelOffset, indent}) => ReactNode | - |  |
 
 ### TreeNode props
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -81,10 +81,15 @@ demo:
 | onDragOver | dragover 触发时调用 | function({event, node}) | - |  |
 | onDragStart | 开始拖拽时调用 | function({event, node}) | - |  |
 | onDrop | drop 触发时调用 | function({event, node, dragNode, dragNodesKeys}) | - |  |
+| onDoubleClick | 双击树节点时调用 | function(event, node) | - |  |
 | onExpand | 展开/收起节点时触发 | function(expandedKeys, {expanded: boolean, node}) | - |  |
 | onLoad | 节点加载完毕时触发 | function(loadedKeys, {event, node}) | - |  |
+| onMouseEnter | 鼠标移入节点时触发 | function({event, node}) | - |  |
+| onMouseLeave | 鼠标移出节点时触发 | function({event, node}) | - |  |
 | onRightClick | 响应右键点击 | function({event, node}) | - |  |
 | onSelect | 点击树节点触发 | function(selectedKeys, e:{selected: boolean, selectedNodes, node, event}) | - |  |
+| onScroll | 滚动容器时触发 | function(event) | - |  |
+| dropIndicatorRender | 自定义拖动时的提示线 | (props: {dropPosition, dropLevelOffset, indent}) => ReactNode | - |  |
 
 ### TreeNode props
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

Adding missing props to the API section in docs. These props are inherited from the rc-tree package https://github.com/react-component/tree/blob/master/src/Tree.tsx

I can verify the EN version reads OK, I can't with the Chinese version 😢 its guess work with AI to translate.

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
