### PR TITLE
docs: workaround for avoid searchbar styles async

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,5 +1,5 @@
 // FIXME: workaround for avoid searchbar styles be extracted to async chunk
-@import url('dumi/theme-default/slots/SearchBar/index.less');
+@import 'dumi/theme-default/slots/SearchBar/index.less';
 
 .demo-logo {
   width: 120px;

--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,3 +1,6 @@
+// FIXME: workaround for avoid searchbar styles be extracted to async chunk
+@import url('dumi/theme-default/slots/SearchBar/index.less');
+
 .demo-logo {
   width: 120px;
   min-width: 120px;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

绕过搜索栏样式被拆到异步 chunk 导致的首屏样式缺失而后又加载导致的闪动问题，临时解法是在 global 里主动引入一遍样式，本质解需要再继续排查下，可能与 Mako 的 split 行为有关

before:
![图片](https://github.com/user-attachments/assets/da8cc62f-46a8-4960-9769-f539a57bf1ad)

after:
![图片](https://github.com/user-attachments/assets/20d75fd9-4abc-4085-b551-75151777c179)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | --        |
| 🇨🇳 Chinese | --        |
