### PR TITLE
fix(float-button): remove bottom border when pop left or right

### DIFF
--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -254,6 +254,7 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token
             borderEndEndRadius: borderRadiusLG,
           },
           '&:not(:last-child)': {
+            borderBottom: 'none',
             borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           },
         },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

remove bottom border when placement is horizontal and shape is `square`。

link: https://stackblitz.com/edit/react-jh7fb5yu?file=demo.tsx

<img width="507" alt="截屏2025-07-02 11 33 12" src="https://github.com/user-attachments/assets/de8f648f-299f-4af2-af29-d16db55786ed" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix(float-button): remove bottom border when placement is `left` or `right` while shape is `square`      |
| 🇨🇳 Chinese |     修复(float-button): 当菜单弹出方向为水平方向且 float btn 的形状为 `square` 时，移除 bottom border      |
