### PR TITLE
feat[Segmented]: add tooltip to segmented option item

### DIFF
--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -588,7 +588,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
             id="test-id"
             role="tooltip"
           >
-            hello user1
+            hello user2
           </div>
         </div>
       </div>
@@ -655,7 +655,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
             id="test-id"
             role="tooltip"
           >
-            hello user1
+            hello user3
           </div>
         </div>
       </div>

--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`] = `
 <div
@@ -488,6 +488,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
       class="ant-segmented-group"
     >
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item ant-segmented-item-selected"
       >
         <input
@@ -517,7 +518,28 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           </div>
         </div>
       </label>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-gold css-var-test-id ant-tooltip-placement-top"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; bottom: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            id="test-id"
+            role="tooltip"
+          >
+            hello user1
+          </div>
+        </div>
+      </div>
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item"
       >
         <input
@@ -550,7 +572,28 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           </div>
         </div>
       </label>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-pink css-var-test-id ant-tooltip-placement-top"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; bottom: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            id="test-id"
+            role="tooltip"
+          >
+            hello user1
+          </div>
+        </div>
+      </div>
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item"
       >
         <input
@@ -596,6 +639,26 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           </div>
         </div>
       </label>
+      <div
+        class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-geekblue css-var-test-id ant-tooltip-placement-top"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+      >
+        <div
+          class="ant-tooltip-arrow"
+          style="position: absolute; bottom: 0px; left: 0px;"
+        />
+        <div
+          class="ant-tooltip-content"
+        >
+          <div
+            class="ant-tooltip-inner"
+            id="test-id"
+            role="tooltip"
+          >
+            hello user1
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
 <div
@@ -478,6 +478,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
       class="ant-segmented-group"
     >
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item ant-segmented-item-selected"
       >
         <input
@@ -508,6 +509,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
         </div>
       </label>
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item"
       >
         <input
@@ -541,6 +543,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
         </div>
       </label>
       <label
+        aria-describedby="test-id"
         class="ant-segmented-item"
       >
         <input

--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -3,7 +3,7 @@ import { AppstoreOutlined, BarsOutlined } from '@ant-design/icons';
 
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, waitFor } from '../../../tests/utils';
 import type { SegmentedValue } from '../index';
 import Segmented from '../index';
 
@@ -412,6 +412,33 @@ describe('Segmented', () => {
         <Segmented orientation="vertical" options={['Daily', 'Weekly', 'Monthly']} />,
       );
       expect(container.querySelector<HTMLDivElement>('.ant-segmented-vertical')).not.toBeNull();
+    });
+  });
+
+  describe('toolTip for optionItem ', () => {
+    it('Configuring tooTip in the options should display the corresponding information', async () => {
+      const { container } = render(
+        <Segmented
+          orientation="vertical"
+          options={[
+            { label: 'Daily', value: 'Daily', tooltip: 'hello Daily' },
+            'Weekly',
+            { label: 'Monthly', value: 'Monthly', tooltip: 'hello Monthly' },
+          ]}
+        />,
+      );
+      const itemList = container.querySelectorAll('.ant-segmented-item');
+      fireEvent.mouseEnter(itemList[0]);
+      fireEvent.mouseEnter(itemList[1]);
+      fireEvent.mouseEnter(itemList[2]);
+      await waitFor(() => {
+        const tooltipList = document.querySelectorAll('.ant-tooltip');
+        expect(tooltipList).toHaveLength(2);
+        const tooltipInnerList = document.querySelectorAll('.ant-tooltip-inner');
+        expect(tooltipInnerList).toHaveLength(2);
+        expect(tooltipInnerList[0]?.textContent).toBe('hello Daily');
+        expect(tooltipInnerList[1]?.textContent).toBe('hello Monthly');
+      });
     });
   });
 });

--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -416,7 +416,7 @@ describe('Segmented', () => {
   });
 
   describe('toolTip for optionItem ', () => {
-    it('Configuring tooTip in the options should display the corresponding information', async () => {
+    it('Configuring tooltip in the options should display the corresponding information', async () => {
       const { container } = render(
         <Segmented
           orientation="vertical"

--- a/components/segmented/demo/custom.md
+++ b/components/segmented/demo/custom.md
@@ -1,6 +1,6 @@
 ## zh-CN
 
-使用 自定义渲染每一个 Segmented Item。
+自定义渲染每一个 Segmented Item。
 
 ## en-US
 

--- a/components/segmented/demo/custom.md
+++ b/components/segmented/demo/custom.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-使用 ReactNode 自定义渲染每一个 Segmented Item。
+使用 自定义渲染每一个 Segmented Item。
 
 ## en-US
 
-Custom each Segmented Item by ReactNode.
+Custom each Segmented Item.

--- a/components/segmented/demo/custom.tsx
+++ b/components/segmented/demo/custom.tsx
@@ -24,7 +24,7 @@ const App: React.FC = () => (
             </div>
           ),
           value: 'user2',
-          tooltip: { title: 'hello user1', color: 'pink' },
+          tooltip: { title: 'hello user2', color: 'pink' },
         },
         {
           label: (

--- a/components/segmented/demo/custom.tsx
+++ b/components/segmented/demo/custom.tsx
@@ -14,6 +14,7 @@ const App: React.FC = () => (
             </div>
           ),
           value: 'user1',
+          tooltip: { title: 'hello user1', color: 'gold' },
         },
         {
           label: (
@@ -23,6 +24,7 @@ const App: React.FC = () => (
             </div>
           ),
           value: 'user2',
+          tooltip: { title: 'hello user1', color: 'pink' },
         },
         {
           label: (
@@ -32,6 +34,7 @@ const App: React.FC = () => (
             </div>
           ),
           value: 'user3',
+          tooltip: { title: 'hello user1', color: 'geekblue' },
         },
       ]}
     />

--- a/components/segmented/demo/custom.tsx
+++ b/components/segmented/demo/custom.tsx
@@ -34,7 +34,7 @@ const App: React.FC = () => (
             </div>
           ),
           value: 'user3',
-          tooltip: { title: 'hello user1', color: 'geekblue' },
+          tooltip: { title: 'hello user3', color: 'geekblue' },
         },
       ]}
     />

--- a/components/segmented/index.en-US.md
+++ b/components/segmented/index.en-US.md
@@ -59,11 +59,12 @@ Common props ref：[Common props](/docs/react/common-props)
 
 | Property  | Description                      | Type             | Default | Version |
 | --------- | -------------------------------- | ---------------- | ------- | ------- |
-| label     | Display text for Segmented item  | ReactNode        | -       |         |
-| value     | Value for Segmented item         | string \| number | -       |         |
-| icon      | Display icon for Segmented item  | ReactNode        | -       |         |
 | disabled  | Disabled state of segmented item | boolean          | false   |         |
 | className | The additional css class         | string           | -       |         |
+| icon      | Display icon for Segmented item  | ReactNode        | -       |         |
+| label     | Display text for Segmented item  | ReactNode        | -       |         |
+| tooltip   | tooltip for Segmented item       | string           | -       |         |
+| value     | Value for Segmented item         | string \| number | -       |         |
 
 ## Semantic DOM
 

--- a/components/segmented/index.en-US.md
+++ b/components/segmented/index.en-US.md
@@ -57,14 +57,14 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### SegmentedItemType
 
-| Property  | Description                      | Type             | Default | Version |
-| --------- | -------------------------------- | ---------------- | ------- | ------- |
-| disabled  | Disabled state of segmented item | boolean          | false   |         |
-| className | The additional css class         | string           | -       |         |
-| icon      | Display icon for Segmented item  | ReactNode        | -       |         |
-| label     | Display text for Segmented item  | ReactNode        | -       |         |
-| tooltip   | tooltip for Segmented item       | string           | -       |         |
-| value     | Value for Segmented item         | string \| number | -       |         |
+| Property  | Description                      | Type                   | Default | Version |
+| --------- | -------------------------------- | ---------------------- | ------- | ------- |
+| disabled  | Disabled state of segmented item | boolean                | false   |         |
+| className | The additional css class         | string                 | -       |         |
+| icon      | Display icon for Segmented item  | ReactNode              | -       |         |
+| label     | Display text for Segmented item  | ReactNode              | -       |         |
+| tooltip   | tooltip for Segmented item       | string \| TooltipProps | -       |         |
+| value     | Value for Segmented item         | string \| number       | -       |         |
 
 ## Semantic DOM
 

--- a/components/segmented/index.en-US.md
+++ b/components/segmented/index.en-US.md
@@ -57,14 +57,14 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### SegmentedItemType
 
-| Property  | Description                      | Type                   | Default | Version |
-| --------- | -------------------------------- | ---------------------- | ------- | ------- |
-| disabled  | Disabled state of segmented item | boolean                | false   |         |
-| className | The additional css class         | string                 | -       |         |
-| icon      | Display icon for Segmented item  | ReactNode              | -       |         |
-| label     | Display text for Segmented item  | ReactNode              | -       |         |
-| tooltip   | tooltip for Segmented item       | string \| TooltipProps | -       |         |
-| value     | Value for Segmented item         | string \| number       | -       |         |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| disabled | Disabled state of segmented item | boolean | false |  |
+| className | The additional css class | string | - |  |
+| icon | Display icon for Segmented item | ReactNode | - |  |
+| label | Display text for Segmented item | ReactNode | - |  |
+| tooltip | tooltip for Segmented item | string \| [TooltipProps](../tooltip/index.zh-CN.md#api) | - |  |
+| value | Value for Segmented item | string \| number | - |  |
 
 ## Semantic DOM
 

--- a/components/segmented/index.en-US.md
+++ b/components/segmented/index.en-US.md
@@ -63,7 +63,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | className | The additional css class | string | - |  |
 | icon | Display icon for Segmented item | ReactNode | - |  |
 | label | Display text for Segmented item | ReactNode | - |  |
-| tooltip | tooltip for Segmented item | string \| [TooltipProps](../tooltip/index.zh-CN.md#api) | - |  |
+| tooltip | tooltip for Segmented item | string \| [TooltipProps](../tooltip/index.en-US.md#api) | - |  |
 | value | Value for Segmented item | string \| number | - |  |
 
 ## Semantic DOM

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@rc-component/segmented';
 import RcSegmented from '@rc-component/segmented';
 import useId from '@rc-component/util/lib/hooks/useId';
+import { Tooltip } from 'antd';
 import classNames from 'classnames';
 
 import useOrientation from '../_util/hooks/useOrientation';
@@ -18,9 +19,11 @@ import useStyle from './style';
 
 export type { SegmentedValue } from '@rc-component/segmented';
 export type SemanticName = 'root' | 'icon' | 'label' | 'item';
+
 interface SegmentedLabeledOptionWithoutIcon<ValueType = RcSegmentedValue>
   extends RcSegmentedLabeledOption<ValueType> {
   label: RcSegmentedLabeledOption['label'];
+  tooltip?: string;
 }
 
 interface SegmentedLabeledOptionWithIcon<ValueType = RcSegmentedValue>
@@ -28,6 +31,7 @@ interface SegmentedLabeledOptionWithIcon<ValueType = RcSegmentedValue>
   label?: RcSegmentedLabeledOption['label'];
   /** Set icon for Segmented item */
   icon: React.ReactNode;
+  tooltip?: string;
 }
 
 function isSegmentedLabeledOptionWithIcon(
@@ -57,122 +61,136 @@ export interface SegmentedProps<ValueType = RcSegmentedValue>
   shape?: 'default' | 'round';
 }
 
-const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) => {
-  const defaultName = useId();
+const InternalSegmented = React.forwardRef<HTMLDivElement, Omit<SegmentedProps, 'itemRender'>>(
+  (props, ref) => {
+    const defaultName = useId();
 
-  const {
-    prefixCls: customizePrefixCls,
-    className,
-    rootClassName,
-    block,
-    options = [],
-    size: customSize = 'middle',
-    style,
-    vertical,
-    orientation,
-    shape = 'default',
-    name = defaultName,
-    styles,
-    classNames: segmentedClassNames,
-    ...restProps
-  } = props;
+    const {
+      prefixCls: customizePrefixCls,
+      className,
+      rootClassName,
+      block,
+      options = [],
+      size: customSize = 'middle',
+      style,
+      vertical,
+      orientation,
+      shape = 'default',
+      name = defaultName,
+      styles,
+      classNames: segmentedClassNames,
+      ...restProps
+    } = props;
 
-  const {
-    getPrefixCls,
-    direction,
-    className: contextClassName,
-    style: contextStyle,
-    classNames: contextClassNames,
-    styles: contextStyles,
-  } = useComponentConfig('segmented');
-  const prefixCls = getPrefixCls('segmented', customizePrefixCls);
-  // Style
-  const [hashId, cssVarCls] = useStyle(prefixCls);
+    const {
+      getPrefixCls,
+      direction,
+      className: contextClassName,
+      style: contextStyle,
+      classNames: contextClassNames,
+      styles: contextStyles,
+    } = useComponentConfig('segmented');
+    const prefixCls = getPrefixCls('segmented', customizePrefixCls);
+    // Style
+    const [hashId, cssVarCls] = useStyle(prefixCls);
 
-  // ===================== Size =====================
-  const mergedSize = useSize(customSize);
+    // ===================== Size =====================
+    const mergedSize = useSize(customSize);
 
-  // syntactic sugar to support `icon` for Segmented Item
-  const extendedOptions = React.useMemo<RCSegmentedProps['options']>(
-    () =>
-      options.map((option) => {
-        if (isSegmentedLabeledOptionWithIcon(option)) {
-          const { icon, label, ...restOption } = option;
-          return {
-            ...restOption,
-            label: (
-              <>
-                <span
-                  className={classNames(
-                    `${prefixCls}-item-icon`,
-                    contextClassNames.icon,
-                    segmentedClassNames?.icon,
-                  )}
-                  style={{
-                    ...contextStyles.icon,
-                    ...styles?.icon,
-                  }}
-                >
-                  {icon}
-                </span>
-                {label && <span>{label}</span>}
-              </>
-            ),
-          };
-        }
-        return option;
-      }),
-    [options, prefixCls],
-  );
+    // syntactic sugar to support `icon` for Segmented Item
+    const extendedOptions = React.useMemo<RCSegmentedProps['options']>(
+      () =>
+        options.map((option) => {
+          if (isSegmentedLabeledOptionWithIcon(option)) {
+            const { icon, label, ...restOption } = option;
+            return {
+              ...restOption,
+              label: (
+                <>
+                  <span
+                    className={classNames(
+                      `${prefixCls}-item-icon`,
+                      contextClassNames.icon,
+                      segmentedClassNames?.icon,
+                    )}
+                    style={{
+                      ...contextStyles.icon,
+                      ...styles?.icon,
+                    }}
+                  >
+                    {icon}
+                  </span>
+                  {label && <span>{label}</span>}
+                </>
+              ),
+            };
+          }
+          return option;
+        }),
+      [options, prefixCls],
+    );
 
-  const [, mergedVertical] = useOrientation(orientation, vertical);
+    const [, mergedVertical] = useOrientation(orientation, vertical);
 
-  const cls = classNames(
-    className,
-    rootClassName,
-    contextClassName,
-    segmentedClassNames?.root,
-    contextClassNames.root,
-    {
-      [`${prefixCls}-block`]: block,
-      [`${prefixCls}-sm`]: mergedSize === 'small',
-      [`${prefixCls}-lg`]: mergedSize === 'large',
-      [`${prefixCls}-vertical`]: mergedVertical,
-      [`${prefixCls}-shape-${shape}`]: shape === 'round',
-    },
-    hashId,
-    cssVarCls,
-  );
+    const cls = classNames(
+      className,
+      rootClassName,
+      contextClassName,
+      segmentedClassNames?.root,
+      contextClassNames.root,
+      {
+        [`${prefixCls}-block`]: block,
+        [`${prefixCls}-sm`]: mergedSize === 'small',
+        [`${prefixCls}-lg`]: mergedSize === 'large',
+        [`${prefixCls}-vertical`]: mergedVertical,
+        [`${prefixCls}-shape-${shape}`]: shape === 'round',
+      },
+      hashId,
+      cssVarCls,
+    );
 
-  const mergedStyle: React.CSSProperties = {
-    ...contextStyles.root,
-    ...contextStyle,
-    ...styles?.root,
-    ...style,
-  };
+    const mergedStyle: React.CSSProperties = {
+      ...contextStyles.root,
+      ...contextStyle,
+      ...styles?.root,
+      ...style,
+    };
 
-  return (
-    <RcSegmented
-      {...restProps}
-      name={name}
-      className={cls}
-      style={mergedStyle}
-      classNames={{
-        label: classNames(segmentedClassNames?.label, contextClassNames.label),
-        item: classNames(segmentedClassNames?.item, contextClassNames.item),
-      }}
-      styles={{
-        item: { ...contextStyles.item, ...styles?.item },
-        label: { ...contextStyles.label, ...styles?.label },
-      }}
-      options={extendedOptions}
-      ref={ref}
-      prefixCls={prefixCls}
-      direction={direction}
-      vertical={mergedVertical}
-    />
-  );
-});
+    const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
+      const data = (extendedOptions as SegmentedLabeledOption<RcSegmentedValue>[]).find(
+        (option) => option?.value === item?.value && !!option?.tooltip,
+      );
+      let itemNode = node;
+      if (data?.tooltip) {
+        itemNode = <Tooltip title={data.tooltip}>{node}</Tooltip>;
+      }
+      return itemNode;
+    };
+
+    return (
+      <RcSegmented
+        {...restProps}
+        name={name}
+        className={cls}
+        style={mergedStyle}
+        classNames={{
+          label: classNames(segmentedClassNames?.label, contextClassNames.label),
+          item: classNames(segmentedClassNames?.item, contextClassNames.item),
+        }}
+        styles={{
+          item: { ...contextStyles.item, ...styles?.item },
+          label: { ...contextStyles.label, ...styles?.label },
+        }}
+        itemRender={itemRender}
+        options={extendedOptions}
+        ref={ref}
+        prefixCls={prefixCls}
+        direction={direction}
+        vertical={mergedVertical}
+      />
+    );
+  },
+);
 
 const Segmented = InternalSegmented as (<ValueType>(
   props: SegmentedProps<ValueType> & React.RefAttributes<HTMLDivElement>,

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -155,7 +155,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
   };
 
   const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
-    if (!item?.tooltip) return node;
+    if (!item.tooltip) return node;
 
     const tooltipProps: TooltipProps =
       typeof item.tooltip === 'object' ? item.tooltip : { title: item.tooltip };

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -155,14 +155,12 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
   };
 
   const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
-    if (!item.tooltip) return node;
-
-    let tooltipProps: TooltipProps;
-    if (typeof item.tooltip === 'object') {
-      tooltipProps = item.tooltip;
-    } else {
-      tooltipProps = { title: item.tooltip };
+    if (!item.tooltip) {
+      return node;
     }
+
+    const tooltipProps: TooltipProps =
+      typeof item.tooltip === 'object' ? item.tooltip : { title: item.tooltip };
     return <Tooltip {...tooltipProps}>{node}</Tooltip>;
   };
 

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -7,7 +7,8 @@ import type {
 } from '@rc-component/segmented';
 import RcSegmented from '@rc-component/segmented';
 import useId from '@rc-component/util/lib/hooks/useId';
-import { Tooltip } from 'antd';
+import omit from '@rc-component/util/lib/omit';
+import { Tooltip, TooltipProps } from 'antd';
 import classNames from 'classnames';
 
 import useOrientation from '../_util/hooks/useOrientation';
@@ -23,7 +24,7 @@ export type SemanticName = 'root' | 'icon' | 'label' | 'item';
 interface SegmentedLabeledOptionWithoutIcon<ValueType = RcSegmentedValue>
   extends RcSegmentedLabeledOption<ValueType> {
   label: RcSegmentedLabeledOption['label'];
-  tooltip?: string;
+  tooltip?: string | Omit<TooltipProps, 'children'>;
 }
 
 interface SegmentedLabeledOptionWithIcon<ValueType = RcSegmentedValue>
@@ -31,7 +32,7 @@ interface SegmentedLabeledOptionWithIcon<ValueType = RcSegmentedValue>
   label?: RcSegmentedLabeledOption['label'];
   /** Set icon for Segmented item */
   icon: React.ReactNode;
-  tooltip?: string;
+  tooltip?: string | Omit<TooltipProps, 'children'>;
 }
 
 function isSegmentedLabeledOptionWithIcon(
@@ -79,9 +80,10 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, Omit<SegmentedProps, 
       name = defaultName,
       styles,
       classNames: segmentedClassNames,
-      ...restProps
+      ...rest
     } = props;
 
+    const restProps = omit(rest as RCSegmentedProps, ['itemRender']);
     const {
       getPrefixCls,
       direction,
@@ -157,14 +159,14 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, Omit<SegmentedProps, 
     };
 
     const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
-      const data = (extendedOptions as SegmentedLabeledOption<RcSegmentedValue>[]).find(
-        (option) => option?.value === item?.value && !!option?.tooltip,
-      );
-      let itemNode = node;
-      if (data?.tooltip) {
-        itemNode = <Tooltip title={data.tooltip}>{node}</Tooltip>;
-      }
-      return itemNode;
+      if (!item?.tooltip) return node;
+
+      const tooltipProps: TooltipProps =
+        typeof item.tooltip === 'object'
+          ? { ...item.tooltip, children: node }
+          : { title: item.tooltip, children: node };
+
+      return <Tooltip {...tooltipProps} />;
     };
 
     return (

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -157,8 +157,12 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
   const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
     if (!item.tooltip) return node;
 
-    const tooltipProps: TooltipProps =
-      typeof item.tooltip === 'object' ? item.tooltip : { title: item.tooltip };
+    let tooltipProps: TooltipProps;
+    if (typeof item.tooltip === 'object') {
+      tooltipProps = item.tooltip;
+    } else {
+      tooltipProps = { title: item.tooltip };
+    }
     return <Tooltip {...tooltipProps}>{node}</Tooltip>;
   };
 

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -158,11 +158,8 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
     if (!item?.tooltip) return node;
 
     const tooltipProps: TooltipProps =
-      typeof item.tooltip === 'object'
-        ? { ...item.tooltip, children: node }
-        : { title: item.tooltip, children: node };
-
-    return <Tooltip {...tooltipProps} />;
+      typeof item.tooltip === 'object' ? item.tooltip : { title: item.tooltip };
+    return <Tooltip {...tooltipProps}>{node}</Tooltip>;
   };
 
   return (

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -7,7 +7,6 @@ import type {
 } from '@rc-component/segmented';
 import RcSegmented from '@rc-component/segmented';
 import useId from '@rc-component/util/lib/hooks/useId';
-import omit from '@rc-component/util/lib/omit';
 import { Tooltip, TooltipProps } from 'antd';
 import classNames from 'classnames';
 
@@ -48,7 +47,7 @@ export type SegmentedLabeledOption<ValueType = RcSegmentedValue> =
 export type SegmentedOptions<T = SegmentedRawOption> = (T | SegmentedLabeledOption<T>)[];
 
 export interface SegmentedProps<ValueType = RcSegmentedValue>
-  extends Omit<RCSegmentedProps<ValueType>, 'size' | 'options'> {
+  extends Omit<RCSegmentedProps<ValueType>, 'size' | 'options' | 'itemRender'> {
   rootClassName?: string;
   options: SegmentedOptions<ValueType>;
   /** Option to fit width to its parent's width */
@@ -62,11 +61,8 @@ export interface SegmentedProps<ValueType = RcSegmentedValue>
   shape?: 'default' | 'round';
 }
 
-type InternalSegmentedProps = Omit<SegmentedProps, 'itemRender'>;
-
-const InternalSegmented = React.forwardRef<HTMLDivElement, InternalSegmentedProps>((props, ref) => {
+const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((props, ref) => {
   const defaultName = useId();
-
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -81,10 +77,9 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, InternalSegmentedProp
     name = defaultName,
     styles,
     classNames: segmentedClassNames,
-    ...rest
+    ...restProps
   } = props;
 
-  const restProps = omit(rest as RCSegmentedProps, ['itemRender']);
   const {
     getPrefixCls,
     direction,

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -62,137 +62,137 @@ export interface SegmentedProps<ValueType = RcSegmentedValue>
   shape?: 'default' | 'round';
 }
 
-const InternalSegmented = React.forwardRef<HTMLDivElement, Omit<SegmentedProps, 'itemRender'>>(
-  (props, ref) => {
-    const defaultName = useId();
+type InternalSegmentedProps = Omit<SegmentedProps, 'itemRender'>;
 
-    const {
-      prefixCls: customizePrefixCls,
-      className,
-      rootClassName,
-      block,
-      options = [],
-      size: customSize = 'middle',
-      style,
-      vertical,
-      orientation,
-      shape = 'default',
-      name = defaultName,
-      styles,
-      classNames: segmentedClassNames,
-      ...rest
-    } = props;
+const InternalSegmented = React.forwardRef<HTMLDivElement, InternalSegmentedProps>((props, ref) => {
+  const defaultName = useId();
 
-    const restProps = omit(rest as RCSegmentedProps, ['itemRender']);
-    const {
-      getPrefixCls,
-      direction,
-      className: contextClassName,
-      style: contextStyle,
-      classNames: contextClassNames,
-      styles: contextStyles,
-    } = useComponentConfig('segmented');
-    const prefixCls = getPrefixCls('segmented', customizePrefixCls);
-    // Style
-    const [hashId, cssVarCls] = useStyle(prefixCls);
+  const {
+    prefixCls: customizePrefixCls,
+    className,
+    rootClassName,
+    block,
+    options = [],
+    size: customSize = 'middle',
+    style,
+    vertical,
+    orientation,
+    shape = 'default',
+    name = defaultName,
+    styles,
+    classNames: segmentedClassNames,
+    ...rest
+  } = props;
 
-    // ===================== Size =====================
-    const mergedSize = useSize(customSize);
+  const restProps = omit(rest as RCSegmentedProps, ['itemRender']);
+  const {
+    getPrefixCls,
+    direction,
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('segmented');
+  const prefixCls = getPrefixCls('segmented', customizePrefixCls);
+  // Style
+  const [hashId, cssVarCls] = useStyle(prefixCls);
 
-    // syntactic sugar to support `icon` for Segmented Item
-    const extendedOptions = React.useMemo<RCSegmentedProps['options']>(
-      () =>
-        options.map((option) => {
-          if (isSegmentedLabeledOptionWithIcon(option)) {
-            const { icon, label, ...restOption } = option;
-            return {
-              ...restOption,
-              label: (
-                <>
-                  <span
-                    className={classNames(
-                      `${prefixCls}-item-icon`,
-                      contextClassNames.icon,
-                      segmentedClassNames?.icon,
-                    )}
-                    style={{
-                      ...contextStyles.icon,
-                      ...styles?.icon,
-                    }}
-                  >
-                    {icon}
-                  </span>
-                  {label && <span>{label}</span>}
-                </>
-              ),
-            };
-          }
-          return option;
-        }),
-      [options, prefixCls],
-    );
+  // ===================== Size =====================
+  const mergedSize = useSize(customSize);
 
-    const [, mergedVertical] = useOrientation(orientation, vertical);
+  // syntactic sugar to support `icon` for Segmented Item
+  const extendedOptions = React.useMemo<RCSegmentedProps['options']>(
+    () =>
+      options.map((option) => {
+        if (isSegmentedLabeledOptionWithIcon(option)) {
+          const { icon, label, ...restOption } = option;
+          return {
+            ...restOption,
+            label: (
+              <>
+                <span
+                  className={classNames(
+                    `${prefixCls}-item-icon`,
+                    contextClassNames.icon,
+                    segmentedClassNames?.icon,
+                  )}
+                  style={{
+                    ...contextStyles.icon,
+                    ...styles?.icon,
+                  }}
+                >
+                  {icon}
+                </span>
+                {label && <span>{label}</span>}
+              </>
+            ),
+          };
+        }
+        return option;
+      }),
+    [options, prefixCls],
+  );
 
-    const cls = classNames(
-      className,
-      rootClassName,
-      contextClassName,
-      segmentedClassNames?.root,
-      contextClassNames.root,
-      {
-        [`${prefixCls}-block`]: block,
-        [`${prefixCls}-sm`]: mergedSize === 'small',
-        [`${prefixCls}-lg`]: mergedSize === 'large',
-        [`${prefixCls}-vertical`]: mergedVertical,
-        [`${prefixCls}-shape-${shape}`]: shape === 'round',
-      },
-      hashId,
-      cssVarCls,
-    );
+  const [, mergedVertical] = useOrientation(orientation, vertical);
 
-    const mergedStyle: React.CSSProperties = {
-      ...contextStyles.root,
-      ...contextStyle,
-      ...styles?.root,
-      ...style,
-    };
+  const cls = classNames(
+    className,
+    rootClassName,
+    contextClassName,
+    segmentedClassNames?.root,
+    contextClassNames.root,
+    {
+      [`${prefixCls}-block`]: block,
+      [`${prefixCls}-sm`]: mergedSize === 'small',
+      [`${prefixCls}-lg`]: mergedSize === 'large',
+      [`${prefixCls}-vertical`]: mergedVertical,
+      [`${prefixCls}-shape-${shape}`]: shape === 'round',
+    },
+    hashId,
+    cssVarCls,
+  );
 
-    const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
-      if (!item?.tooltip) return node;
+  const mergedStyle: React.CSSProperties = {
+    ...contextStyles.root,
+    ...contextStyle,
+    ...styles?.root,
+    ...style,
+  };
 
-      const tooltipProps: TooltipProps =
-        typeof item.tooltip === 'object'
-          ? { ...item.tooltip, children: node }
-          : { title: item.tooltip, children: node };
+  const itemRender = (node: React.ReactNode, { item }: { item: SegmentedLabeledOption }) => {
+    if (!item?.tooltip) return node;
 
-      return <Tooltip {...tooltipProps} />;
-    };
+    const tooltipProps: TooltipProps =
+      typeof item.tooltip === 'object'
+        ? { ...item.tooltip, children: node }
+        : { title: item.tooltip, children: node };
 
-    return (
-      <RcSegmented
-        {...restProps}
-        name={name}
-        className={cls}
-        style={mergedStyle}
-        classNames={{
-          label: classNames(segmentedClassNames?.label, contextClassNames.label),
-          item: classNames(segmentedClassNames?.item, contextClassNames.item),
-        }}
-        styles={{
-          item: { ...contextStyles.item, ...styles?.item },
-          label: { ...contextStyles.label, ...styles?.label },
-        }}
-        itemRender={itemRender}
-        options={extendedOptions}
-        ref={ref}
-        prefixCls={prefixCls}
-        direction={direction}
-        vertical={mergedVertical}
-      />
-    );
-  },
-);
+    return <Tooltip {...tooltipProps} />;
+  };
+
+  return (
+    <RcSegmented
+      {...restProps}
+      name={name}
+      className={cls}
+      style={mergedStyle}
+      classNames={{
+        label: classNames(segmentedClassNames?.label, contextClassNames.label),
+        item: classNames(segmentedClassNames?.item, contextClassNames.item),
+      }}
+      styles={{
+        item: { ...contextStyles.item, ...styles?.item },
+        label: { ...contextStyles.label, ...styles?.label },
+      }}
+      itemRender={itemRender}
+      options={extendedOptions}
+      ref={ref}
+      prefixCls={prefixCls}
+      direction={direction}
+      vertical={mergedVertical}
+    />
+  );
+});
 
 const Segmented = InternalSegmented as (<ValueType>(
   props: SegmentedProps<ValueType> & React.RefAttributes<HTMLDivElement>,

--- a/components/segmented/index.zh-CN.md
+++ b/components/segmented/index.zh-CN.md
@@ -62,11 +62,12 @@ demo:
 
 | 属性      | 描述             | 类型             | 默认值 | 版本 |
 | --------- | ---------------- | ---------------- | ------ | ---- |
-| label     | 分段项的显示文本 | ReactNode        | -      |      |
-| value     | 分段项的值       | string \| number | -      |      |
-| icon      | 分段项的显示图标 | ReactNode        | -      |      |
-| disabled  | 分段项的禁用状态 | boolean          | false  |      |
 | className | 自定义类名       | string           | -      |      |
+| disabled  | 分段项的禁用状态 | boolean          | false  |      |
+| icon      | 分段项的显示图标 | ReactNode        | -      |      |
+| label     | 分段项的显示文本 | ReactNode        | -      |      |
+| tooltip   | 分段项的工具提示 | string           | -      |      |
+| value     | 分段项的值       | string \| number | -      |      |
 
 ## Semantic DOM
 

--- a/components/segmented/index.zh-CN.md
+++ b/components/segmented/index.zh-CN.md
@@ -60,14 +60,14 @@ demo:
 
 ### SegmentedItemType
 
-| 属性      | 描述             | 类型             | 默认值 | 版本 |
-| --------- | ---------------- | ---------------- | ------ | ---- |
-| className | 自定义类名       | string           | -      |      |
-| disabled  | 分段项的禁用状态 | boolean          | false  |      |
-| icon      | 分段项的显示图标 | ReactNode        | -      |      |
-| label     | 分段项的显示文本 | ReactNode        | -      |      |
-| tooltip   | 分段项的工具提示 | string           | -      |      |
-| value     | 分段项的值       | string \| number | -      |      |
+| 属性      | 描述             | 类型                   | 默认值 | 版本 |
+| --------- | ---------------- | ---------------------- | ------ | ---- |
+| className | 自定义类名       | string                 | -      |      |
+| disabled  | 分段项的禁用状态 | boolean                | false  |      |
+| icon      | 分段项的显示图标 | ReactNode              | -      |      |
+| label     | 分段项的显示文本 | ReactNode              | -      |      |
+| tooltip   | 分段项的工具提示 | string \| TooltipProps | -      |      |
+| value     | 分段项的值       | string \| number       | -      |      |
 
 ## Semantic DOM
 

--- a/components/segmented/index.zh-CN.md
+++ b/components/segmented/index.zh-CN.md
@@ -60,14 +60,14 @@ demo:
 
 ### SegmentedItemType
 
-| 属性      | 描述             | 类型                   | 默认值 | 版本 |
-| --------- | ---------------- | ---------------------- | ------ | ---- |
-| className | 自定义类名       | string                 | -      |      |
-| disabled  | 分段项的禁用状态 | boolean                | false  |      |
-| icon      | 分段项的显示图标 | ReactNode              | -      |      |
-| label     | 分段项的显示文本 | ReactNode              | -      |      |
-| tooltip   | 分段项的工具提示 | string \| TooltipProps | -      |      |
-| value     | 分段项的值       | string \| number       | -      |      |
+| 属性 | 描述 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| className | 自定义类名 | string | - |  |
+| disabled | 分段项的禁用状态 | boolean | false |  |
+| icon | 分段项的显示图标 | ReactNode | - |  |
+| label | 分段项的显示文本 | ReactNode | - |  |
+| tooltip | 分段项的工具提示 | string \| [TooltipProps](../tooltip/index.zh-CN.md#api) | - |  |
+| value | 分段项的值 | string \| number | - |  |
 
 ## Semantic DOM
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@rc-component/progress": "~1.0.1",
     "@rc-component/qrcode": "~1.0.0",
     "@rc-component/resize-observer": "^1.0.0",
-    "@rc-component/segmented": "~1.1.0",
+    "@rc-component/segmented": "~1.2.0",
     "@rc-component/select": "~1.1.2",
     "@rc-component/steps": "~1.2.1",
     "@rc-component/switch": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@rc-component/progress": "~1.0.1",
     "@rc-component/qrcode": "~1.0.0",
     "@rc-component/resize-observer": "^1.0.0",
-    "@rc-component/segmented": "~1.2.0",
+    "@rc-component/segmented": "~1.2.1",
     "@rc-component/select": "~1.1.2",
     "@rc-component/steps": "~1.2.1",
     "@rc-component/switch": "~1.0.0",


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🆕 New feature
### 🔗 Related Issues
close https://github.com/ant-design/ant-design/issues/35739

### 💡 Background and Solution


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add tooltips for segmented option items and modify the corresponding field documentation    |
| 🇨🇳 Chinese |      分段控制器的选项可以配置tooltip，并修改对应字段文档     |
