### PR TITLE
fix: prevent unnecessary theme switch when current theme is already selected

### DIFF
--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -100,6 +100,11 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = () => {
       return;
     }
 
+    // 校验当前主题是否包含要切换的主题（避免 timeout in DOM update）
+    if (theme.includes(key as ThemeName)) {
+      return;
+    }
+
     // 亮色/暗色模式切换时应用动画效果
     if (key === 'dark' || key === 'light') {
       lastThemeKey.current = key;

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -104,7 +104,7 @@ const GlobalLayout: React.FC = () => {
         if (key === 'theme') {
           nextSearchParams = createSearchParams({
             ...nextSearchParams,
-            theme: value.filter((t) => t !== 'light'),
+            theme: value,
           });
 
           document


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

- releated to https://github.com/ant-design/ant-design/pull/54193#discussion_r2182609565

### 💡 Background and Solution

之前切换时没校验当前主题是否和要切换的主题是否一致，导致重新触发transition，dom 更新超时，页面会卡死一段时间
顺便把上个pr遗漏的逻辑补了一下，当用户主动切换当浅色模式时也应该在url中添加theme参数

![image](https://github.com/user-attachments/assets/860e644e-148b-4ec8-8118-f0cd1544ffe9)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    --       |
| 🇨🇳 Chinese |    --       |
