### PR TITLE
fix(performance): Avoid redundant array copying in flattenData for large datasets

### DIFF
--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -61,12 +61,12 @@ export type INTERNAL_SELECTION_ITEM =
 const flattenData = <RecordType extends AnyObject = AnyObject>(
   childrenColumnName: keyof RecordType,
   data?: RecordType[],
+  list: RecordType[] = [],
 ): RecordType[] => {
-  let list: RecordType[] = [];
   (data || []).forEach((record) => {
     list.push(record);
     if (record && typeof record === 'object' && childrenColumnName in record) {
-      list = [...list, ...flattenData<RecordType>(childrenColumnName, record[childrenColumnName])];
+      flattenData<RecordType>(childrenColumnName, record[childrenColumnName], list);
     }
   });
   return list;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
I have no create issue yet

### 💡 Background and Solution
背景说明：
使用了Table组件，且是虚拟滚动场景，大概有3万条数据，且嵌套层级有2层。
渲染会出现卡死10几秒以上。
火焰图如下：
![img_v3_02nr_1196aa0b-e2fb-471a-8afe-c3883b0e4f2l](https://github.com/user-attachments/assets/6e802d0f-e419-45bc-bfab-5f2decbb398c)
![image](https://github.com/user-attachments/assets/0973c927-1427-4477-b438-f84862e33d0f)

**优化后效果：**
![image](https://github.com/user-attachments/assets/7df43b7b-6993-4637-b7ed-4a98fd7f49b0)



### 📝 Change Log

> - 优化flattenData 函数以避免不必要的数组复制，优化大数据量下的卡顿问题


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Optimize the flattenData function to avoid unnecessary array copying and improve performance issues with large data sets.         |
| 🇨🇳 Chinese |   优化flattenData 函数以避免不必要的数组复制，优化大数据量下的卡顿问题        |
