### PR TITLE
fix: Tag.checkableTag not render icon

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -13,6 +13,7 @@ export interface CheckableTagProps {
    */
   checked: boolean;
   children?: React.ReactNode;
+  icon?: React.ReactNode;
   onChange?: (checked: boolean) => void;
   onClick?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
 }
@@ -23,6 +24,8 @@ const CheckableTag: React.FC<CheckableTagProps> = ({
   checked,
   onChange,
   onClick,
+  children,
+  icon,
   ...restProps
 }) => {
   const { getPrefixCls } = React.useContext(ConfigContext);
@@ -42,7 +45,22 @@ const CheckableTag: React.FC<CheckableTagProps> = ({
     className,
   );
 
-  return <span {...restProps} className={cls} onClick={handleClick} />;
+  const iconNode = icon || null;
+
+  const kids = iconNode ? (
+    <>
+      {iconNode}
+      <span>{children}</span>
+    </>
+  ) : (
+    children
+  );
+
+  return (
+    <span {...restProps} className={cls} onClick={handleClick}>
+      {kids}
+    </span>
+  );
 };
 
 export default CheckableTag;

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, render, fireEvent } from '../../../tests/utils';
+import { LinkedinOutlined } from '@ant-design/icons';
 
 describe('Tag', () => {
   mountTest(Tag);
@@ -145,6 +146,29 @@ describe('Tag', () => {
       const { container } = render(<Tag.CheckableTag checked={false} onChange={onChange} />);
       fireEvent.click(container.querySelectorAll('.ant-tag')[0]);
       expect(onChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('CheckableTag with icon', () => {
+    it('should render icon', () => {
+      const { container } = render(<Tag.CheckableTag icon={<LinkedinOutlined />} checked={true} />);
+      expect(container.querySelector('.anticon')).toBeInTheDocument();
+    });
+  });
+
+  describe('CheckableTag with icon', () => {
+    it('should render custom icon', () => {
+      const { container } = render(
+        <Tag.CheckableTag icon={<div className="custom-icon">custom icon</div>} checked={true} />,
+      );
+      expect(container.querySelector('.custom-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('CheckableTag without icon', () => {
+    it('not render icon', () => {
+      const { container } = render(<Tag.CheckableTag checked={true} />);
+      expect(container.querySelector('.anticon')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx
[issue](https://github.com/ant-design/ant-design/issues/54210)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.
1. When using Tag.CheckableTag and passing the icon property, the icon does not appear.
2. Determine whether the icon property exists in CheckableTag and render the icon dynamically.
![image](https://github.com/user-attachments/assets/f5c3c67b-2fa8-4940-a379-1633b0d7834b)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog
1. CheckableTag supports passing an icon for rendering.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
