### PR TITLE
revert: MenuProps add activeKey in Dropdown

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -7,6 +7,7 @@ import RcDropdown from 'rc-dropdown';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
+import type { MenuProps as RcMenuProps } from 'rc-menu';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
 import isPrimitive from '../_util/isPrimitive';
@@ -45,7 +46,7 @@ export type DropdownArrowOptions = {
 };
 
 export interface DropdownProps {
-  menu?: MenuProps;
+  menu?: MenuProps & { activeKey?: RcMenuProps['activeKey'] };
   autoFocus?: boolean;
   arrow?: boolean | DropdownArrowOptions;
   trigger?: ('click' | 'hover' | 'contextMenu')[];


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [X] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

 - ref https://github.com/ant-design/ant-design/pull/54189

### 💡 Background and Solution

Dropdown 组件中需要 activeKey 属性，先加回来避免造成影响 
[demo](https://stackblitz.com/edit/react-uhnhyxwj-tuqcflxb?file=demo.tsx)

![image](https://github.com/user-attachments/assets/a055bf7f-d8f3-4a81-8e7b-5c72727ab351)
 

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Dropdown menu类型添加 activeKey 定义     |
| 🇨🇳 Chinese |    chore: MenuProps add activeKey in Dropdown       |
