### PR TITLE
fix[Splitter]:  ant-splitter-mask should be removed when drag end

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -98,7 +98,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     onOffsetEnd(true);
   });
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (startPos) {
       const onMouseMove = (e: MouseEvent) => {
         const { pageX, pageY } = e;

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -113,8 +113,6 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       };
 
       const onMouseUp = () => {
-        window.removeEventListener('mousemove', onMouseMove);
-        window.removeEventListener('mouseup', onMouseUp);
         if (lazy) {
           handleLazyEnd();
         } else {
@@ -138,8 +136,6 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       };
 
       const handleTouchEnd = () => {
-        window.removeEventListener('touchmove', handleTouchMove);
-        window.removeEventListener('touchend', handleTouchEnd);
         if (lazy) {
           handleLazyEnd();
         } else {
@@ -152,6 +148,13 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       window.addEventListener('touchend', handleTouchEnd);
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
+
+      return () => {
+        window.removeEventListener('touchmove', handleTouchMove);
+        window.removeEventListener('touchend', handleTouchEnd);
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+      };
     }
   }, [startPos]);
 

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -113,6 +113,8 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       };
 
       const onMouseUp = () => {
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
         if (lazy) {
           handleLazyEnd();
         } else {
@@ -136,6 +138,8 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       };
 
       const handleTouchEnd = () => {
+        window.removeEventListener('touchmove', handleTouchMove);
+        window.removeEventListener('touchend', handleTouchEnd);
         if (lazy) {
           handleLazyEnd();
         } else {
@@ -148,15 +152,8 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       window.addEventListener('touchend', handleTouchEnd);
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
-
-      return () => {
-        window.removeEventListener('mousemove', onMouseMove);
-        window.removeEventListener('mouseup', onMouseUp);
-        window.removeEventListener('touchmove', handleTouchMove);
-        window.removeEventListener('touchend', handleTouchEnd);
-      };
     }
-  }, [startPos, lazy, vertical, index, containerSize, ariaNow, ariaMin, ariaMax]);
+  }, [startPos]);
 
   const transformStyle = {
     [`--${splitBarPrefixCls}-preview-offset`]: `${constrainedOffset}px`,

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -328,38 +328,6 @@ describe('Splitter', () => {
         'NaN',
       );
     });
-
-    it('ant-splitter-mask should be removed when horizontal drag end', async () => {
-      const { container } = render(<SplitterDemo items={[{}, {}]} />);
-
-      await resizeSplitter();
-
-      const draggerElement = container.querySelector('.ant-splitter-bar-dragger')!;
-      fireEvent.mouseDown(draggerElement, { pageX: 0, pageY: 0 });
-      fireEvent.mouseMove(draggerElement, { pageX: 40, pageY: 0 });
-      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
-      fireEvent.mouseUp(draggerElement);
-      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
-    });
-
-    it('ant-splitter-mask should be removed when vertical drag end', async () => {
-      const { container } = render(<SplitterDemo items={[{}, {}, {}]} layout="vertical" />);
-
-      await resizeSplitter();
-
-      const draggerElements = container.querySelectorAll('.ant-splitter-bar-dragger')!;
-      fireEvent.touchStart(draggerElements[0], { touches: [{ pageX: 0, pageY: 0 }] });
-      fireEvent.touchMove(draggerElements[0], { touches: [{ pageX: 0, pageY: 50 }] });
-      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
-      fireEvent.touchEnd(draggerElements[0]);
-      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
-
-      fireEvent.touchStart(draggerElements[1], { touches: [{ pageX: 0, pageY: 100 }] });
-      fireEvent.touchMove(draggerElements[1], { touches: [{ pageX: 0, pageY: 150 }] });
-      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
-      fireEvent.touchEnd(draggerElements[1]);
-      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
-    });
   });
 
   // ============================= Collapsible =============================

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -328,6 +328,38 @@ describe('Splitter', () => {
         'NaN',
       );
     });
+
+    it('ant-splitter-mask should be removed when horizontal drag end', async () => {
+      const { container } = render(<SplitterDemo items={[{}, {}]} />);
+
+      await resizeSplitter();
+
+      const draggerElement = container.querySelector('.ant-splitter-bar-dragger')!;
+      fireEvent.mouseDown(draggerElement, { pageX: 0, pageY: 0 });
+      fireEvent.mouseMove(draggerElement, { pageX: 40, pageY: 0 });
+      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
+      fireEvent.mouseUp(draggerElement);
+      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
+    });
+
+    it('ant-splitter-mask should be removed when vertical drag end', async () => {
+      const { container } = render(<SplitterDemo items={[{}, {}, {}]} layout="vertical" />);
+
+      await resizeSplitter();
+
+      const draggerElements = container.querySelectorAll('.ant-splitter-bar-dragger')!;
+      fireEvent.touchStart(draggerElements[0], { touches: [{ pageX: 0, pageY: 0 }] });
+      fireEvent.touchMove(draggerElements[0], { touches: [{ pageX: 0, pageY: 50 }] });
+      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
+      fireEvent.touchEnd(draggerElements[0]);
+      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
+
+      fireEvent.touchStart(draggerElements[1], { touches: [{ pageX: 0, pageY: 100 }] });
+      fireEvent.touchMove(draggerElements[1], { touches: [{ pageX: 0, pageY: 150 }] });
+      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
+      fireEvent.touchEnd(draggerElements[1]);
+      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
+    });
   });
 
   // ============================= Collapsible =============================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [issue](https://github.com/ant-design/ant-design/issues/54315)

### 💡 Background and Solution
1. The ant-splitter-mask overlay element stays on the top layer and is not hidden, which causes the so-called "freezing" issue.
![image](https://github.com/user-attachments/assets/194e309c-d3cd-48e4-b30b-0fd5320dd149)
2. The ant-splitter-mask overlay element appears during the`mousemove` event and is hidden when`mouseup` is called.
3. after mouseup is triggered, moving the mouse may occasionally trigger another mousemove event, which causes the ant-splitter-mask overlay to reappear, making the page unresponsive.
![image](https://github.com/user-attachments/assets/08cf3f72-590d-4ce2-9b43-2d589703ea19)

### 📝 Change Log
ant-splitter-mask should be removed when drag end

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  ant-splitter-mask should be removed when drag end |
| 🇨🇳 Chinese |  ant-splitter-mask 元素在拖拽结束后应该被移除  |
