### PR TITLE
Add size prop to Tag component for size customization

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,16 @@ tag: vVERSION
 
 ---
 
+## 5.26.4
+
+`2025-07-07`
+
+- 🐞 Fix Radio.Group does not inherit `name` property problem from Form ancestor. [#54206](https://github.com/ant-design/ant-design/pull/54206) [@aojunhao123](https://github.com/aojunhao123)
+- 🐞 Fix Select clear icon flickering on Safari with GPU compositing. [#54237](https://github.com/ant-design/ant-design/pull/54237) [@afc163](https://github.com/afc163)
+- 💄 Fix Cascader `font-weight` when selected. [#54251](https://github.com/ant-design/ant-design/pull/54251) [@li-jia-nan](https://github.com/li-jia-nan)
+- ⚡️ Optimize Table performance since copy logic for flatten data. [#54288](https://github.com/ant-design/ant-design/pull/54288) [@zhouxinyong](https://github.com/zhouxinyong)
+
+
 ## 5.26.3
 
 `2025-06-30`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,15 @@ tag: vVERSION
 
 ---
 
+## 5.26.4
+
+`2025-07-07`
+
+- 🐞 修复 Radio.Group 未从 Form 继承 `name` 属性的问题。[#54206](https://github.com/ant-design/ant-design/pull/54206) [@aojunhao123](https://github.com/aojunhao123)
+- 🐞 修复 Select 清除图标在 Safari 中闪动的问题。[#54237](https://github.com/ant-design/ant-design/pull/54237) [@afc163](https://github.com/afc163)
+- 💄 修复 Cascader 选中后的 `font-weight` 设置值。[#54251](https://github.com/ant-design/ant-design/pull/54251) [@li-jia-nan](https://github.com/li-jia-nan)
+- ⚡️ 优化 Table 数据展开时的拷贝逻辑以提升性能。[#54288](https://github.com/ant-design/ant-design/pull/54288) [@zhouxinyong](https://github.com/zhouxinyong)
+
 ## 5.26.3
 
 `2025-06-30`

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -7,6 +7,7 @@ import RcDropdown from 'rc-dropdown';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
+import type { MenuProps as RcMenuProps } from 'rc-menu';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
 import isPrimitive from '../_util/isPrimitive';
@@ -45,7 +46,7 @@ export type DropdownArrowOptions = {
 };
 
 export interface DropdownProps {
-  menu?: MenuProps;
+  menu?: MenuProps & { activeKey?: RcMenuProps['activeKey'] };
   autoFocus?: boolean;
   arrow?: boolean | DropdownArrowOptions;
   trigger?: ('click' | 'hover' | 'contextMenu')[];

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -48,6 +48,7 @@ export default function ItemHolder(props: ItemHolderProps) {
     isRequired,
     onSubItemMetaChange,
     layout,
+    name,
     ...restProps
   } = props;
 
@@ -173,6 +174,7 @@ export default function ItemHolder(props: ItemHolderProps) {
               hasFeedback={hasFeedback}
               // Already calculated
               validateStatus={mergedValidateStatus}
+              name={name}
             >
               {children}
             </StatusProvider>

--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -4,7 +4,7 @@ import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import classNames from 'classnames';
-import type { Meta } from 'rc-field-form/lib/interface';
+import type { Meta, NamePath } from 'rc-field-form/lib/interface';
 
 import type { FeedbackIcons, ValidateStatus } from '.';
 import { FormContext, FormItemInputContext } from '../context';
@@ -27,6 +27,7 @@ export interface StatusProviderProps {
   warnings: React.ReactNode[];
   hasFeedback?: boolean | { icons?: FeedbackIcons };
   noStyle?: boolean;
+  name?: NamePath;
 }
 
 export default function StatusProvider({
@@ -38,6 +39,7 @@ export default function StatusProvider({
   prefixCls,
   meta,
   noStyle,
+  name,
 }: StatusProviderProps) {
   const itemPrefixCls = `${prefixCls}-item`;
   const { feedbackIcons } = React.useContext(FormContext);
@@ -56,6 +58,7 @@ export default function StatusProvider({
     status: parentStatus,
     hasFeedback: parentHasFeedback,
     feedbackIcon: parentFeedbackIcon,
+    name: parentName,
   } = React.useContext(FormItemInputContext);
 
   // ====================== Context =======================
@@ -87,6 +90,7 @@ export default function StatusProvider({
       hasFeedback: !!hasFeedback,
       feedbackIcon,
       isFormItemInput: true,
+      name,
     };
 
     // No style will follow parent context
@@ -95,6 +99,7 @@ export default function StatusProvider({
       context.isFormItemInput = parentIsFormItemInput;
       context.hasFeedback = !!(hasFeedback ?? parentHasFeedback);
       context.feedbackIcon = hasFeedback !== undefined ? context.feedbackIcon : parentFeedbackIcon;
+      context.name = name ?? parentName;
     }
 
     return context;

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -258,6 +258,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
           errors={mergedErrors}
           warnings={mergedWarnings}
           noStyle
+          name={name}
         >
           {baseChildren}
         </StatusProvider>
@@ -277,6 +278,7 @@ function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.Rea
         meta={meta}
         onSubItemMetaChange={onSubItemMetaChange}
         layout={layout}
+        name={name}
       >
         {baseChildren}
       </ItemHolder>

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/form/demo/advanced-search.tsx extend context correctly 1`] = `
 Array [
@@ -8883,7 +8883,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="horizontal"
                   />
@@ -8905,7 +8905,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="vertical"
                   />
@@ -8927,7 +8927,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="inline"
                   />
@@ -11429,7 +11429,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="true"
                   />
@@ -11452,7 +11452,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="optional"
                   />
@@ -11474,7 +11474,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="false"
                   />
@@ -11496,7 +11496,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="customize"
                   />
@@ -11758,7 +11758,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="small"
                   />
@@ -11781,7 +11781,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="default"
                   />
@@ -11803,7 +11803,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="large"
                   />
@@ -22314,7 +22314,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="a"
                   />
@@ -22336,7 +22336,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="b"
                   />
@@ -22358,7 +22358,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="c"
                   />
@@ -22417,7 +22417,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="a"
                   />
@@ -22439,7 +22439,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="b"
                   />
@@ -22461,7 +22461,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="c"
                   />

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/form/demo/advanced-search.tsx correctly 1`] = `
 Array [
@@ -5234,7 +5234,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="horizontal"
                   />
@@ -5256,7 +5256,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="vertical"
                   />
@@ -5278,7 +5278,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="layout"
                     type="radio"
                     value="inline"
                   />
@@ -7389,7 +7389,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="true"
                   />
@@ -7412,7 +7412,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="optional"
                   />
@@ -7434,7 +7434,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="false"
                   />
@@ -7456,7 +7456,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="requiredMarkValue"
                     type="radio"
                     value="customize"
                   />
@@ -7676,7 +7676,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="small"
                   />
@@ -7699,7 +7699,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   <input
                     checked=""
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="default"
                   />
@@ -7721,7 +7721,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="size"
                     type="radio"
                     value="large"
                   />
@@ -9736,7 +9736,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="a"
                   />
@@ -9758,7 +9758,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="b"
                   />
@@ -9780,7 +9780,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-input"
-                    name="test-id"
+                    name="radio-group"
                     type="radio"
                     value="c"
                   />
@@ -9839,7 +9839,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="a"
                   />
@@ -9861,7 +9861,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="b"
                   />
@@ -9883,7 +9883,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                 >
                   <input
                     class="ant-radio-button-input"
-                    name="test-id"
+                    name="radio-button"
                     type="radio"
                     value="c"
                   />

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -9,7 +9,7 @@ import type { ColProps } from '../grid/col';
 import type { FormInstance, RequiredMark } from './Form';
 import type { FeedbackIcons, ValidateStatus } from './FormItem';
 import type { Variant } from '../config-provider';
-import type { FormLabelAlign } from './interface';
+import type { FormLabelAlign, NamePath } from './interface';
 
 /** Form Context. Set top form style and pass to Form Item usage. */
 export interface FormContextProps {
@@ -63,6 +63,7 @@ export interface FormItemStatusContextProps {
   warnings?: React.ReactNode[];
   hasFeedback?: boolean;
   feedbackIcon?: ReactNode;
+  name?: NamePath;
 }
 
 export const FormItemInputContext = React.createContext<FormItemStatusContextProps>({});

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -20,7 +20,7 @@ export interface FormInstance<Values = any> extends RcFormInstance<Values> {
   getFieldInstance: (name: NamePath) => any;
 }
 
-function toNamePathStr(name: NamePath) {
+export function toNamePathStr(name: NamePath) {
   const namePath = toArray(name);
   return namePath.join('_');
 }

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import type { RadioGroupProps } from '..';
 import Radio from '..';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, screen } from '../../../tests/utils';
+import Form from '../../form';
 
 describe('Radio Group', () => {
   const RadioGroupComponent: React.FC<RadioGroupProps> = (props) => (
@@ -248,5 +249,124 @@ describe('Radio Group', () => {
     expect(select!.getAttribute('title')).toBeFalsy();
     // fix 46739 solution
     expect(container.querySelector('.ant-radio-group label')).toHaveAttribute('title', 'bamboo');
+  });
+
+  it('should use FormItem name', () => {
+    const RadioForm: React.FC = () => (
+      <Form name="preference-form">
+        <Form.Item name="preference" initialValue="option2">
+          <Radio.Group>
+            <Radio value="option1">Option 1</Radio>
+            <Radio value="option2">Option 2</Radio>
+            <Radio value="option3">Option 3</Radio>
+          </Radio.Group>
+        </Form.Item>
+      </Form>
+    );
+
+    render(<RadioForm />);
+
+    const radioInputs = screen.getAllByRole('radio');
+    radioInputs.forEach((input) => {
+      expect(input).toHaveAttribute('name', 'preference');
+    });
+
+    const preferenceOption2 = screen.getByRole('radio', { name: 'Option 2' });
+    expect(preferenceOption2).toBeChecked();
+  });
+
+  it('should prioritize FormItem name over RadioGroup name prop', () => {
+    const RadioForm: React.FC = () => (
+      <Form>
+        <Form.Item name="form-item-name">
+          <Radio.Group name="radio-group-name">
+            <Radio value="A">A</Radio>
+            <Radio value="B">B</Radio>
+          </Radio.Group>
+        </Form.Item>
+      </Form>
+    );
+
+    render(<RadioForm />);
+    const radioInputs = screen.getAllByRole('radio');
+
+    // when both FormItem name and RadioGroup name are provided, the RadioGroup name should be used
+    radioInputs.forEach((input) => {
+      expect(input).toHaveAttribute('name', 'radio-group-name');
+    });
+  });
+
+  describe('FormItem complex NamePath conversion', () => {
+    it('should convert array NamePath to valid HTML name attribute', () => {
+      const RadioForm: React.FC = () => (
+        <Form>
+          <Form.Item name={['user', 'profile', 'preference']}>
+            <Radio.Group>
+              <Radio value="A">A</Radio>
+              <Radio value="B">B</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+      );
+
+      render(<RadioForm />);
+      const radioInputs = screen.getAllByRole('radio');
+
+      radioInputs.forEach((input) => {
+        expect(input).toHaveAttribute('name', 'user_profile_preference');
+      });
+    });
+
+    it('should convert number NamePath to valid HTML name attribute', () => {
+      const RadioForm: React.FC = () => (
+        <Form>
+          <Form.Item name={0}>
+            <Radio.Group>
+              <Radio value="option1">Option 1</Radio>
+              <Radio value="option2">Option 2</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+      );
+
+      render(<RadioForm />);
+      const radioInputs = screen.getAllByRole('radio');
+
+      radioInputs.forEach((input) => {
+        expect(input).toHaveAttribute('name', '0');
+      });
+    });
+
+    it('should work with Form.List dynamic fields', () => {
+      const DynamicForm: React.FC = () => {
+        const [form] = Form.useForm();
+
+        return (
+          <Form form={form} initialValues={{ users: [{ preferences: 'A' }] }}>
+            <Form.List name="users">
+              {(fields) => (
+                <>
+                  {fields.map((field) => (
+                    <Form.Item key={field.key} name={[field.name, 'preferences']}>
+                      <Radio.Group>
+                        <Radio value="A">Preference A</Radio>
+                        <Radio value="B">Preference B</Radio>
+                      </Radio.Group>
+                    </Form.Item>
+                  ))}
+                </>
+              )}
+            </Form.List>
+          </Form>
+        );
+      };
+
+      render(<DynamicForm />);
+      const radioInputs = screen.getAllByRole('radio');
+
+      radioInputs.forEach((input) => {
+        expect(input).toHaveAttribute('name', '0_preferences');
+      });
+    });
   });
 });

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -16,11 +16,14 @@ import type {
 } from './interface';
 import Radio from './radio';
 import useStyle from './style';
+import { FormItemInputContext } from '../form/context';
+import { toNamePathStr } from '../form/hooks/useForm';
 
 const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const { name: formItemName } = React.useContext(FormItemInputContext);
 
-  const defaultName = useId();
+  const defaultName = useId(toNamePathStr(formItemName));
 
   const {
     prefixCls: customizePrefixCls,

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -204,4 +204,19 @@ describe('Tag', () => {
     );
     expect(container.querySelector('.ant-tag-close-icon')?.textContent).toEqual('X');
   });
+  it('should support size prop', () => {
+    const { container: largeContainer } = render(<Tag size="large">Large</Tag>);
+    expect(largeContainer.querySelector('.ant-tag-lg')).toBeTruthy();
+
+    const { container: middleContainer } = render(<Tag size="middle">Middle</Tag>);
+    expect(middleContainer.querySelector('.ant-tag-md')).toBeTruthy();
+
+    const { container: smallContainer } = render(<Tag size="small">Small</Tag>);
+    expect(smallContainer.querySelector('.ant-tag-sm')).toBeTruthy();
+
+    const { container: defaultContainer } = render(<Tag>Default</Tag>);
+    expect(defaultContainer.querySelector('.ant-tag-lg')).toBeFalsy();
+    expect(defaultContainer.querySelector('.ant-tag-md')).toBeFalsy();
+    expect(defaultContainer.querySelector('.ant-tag-sm')).toBeFalsy();
+  });
 });

--- a/components/tag/demo/size.md
+++ b/components/tag/demo/size.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+标签有三种尺寸：`small`, `middle` 和 `large`。
+
+## en-US
+
+There is three sizes of tags: `small`, `middle` and `large`.

--- a/components/tag/demo/size.tsx
+++ b/components/tag/demo/size.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Flex, Tag } from 'antd';
+
+const App: React.FC = () => (
+  <Flex align="flex-end" gap="4px 0" wrap>
+    <Tag>Default</Tag>
+    <Tag size="small">Small</Tag>
+    <Tag size="middle">Medium</Tag>
+    <Tag size="large">Large</Tag>
+  </Flex>
+);
+
+export default App;

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/animation.tsx">Animate</code>
 <code src="./demo/icon.tsx">Icon</code>
 <code src="./demo/status.tsx">Status Tag</code>
+<code src="./demo/size.tsx">Size</code>
 <code src="./demo/borderless.tsx">borderless</code>
 <code src="./demo/borderlessLayout.tsx" debug>borderless in layout</code>
 <code src="./demo/customize.tsx" debug>Customize close</code>
@@ -45,6 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | icon | Set the icon of tag | ReactNode | - |  |
 | bordered | Whether has border style | boolean | true | 5.4.0 |
 | onClose | Callback executed when tag is closed | (e: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |  |
+| size | Set the size of button | `large` \| `middle` \| `small` | `small` |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -11,6 +11,8 @@ import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
+import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import CheckableTag from './CheckableTag';
 import useStyle from './style';
 import PresetCmp from './style/presetCmp';
@@ -21,6 +23,7 @@ export type { CheckableTagProps } from './CheckableTag';
 export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   prefixCls?: string;
   className?: string;
+  size?: SizeType;
   rootClassName?: string;
   color?: LiteralUnion<PresetColorType | PresetStatusColorType>;
   /** Advised to use closeIcon instead. */
@@ -38,6 +41,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement, TagProps>((tagProps, ref) 
   const {
     prefixCls: customizePrefixCls,
     className,
+    size: customizeSize,
     rootClassName,
     style,
     children,
@@ -80,12 +84,19 @@ const InternalTag = React.forwardRef<HTMLSpanElement, TagProps>((tagProps, ref) 
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   // Style
 
+  const sizeClassNameMap = { large: 'lg', small: 'sm', middle: 'md' };
+
+  const sizeFullName = useSize((ctxSize) => customizeSize ?? ctxSize);
+
+  const sizeCls = sizeFullName ? (sizeClassNameMap[sizeFullName] ?? '') : '';
+
   const tagClassName = classNames(
     prefixCls,
     tagContext?.className,
     {
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,
+      [`${prefixCls}-${sizeCls}`]: sizeCls,
       [`${prefixCls}-hidden`]: !visible,
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-borderless`]: !bordered,

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/animation.tsx">添加动画</code>
 <code src="./demo/icon.tsx">图标按钮</code>
 <code src="./demo/status.tsx">预设状态的标签</code>
+<code src="./demo/size.tsx">标签尺寸</code>
 <code src="./demo/borderless.tsx">无边框</code>
 <code src="./demo/borderlessLayout.tsx" debug>深色背景中无边框</code>
 <code src="./demo/customize.tsx" debug>自定义关闭按钮</code>
@@ -45,6 +46,7 @@ demo:
 | icon | 设置图标 | ReactNode | - |  |
 | bordered | 是否有边框 | boolean | true | 5.4.0 |
 | onClose | 关闭时的回调（可通过 `e.preventDefault()` 来阻止默认行为） | (e: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |  |
+| size | 设置标签大小 | `large` \| `middle` \| `small` | `small` |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -122,6 +122,17 @@ const genBaseStyle = (token: TagToken): CSSInterpolation => {
       borderColor: 'transparent',
       background: token.tagBorderlessBg,
     },
+
+    [`${componentCls}-lg`]: {
+      fontSize: token.fontSizeLG,
+      fontWeight: token.fontWeightStrong,
+      padding: `${token.paddingXS} ${token.paddingMD}`,
+    },
+
+    [`${componentCls}-md`]: {
+      fontSize: `calc(${token.fontSizeLG}*0.8)`,
+      padding: `${token.paddingXXS} ${token.paddingXS}`,
+    },
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "5.26.3",
+  "version": "5.26.4",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
### 🤔 This is a ...

- [ x] 💄 Component style improvement
- [ x] 🎨 Code style optimization


### 🔗 Related Issues
Ref: close [#47949](https://github.com/ant-design/ant-design/issues/47949)

### 💡 Background and Solution

1. The requirement comes from the need for embedded customization, like other Ant Design components.
2. Facilitate style customization for the `Tag` component.
3. API Implementation: 

Added a size prop (`small`, `middle`, `large`) to help set a custom size for `Tag`:

```js
    [`${componentCls}-lg`]: {
      fontSize: token.fontSizeLG,
      fontWeight: token.fontWeightStrong,
      padding: `${token.paddingXS} ${token.paddingMD}`,
    },

    [`${componentCls}-md`]: {
      fontSize: `calc(${token.fontSizeLG}*0.8)`,
      padding: `${token.paddingXXS} ${token.paddingXS}`,
    },
```

The default `size` is small, so it does not affect the existing `Tag` styles.

demo:

```javascript
  <Flex align="flex-end" gap="4px 0" wrap>
    <Tag>Default</Tag>
    <Tag size="small">Small</Tag>
    <Tag size="middle">Medium</Tag>
    <Tag size="large">Large</Tag>
  </Flex>
```
![ant-tag-size](https://github.com/user-attachments/assets/20b61854-f374-4735-9294-30e7f17979e6)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Add `size` prop to `Tag` component for size customization, no impact or change needed.    |
| 🇨🇳 Chinese |      为 `Tag` 组件新增 `size` 属性用于自定义尺寸，默认不影响现有样式，无需额外改动。     |
