### PR TITLE
Add size prop to Tag component for size customization 

### DIFF
--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -219,4 +219,19 @@ describe('Tag', () => {
     );
     expect(container.querySelector('.ant-tag-close-icon')?.textContent).toEqual('X');
   });
+  it('should support size prop', () => {
+    const { container: largeContainer } = render(<Tag size="large">Large</Tag>);
+    expect(largeContainer.querySelector('.ant-tag-lg')).toBeTruthy();
+
+    const { container: middleContainer } = render(<Tag size="middle">Middle</Tag>);
+    expect(middleContainer.querySelector('.ant-tag-md')).toBeTruthy();
+
+    const { container: smallContainer } = render(<Tag size="small">Small</Tag>);
+    expect(smallContainer.querySelector('.ant-tag-sm')).toBeTruthy();
+
+    const { container: defaultContainer } = render(<Tag>Default</Tag>);
+    expect(defaultContainer.querySelector('.ant-tag-lg')).toBeFalsy();
+    expect(defaultContainer.querySelector('.ant-tag-md')).toBeFalsy();
+    expect(defaultContainer.querySelector('.ant-tag-sm')).toBeFalsy();
+  });
 });

--- a/components/tag/demo/size.md
+++ b/components/tag/demo/size.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+标签有三种尺寸：`small`, `middle` 和 `large`。
+
+## en-US
+
+There is three sizes of tags: `small`, `middle` and `large`.

--- a/components/tag/demo/size.tsx
+++ b/components/tag/demo/size.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Flex, Tag } from 'antd';
+
+const App: React.FC = () => (
+  <Flex align="flex-end" gap="4px 0" wrap>
+    <Tag>Default</Tag>
+    <Tag size="small">Small</Tag>
+    <Tag size="middle">Medium</Tag>
+    <Tag size="large">Large</Tag>
+  </Flex>
+);
+
+export default App;

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/animation.tsx">Animate</code>
 <code src="./demo/icon.tsx">Icon</code>
 <code src="./demo/status.tsx">Status Tag</code>
+<code src="./demo/size.tsx">Size</code>
 <code src="./demo/borderless.tsx">borderless</code>
 <code src="./demo/borderlessLayout.tsx" debug>borderless in layout</code>
 <code src="./demo/customize.tsx" debug>Customize close</code>
@@ -45,6 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | icon | Set the icon of tag | ReactNode | - |  |
 | bordered | Whether has border style | boolean | true | 5.4.0 |
 | onClose | Callback executed when tag is closed | (e: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |  |
+| size | Set the size of button | `large` \| `middle` \| `small` | `small` |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -46,7 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | icon | Set the icon of tag | ReactNode | - |  |
 | bordered | Whether has border style | boolean | true | 5.4.0 |
 | onClose | Callback executed when tag is closed | (e: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |  |
-| size | Set the size of button | `large` \| `middle` \| `small` | `small` |  |
+| size | Set the size of tag | `large` \| `middle` \| `small` | `small` |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -11,6 +11,8 @@ import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { ConfigContext } from '../config-provider';
+import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import CheckableTag from './CheckableTag';
 import useStyle from './style';
 import PresetCmp from './style/presetCmp';
@@ -21,6 +23,7 @@ export type { CheckableTagProps } from './CheckableTag';
 export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
   prefixCls?: string;
   className?: string;
+  size?: SizeType;
   rootClassName?: string;
   color?: LiteralUnion<PresetColorType | PresetStatusColorType>;
   /** Advised to use closeIcon instead. */
@@ -38,6 +41,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement, TagProps>((tagProps, ref) 
   const {
     prefixCls: customizePrefixCls,
     className,
+    size: customizeSize,
     rootClassName,
     style,
     children,
@@ -80,12 +84,19 @@ const InternalTag = React.forwardRef<HTMLSpanElement, TagProps>((tagProps, ref) 
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
   // Style
 
+  const sizeClassNameMap = { large: 'lg', small: 'sm', middle: 'md' };
+
+  const sizeFullName = useSize((ctxSize) => customizeSize ?? ctxSize);
+
+  const sizeCls = sizeFullName ? (sizeClassNameMap[sizeFullName] ?? '') : '';
+
   const tagClassName = classNames(
     prefixCls,
     tagContext?.className,
     {
       [`${prefixCls}-${color}`]: isInternalColor,
       [`${prefixCls}-has-color`]: color && !isInternalColor,
+      [`${prefixCls}-${sizeCls}`]: sizeCls,
       [`${prefixCls}-hidden`]: !visible,
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-borderless`]: !bordered,

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -86,7 +86,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement, TagProps>((tagProps, ref) 
 
   const sizeClassNameMap = { large: 'lg', small: 'sm', middle: 'md' };
 
-  const sizeFullName = useSize((ctxSize) => customizeSize ?? ctxSize);
+  const sizeFullName = useSize(customizeSize);
 
   const sizeCls = sizeFullName ? (sizeClassNameMap[sizeFullName] ?? '') : '';
 

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/animation.tsx">添加动画</code>
 <code src="./demo/icon.tsx">图标按钮</code>
 <code src="./demo/status.tsx">预设状态的标签</code>
+<code src="./demo/size.tsx">标签尺寸</code>
 <code src="./demo/borderless.tsx">无边框</code>
 <code src="./demo/borderlessLayout.tsx" debug>深色背景中无边框</code>
 <code src="./demo/customize.tsx" debug>自定义关闭按钮</code>
@@ -45,6 +46,7 @@ demo:
 | icon | 设置图标 | ReactNode | - |  |
 | bordered | 是否有边框 | boolean | true | 5.4.0 |
 | onClose | 关闭时的回调（可通过 `e.preventDefault()` 来阻止默认行为） | (e: React.MouseEvent<HTMLElement, MouseEvent>) => void | - |  |
+| size | 设置标签大小 | `large` \| `middle` \| `small` | `small` |  |
 
 ### Tag.CheckableTag
 

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -122,6 +122,17 @@ const genBaseStyle = (token: TagToken): CSSInterpolation => {
       borderColor: 'transparent',
       background: token.tagBorderlessBg,
     },
+
+    [`${componentCls}-lg`]: {
+      fontSize: token.fontSizeLG,
+      fontWeight: token.fontWeightStrong,
+      padding: `${token.paddingXS} ${token.paddingMD}`,
+    },
+
+    [`${componentCls}-md`]: {
+      fontSize: `calc(${token.fontSizeLG}*0.8)`,
+      padding: `${token.paddingXXS} ${token.paddingXS}`,
+    },
   };
 };
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ x] 💄 Component style improvement
- [ x] 🎨 Code style optimization


### 🔗 Related Issues
Ref: close [#47949](https://github.com/ant-design/ant-design/issues/47949)

### 💡 Background and Solution

1. The requirement comes from the need for embedded customization, like other Ant Design components.
2. Facilitate style customization for the `Tag` component.
3. API Implementation: 

Added a size prop (`small`, `middle`, `large`) to help set a custom size for `Tag`:

```js
    [`${componentCls}-lg`]: {
      fontSize: token.fontSizeLG,
      fontWeight: token.fontWeightStrong,
      padding: `${token.paddingXS} ${token.paddingMD}`,
    },

    [`${componentCls}-md`]: {
      fontSize: `calc(${token.fontSizeLG}*0.8)`,
      padding: `${token.paddingXXS} ${token.paddingXS}`,
    },
```

The default `size` is small, so it does not affect the existing `Tag` styles.

demo:

```javascript
  <Flex align="flex-end" gap="4px 0" wrap>
    <Tag>Default</Tag>
    <Tag size="small">Small</Tag>
    <Tag size="middle">Medium</Tag>
    <Tag size="large">Large</Tag>
  </Flex>
```
![ant-tag-size](https://github.com/user-attachments/assets/20b61854-f374-4735-9294-30e7f17979e6)


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       Add `size` prop to `Tag` component for size customization, no impact or change needed.    |
| 🇨🇳 Chinese |      为 `Tag` 组件新增 `size` 属性用于自定义尺寸，默认不影响现有样式，无需额外改动。     |
