### PR TITLE
fix(notification): style should be correct when description is null

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -64,7 +64,7 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
     <div className={classNames({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
       <div className={`${prefixCls}-message`}>{message}</div>
-      <div className={`${prefixCls}-description`}>{description}</div>
+      {description && <div className={`${prefixCls}-description`}>{description}</div>}
       {actions && <div className={`${prefixCls}-actions`}>{actions}</div>}
     </div>
   );

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -413,4 +413,13 @@ describe('notification', () => {
     await awaitPromise();
     expect(document.querySelector('.with-style')).toHaveStyle({ width: '600px' });
   });
+
+  it('dom should be correct when description is null', () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+      });
+    });
+    expect(document.querySelectorAll('.ant-notification-description').length).toBe(0);
+  });
 });

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -134,7 +134,6 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     },
 
     [`${noticeCls}-message`]: {
-      marginBottom: token.marginXS,
       color: colorTextHeading,
       fontSize: fontSizeLG,
       lineHeight: token.lineHeightLG,
@@ -143,6 +142,7 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     [`${noticeCls}-description`]: {
       fontSize,
       color: colorText,
+      marginTop: token.marginXS,
     },
 
     [`${noticeCls}-closable ${noticeCls}-message`]: {
@@ -150,7 +150,6 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     },
 
     [`${noticeCls}-with-icon ${noticeCls}-message`]: {
-      marginBottom: token.marginXS,
       marginInlineStart: token.calc(token.marginSM).add(notificationIconSize).equal(),
       fontSize: fontSizeLG,
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- None

### 💡 Background and Solution

- should remove `margin` when description is null.

![image](https://github.com/user-attachments/assets/e0c8c927-2170-4356-8d15-483d03b33dc9)

| Before | After |
| :--- | :--- |
| ![image](https://github.com/user-attachments/assets/637f1bd6-e7a7-477d-9ade-9191585f520e) | ![image](https://github.com/user-attachments/assets/41345d89-bc13-45b6-88c0-22fc55051ef7) |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - 💄 Improve notification margin style when `description` is null.       |
| 🇨🇳 Chinese | - 💄 优化 `notification` description 为空时的间距。          |
