### PR TITLE
fix: fix toggle theme switch unable to turn off in docs

### DIFF
--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -100,21 +100,19 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = () => {
       return;
     }
 
-    // 校验当前主题是否包含要切换的主题（避免 timeout in DOM update）
-    if (theme.includes(key as ThemeName)) {
-      return;
-    }
-
-    // 亮色/暗色模式切换时应用动画效果
-    if (key === 'dark' || key === 'light') {
-      lastThemeKey.current = key;
-      toggleAnimationTheme(domEvent, theme.includes('dark'));
-    }
-
     const themeKey = key as ThemeName;
 
     // 亮色/暗色模式是互斥的
     if (['light', 'dark'].includes(key)) {
+      // 校验当前主题是否包含要切换的主题（避免 timeout in DOM update）
+      if (theme.includes(themeKey)) {
+        return;
+      }
+
+      // 亮色/暗色模式切换时应用动画效果
+      lastThemeKey.current = key;
+      toggleAnimationTheme(domEvent, theme.includes('dark'));
+
       const filteredTheme = theme.filter((t) => !['light', 'dark'].includes(t));
       updateSiteConfig({
         theme: [...filteredTheme, themeKey],


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

**Problem:**
In the documentation site's theme switcher, toggle themes (like `compact` and `happy-work`) could not be turned off once enabled. The validation logic `theme.includes(themeKey)` was preventing all theme changes if the theme was already active, affecting both mutually exclusive themes (light/dark) and toggle themes.

**Solution:**
- Move the validation logic `theme.includes(themeKey)` to only apply to mutually exclusive themes (light/dark)
- Allow toggle themes to be turned off by removing the early return for these themes
- Preserve the original behavior for light/dark theme switching

**before:**
![PixPin_2025-07-11_11-49-55](https://github.com/user-attachments/assets/a1fa97c2-c57d-475e-a470-eb64b3d68136)

**after:**
![PixPin_2025-07-11_11-58-28](https://github.com/user-attachments/assets/38024214-e818-4dbd-b0d6-3ce654e49c3c)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix theme switcher toggle themes unable to turn off in documentation site |
| 🇨🇳 Chinese | 修复文档站点主题切换器中开关式主题无法关闭的问题 |
