### PR TITLE
Alert: move onClose afterClose into closable prop

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -273,7 +273,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
   const mergedAriaProps = React.useMemo<React.AriaAttributes>(() => {
     const merged = closable ?? contextClosable;
     if (typeof merged === 'object') {
-      const { closeIcon: _, ...ariaProps } = merged;
+      const { closeIcon: _, afterClose: __, onClose: ___, ...ariaProps } = merged;
       return ariaProps;
     }
     return {};

--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -197,8 +197,8 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
 
   const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
     setClosed(true);
-    if (props.closable?.onClose) {
-      props.closable.onClose(e);
+    if (closable?.onClose) {
+      closable.onClose(e);
     } else {
       props.onClose?.(e);
     }

--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -588,11 +588,7 @@ Array [
 ]
 `;
 
-exports[`renders components/alert/demo/closable.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: Alert] \`onClose\` is deprecated. Please use \`closable.onClose\` instead.",
-]
-`;
+exports[`renders components/alert/demo/closable.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/custom-icon.tsx extend context correctly 1`] = `
 Array [

--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/alert/demo/action.tsx extend context correctly 1`] = `
 Array [
@@ -588,7 +588,11 @@ Array [
 ]
 `;
 
-exports[`renders components/alert/demo/closable.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/alert/demo/closable.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: Alert] \`onClose\` is deprecated. Please use \`closable.onClose\` instead.",
+]
+`;
 
 exports[`renders components/alert/demo/custom-icon.tsx extend context correctly 1`] = `
 Array [
@@ -1445,7 +1449,11 @@ Array [
 ]
 `;
 
-exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: Alert] \`afterClose\` is deprecated. Please use \`closable.afterClose\` instead.",
+]
+`;
 
 exports[`renders components/alert/demo/style.tsx extend context correctly 1`] = `
 Array [

--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1445,11 +1445,7 @@ Array [
 ]
 `;
 
-exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `
-[
-  "React does not recognize the \`%s\` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase \`%s\` instead. If you accidentally passed it from a parent component, remove it from the DOM element.",
-]
-`;
+exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/alert/demo/style.tsx extend context correctly 1`] = `
 Array [

--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1447,7 +1447,7 @@ Array [
 
 exports[`renders components/alert/demo/smooth-closed.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: Alert] \`afterClose\` is deprecated. Please use \`closable.afterClose\` instead.",
+  "React does not recognize the \`%s\` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase \`%s\` instead. If you accidentally passed it from a parent component, remove it from the DOM element.",
 ]
 `;
 

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -32,8 +32,7 @@ describe('Alert', () => {
       <Alert
         title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
         type="warning"
-        closable
-        onClose={onClose}
+        closable={{ onClose, closeIcon: 'closeBtn' }}
       />,
     );
 

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -25,16 +25,19 @@ describe('Alert', () => {
     jest.useRealTimers();
   });
 
-  it('should show close button and could be closed', async () => {
+  it('should trigger onClose callback when clicking close icon of a closable Alert', async () => {
+    const onClose = jest.fn();
+    const { container } = render(<Alert closable onClose={onClose} />);
+
+    fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should trigger custom onClose callback when clicking close icon of a Alert with closable object config', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const onClose = jest.fn();
-    const { container } = render(
-      <Alert
-        title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
-        type="warning"
-        closable={{ onClose, closeIcon: 'closeBtn' }}
-      />,
-    );
+    const { container } = render(<Alert closable={{ onClose, closeIcon: 'closeBtn' }} />);
 
     fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
 

--- a/components/alert/demo/closable.tsx
+++ b/components/alert/demo/closable.tsx
@@ -11,26 +11,24 @@ const App: React.FC = () => (
     <Alert
       title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
       type="warning"
-      closable
-      onClose={onClose}
+      closable={{ onClose, closeIcon: true }}
     />
     <br />
     <Alert
       title="Error Text"
       description="Error Description Error Description Error Description Error Description Error Description Error Description"
       type="error"
-      closable
-      onClose={onClose}
+      closable={{ onClose, closeIcon: true }}
     />
     <br />
     <Alert
       title="Error Text"
       description="Error Description Error Description Error Description Error Description Error Description Error Description"
       type="error"
-      onClose={onClose}
       closable={{
         'aria-label': 'close',
         closeIcon: <CloseSquareOutlined />,
+        onClose,
       }}
     />
   </>

--- a/components/alert/demo/smooth-closed.tsx
+++ b/components/alert/demo/smooth-closed.tsx
@@ -11,7 +11,11 @@ const App: React.FC = () => {
   return (
     <>
       {visible && (
-        <Alert title="Alert Message Text" type="success" closable afterClose={handleClose} />
+        <Alert
+          title="Alert Message Text"
+          type="success"
+          closable={{ afterClose: handleClose, closeIcon: true }}
+        />
       )}
       <p>click the close button to see the effect</p>
       <Switch onChange={setVisible} checked={visible} disabled={visible} />

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -39,16 +39,16 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | action | The action of Alert | ReactNode | - | 4.9.0 |
-| afterClose | Called when close animation is finished | () => void | - |  |
+| ~~afterClose~~ | Called when close animation is finished, please use `closable.afterClose` instead | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| ({ closeIcon?: React.ReactNode } & React.AriaAttributes) | `false` |  |
+| closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| ({ closeIcon?: React.ReactNode; onClose?:(e: MouseEvent) => void; afterClose?: () => void; } & React.AriaAttributes) | `false` |  |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
 | ~~message~~ | Content of Alert, please use `title` instead | ReactNode | - |  |
 | title | Content of Alert | ReactNode | - |  |
 | showIcon | Whether to show icon | boolean | false, in `banner` mode default is true |  |
 | type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | string | `info`, in `banner` mode default is `warning` |  |
-| onClose | Callback when Alert is closed | (e: MouseEvent) => void | - |  |
+| ~~onClose~~ | Callback when Alert is closed, please use `closable.onClose` instead | (e: MouseEvent) => void | - |  |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -40,16 +40,16 @@ group:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
-| afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
+| ~~afterClose~~ | 关闭动画结束后触发的回调函数，请使用`closable.afterClose`替换 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
-| closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| ({ closeIcon?: React.ReactNode } & React.AriaAttributes) | `false` |  |
+| closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| ({ closeIcon?: React.ReactNode; onClose?:(e: MouseEvent) => void; afterClose?: () => void; } & React.AriaAttributes) | `false` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
 | icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
 | ~~message~~ | 警告提示内容，请使用 `title` 替换 | ReactNode | - |  |
 | title | 警告提示内容 | ReactNode | - |  |
 | showIcon | 是否显示辅助图标 | boolean | false，`banner` 模式下默认值为 true |  |
 | type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | string | `info`，`banner` 模式下默认值为 `warning` |  |
-| onClose | 关闭时触发的回调函数 | (e: MouseEvent) => void | - |  |
+| ~~onClose~~ | 关闭时触发的回调函数，请使用`closable.onClose`替换 | (e: MouseEvent) => void | - |  |
 
 ### Alert.ErrorBoundary
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

- [✔ ] 🛠 Refactoring

### 🔗 Related Issues

https://github.com/ant-design/ant-design/issues/53682

| Language](https://github.com/ant-design/ant-design/issues/53682)   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Alert: move onClose afterClose into closable prop     |
| 🇨🇳 Chinese |     Alert组件移动onClose afterClose参数至 closable      |
