### PR TITLE
fix: correct SiteState type property name in GlobalLayout

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -27,7 +27,7 @@ import SiteContext from '../slots/SiteContext';
 import '@ant-design/v5-patch-for-react-19';
 
 type Entries<T> = { [K in keyof T]: [K, T[K]] }[keyof T][];
-type SiteState = Partial<Omit<SiteContextProps, 'updateSiteContext'>>;
+type SiteState = Partial<Omit<SiteContextProps, 'updateSiteConfig'>>;
 
 const RESPONSIVE_MOBILE = 768;
 export const ANT_DESIGN_NOT_SHOW_BANNER = 'ANT_DESIGN_NOT_SHOW_BANNER';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Fix TypeScript type definition inconsistency found during code review
> - No specific issue, this is a proactive improvement

### 💡 Background and Solution

**Problem:**
The `SiteState` type definition in `GlobalLayout.tsx` incorrectly references `updateSiteContext` property, but the actual property name in `SiteContextProps` interface is `updateSiteConfig`.

**Solution:**
- Fixed the property name in `SiteState` type from `updateSiteContext` to `updateSiteConfig`
- This ensures type consistency and prevents potential TypeScript compilation errors
- The change is located in `.dumi/theme/layouts/GlobalLayout.tsx` at line 30

**Before:**
```typescript
type SiteState = Partial<Omit<SiteContextProps, 'updateSiteContext'>>;
```

**After:**
```typescript
type SiteState = Partial<Omit<SiteContextProps, 'updateSiteConfig'>>;
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: correct SiteState type property name to match SiteContextProps interface |
| 🇨🇳 Chinese | 修复：修正 SiteState 类型属性名以匹配 SiteContextProps 接口 |
