### PR TITLE
fix: resolve non-null assertion logic error in useLocale hook

### DIFF
--- a/.dumi/hooks/useLocale.ts
+++ b/.dumi/hooks/useLocale.ts
@@ -16,7 +16,7 @@ const useLocale = <
 ): [Record<K, V>, 'cn' | 'en'] => {
   const { id } = useDumiLocale();
   const localeType = id === 'zh-CN' ? 'cn' : 'en';
-  return [localeMap?.[localeType]!, localeType] as const;
+  return [localeMap?.[localeType] ?? ({} as Record<K, V>), localeType] as const;
 };
 
 export default useLocale;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Fix non-null assertion logic error in useLocale hook
> - Resolve potential runtime errors when localeMap is undefined

### 💡 Background and Solution

**Problem:**
The `useLocale` hook in `.dumi/hooks/useLocale.ts` contains a logical contradiction by using both optional chaining (`?.`) and non-null assertion (`!`) operators together:

```typescript
return [localeMap?.[localeType]!, localeType] as const;
```

This can cause runtime errors when `localeMap` is `undefined`, as the optional chaining returns `undefined` but the non-null assertion tells TypeScript to ignore this possibility.

**Solution:**
Replace the non-null assertion with a nullish coalescing operator to provide a safe default value:

```typescript
return [localeMap?.[localeType] ?? {} as Record<K, V>, localeType] as const;
```

This ensures:
- Type safety without runtime errors
- Backward compatibility with existing code
- Graceful handling of undefined localeMap parameters

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix non-null assertion logic error in useLocale hook |
| 🇨🇳 Chinese | 修复 useLocale hook 中的非空断言逻辑错误 |
