### PR TITLE
feat[Tour]: Tour support contentRender property

### DIFF
--- a/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/tour/demo/actions-render.tsx extend context correctly 1`] = `
 Array [
@@ -345,6 +345,95 @@ Array [
 `;
 
 exports[`renders components/tour/demo/basic.tsx extend context correctly 2`] = `[]`;
+
+exports[`renders components/tour/demo/content-render.tsx extend context correctly 1`] = `
+Array [
+  <button
+    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <span>
+      Begin Tour
+    </span>
+  </button>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Content Render 1
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <span>
+          Content Render 2
+        </span>
+      </button>
+    </div>
+  </div>,
+  <div
+    class="ant-tour ant-tour-placement-bottom"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
+  >
+    <div
+      style="background-color: rgb(255, 255, 255); padding: 10px; border-radius: 10px; display: flex; flex-direction: column; align-items: flex-end;"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Next Step
+        </span>
+      </button>
+      <div
+        style="margin-top: 10px; margin-bottom: 10px; font-size: 14px; color: rgb(102, 102, 102);"
+      >
+        <i
+          style="font-weight: bold; color: rgb(51, 51, 51);"
+        >
+          Lorem ipsum dolor sit amet consectetur adipisicing elit
+        </i>
+        . Perspiciatis pariatur, quidem asperiores laboriosam nostrum commodi cumque aperiam ab consequuntur dolores natus accusantium neque incidunt blanditiis aliquam iure deserunt aspernatur nam!
+      </div>
+      <div
+        style="width: 100%; display: flex; align-items: center; justify-content: space-between;"
+      >
+        <span>
+          1 / 2
+        </span>
+        <button
+          class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+          type="button"
+        >
+          <span>
+            Close
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`renders components/tour/demo/content-render.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/tour/demo/gap.tsx extend context correctly 1`] = `
 <div>
@@ -1315,7 +1404,11 @@ Array [
 ]
 `;
 
-exports[`renders components/tour/demo/placement.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/tour/demo/placement.tsx extend context correctly 2`] = `
+[
+  "Cannot update a component (\`%s\`) while rendering a different component (\`%s\`). To locate the bad setState() call inside \`%s\`, follow the stack trace as described in https://react.dev/link/setstate-in-render",
+]
+`;
 
 exports[`renders components/tour/demo/render-panel.tsx extend context correctly 1`] = `
 <div

--- a/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1404,11 +1404,7 @@ Array [
 ]
 `;
 
-exports[`renders components/tour/demo/placement.tsx extend context correctly 2`] = `
-[
-  "Cannot update a component (\`%s\`) while rendering a different component (\`%s\`). To locate the bad setState() call inside \`%s\`, follow the stack trace as described in https://react.dev/link/setstate-in-render",
-]
-`;
+exports[`renders components/tour/demo/placement.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/tour/demo/render-panel.tsx extend context correctly 1`] = `
 <div

--- a/components/tour/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1,4 +1,81 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders components/tour/demo/actions-render.tsx correctly 1`] = `
+Array [
+  <button
+    class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    type="button"
+  >
+    <span>
+      Begin Tour
+    </span>
+  </button>,
+  <div
+    class="ant-divider ant-divider-horizontal"
+    role="separator"
+  />,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Upload
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <span>
+          Save
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="ellipsis"
+            class="anticon anticon-ellipsis"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="ellipsis"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+]
+`;
 
 exports[`renders components/tour/demo/basic.tsx correctly 1`] = `
 Array [
@@ -77,7 +154,7 @@ Array [
 ]
 `;
 
-exports[`renders components/tour/demo/actions-render.tsx correctly 1`] = `
+exports[`renders components/tour/demo/content-render.tsx correctly 1`] = `
 Array [
   <button
     class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
@@ -102,7 +179,7 @@ Array [
         type="button"
       >
         <span>
-          Upload
+          Content Render 1
         </span>
       </button>
     </div>
@@ -114,39 +191,7 @@ Array [
         type="button"
       >
         <span>
-          Save
-        </span>
-      </button>
-    </div>
-    <div
-      class="ant-space-item"
-    >
-      <button
-        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
-        type="button"
-      >
-        <span
-          class="ant-btn-icon"
-        >
-          <span
-            aria-label="ellipsis"
-            class="anticon anticon-ellipsis"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="ellipsis"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
-              />
-            </svg>
-          </span>
+          Content Render 2
         </span>
       </button>
     </div>

--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -797,4 +797,39 @@ describe('Tour', () => {
     expect(baseElement.querySelector('#content-render-1')).toBeFalsy();
     expect(baseElement.querySelector('#content-render-2')).toBeFalsy();
   });
+
+  it('contentRender with arrow pointAtCenter', () => {
+    const App: React.FC = () => {
+      const ref1 = useRef<HTMLButtonElement>(null);
+      const [show, setShow] = React.useState<boolean>();
+      const steps: TourProps['steps'] = [
+        {
+          contentRender: (
+            <div id="content-render-arrow">
+              <div>Content with arrow pointAtCenter</div>
+              <Button id="content-render-arrow-close" onClick={() => setShow(false)}>
+                Close
+              </Button>
+            </div>
+          ),
+          arrow: { pointAtCenter: true },
+        },
+      ];
+
+      return (
+        <>
+          <button id="start-button" type="button" onClick={() => setShow(true)} ref={ref1}>
+            Start
+          </button>
+          <Tour steps={steps} open={show} />
+        </>
+      );
+    };
+
+    const { baseElement } = render(<App />);
+    fireEvent.click(baseElement.querySelector('#start-button')!);
+    expect(baseElement.querySelector('#content-render-arrow')).toBeTruthy();
+    fireEvent.click(baseElement.querySelector('#content-render-arrow-close')!);
+    expect(baseElement.querySelector('#content-render-arrow')).toBeFalsy();
+  });
 });

--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -741,7 +741,7 @@ describe('Tour', () => {
       const [current, setCurrent] = React.useState<number>(0);
       const steps: TourProps['steps'] = [
         {
-          contentRender: () => (
+          contentRender: (
             <div id="content-render-1">
               <div id="content-render-1-title">Content Render 1</div>
               <Button id="content-render-1-next" onClick={() => setCurrent(1)}>
@@ -755,7 +755,7 @@ describe('Tour', () => {
           target: () => ref2.current!,
         },
         {
-          contentRender: () => (
+          contentRender: (
             <div id="content-render-2">
               <Button id="content-render-2-prev" onClick={() => setCurrent(0)}>
                 Prev

--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -732,7 +732,7 @@ describe('Tour', () => {
     );
   });
 
-  it('contentRender', () => {
+  it('contentRender', async () => {
     const App: React.FC = () => {
       const ref1 = useRef<HTMLButtonElement>(null);
       const ref2 = useRef<HTMLButtonElement>(null);

--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, screen } from '../../../tests/utils';
 import type { TourProps } from '../interface';
+import { Button } from 'antd';
 
 const mockBtnRect = (
   rect: { x: number; y: number; width: number; height: number },
@@ -729,5 +730,71 @@ describe('Tour', () => {
     expect(container.querySelector('.ant-tour-close')?.getAttribute('aria-label')).toBe(
       'Custom Close Button',
     );
+  });
+
+  it('contentRender', () => {
+    const App: React.FC = () => {
+      const ref1 = useRef<HTMLButtonElement>(null);
+      const ref2 = useRef<HTMLButtonElement>(null);
+      const ref3 = useRef<HTMLButtonElement>(null);
+      const [show, setShow] = React.useState<boolean>();
+      const [current, setCurrent] = React.useState<number>(0);
+      const steps: TourProps['steps'] = [
+        {
+          contentRender: () => (
+            <div id="content-render-1">
+              <div id="content-render-1-title">Content Render 1</div>
+              <Button id="content-render-1-next" onClick={() => setCurrent(1)}>
+                Next
+              </Button>
+              <Button id="content-render-1-close" onClick={() => setShow(false)}>
+                Close
+              </Button>
+            </div>
+          ),
+          target: () => ref2.current!,
+        },
+        {
+          contentRender: () => (
+            <div id="content-render-2">
+              <Button id="content-render-2-prev" onClick={() => setCurrent(0)}>
+                Prev
+              </Button>
+              <Button id="content-render-2-finish" onClick={() => setShow(false)}>
+                Finish
+              </Button>
+            </div>
+          ),
+          target: () => ref2.current!,
+        },
+      ];
+
+      return (
+        <>
+          <button id="start-button" type="button" onClick={() => setShow(true)} ref={ref1}>
+            Start
+          </button>
+          <button type="button" ref={ref2}>
+            Content Render 1
+          </button>
+          <button type="button" ref={ref3}>
+            Content Render 2
+          </button>
+          <Tour steps={steps} open={show} current={current} />
+        </>
+      );
+    };
+
+    const { baseElement } = render(<App />);
+    fireEvent.click(baseElement.querySelector('#start-button')!);
+    expect(baseElement.querySelector('#content-render-1')).toBeTruthy();
+    expect(baseElement.querySelector('#content-render-1-title')).toBeTruthy();
+    fireEvent.click(baseElement.querySelector('#content-render-1-next')!);
+    expect(baseElement.querySelector('#content-render-2')).toBeTruthy();
+    fireEvent.click(baseElement.querySelector('#content-render-2-prev')!);
+    expect(baseElement.querySelector('#content-render-1')).toBeTruthy();
+    fireEvent.click(baseElement.querySelector('#content-render-1-close')!);
+    expect(baseElement.querySelector('#content-render-1')).toBeFalsy();
+    expect(baseElement.querySelector('#content-render-2')).toBeFalsy();
   });
 });

--- a/components/tour/demo/content-render.md
+++ b/components/tour/demo/content-render.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+`steps`支持传入`panelRender`，自定义渲染面板内容，`panelRender`接收四个参数：`next`下一步，`prev`上一步，`close`关闭，`finish`结束。注意：Tour 的 `contenRender` 属性在 `>=5.27.0` 版本支持。
+
+## en-US
+
+`steps` supports passing `panelRender` to customize the panel content rendering. `panelRender` receives four parameters: `next` for next step, `prev` for previous step, `close` for closing, and `finish` for finishing. Note: The `contenRender` prop for Tour is supported starting from version `5.27.0`.

--- a/components/tour/demo/content-render.md
+++ b/components/tour/demo/content-render.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-`steps`支持传入`panelRender`，自定义渲染面板内容，`panelRender`接收四个参数：`next`下一步，`prev`上一步，`close`关闭，`finish`结束。注意：Tour 的 `contenRender` 属性在 `>=5.27.0` 版本支持。
+`steps`支持传入`contentRender`，自定义渲染面板内容。注意：Tour 的 `contenRender` 属性在 `>=5.27.0` 版本支持。
 
 ## en-US
 
-`steps` supports passing `panelRender` to customize the panel content rendering. `panelRender` receives four parameters: `next` for next step, `prev` for previous step, `close` for closing, and `finish` for finishing. Note: The `contenRender` prop for Tour is supported starting from version `5.27.0`.
+`steps` supports passing `contentRender` to customize the panel content rendering. Note: The `contenRender` prop for Tour is supported starting from version `5.27.0`.

--- a/components/tour/demo/content-render.tsx
+++ b/components/tour/demo/content-render.tsx
@@ -1,0 +1,137 @@
+import { Button, Divider, Space, Tour } from 'antd';
+import React, { useRef, useState } from 'react';
+import type { TourProps } from 'antd';
+
+const Content1: React.FC<{
+  setCurrent: (current: number) => void;
+  setOpen: (open: boolean) => void;
+}> = ({ setCurrent, setOpen }) => {
+  return (
+    <div
+      style={
+        {
+          backgroundColor: '#fff',
+          padding: '10px',
+          borderRadius: '10px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+        } as React.CSSProperties
+      }
+    >
+      <Button onClick={() => setCurrent(1)}>Next Step</Button>
+      <div
+        style={
+          {
+            marginTop: '10px',
+            marginBottom: '10px',
+            fontSize: '14px',
+            color: '#666',
+          } as React.CSSProperties
+        }
+      >
+        <i style={{ fontWeight: 'bold', color: '#333' } as React.CSSProperties}>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit
+        </i>
+        . Perspiciatis pariatur, quidem asperiores laboriosam nostrum commodi cumque aperiam ab
+        consequuntur dolores natus accusantium neque incidunt blanditiis aliquam iure deserunt
+        aspernatur nam!
+      </div>
+      <div
+        style={
+          {
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          } as React.CSSProperties
+        }
+      >
+        <span>1 / 2</span>
+        <Button type="primary" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const Content2: React.FC<{
+  setCurrent: (current: number) => void;
+  setOpen: (open: boolean) => void;
+}> = ({ setCurrent, setOpen }) => {
+  return (
+    <div
+      style={
+        {
+          backgroundColor: '#fff',
+          padding: '10px',
+          borderRadius: '10px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+        } as React.CSSProperties
+      }
+    >
+      <Button onClick={() => setCurrent(0)}>Last Step</Button>
+      <img
+        style={{ width: '100%', margin: '10px 0' } as React.CSSProperties}
+        alt="tour.png"
+        src="https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png"
+      />
+      <div
+        style={
+          {
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          } as React.CSSProperties
+        }
+      >
+        <span>2 / 2</span>
+        <Button type="primary" onClick={() => setOpen(false)}>
+          Finish
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const App: React.FC = () => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const ref1 = useRef(null);
+  const ref2 = useRef(null);
+
+  const [current, setCurrent] = useState<number>(0);
+
+  const steps: TourProps['steps'] = [
+    {
+      contentRender: () => <Content1 setCurrent={setCurrent} setOpen={setOpen} />,
+      target: () => ref1.current,
+    },
+    {
+      contentRender: () => <Content2 setCurrent={setCurrent} setOpen={setOpen} />,
+      target: () => ref2.current,
+      placement: 'top',
+    },
+  ];
+  return (
+    <>
+      <Button type="primary" onClick={() => setOpen(true)}>
+        Begin Tour
+      </Button>
+      <Divider />
+      <Space>
+        <Button ref={ref1}>Content Render 1</Button>
+        <Button ref={ref2} type="primary">
+          Content Render 2
+        </Button>
+      </Space>
+      <Tour current={current} open={open} onClose={() => setOpen(false)} steps={steps} />
+    </>
+  );
+};
+
+export default App;

--- a/components/tour/demo/content-render.tsx
+++ b/components/tour/demo/content-render.tsx
@@ -108,11 +108,11 @@ const App: React.FC = () => {
 
   const steps: TourProps['steps'] = [
     {
-      contentRender: () => <Content1 setCurrent={setCurrent} setOpen={setOpen} />,
+      contentRender: <Content1 setCurrent={setCurrent} setOpen={setOpen} />,
       target: () => ref1.current,
     },
     {
-      contentRender: () => <Content2 setCurrent={setCurrent} setOpen={setOpen} />,
+      contentRender: <Content2 setCurrent={setCurrent} setOpen={setOpen} />,
       target: () => ref2.current,
       placement: 'top',
     },

--- a/components/tour/index.en-US.md
+++ b/components/tour/index.en-US.md
@@ -24,7 +24,7 @@ Use when you want to guide users through a product.
 <code src="./demo/indicator.tsx">Custom indicator</code>
 <code src="./demo/actions-render.tsx" version="5.25.0">Custom action</code>
 <code src="./demo/gap.tsx">Custom highlighted area style</code>
-<code src="./demo/content-render.tsx">Custom render content</code>
+<code src="./demo/content-render.tsx" version="5.27.0">Custom render content</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API

--- a/components/tour/index.en-US.md
+++ b/components/tour/index.en-US.md
@@ -69,7 +69,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | nextButtonProps | Properties of the Next button | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | Properties of the previous button | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | support pass custom scrollIntoView options, the default follows the `scrollIntoViewOptions` property of Tour | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
-| contentRender | Custom render content 属性 | `(next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode` | - | 5.27.0 |
+| contentRender | Custom render content 属性 | `ReactNode` | - | 5.27.0 |
 
 ## Design Token
 

--- a/components/tour/index.en-US.md
+++ b/components/tour/index.en-US.md
@@ -24,6 +24,7 @@ Use when you want to guide users through a product.
 <code src="./demo/indicator.tsx">Custom indicator</code>
 <code src="./demo/actions-render.tsx" version="5.25.0">Custom action</code>
 <code src="./demo/gap.tsx">Custom highlighted area style</code>
+<code src="./demo/content-render.tsx">Custom render content</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API
@@ -68,6 +69,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | nextButtonProps | Properties of the Next button | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | Properties of the previous button | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | support pass custom scrollIntoView options, the default follows the `scrollIntoViewOptions` property of Tour | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
+| contentRender | Custom render content 属性 | `(next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode` | - | 5.27.0 |
 
 ## Design Token
 

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -24,6 +24,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
     actionsRender,
     steps,
     closeIcon,
+    current,
     ...restProps
   } = props;
   const { getPrefixCls, direction, tour } = useContext<ConfigConsumerProps>(ConfigContext);
@@ -63,6 +64,13 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
   const [arrows, setArrows] = useState<Array<boolean | { pointAtCenter: boolean } | undefined>>([]);
   const [currentStep, setCurrentStep] = useState<number>(0);
 
+  // Sync currentStep with the current prop from RCTour
+  React.useEffect(() => {
+    if (current !== undefined) {
+      setCurrentStep(current);
+    }
+  }, [current]);
+
   useEffect(() => {
     const arrowItems = [];
     for (const item of steps ?? []) {
@@ -80,7 +88,6 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
   }, [steps]);
 
   const mergedRenderPanel: RcTourProps['renderPanel'] = (stepProps, stepCurrent) => {
-    setCurrentStep(stepCurrent);
     return (stepProps as TourStepProps).contentRender ? (
       (stepProps as TourStepProps).contentRender
     ) : (
@@ -101,6 +108,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
     <zIndexContext.Provider value={contextZIndex}>
       <RCTour
         {...restProps}
+        current={current}
         closeIcon={closeIcon ?? tour?.closeIcon}
         arrow={arrows[currentStep]}
         zIndex={zIndex}

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -86,7 +86,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
     return (
       <>
         {(stepProps as TourStepProps).contentRender ? (
-          (stepProps as TourStepProps).contentRender!()
+          (stepProps as TourStepProps).contentRender
         ) : (
           <TourPanel
             type={type}

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import RCTour from '@rc-component/tour';
 import type { TourProps as RcTourProps } from '@rc-component/tour';
 import classNames from 'classnames';
-
 import { useZIndex } from '../_util/hooks/useZIndex';
 import getPlacements from '../_util/placements';
 import zIndexContext from '../_util/zindexContext';

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -82,20 +82,16 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
 
   const mergedRenderPanel: RcTourProps['renderPanel'] = (stepProps, stepCurrent) => {
     setCurrentStep(stepCurrent);
-    return (
-      <>
-        {(stepProps as TourStepProps).contentRender ? (
-          (stepProps as TourStepProps).contentRender
-        ) : (
-          <TourPanel
-            type={type}
-            stepProps={stepProps}
-            current={stepCurrent}
-            indicatorsRender={indicatorsRender}
-            actionsRender={actionsRender}
-          />
-        )}
-      </>
+    return (stepProps as TourStepProps).contentRender ? (
+      (stepProps as TourStepProps).contentRender
+    ) : (
+      <TourPanel
+        type={type}
+        stepProps={stepProps}
+        current={stepCurrent}
+        indicatorsRender={indicatorsRender}
+        actionsRender={actionsRender}
+      />
     );
   };
 

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import RCTour from '@rc-component/tour';
-import type { TourProps as RcTourProps, TourRef as RcTourRef } from '@rc-component/tour';
+import type { TourProps as RcTourProps } from '@rc-component/tour';
 import classNames from 'classnames';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
@@ -27,7 +27,6 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
     closeIcon,
     ...restProps
   } = props;
-  const rcTourRef = useRef<RcTourRef>(null);
   const { getPrefixCls, direction, tour } = useContext<ConfigConsumerProps>(ConfigContext);
   const prefixCls = getPrefixCls('tour', customizePrefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
@@ -106,7 +105,6 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
   return wrapCSSVar(
     <zIndexContext.Provider value={contextZIndex}>
       <RCTour
-        ref={rcTourRef}
         {...restProps}
         closeIcon={closeIcon ?? tour?.closeIcon}
         arrow={arrows[currentStep]}

--- a/components/tour/index.zh-CN.md
+++ b/components/tour/index.zh-CN.md
@@ -25,7 +25,7 @@ tag: 5.0.0
 <code src="./demo/indicator.tsx">自定义指示器</code>
 <code src="./demo/actions-render.tsx" version="5.25.0">自定义操作按钮</code>
 <code src="./demo/gap.tsx">自定义高亮区域的样式</code>
-<code src="./demo/content-render.tsx">自定义渲染内容</code>
+<code src="./demo/content-render.tsx" version="5.27.0">自定义渲染内容</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API
@@ -71,7 +71,7 @@ tag: 5.0.0
 | nextButtonProps | 下一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | 上一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | 是否支持当前元素滚动到视窗内，也可传入配置指定滚动视窗的相关参数，默认跟随 Tour 的 `scrollIntoViewOptions` 属性 | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
-| contentRender | 自定义渲染内容 属性 | `ReactNode` | - | 5.27.0 |
+| contentRender | 自定义渲染内容属性 | `ReactNode` | - | 5.27.0 |
 
 ## 主题变量（Design Token）
 

--- a/components/tour/index.zh-CN.md
+++ b/components/tour/index.zh-CN.md
@@ -71,7 +71,7 @@ tag: 5.0.0
 | nextButtonProps | 下一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | 上一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | 是否支持当前元素滚动到视窗内，也可传入配置指定滚动视窗的相关参数，默认跟随 Tour 的 `scrollIntoViewOptions` 属性 | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
-| panelRender | 自定义渲染内容 属性 | `(next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode` | - | 5.27.0 |
+| contentRender | 自定义渲染内容 属性 | `ReactNode` | - | 5.27.0 |
 
 ## 主题变量（Design Token）
 

--- a/components/tour/index.zh-CN.md
+++ b/components/tour/index.zh-CN.md
@@ -25,6 +25,7 @@ tag: 5.0.0
 <code src="./demo/indicator.tsx">自定义指示器</code>
 <code src="./demo/actions-render.tsx" version="5.25.0">自定义操作按钮</code>
 <code src="./demo/gap.tsx">自定义高亮区域的样式</code>
+<code src="./demo/content-render.tsx">自定义渲染内容</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API
@@ -70,6 +71,7 @@ tag: 5.0.0
 | nextButtonProps | 下一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | 上一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | 是否支持当前元素滚动到视窗内，也可传入配置指定滚动视窗的相关参数，默认跟随 Tour 的 `scrollIntoViewOptions` 属性 | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
+| panelRender | 自定义渲染内容 属性 | `(next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode` | - | 5.27.0 |
 
 ## 主题变量（Design Token）
 

--- a/components/tour/index.zh-CN.md
+++ b/components/tour/index.zh-CN.md
@@ -71,7 +71,7 @@ tag: 5.0.0
 | nextButtonProps | 下一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | prevButtonProps | 上一步按钮的属性 | `{ children: ReactNode; onClick: Function }` | - |  |
 | scrollIntoViewOptions | 是否支持当前元素滚动到视窗内，也可传入配置指定滚动视窗的相关参数，默认跟随 Tour 的 `scrollIntoViewOptions` 属性 | `boolean \| ScrollIntoViewOptions` | `true` | 5.2.0 |
-| contentRender | 自定义渲染内容属性 | `ReactNode` | - | 5.27.0 |
+| contentRender | 自定义渲染内容 | `ReactNode` | - | 5.27.0 |
 
 ## 主题变量（Design Token）
 

--- a/components/tour/interface.ts
+++ b/components/tour/interface.ts
@@ -31,7 +31,7 @@ export interface TourStepProps extends Omit<RCTourStepProps, 'title'> {
   actionsRender?: (originNode: ReactNode, info: { current: number; total: number }) => ReactNode;
   type?: 'default' | 'primary'; //	default type, affects the background color and text color
   title?: ReactNode;
-  contentRender?: () => ReactNode;
+  contentRender?: ReactNode;
 }
 
 export interface TourLocale {

--- a/components/tour/interface.ts
+++ b/components/tour/interface.ts
@@ -4,7 +4,7 @@ import type {
   TourStepProps as RCTourStepProps,
 } from '@rc-component/tour';
 
-export interface TourProps extends Omit<RCTourProps, 'renderPanel'> {
+export interface TourProps extends Omit<RCTourProps, 'renderPanel' | 'steps'> {
   steps?: TourStepProps[];
   prefixCls?: string;
   current?: number;
@@ -13,7 +13,7 @@ export interface TourProps extends Omit<RCTourProps, 'renderPanel'> {
   type?: 'default' | 'primary'; //	default type, affects the background color and text color
 }
 
-export interface TourStepProps extends RCTourStepProps {
+export interface TourStepProps extends Omit<RCTourStepProps, 'title'> {
   cover?: ReactNode; // Display pictures or videos
   nextButtonProps?: {
     children?: ReactNode;
@@ -30,6 +30,8 @@ export interface TourStepProps extends RCTourStepProps {
   indicatorsRender?: (current: number, total: number) => ReactNode;
   actionsRender?: (originNode: ReactNode, info: { current: number; total: number }) => ReactNode;
   type?: 'default' | 'primary'; //	default type, affects the background color and text color
+  title?: ReactNode;
+  contentRender?: () => ReactNode;
 }
 
 export interface TourLocale {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
feat: [https://github.com/ant-design/ant-design/issues/54204](https://github.com/ant-design/ant-design/issues/54204)


### 💡 Background and Solution
want to be able to modify the position or style of each Tour step.
Add contentRender property to support passing ReactNode for custom rendering.


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Tour support `contentRender` property |
| 🇨🇳 Chinese | Tour 支持 `contentRender` 属性 |
