### PR TITLE
fix[Mentions]: fix overlap of clear and feedback icons in Mentions

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2100,6 +2100,103 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx extend context c
     />
   </div>
   <div
+    class="ant-form-item acss-140b0ev ant-form-item-has-feedback ant-form-item-has-success"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="custom-feedback-icons_custom-feedback-test-item3"
+          title="Test"
+        >
+          Test
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions-status-success"
+            >
+              <div
+                class="ant-mentions"
+              >
+                <textarea
+                  class="rc-textarea"
+                  id="custom-feedback-icons_custom-feedback-test-item3"
+                  rows="1"
+                />
+              </div>
+              <span
+                class="ant-mentions-suffix"
+              >
+                <button
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-hidden ant-mentions-clear-icon-has-suffix"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
     class="ant-form-item"
   >
     <div

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2126,7 +2126,7 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx extend context c
             class="ant-form-item-control-input-content"
           >
             <span
-              class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions-status-success"
+              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
             >
               <div
                 class="ant-mentions"
@@ -2135,13 +2135,15 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx extend context c
                   class="rc-textarea"
                   id="custom-feedback-icons_custom-feedback-test-item3"
                   rows="1"
-                />
+                >
+                  @mention1
+                </textarea>
               </div>
               <span
                 class="ant-mentions-suffix"
               >
                 <button
-                  class="ant-mentions-clear-icon ant-mentions-clear-icon-hidden ant-mentions-clear-icon-has-suffix"
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
                   tabindex="-1"
                   type="button"
                 >

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1615,7 +1615,7 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx correctly 1`] = 
             class="ant-form-item-control-input-content"
           >
             <span
-              class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions-status-success"
+              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
             >
               <div
                 class="ant-mentions"
@@ -1624,13 +1624,15 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx correctly 1`] = 
                   class="rc-textarea"
                   id="custom-feedback-icons_custom-feedback-test-item3"
                   rows="1"
-                />
+                >
+                  @mention1
+                </textarea>
               </div>
               <span
                 class="ant-mentions-suffix"
               >
                 <button
-                  class="ant-mentions-clear-icon ant-mentions-clear-icon-hidden ant-mentions-clear-icon-has-suffix"
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
                   tabindex="-1"
                   type="button"
                 >

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1589,6 +1589,103 @@ exports[`renders components/form/demo/custom-feedback-icons.tsx correctly 1`] = 
     </div>
   </div>
   <div
+    class="ant-form-item acss-140b0ev ant-form-item-has-feedback ant-form-item-has-success"
+  >
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="custom-feedback-icons_custom-feedback-test-item3"
+          title="Test"
+        >
+          Test
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-mentions-affix-wrapper ant-mentions-outlined ant-mentions-status-success"
+            >
+              <div
+                class="ant-mentions"
+              >
+                <textarea
+                  class="rc-textarea"
+                  id="custom-feedback-icons_custom-feedback-test-item3"
+                  rows="1"
+                />
+              </div>
+              <span
+                class="ant-mentions-suffix"
+              >
+                <button
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-hidden ant-mentions-clear-icon-has-suffix"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
     class="ant-form-item"
   >
     <div

--- a/components/form/demo/custom-feedback-icons.tsx
+++ b/components/form/demo/custom-feedback-icons.tsx
@@ -72,6 +72,7 @@ const App: React.FC = () => {
         className={styles['custom-feedback-icons']}
         hasFeedback
         validateStatus="success"
+        initialValue={['@mention1']}
       >
         <Mentions
           allowClear

--- a/components/form/demo/custom-feedback-icons.tsx
+++ b/components/form/demo/custom-feedback-icons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AlertFilled, CloseSquareFilled } from '@ant-design/icons';
-import { Button, Form, Input, Tooltip } from 'antd';
+import { Button, Form, Input, Tooltip, Mentions } from 'antd';
 import { createStyles, css } from 'antd-style';
 import uniqueId from 'lodash/uniqueId';
 
@@ -65,6 +65,27 @@ const App: React.FC = () => {
         }}
       >
         <Input />
+      </Form.Item>
+      <Form.Item
+        name="custom-feedback-test-item3"
+        label="Test"
+        className={styles['custom-feedback-icons']}
+        hasFeedback
+        validateStatus="success"
+      >
+        <Mentions
+          allowClear
+          options={[
+            {
+              value: 'mention1',
+              label: 'mention1',
+            },
+            {
+              value: 'mention2',
+              label: 'mention2',
+            },
+          ]}
+        />
       </Form.Item>
       <Form.Item>
         <Button htmlType="submit">Submit</Button>

--- a/components/form/demo/custom-feedback-icons.tsx
+++ b/components/form/demo/custom-feedback-icons.tsx
@@ -72,7 +72,7 @@ const App: React.FC = () => {
         className={styles['custom-feedback-icons']}
         hasFeedback
         validateStatus="success"
-        initialValue={['@mention1']}
+        initialValue="@mention1"
       >
         <Mentions
           allowClear

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/input/demo/addon.tsx extend context correctly 1`] = `
 <div

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -177,117 +177,20 @@ exports[`renders components/mentions/demo/autoSize.tsx extend context correctly 
 `;
 
 exports[`renders components/mentions/demo/basic.tsx extend context correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
+<div
+  class="ant-mentions ant-mentions-outlined"
+  style="width: 100%;"
 >
-  <div
-    class="ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+  <textarea
+    class="rc-textarea"
+    rows="1"
   >
-    <div
-      class="ant-row ant-form-item-row"
-    >
-      <div
-        class="ant-col ant-form-item-label"
-      >
-        <label
-          class=""
-          for="mentions"
-          title="Mentions"
-        >
-          Mentions
-        </label>
-      </div>
-      <div
-        class="ant-col ant-form-item-control"
-      >
-        <div
-          class="ant-form-item-control-input"
-        >
-          <div
-            class="ant-form-item-control-input-content"
-          >
-            <span
-              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
-            >
-              <div
-                class="ant-mentions"
-                style="width: 100%;"
-              >
-                <textarea
-                  class="rc-textarea"
-                  id="mentions"
-                  rows="1"
-                >
-                  @afc163
-                </textarea>
-              </div>
-              <span
-                class="ant-mentions-suffix"
-              >
-                <button
-                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
-                  tabindex="-1"
-                  type="button"
-                >
-                  <span
-                    aria-label="close-circle"
-                    class="anticon anticon-close-circle"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close-circle"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <span
-                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
-                >
-                  <span
-                    aria-label="check-circle"
-                    class="anticon anticon-check-circle"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="check-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
+    @afc163
+  </textarea>
+</div>
 `;
 
-exports[`renders components/mentions/demo/basic.tsx extend context correctly 2`] = `
-[
-  "Warning: [antd: Form.Item] \`defaultValue\` will not work on controlled Field. You should use \`initialValues\` of Form instead.",
-]
-`;
+exports[`renders components/mentions/demo/basic.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/mentions/demo/component-token.tsx extend context correctly 1`] = `
 <div

--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/mentions/demo/allowClear.tsx extend context correctly 1`] = `
 Array [
@@ -177,20 +177,117 @@ exports[`renders components/mentions/demo/autoSize.tsx extend context correctly 
 `;
 
 exports[`renders components/mentions/demo/basic.tsx extend context correctly 1`] = `
-<div
-  class="ant-mentions ant-mentions-outlined"
-  style="width: 100%;"
+<form
+  class="ant-form ant-form-horizontal"
 >
-  <textarea
-    class="rc-textarea"
-    rows="1"
+  <div
+    class="ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
   >
-    @afc163
-  </textarea>
-</div>
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="mentions"
+          title="Mentions"
+        >
+          Mentions
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
+            >
+              <div
+                class="ant-mentions"
+                style="width: 100%;"
+              >
+                <textarea
+                  class="rc-textarea"
+                  id="mentions"
+                  rows="1"
+                >
+                  @afc163
+                </textarea>
+              </div>
+              <span
+                class="ant-mentions-suffix"
+              >
+                <button
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
 `;
 
-exports[`renders components/mentions/demo/basic.tsx extend context correctly 2`] = `[]`;
+exports[`renders components/mentions/demo/basic.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: Form.Item] \`defaultValue\` will not work on controlled Field. You should use \`initialValues\` of Form instead.",
+]
+`;
 
 exports[`renders components/mentions/demo/component-token.tsx extend context correctly 1`] = `
 <div

--- a/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
@@ -166,110 +166,17 @@ exports[`renders components/mentions/demo/autoSize.tsx correctly 1`] = `
 `;
 
 exports[`renders components/mentions/demo/basic.tsx correctly 1`] = `
-<form
-  class="ant-form ant-form-horizontal"
+<div
+  class="ant-mentions ant-mentions-outlined"
+  style="width:100%"
 >
-  <div
-    class="ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
+  <textarea
+    class="rc-textarea"
+    rows="1"
   >
-    <div
-      class="ant-row ant-form-item-row"
-    >
-      <div
-        class="ant-col ant-form-item-label"
-      >
-        <label
-          class=""
-          for="mentions"
-          title="Mentions"
-        >
-          Mentions
-        </label>
-      </div>
-      <div
-        class="ant-col ant-form-item-control"
-      >
-        <div
-          class="ant-form-item-control-input"
-        >
-          <div
-            class="ant-form-item-control-input-content"
-          >
-            <span
-              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
-            >
-              <div
-                class="ant-mentions"
-                style="width:100%"
-              >
-                <textarea
-                  class="rc-textarea"
-                  id="mentions"
-                  rows="1"
-                >
-                  @afc163
-                </textarea>
-              </div>
-              <span
-                class="ant-mentions-suffix"
-              >
-                <button
-                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
-                  tabindex="-1"
-                  type="button"
-                >
-                  <span
-                    aria-label="close-circle"
-                    class="anticon anticon-close-circle"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="close-circle"
-                      fill="currentColor"
-                      fill-rule="evenodd"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <span
-                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
-                >
-                  <span
-                    aria-label="check-circle"
-                    class="anticon anticon-check-circle"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      data-icon="check-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
+    @afc163
+  </textarea>
+</div>
 `;
 
 exports[`renders components/mentions/demo/component-token.tsx correctly 1`] = `

--- a/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/mentions/demo/allowClear.tsx correctly 1`] = `
 Array [
@@ -166,17 +166,110 @@ exports[`renders components/mentions/demo/autoSize.tsx correctly 1`] = `
 `;
 
 exports[`renders components/mentions/demo/basic.tsx correctly 1`] = `
-<div
-  class="ant-mentions ant-mentions-outlined"
-  style="width:100%"
+<form
+  class="ant-form ant-form-horizontal"
 >
-  <textarea
-    class="rc-textarea"
-    rows="1"
+  <div
+    class="ant-form-item ant-form-item-has-feedback ant-form-item-has-success"
   >
-    @afc163
-  </textarea>
-</div>
+    <div
+      class="ant-row ant-form-item-row"
+    >
+      <div
+        class="ant-col ant-form-item-label"
+      >
+        <label
+          class=""
+          for="mentions"
+          title="Mentions"
+        >
+          Mentions
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <span
+              class="ant-mentions-affix-wrapper ant-mentions-affix-wrapper-input-with-clear-btn ant-mentions-outlined ant-mentions-status-success"
+            >
+              <div
+                class="ant-mentions"
+                style="width:100%"
+              >
+                <textarea
+                  class="rc-textarea"
+                  id="mentions"
+                  rows="1"
+                >
+                  @afc163
+                </textarea>
+              </div>
+              <span
+                class="ant-mentions-suffix"
+              >
+                <button
+                  class="ant-mentions-clear-icon ant-mentions-clear-icon-has-suffix"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    aria-label="close-circle"
+                    class="anticon anticon-close-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="close-circle"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
 `;
 
 exports[`renders components/mentions/demo/component-token.tsx correctly 1`] = `

--- a/components/mentions/__tests__/index.test.tsx
+++ b/components/mentions/__tests__/index.test.tsx
@@ -147,14 +147,14 @@ describe('Mentions', () => {
     const clearIcon = container.querySelector('.ant-mentions-clear-icon');
     const feedbackIcon = container.querySelector('.ant-form-item-feedback-icon');
 
-    function isGap8px(el1: Element | null, el2: Element | null) {
-      if (!el1 || !el2) return false;
-      const rect1 = el1.getBoundingClientRect();
-      const rect2 = el2.getBoundingClientRect();
-      const gap = rect1.left < rect2.left ? rect2.left - rect1.right : rect1.left - rect2.right;
-      return Math.abs(gap - 8) < 1;
-    }
+    // 判断清除图标和反馈图标在水平方向上不重叠
+    const clearRect = clearIcon!.getBoundingClientRect();
+    const feedbackRect = feedbackIcon!.getBoundingClientRect();
 
-    expect(isGap8px(clearIcon, feedbackIcon)).toBe(false);
+    // 判断两个元素的右侧是否在对方的左侧左边，或左侧是否在对方的右侧右边
+    const isNotOverlap =
+      clearRect.right <= feedbackRect.left || feedbackRect.right <= clearRect.left;
+
+    expect(isNotOverlap).toBe(true);
   });
 });

--- a/components/mentions/__tests__/index.test.tsx
+++ b/components/mentions/__tests__/index.test.tsx
@@ -5,7 +5,6 @@ import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
-import { Form } from 'antd';
 
 const { getMentions } = Mentions;
 
@@ -133,28 +132,5 @@ describe('Mentions', () => {
     expect(
       wrapper.container.querySelector('.ant-mentions-dropdown-menu-item-active')?.textContent,
     ).toBe('Yesmeck');
-  });
-
-  it('clear icon and feedback icon should not overlap', () => {
-    const { container } = render(
-      <Form>
-        <Form.Item hasFeedback validateStatus="success">
-          <Mentions allowClear defaultValue="default value" />
-        </Form.Item>
-      </Form>,
-    );
-
-    const clearIcon = container.querySelector('.ant-mentions-clear-icon');
-    const feedbackIcon = container.querySelector('.ant-form-item-feedback-icon');
-
-    // 判断清除图标和反馈图标在水平方向上不重叠
-    const clearRect = clearIcon!.getBoundingClientRect();
-    const feedbackRect = feedbackIcon!.getBoundingClientRect();
-
-    // 判断两个元素的右侧是否在对方的左侧左边，或左侧是否在对方的右侧右边
-    const isNotOverlap =
-      clearRect.right <= feedbackRect.left || feedbackRect.right <= clearRect.left;
-
-    expect(isNotOverlap).toBe(true);
   });
 });

--- a/components/mentions/__tests__/index.test.tsx
+++ b/components/mentions/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
+import { Form } from 'antd';
 
 const { getMentions } = Mentions;
 
@@ -132,5 +133,28 @@ describe('Mentions', () => {
     expect(
       wrapper.container.querySelector('.ant-mentions-dropdown-menu-item-active')?.textContent,
     ).toBe('Yesmeck');
+  });
+
+  it('clear icon and feedback icon should not overlap', () => {
+    const { container } = render(
+      <Form>
+        <Form.Item hasFeedback validateStatus="success">
+          <Mentions allowClear defaultValue="default value" />
+        </Form.Item>
+      </Form>,
+    );
+
+    const clearIcon = container.querySelector('.ant-mentions-clear-icon');
+    const feedbackIcon = container.querySelector('.ant-form-item-feedback-icon');
+
+    function isGap8px(el1: Element | null, el2: Element | null) {
+      if (!el1 || !el2) return false;
+      const rect1 = el1.getBoundingClientRect();
+      const rect2 = el2.getBoundingClientRect();
+      const gap = rect1.left < rect2.left ? rect2.left - rect1.right : rect1.left - rect2.right;
+      return Math.abs(gap - 8) < 1;
+    }
+
+    expect(isGap8px(clearIcon, feedbackIcon)).toBe(false);
   });
 });

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -52,6 +52,7 @@ type MentionsToken = FullToken<'Mentions'> &
 const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
   const {
     componentCls,
+    antCls,
     colorTextDisabled,
     controlItemBgHover,
     controlPaddingHorizontal,
@@ -67,14 +68,12 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
     colorTextQuaternary,
     colorBgElevated,
     paddingXXS,
-    paddingLG,
     borderRadius,
     borderRadiusLG,
     boxShadowSecondary,
     itemPaddingVertical,
     calc,
   } = token;
-
   return {
     [componentCls]: {
       ...resetComponent(token),
@@ -83,7 +82,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
       position: 'relative',
       display: 'inline-block',
       height: 'auto',
-      padding: 0,
+      padding: `0 ${unit(token.paddingInline)}`,
       overflow: 'hidden',
       lineHeight,
       whiteSpace: 'pre-wrap',
@@ -97,7 +96,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
       '&-affix-wrapper': {
         ...genBasicInputStyle(token),
         display: 'inline-flex',
-        padding: 0,
+        padding: `0 ${unit(token.paddingInline)} 0 0`,
 
         '&::before': {
           display: 'inline-block',
@@ -107,25 +106,18 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
         },
 
         [`${componentCls}-suffix`]: {
-          position: 'absolute',
-          top: 0,
-          insetInlineEnd: paddingInline,
-          bottom: 0,
-          zIndex: 1,
           display: 'inline-flex',
           alignItems: 'center',
-          margin: 'auto',
-        },
 
-        [`&:has(${componentCls}-suffix) > ${componentCls} > textarea`]: {
-          paddingInlineEnd: paddingLG,
+          // 当页面中存在 feedback-icon 时，给 clear-icon 添加右边距
+          [`&:has(${antCls}-form-item-feedback-icon) ${componentCls}-clear-icon`]: {
+            marginRight: unit(token.marginXS),
+          },
         },
 
         [`${componentCls}-clear-icon`]: {
           insetInlineEnd: 0,
           insetBlockStart: calc(fontSize).mul(lineHeight).mul(0.5).add(paddingBlock).equal(),
-          margin: 0,
-
           padding: 0,
           lineHeight: 0,
           color: colorTextQuaternary,
@@ -148,10 +140,6 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           '&-hidden': {
             visibility: 'hidden',
           },
-        },
-
-        [`${componentCls}-suffix:has(> *:nth-child(2)) ${componentCls}-clear-icon`]: {
-          margin: `0 ${unit(8)}`,
         },
       },
 
@@ -200,6 +188,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           resize: 'none',
           backgroundColor: 'transparent',
           ...genPlaceholderStyle(token.colorTextPlaceholder),
+          padding: `${unit(token.paddingBlock)} 0`,
         },
 
         [`${componentCls}-measure`]: {

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -98,7 +98,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
         display: 'inline-flex',
         paddingBlock: 0,
         paddingInlineStart: 0,
-        paddingInlineEnd: unit(token.paddingInline),
+        paddingInlineEnd: token.paddingInline,
 
         '&::before': {
           display: 'inline-block',

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -96,7 +96,9 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
       '&-affix-wrapper': {
         ...genBasicInputStyle(token),
         display: 'inline-flex',
-        padding: `0 ${unit(token.paddingInline)} 0 0`,
+        paddingBlock: 0,
+        paddingInlineStart: 0,
+        paddingInlineEnd: unit(token.paddingInline),
 
         '&::before': {
           display: 'inline-block',
@@ -111,7 +113,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
 
           // 当页面中存在 feedback-icon 时，给 clear-icon 添加右边距
           [`&:has(${antCls}-form-item-feedback-icon) ${componentCls}-clear-icon`]: {
-            marginRight: unit(token.marginXS),
+            marginInlineEnd: unit(token.marginXS),
           },
 
           [`${antCls}-form-item-feedback-icon`]: {

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -113,6 +113,12 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           [`&:has(${antCls}-form-item-feedback-icon) ${componentCls}-clear-icon`]: {
             marginRight: unit(token.marginXS),
           },
+
+          [`${antCls}-form-item-feedback-icon`]: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
         },
 
         [`${componentCls}-clear-icon`]: {
@@ -123,8 +129,11 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           color: colorTextQuaternary,
           fontSize: fontSizeIcon,
           verticalAlign: -1,
+          // https://github.com/ant-design/ant-design/pull/18151
+          // https://codesandbox.io/s/wizardly-sun-u10br
           cursor: 'pointer',
           transition: `color ${motionDurationSlow}`,
+
           border: 'none',
           outline: 'none',
           backgroundColor: 'transparent',

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -122,20 +122,17 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
         },
 
         [`${componentCls}-clear-icon`]: {
-          position: 'absolute',
           insetInlineEnd: 0,
           insetBlockStart: calc(fontSize).mul(lineHeight).mul(0.5).add(paddingBlock).equal(),
-          transform: `translateY(-50%)`,
           margin: 0,
+
           padding: 0,
+          lineHeight: 0,
           color: colorTextQuaternary,
           fontSize: fontSizeIcon,
           verticalAlign: -1,
-          // https://github.com/ant-design/ant-design/pull/18151
-          // https://codesandbox.io/s/wizardly-sun-u10br
           cursor: 'pointer',
           transition: `color ${motionDurationSlow}`,
-
           border: 'none',
           outline: 'none',
           backgroundColor: 'transparent',
@@ -151,6 +148,10 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           '&-hidden': {
             visibility: 'hidden',
           },
+        },
+
+        [`${componentCls}-suffix:has(> *:nth-child(2)) ${componentCls}-clear-icon`]: {
+          margin: `0 ${unit(8)}`,
         },
       },
 

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -113,7 +113,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
 
           // 当页面中存在 feedback-icon 时，给 clear-icon 添加右边距
           [`&:has(${antCls}-form-item-feedback-icon) ${componentCls}-clear-icon`]: {
-            marginInlineEnd: unit(token.marginXS),
+            marginInlineEnd: token.marginXS,
           },
 
           [`${antCls}-form-item-feedback-icon`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
issue: [https://github.com/ant-design/ant-design/issues/54389](https://github.com/ant-design/ant-design/issues/54389) 

### 💡 Background and Solution
When both suffix-icon and clear-icon appear simultaneously, their positions will overlap.
Check if suffix-icon exists, if it does, add margin: 0 8px to clear-icon.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix overlap of clear and feedback icons in Mentions |
| 🇨🇳 Chinese | 修复 Mentions 中 clear 和 hasFeedback 重叠问题 |
