### PR TITLE
fix(Menu): Allow data attributes for menu items

### DIFF
--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -6,7 +6,7 @@ import type {
 } from 'rc-menu/lib/interface';
 
 export type DataAttributes = {
-  [Key in `data-${string}`]: string;
+  [Key in `data-${string}`]: string | number;
 };
 
 export interface MenuItemType extends RcMenuItemType, DataAttributes {

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -5,7 +5,11 @@ import type {
   SubMenuType as RcSubMenuType,
 } from 'rc-menu/lib/interface';
 
-export interface MenuItemType extends RcMenuItemType {
+export type DataAttributes = {
+  [Key in `data-${string}`]: string;
+};
+
+export interface MenuItemType extends RcMenuItemType, DataAttributes {
   danger?: boolean;
   icon?: React.ReactNode;
   title?: string;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
Fixes #39518

### 💡 Background and Solution
Menu items accept data attributes but in a convoluted and a hacky way:
```tsx
<Dropdown 
  menu={{
    items, 
    ...{'data-testid': 'user-menu'}
  }} 
/>
```
This PR aims to fix that by allowing props starting with `data-`. This also avoids having to allow any props for menu item #53128(although menu item allows anything, only typescript errors.)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Menu items support data attributes |
| 🇨🇳 Chinese |           |
