### PR TITLE
test: update Affix component test case

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -29,7 +29,7 @@ const AffixMounter: React.FC<AffixProps> = (props) => {
   }, []);
   return (
     <div ref={container} className="container">
-      <Affix className="fixed" target={() => container.current} {...props}>
+      <Affix className="placeholder" target={() => container.current} {...props}>
         <Button type="primary">Fixed at the top of container</Button>
       </Affix>
     </div>
@@ -64,7 +64,7 @@ describe('Affix Render', () => {
   });
 
   const movePlaceholder = async (top: number) => {
-    classRect.fixed = { top, bottom: top } as DOMRect;
+    classRect.placeholder = { top, bottom: top } as DOMRect;
     if (events.scroll == null) {
       throw new Error('scroll should be set');
     }
@@ -183,7 +183,7 @@ describe('Affix Render', () => {
     });
 
     // Trigger inner and outer element for the two <ResizeObserver>s.
-    ['.ant-btn', '.fixed'].forEach((selector) => {
+    ['.ant-btn', '.placeholder'].forEach((selector) => {
       it(`trigger listener when size change: ${selector}`, async () => {
         const updateCalled = jest.fn();
         const { container } = render(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

### 🤔 This is a ...

- [ ] 🆕 New feature  
- [ ] 🐞 Bug fix  
- [ ] 📝 Site / documentation improvement  
- [ ] 📽️ Demo improvement  
- [ ] 💄 Component style improvement  
- [ ] 🤖 TypeScript definition improvement  
- [ ] 📦 Bundle size optimization  
- [ ] ⚡️ Performance optimization  
- [ ] ⭐️ Feature enhancement  
- [ ] 🌐 Internationalization  
- [ ] 🛠 Refactoring  
- [ ] 🎨 Code style optimization  
- [x] ✅ Test Case  
- [ ] 🔀 Branch merge  
- [ ] ⏩ Workflow  
- [ ] ⌨️ Accessibility improvement  
- [ ] ❓ Other (about what?)  

---

### 🔗 Related Issues

N/A

---

### 💡 Background and Solution

In the `Affix` component's test cases, we use a class-based mapping in `getBoundingClientRect` to simulate layout positioning for different elements.

Previously, the class name `.fixed` was used on the affixed element. However, in frontend development, `.fixed` is commonly associated with CSS `position: fixed` layout behavior. This naming overlap may cause confusion when reading tests, and could also lead to false assumptions about how the component is positioned.

To improve clarity and avoid semantic conflicts:

- The test class name `.fixed` has been replaced with `.placeholder` to better reflect its role as a layout reference point.
- Corresponding mocks in `classRect`, DOM simulation logic, and selector assertions are updated accordingly.

#### Why `.placeholder` is more appropriate

In frontend development, `placeholder` commonly refers to:

1. **Form placeholder text** (e.g. `<input placeholder="..." />`);
2. **Layout placeholder elements** — divs used to reserve space or act as measurement anchors;
3. **Test references** — simulated anchors or container elements for positioning logic.

In this context, `.placeholder` more accurately describes the element being used to simulate layout offset for scroll and affix behavior, without implying any specific CSS positioning. It reduces confusion for future contributors and better reflects test intent.

---

### 📝 Change Log

| Language   | Changelog                                                                 |
|------------|--------------------------------------------------------------------------|
| 🇺🇸 English | Optimize test by renaming class `.fixed` to `.placeholder` to avoid confusion with `position: fixed`. |
| 🇨🇳 Chinese | 优化 Affix 测试代码，将 `.fixed` 更名为 `.placeholder`，避免与 CSS 中的 `position: fixed` 含义混淆。 |

---

✅ Thank you for reviewing this pull request! Let me know if any revisions are needed.