### PR TITLE
Fix: Flex children is now optional instead of required.

### DIFF
--- a/components/flex/__tests__/index.test.tsx
+++ b/components/flex/__tests__/index.test.tsx
@@ -35,9 +35,32 @@ describe('Flex', () => {
     expect(container.querySelector('.ant-flex')).toHaveStyle({ justifyContent: 'center' });
     rerender(<Flex flex="0 1 auto">test</Flex>);
     expect(container.querySelector('.ant-flex')).toHaveStyle({ flex: '0 1 auto' });
-    rerender(<Flex gap={100}>test</Flex>);
-    expect(container.querySelector('.ant-flex')).toHaveStyle({ gap: '100px' });
   });
+
+  describe('Props: gap', () => {
+    it('support string', () => {
+      const { container } = render(<Flex id="flex-inherit" gap="inherit" />);
+
+      expect(container.querySelector('#flex-inherit')).toHaveStyle({
+        gap: 'inherit',
+      });
+    });
+
+    it('support number', () => {
+      const { container } = render(<Flex gap={100} />);
+
+      expect(container.querySelector('.ant-flex')).toHaveStyle({
+        gap: '100px',
+      });
+    });
+
+    it('support preset size', () => {
+      const { container } = render(<Flex gap="small" />);
+
+      expect(container.querySelector('.ant-flex')).toHaveClass('ant-flex-gap-small');
+    });
+  });
+
   it('Component work', () => {
     const testFcRef = React.createRef<HTMLDivElement>();
     const testClsRef = React.createRef<ClassCom>();

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
 
-import { isPresetSize, isValidGapNumber } from '../_util/gapSize';
+import { isPresetSize } from '../_util/gapSize';
 import { ConfigContext } from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import type { FlexProps } from './interface';
@@ -34,8 +34,6 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
 
   const mergedVertical = vertical ?? ctxFlex?.vertical;
 
-  const checkIfPresetSize = isPresetSize(gap);
-
   const mergedCls = classNames(
     className,
     rootClassName,
@@ -46,7 +44,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     createFlexClassNames(prefixCls, props),
     {
       [`${prefixCls}-rtl`]: ctxDirection === 'rtl',
-      [`${prefixCls}-gap-${gap}`]: checkIfPresetSize,
+      [`${prefixCls}-gap-${gap}`]: isPresetSize(gap),
       [`${prefixCls}-vertical`]: mergedVertical,
     },
   );
@@ -57,7 +55,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     mergedStyle.flex = flex;
   }
 
-  if (!checkIfPresetSize && isValidGapNumber(gap)) {
+  if (gap && !isPresetSize(gap)) {
     mergedStyle.gap = gap;
   }
 

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import omit from 'rc-util/lib/omit';
 
-import { isPresetSize } from '../_util/gapSize';
+import { isPresetSize, isValidGapNumber } from '../_util/gapSize';
 import { ConfigContext } from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import type { FlexProps } from './interface';
@@ -17,7 +17,6 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     style,
     flex,
     gap,
-    children,
     vertical = false,
     component: Component = 'div',
     ...othersProps
@@ -35,6 +34,8 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
 
   const mergedVertical = vertical ?? ctxFlex?.vertical;
 
+  const checkIfPresetSize = isPresetSize(gap);
+
   const mergedCls = classNames(
     className,
     rootClassName,
@@ -45,7 +46,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     createFlexClassNames(prefixCls, props),
     {
       [`${prefixCls}-rtl`]: ctxDirection === 'rtl',
-      [`${prefixCls}-gap-${gap}`]: isPresetSize(gap),
+      [`${prefixCls}-gap-${gap}`]: checkIfPresetSize,
       [`${prefixCls}-vertical`]: mergedVertical,
     },
   );
@@ -56,7 +57,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
     mergedStyle.flex = flex;
   }
 
-  if (gap && !isPresetSize(gap)) {
+  if (!checkIfPresetSize && isValidGapNumber(gap)) {
     mergedStyle.gap = gap;
   }
 
@@ -66,9 +67,7 @@ const Flex = React.forwardRef<HTMLElement, FlexProps>((props, ref) => {
       className={mergedCls}
       style={mergedStyle}
       {...omit(othersProps, ['justify', 'wrap', 'align'])}
-    >
-      {children}
-    </Component>,
+    />,
   );
 });
 

--- a/components/flex/interface.ts
+++ b/components/flex/interface.ts
@@ -12,6 +12,5 @@ export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLEleme
   align?: React.CSSProperties['alignItems'];
   flex?: React.CSSProperties['flex'];
   gap?: React.CSSProperties['gap'] | SizeType;
-  children: React.ReactNode;
   component?: CustomComponent<P>;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

Flex 组件从发布到  (5.26.5) 的版本 children 都是必填了，体验并不是很好，开发者其实可以选择先空着..

~~另外改进了一下 gap 的判断。 ~~  补充了一些测试用例

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Modify the `Flex` component's `children` option to be optional.     |
| 🇨🇳 Chinese |    修改 `Flex` 组件的 `children` 选项为可选项       |
