### PR TITLE
feat<Notification>:add delay props

### DIFF
--- a/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/notification/demo/basic.tsx extend context correctly 1`] = `
 <button
@@ -38,6 +38,50 @@ exports[`renders components/notification/demo/custom-style.tsx extend context co
 `;
 
 exports[`renders components/notification/demo/custom-style.tsx extend context correctly 2`] = `[]`;
+
+exports[`renders components/notification/demo/delay-show.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+>
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-divider ant-divider-horizontal"
+      role="separator"
+    />
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span>
+        Poor interaction effect
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span>
+        Good interaction effect
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`renders components/notification/demo/delay-show.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/notification/demo/duration.tsx extend context correctly 1`] = `
 <button

--- a/components/notification/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/notification/demo/basic.tsx correctly 1`] = `
 <button
@@ -31,6 +31,48 @@ exports[`renders components/notification/demo/custom-style.tsx correctly 1`] = `
     Open the notification box
   </span>
 </button>
+`;
+
+exports[`renders components/notification/demo/delay-show.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+>
+  <div
+    class="ant-space-item"
+  />
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-divider ant-divider-horizontal"
+      role="separator"
+    />
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span>
+        Poor interaction effect
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span>
+        Good interaction effect
+      </span>
+    </button>
+  </div>
+</div>
 `;
 
 exports[`renders components/notification/demo/duration.tsx correctly 1`] = `

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render as testLibRender } from '@testing-library/react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import { render as testLibRender } from '@testing-library/react';
 
 import notification from '..';
 import { act, fireEvent, pureRender, render } from '../../../tests/utils';
@@ -270,5 +270,34 @@ describe('notification.hooks', () => {
     expect(document.querySelectorAll('.custom .custom-close-icon').length).toBe(1);
     expect(document.querySelectorAll('.with-null .ant-notification-notice-close').length).toBe(0);
     expect(document.querySelectorAll('.with-false .ant-notification-notice-close').length).toBe(0);
+  });
+
+  it('support delay', () => {
+    const Demo = () => {
+      const [api, holder] = notification.useNotification();
+
+      return (
+        <>
+          <a onClick={() => api.info({ message: null, description: 'test', delay: 1000 })}>Show</a>
+          {holder}
+        </>
+      );
+    };
+
+    const { container } = render(<Demo />);
+    fireEvent.click(container.querySelector('a')!);
+
+    function getNoticeCount() {
+      return Array.from(document.querySelectorAll('.ant-notification-notice-wrapper')).filter(
+        (node) => !node.classList.contains('ant-notification-fade-leave'),
+      ).length;
+    }
+    expect(getNoticeCount()).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(getNoticeCount()).toBe(1);
   });
 });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -422,4 +422,27 @@ describe('notification', () => {
     });
     expect(document.querySelectorAll('.ant-notification-description').length).toBe(0);
   });
+
+  it('support delay', () => {
+    act(() => {
+      notification.open({
+        message: 'Notification Title',
+        delay: 1000,
+        className: 'with-style',
+      });
+    });
+
+    function getNoticeCount() {
+      return Array.from(document.querySelectorAll('.ant-notification-notice-wrapper')).filter(
+        (node) => !node.classList.contains('ant-notification-fade-leave'),
+      ).length;
+    }
+    expect(getNoticeCount()).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(getNoticeCount()).toBe(1);
+  });
 });

--- a/components/notification/demo/delay-show.md
+++ b/components/notification/demo/delay-show.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+高频（ `for`循环 ）展示 `notifications` 组件时，动画效果不好，可以设置 `delay` 属性，延迟显示下一个 `notification`。
+
+## en-US
+
+When you show `notifications` in a high frequency ( `for` loop ), the animation effect is not good. You can set the `delay` attribute to delay the display of the next `notification`.

--- a/components/notification/demo/delay-show.tsx
+++ b/components/notification/demo/delay-show.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button, Divider, notification, Space } from 'antd';
+
+const App: React.FC = () => {
+  const [api, contextHolder] = notification.useNotification({ stack: { threshold: 5 } });
+  const [loading, setLoading] = React.useState(false);
+
+  const openNotification = (delay?: number) => {
+    api.info({
+      message: `Notification Title`,
+      description: 'Notification description.',
+      delay,
+    });
+  };
+
+  return (
+    <Space>
+      {contextHolder}
+      <Divider />
+      <Button
+        type="primary"
+        onClick={() => {
+          for (let i = 0; i < 5; i++) {
+            openNotification();
+          }
+        }}
+      >
+        Poor interaction effect
+      </Button>
+      <Button
+        type="primary"
+        loading={loading}
+        onClick={() => {
+          setLoading(true);
+          for (let i = 0; i < 5; i++) {
+            openNotification(300 * i);
+          }
+          setTimeout(() => setLoading(false), 4 * 300);
+        }}
+      >
+        Good interaction effect
+      </Button>
+    </Space>
+  );
+};
+
+export default App;

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -31,6 +31,7 @@ To display a notification message at any of the four corners of the viewport. Ty
 <code src="./demo/update.tsx">Update Message Content</code>
 <code src="./demo/stack.tsx" version="5.10.0">Stack</code>
 <code src="./demo/show-with-progress.tsx" version="5.18.0">Show with progress</code>
+<code src="./demo/delay-show.tsx" version='5.2x.x'>Delay show</code>
 <code src="./demo/basic.tsx">Static Method (deprecated)</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 
@@ -53,6 +54,7 @@ The properties of config are as follows:
 | ~~btn~~ | Customized close button group, please use `actions` instead | ReactNode | - | - |
 | className | Customized CSS class | string | - | - |
 | closeIcon | Custom close icon | ReactNode | true | 5.7.0: close button will be hidden when setting to null or false |
+| delay | Delay time (in milliseconds) before showing the notification | number | - | 5.2x.x |
 | description | The content of notification box (required) | ReactNode | - | - |
 | duration | Time in seconds before Notification is closed. When set to 0 or null, it will never be closed automatically | number | 4.5 | - |
 | showProgress | Show progress bar for auto-closing notification | boolean |  | 5.18.0 |
@@ -75,6 +77,7 @@ The properties of config are as follows:
 | --- | --- | --- | --- | --- |
 | bottom | Distance from the bottom of the viewport, when `placement` is `bottom` `bottomRight` or `bottomLeft` (unit: pixels) | number | 24 |  |
 | closeIcon | Custom close icon | ReactNode | true | 5.7.0: close button will be hidden when setting to null or false |
+| delay | Delay time (in milliseconds) before showing the notification | number | - | 5.2x.x |
 | getContainer | Return the mount node for Notification | () => HTMLNode | () => document.body |  |
 | placement | Position of Notification, can be one of `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | string | `topRight` |  |
 | showProgress | Show progress bar for auto-closing notification | boolean |  | 5.18.0 |

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -158,12 +158,11 @@ function flushNotice() {
   taskQueue.forEach((task) => {
     switch (task.type) {
       case 'open': {
-        act(() => {
-          notification!.instance!.open({
-            ...defaultGlobalConfig,
-            ...task.config,
-          });
-        });
+        const { delay } = task.config;
+        const mergedConfig = { ...defaultGlobalConfig, ...task.config };
+        const open = () => act(() => notification!.instance!.open(mergedConfig));
+        // If delay has a value and is not 0, execute with delay
+        delay ? setTimeout(open, delay) : open();
         break;
       }
 

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -32,6 +32,7 @@ demo:
 <code src="./demo/update.tsx">更新消息内容</code>
 <code src="./demo/stack.tsx" version="5.10.0">堆叠</code>
 <code src="./demo/show-with-progress.tsx" version="5.18.0">显示进度条</code>
+<code src="./demo/delay-show.tsx" version='5.2x.x'>延时显示</code>
 <code src="./demo/basic.tsx">静态方法（不推荐）</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 
@@ -54,6 +55,7 @@ config 参数如下：
 | ~~btn~~ | 自定义按钮组，请使用 `actions` 替换 | ReactNode | - | - |
 | className | 自定义 CSS class | string | - | - |
 | closeIcon | 自定义关闭图标 | ReactNode | true | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
+| delay | 设置通知提醒框延迟显示的时间，单位为毫秒 | number | - | 5.2x.x |
 | description | 通知提醒内容，必选 | ReactNode | - | - |
 | duration | 默认 4.5 秒后自动关闭，配置为 null 则不自动关闭 | number | 4.5 | - |
 | showProgress | 显示自动关闭通知框的进度条 | boolean |  | 5.18.0 |
@@ -76,6 +78,7 @@ config 参数如下：
 | --- | --- | --- | --- | --- |
 | bottom | 消息从底部弹出时，距离底部的位置，单位像素 | number | 24 |  |
 | closeIcon | 自定义关闭图标 | ReactNode | true | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
+| delay | 设置通知提醒框延迟显示的时间，单位为毫秒 | number | - | 5.2x.x |
 | getContainer | 配置渲染节点的输出位置 | () => HTMLNode | () => document.body |  |
 | placement | 弹出位置，可选 `top` \| `topLeft` \| `topRight` \| `bottom` \| `bottomLeft` \| `bottomRight` | string | `topRight` |  |
 | showProgress | 显示自动关闭通知框的进度条 | boolean |  | 5.18.0 |

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -39,6 +39,7 @@ export interface ArgsProps {
   closable?: ClosableType;
   props?: DivProps;
   role?: 'alert' | 'status';
+  delay?: number;
 }
 
 type StaticFn = (args: ArgsProps) => void;

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -17,7 +17,7 @@ import type {
 } from './interface';
 import { getCloseIcon, PureContent } from './PurePanel';
 import useStyle from './style';
-import { getMotion, getPlacementStyle, getCloseIconConfig } from './util';
+import { getCloseIconConfig, getMotion, getPlacementStyle } from './util';
 
 const DEFAULT_OFFSET = 24;
 const DEFAULT_DURATION = 4.5;
@@ -154,6 +154,7 @@ export function useInternalNotification(
         role = 'alert',
         closeIcon,
         closable,
+        delay,
         ...restConfig
       } = config;
       if (process.env.NODE_ENV !== 'production') {
@@ -166,7 +167,7 @@ export function useInternalNotification(
         getCloseIconConfig(closeIcon, notificationConfig, notification),
       );
 
-      return originOpen({
+      const mergeNotificationConfig = {
         // use placement from props instead of hard-coding "topRight"
         placement: notificationConfig?.placement ?? DEFAULT_PLACEMENT,
         ...restConfig,
@@ -189,7 +190,16 @@ export function useInternalNotification(
         style: { ...notification?.style, ...style },
         closeIcon: realCloseIcon,
         closable: closable ?? !!realCloseIcon,
-      });
+      };
+
+      // If delay has a value and is not 0, execute with delay
+      if (delay) {
+        setTimeout(() => {
+          return originOpen(mergeNotificationConfig);
+        }, delay);
+      } else {
+        return originOpen(mergeNotificationConfig);
+      }
     };
 
     // >>> destroy


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [✔ ] 🆕 New feature


### 🔗 Related Issues

https://github.com/ant-design/ant-design/issues/47086

### 💡 Background and Solution

原先的[PR](https://github.com/ant-design/ant-design/pull/47688)好像烂尾了，这个PR修复方法，强制给open设置了300ms的延迟，会影响到原有的逻辑。

我这里直接加了一个delay参数，延迟显示

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add delay props     |
| 🇨🇳 Chinese |      新增delay参数     |
