### PR TITLE
Fix: Input variant=underlined use activeBorderColor

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -374,7 +374,7 @@ export const genBaseUnderlinedStyle = (
   },
 
   '&:focus, &:focus-within': {
-    borderColor: `transparent transparent ${options.borderColor} transparent`,
+    borderColor: `transparent transparent ${options.activeBorderColor} transparent`,
     outline: 0,
     backgroundColor: token.activeBg,
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> - close #54408

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Input variant=underlined use activeBorderColor      |
| 🇨🇳 Chinese |     Input 在 variant=underlined  底边框使用激活色     |
