### PR TITLE
fix[Input.Textarea]: fix textarea cursor position error after pasting text

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -174,18 +174,14 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
     const cursorPosition = textArea.selectionStart;
     // listen to the next input event, the DOM has been updated
     const handleInput = () => {
-      try {
-        isResetCursorPosition.current = true;
-        const newPosition = cursorPosition + pastedText.length;
-        textArea.setSelectionRange(newPosition, newPosition);
-        textArea.blur();
-        textArea.focus();
-        isResetCursorPosition.current = false;
-        // clean up the listener
-        textArea.removeEventListener('input', handleInput);
-      } catch {
-        isResetCursorPosition.current = false;
-      }
+      isResetCursorPosition.current = true;
+      const newPosition = cursorPosition + pastedText.length;
+      textArea.setSelectionRange(newPosition, newPosition);
+      textArea.blur();
+      textArea.focus();
+      isResetCursorPosition.current = false;
+      // clean up the listener
+      textArea.removeEventListener('input', handleInput);
     };
     textArea.addEventListener('input', handleInput, { once: true });
   };

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -58,6 +58,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
     showCount,
     onMouseDown,
     onResize,
+    onPaste,
     ...rest
   } = props;
 
@@ -163,6 +164,8 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
   };
 
   const onInternalPaste: RcTextAreaProps['onPaste'] = (e) => {
+    onPaste?.(e);
+
     const resizableTextArea = innerRef.current?.resizableTextArea;
     if (!resizableTextArea?.textArea) return;
 

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -99,6 +99,35 @@ describe('TextArea', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should reset cursor position after paste', async () => {
+    const { container } = render(<TextArea autoSize={{ minRows: 2, maxRows: 6 }} />);
+    const textArea = container.querySelector('textarea') as HTMLTextAreaElement;
+    // 模拟粘贴事件
+    const pasteData = 'pasted text\n'.repeat(10);
+    const clipboardData = {
+      getData: jest.fn().mockReturnValue(pasteData),
+    };
+
+    fireEvent.paste(textArea, {
+      clipboardData,
+    });
+
+    const expectedPosition = () => {
+      const position = pasteData.length;
+      expect(textArea.selectionStart).toBe(position);
+      expect(textArea.selectionEnd).toBe(position);
+    };
+
+    requestAnimationFrame(() => {
+      expectedPosition();
+      textArea.value = '';
+      fireEvent.paste(textArea, {
+        clipboardData,
+      });
+      requestAnimationFrame(expectedPosition);
+    });
+  });
+
   describe('maxLength', () => {
     it('should support maxLength', () => {
       const { asFragment } = render(<TextArea maxLength={10} />);

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -101,7 +101,10 @@ describe('TextArea', () => {
   });
 
   it('should reset cursor position after paste', async () => {
-    const { container } = render(<TextArea autoSize={{ minRows: 2, maxRows: 6 }} />);
+    const onPaste = jest.fn();
+    const { container } = render(
+      <TextArea autoSize={{ minRows: 2, maxRows: 6 }} onPaste={onPaste} />,
+    );
     const textArea = container.querySelector('textarea') as HTMLTextAreaElement;
     const pasteData = 'pasted text\n'.repeat(10);
     const clipboardData = {
@@ -109,6 +112,7 @@ describe('TextArea', () => {
     };
 
     const pasteEvent = () => {
+      fireEvent.focus(textArea);
       fireEvent.paste(textArea, {
         clipboardData,
         types: ['text/plain'],
@@ -116,6 +120,7 @@ describe('TextArea', () => {
       });
       // 模拟浏览器的 input 事件（在粘贴后自动触发）
       fireEvent.change(textArea, { target: { value: pasteData } });
+      expect(onPaste).toHaveBeenCalled();
     };
 
     const expectedPosition = () => {

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -106,6 +106,9 @@ describe('TextArea', () => {
       <TextArea autoSize={{ minRows: 2, maxRows: 6 }} onPaste={onPaste} />,
     );
     const textArea = container.querySelector('textarea') as HTMLTextAreaElement;
+    // 监听事件绑定和移除
+    const addEventListenerSpy = jest.spyOn(textArea, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(textArea, 'removeEventListener');
     const pasteData = 'pasted text\n'.repeat(10);
     const clipboardData = {
       getData: jest.fn().mockReturnValue(pasteData),
@@ -118,9 +121,21 @@ describe('TextArea', () => {
         types: ['text/plain'],
         items: [],
       });
-      // 模拟浏览器的 input 事件（在粘贴后自动触发）
       fireEvent.change(textArea, { target: { value: pasteData } });
+
       expect(onPaste).toHaveBeenCalled();
+
+      fireEvent.input(textArea, { target: { value: pasteData } });
+
+      act(() => {
+        expect(addEventListenerSpy).toHaveBeenCalledWith('input', expect.any(Function), {
+          once: true,
+        });
+        const inputListener = addEventListenerSpy.mock.calls.find(
+          (call) => call[0] === 'input',
+        )?.[1];
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('input', inputListener);
+      });
     };
 
     const expectedPosition = () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [https://github.com/ant-design/ant-design/issues/54444](https://github.com/ant-design/ant-design/issues/54444)

### 💡 Background and Solution
Input.Textarea cursor position error after pasting text
Listen to onPaste event and recalculate cursor position

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix Input.textarea cursor position error after pasting text |
| 🇨🇳 Chinese | 修复粘贴文本后 Input.textarea 光标位置错误 |
