### PR TITLE
fix(Card): update the type of tabBarExtraContent in Card component

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import type { Tab } from 'rc-tabs/lib/interface';
+import type { Tab, TabBarExtraContent } from 'rc-tabs/lib/interface';
 import omit from 'rc-util/lib/omit';
 
 import { devUseWarning } from '../_util/warning';
@@ -47,7 +47,7 @@ export interface CardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 't
   cover?: React.ReactNode;
   actions?: React.ReactNode[];
   tabList?: CardTabListType[];
-  tabBarExtraContent?: React.ReactNode;
+  tabBarExtraContent?: TabBarExtraContent;
   onTabChange?: (key: string) => void;
   activeTabKey?: string;
   defaultActiveTabKey?: string;

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Card correct pass tabList props 1`] = `
 <div
@@ -337,6 +337,35 @@ exports[`Card should support custom styles 1`] = `
     <div
       class="ant-card-head"
       style="color: red;"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Card title
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <p>
+        Card content
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card should support left and right properties for tabBarExtraContent props 1`] = `
+<div>
+  <div
+    class="ant-card ant-card-bordered"
+  >
+    <div
+      class="ant-card-head"
     >
       <div
         class="ant-card-head-wrapper"

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -244,7 +244,6 @@ describe('Card', () => {
       </Card>,
     );
 
-    expect(container.querySelector('.ant-card-extra-left')).toBeTruthy();
-    expect(container.querySelector('.ant-card-extra-right')).toBeTruthy();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -2,13 +2,14 @@ import '@testing-library/jest-dom';
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { TabBarExtraContent } from 'rc-tabs/lib/interface';
 
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, screen } from '../../../tests/utils';
 import Button from '../../button/index';
-import Card from '../index';
 import ConfigProvider from '../../config-provider';
+import Card from '../index';
 
 describe('Card', () => {
   mountTest(Card);
@@ -229,5 +230,21 @@ describe('Card', () => {
 
     fireEvent.click(getByText('Set outlined'));
     expect(container.querySelector('.ant-card-bordered')).toBeTruthy();
+  });
+
+  it('should support left and right properties for tabBarExtraContent props', () => {
+    const tabBarExtraContent: TabBarExtraContent = {
+      left: <span>Left</span>,
+      right: <span>Right</span>,
+    };
+
+    const { container } = render(
+      <Card title="Card title" tabBarExtraContent={tabBarExtraContent}>
+        <p>Card content</p>
+      </Card>,
+    );
+
+    expect(container.querySelector('.ant-card-extra-left')).toBeTruthy();
+    expect(container.querySelector('.ant-card-extra-right')).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx


### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.


I’ve updated the type of tabBarExtraContent in the Card component from React.ReactNode to TabBarExtraContent from rc-tabs.
This change ensures accurate typing, since rc-tabs supports both React.ReactNode and { left?: React.ReactNode; right?: React.ReactNode }.
Previously, Ant Design’s type definition only allowed React.ReactNode, which restricted the full usage of rc-tabs’ feature.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Card: Fixed `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`.  |
| 🇨🇳 Chinese |     Card：修复 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。      |
