### PR TITLE
docs: add 5.26.7 changelog

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,7 +19,7 @@ tag: vVERSION
 
 `2025-07-28`
 
-- 🐞 Card: Fixed `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`. [#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
+- 🐞 Fixed Card `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`. [#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
 
 ## 5.26.6
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,12 @@ tag: vVERSION
 
 ---
 
+## 5.26.7
+
+`2025-07-27`
+
+- 🐞 Card: Fixed `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`. [#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
+
 ## 5.26.6
 
 `2025-07-20`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,7 +17,7 @@ tag: vVERSION
 
 ## 5.26.7
 
-`2025-07-27`
+`2025-07-28`
 
 - 🐞 Card: Fixed `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`. [#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,7 +19,7 @@ tag: vVERSION
 
 `2025-07-28`
 
-- 🐞 Card 修复 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。[#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
+- 🐞 修复 Card 的 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。[#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
 
 ## 5.26.6
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,7 +17,7 @@ tag: vVERSION
 
 ## 5.26.7
 
-`2025-07-27`
+`2025-07-28`
 
 - 🐞 Card 修复 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。[#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,12 @@ tag: vVERSION
 
 ---
 
+## 5.26.7
+
+`2025-07-27`
+
+- 🐞 Card 修复 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。[#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
+
 ## 5.26.6
 
 `2025-07-20`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "5.26.6",
+  "version": "5.26.7",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
## 5.26.7

`2025-07-27`

- 🐞 Card: Fixed `tabBarExtraContent` typing to support both `React.ReactNode` and `{ left?: React.ReactNode; right?: React.ReactNode }` using `TabBarExtraContent` from `rc-tabs`. [#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)

---------------------

`2025-07-27`

- 🐞 Card 修复 `tabBarExtraContent` 类型定义，仅支持 `React.ReactNode` 的问题。现在支持完整的 `rc-tabs` 类型，包括 `{ left?: React.ReactNode; right?: React.ReactNode }`。[#54470](https://github.com/ant-design/ant-design/pull/54470) [@pueding](https://github.com/pueding)
