### PR TITLE
fix: Adjusted the Carousel dot background to prevent white gaps durin…

### DIFF
--- a/components/carousel/style/index.ts
+++ b/components/carousel/style/index.ts
@@ -277,7 +277,7 @@ const genDotsStyle: GenerateStyle<CarouselToken> = (token) => {
             width: '100%',
             height: dotHeight,
             content: '""',
-            background: colorBgContainer,
+            background: 'transparent',
             borderRadius: dotHeight,
             opacity: 1,
             outline: 'none',
@@ -321,6 +321,7 @@ const genDotsStyle: GenerateStyle<CarouselToken> = (token) => {
               opacity: 1,
             },
             '&::after': {
+              background: colorBgContainer,
               transform: 'translate3d(0, 0, 0)',
               transition: `transform var(${DotDuration}) ease-out`,
             },


### PR DESCRIPTION
…g animation

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- close #54512 

### 💡 Background and Solution

> By setting the initial background color to transparent, the original color is applied only when the slick item becomes active.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Adjusted the Carousel dot background to prevent white gaps during animation.      |
| 🇨🇳 Chinese |      修复轮播图动画中的白缝问题     |
