### PR TITLE
fix(Menu): Set correct value type for MenuItem data attributes

### DIFF
--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -6,7 +6,7 @@ import type {
 } from 'rc-menu/lib/interface';
 
 export type DataAttributes = {
-  [Key in `data-${string}`]: any;
+  [Key in `data-${string}`]: string | number | boolean;
 };
 
 export interface MenuItemType extends RcMenuItemType, DataAttributes {

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -6,7 +6,7 @@ import type {
 } from 'rc-menu/lib/interface';
 
 export type DataAttributes = {
-  [Key in `data-${string}`]: string | number;
+  [Key in `data-${string}`]: any;
 };
 
 export interface MenuItemType extends RcMenuItemType, DataAttributes {

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -6,7 +6,7 @@ import type {
 } from 'rc-menu/lib/interface';
 
 export type DataAttributes = {
-  [Key in `data-${string}`]: unknown; // data- attributes can be anything but we avoid using `any`. As we don't use the attributes anywhere ourselves, we don't care what type they actually have, hence `unknown`
+  [Key in `data-${string}`]: unknown;
 };
 
 export interface MenuItemType extends RcMenuItemType, DataAttributes {

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -6,7 +6,7 @@ import type {
 } from 'rc-menu/lib/interface';
 
 export type DataAttributes = {
-  [Key in `data-${string}`]: string | number | boolean;
+  [Key in `data-${string}`]: unknown; // data- attributes can be anything but we avoid using `any`. As we don't use the attributes anywhere ourselves, we don't care what type they actually have, hence `unknown`
 };
 
 export interface MenuItemType extends RcMenuItemType, DataAttributes {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix #54393
- See [this comment](https://github.com/ant-design/ant-design/pull/54393#pullrequestreview-3070822527)

Here is a quick TS playground to illustrate the issue:

https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wChTgA7GJKTdJRNAWSUoFcBJGkAFQE8wjAN6k4cTBAgAuOAGcYUKgHMA9KrgArdgrgpKcJAA8U4ADZJSAX3LHIsODEGMAIihgoAgjEXAARuw0cnAAvHCi4gDaANJI-HBUcAAGACbuKAC0ACTCCkqUylZJALqyHCB+tHAAPvK+BQDc1k0U1LT0aIysHN6+AUGGRjSUKcFuHr1K-UhyADRM3Vw8AkLhYuJwaQW0APyyflIW+k0bCWgQlHuIxDAAdMjoMAByEClIJxswwDAWV3kqH3E6jgt1B1nImHYlAwwAucAAwrhIJQ2DAABRgHBgOSyRaTfyBGYASjWpyIMHYUAMHDMZjgwJSEBmcEoEHgIHcNCgcAAFrRLDYIVCYXDEeALqjeDN4GiSRENuTKQYADwAPnW4mVYuRqIkUhC+D8KCg+E26QykggZo8GSNUBCwnoZjkSCs1syRoAXiEAEQAVh99NV9I0MB5wGCEYkVCQ8xQkfgch5EHYZhScEqGrgWqREuo7otUgLdodTpdbrSNq9voDQZDjnDkeC53MKCoKgb7mSlqSCWCIAjchUcYT8mTqfTmdOytU6sF50ouggfk0SAwUoUAEZcWx2PjpsEwvKgQAqOAvGjzZMAdwbjFoOCgwUqZggt7k15QtLfd70GHYX6GFAj7zGGXZJD2fZwAOchDgUACEcAnqoWb4JWmSWvgsiKOwsb1kmKZphmjCYDGqHobaxpYRIX4uvMwIEROejOlalTRiiejBPo8Rsny3IAG5frhnHXI8cDXsAtJwOcwFrj88SYhA-HAG8hj8bQ-Bhh28Z6Mk-wFL2MBWmGrgAPLMCyrwzOR5petR+AACwAExkPOFxLiuckbjATk7j0PhTISh6khsqhnsAmC-hRnKBQMpHwFQRm-kkeIBQSQSGc48xJMuq7rtKTm9lGglmCp7hIOmMlEBgZjxPo6YEdewQmUB0BQKBPLgZBUYwXByhIShpxoeamGyA5sw2VWKCevZLnWEAA

See, how in line 30, the objectTest1 does not show the correct error, as objectTest2 in line 37.

### 💡 Background and Solution

The newly introduced type was incorrect and broke type inference as well as existing code that was using the `MenuItemType` on objects.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu component data-* attributes only accepting `number | string`. |
| 🇨🇳 Chinese | 修复菜单组件 data-* 属性只接受 `number | string` 的问题。|