### PR TITLE
feat: Adapt text color based on Tooltip color

### DIFF
--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/tooltip/demo/arrow.tsx extend context correctly 1`] = `
 Array [
@@ -1224,7 +1224,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(255, 85, 0);"
+            style="background: rgb(255, 85, 0); --ant-tooltip-color: #000;"
           >
             prompt text
           </div>
@@ -1258,7 +1258,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(45, 183, 245);"
+            style="background: rgb(45, 183, 245); --ant-tooltip-color: #000;"
           >
             prompt text
           </div>
@@ -1292,7 +1292,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(135, 208, 104);"
+            style="background: rgb(135, 208, 104); --ant-tooltip-color: #000;"
           >
             prompt text
           </div>
@@ -1326,7 +1326,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(16, 142, 233);"
+            style="background: rgb(16, 142, 233); --ant-tooltip-color: #000;"
           >
             prompt text
           </div>
@@ -2217,7 +2217,7 @@ Array [
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-        style="background: rgb(255, 85, 0);"
+        style="background: rgb(255, 85, 0); --ant-tooltip-color: #000;"
       >
         Hello, Customize Color Pure Panel!
       </div>

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1224,7 +1224,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(255, 85, 0); --ant-tooltip-color: #000;"
+            style="background: rgb(255, 85, 0); --ant-tooltip-color: #FFF;"
           >
             prompt text
           </div>
@@ -1326,7 +1326,7 @@ Array [
             class="ant-tooltip-inner"
             id="test-id"
             role="tooltip"
-            style="background: rgb(16, 142, 233); --ant-tooltip-color: #000;"
+            style="background: rgb(16, 142, 233); --ant-tooltip-color: #FFF;"
           >
             prompt text
           </div>
@@ -2217,7 +2217,7 @@ Array [
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-        style="background: rgb(255, 85, 0); --ant-tooltip-color: #000;"
+        style="background: rgb(255, 85, 0); --ant-tooltip-color: #FFF;"
       >
         Hello, Customize Color Pure Panel!
       </div>

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -981,7 +981,7 @@ Array [
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-        style="background:#f50;--ant-tooltip-color:#000"
+        style="background:#f50;--ant-tooltip-color:#FFF"
       >
         Hello, Customize Color Pure Panel!
       </div>

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/tooltip/demo/arrow.tsx correctly 1`] = `
 Array [
@@ -981,7 +981,7 @@ Array [
       <div
         class="ant-tooltip-inner"
         role="tooltip"
-        style="background:#f50"
+        style="background:#f50;--ant-tooltip-color:#000"
       >
         Hello, Customize Color Pure Panel!
       </div>

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -14,6 +14,7 @@ import Input from '../../input';
 import Group from '../../input/Group';
 import Radio from '../../radio';
 import Switch from '../../switch';
+import { parseColor } from '../util';
 import { isTooltipOpen } from './util';
 
 describe('Tooltip', () => {
@@ -638,5 +639,45 @@ describe('Tooltip', () => {
     // 验证 styles
     expect(tooltipElement.style.backgroundColor).toBe('blue');
     expect(tooltipBodyElement.style.color).toBe('red');
+  });
+
+  describe('parseColor', () => {
+    const prefixCls = 'ant-tooltip';
+    it('should set white text for dark backgrounds', () => {
+      const darkColor = '#003366'; // 深色
+      const { overlayStyle } = parseColor(prefixCls, darkColor);
+
+      expect(overlayStyle.background).toBe(darkColor);
+      expect(overlayStyle['--ant-tooltip-color']).toBe('#FFF');
+    });
+
+    it('should set black text for light backgrounds', () => {
+      const lightColor = '#f8f8f8';
+      const { overlayStyle } = parseColor(prefixCls, lightColor);
+
+      expect(overlayStyle.background).toBe(lightColor);
+      expect(overlayStyle['--ant-tooltip-color']).toBe('#000');
+    });
+    it('actual tooltip color rendering(defult)', () => {
+      const { container } = render(
+        <Tooltip title="Test" color="#003366" open>
+          <span>Hover me</span>
+        </Tooltip>,
+      );
+
+      const tooltipInner = container.querySelector('.ant-tooltip-inner');
+
+      expect(tooltipInner).toHaveStyle('--ant-tooltip-color: #FFF');
+    });
+    it('actual tooltip color rendering (styles)', () => {
+      const { container } = render(
+        <Tooltip title="Test" open color="#003366" styles={{ body: { color: 'rgb(0, 255, 255)' } }}>
+          <span>Hover me</span>
+        </Tooltip>,
+      );
+
+      const tooltipInner = container.querySelector('.ant-tooltip-inner');
+      expect(getComputedStyle(tooltipInner!).color).toBe('rgb(0, 255, 255)');
+    });
   });
 });

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -33,7 +33,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     calc,
     componentCls, // ant-tooltip
     tooltipMaxWidth,
-    tooltipColor,
     tooltipBg,
     tooltipBorderRadius,
     zIndexPopup,
@@ -80,7 +79,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
           minWidth: centerAlignMinWidth,
           minHeight: controlHeight,
           padding: `${unit(token.calc(paddingSM).div(2).equal())} ${unit(paddingXS)}`,
-          color: tooltipColor,
+          color: 'var(--ant-tooltip-color)',
           textAlign: 'start',
           textDecoration: 'none',
           wordWrap: 'break-word',

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -33,6 +33,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     calc,
     componentCls, // ant-tooltip
     tooltipMaxWidth,
+    tooltipColor,
     tooltipBg,
     tooltipBorderRadius,
     zIndexPopup,
@@ -79,7 +80,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
           minWidth: centerAlignMinWidth,
           minHeight: controlHeight,
           padding: `${unit(token.calc(paddingSM).div(2).equal())} ${unit(paddingXS)}`,
-          color: 'var(--ant-tooltip-color)',
+          color: `var(--ant-tooltip-color,${tooltipColor})`,
           textAlign: 'start',
           textDecoration: 'none',
           wordWrap: 'break-word',

--- a/components/tooltip/util.ts
+++ b/components/tooltip/util.ts
@@ -2,6 +2,8 @@ import type * as React from 'react';
 import classNames from 'classnames';
 
 import { isPresetColor } from '../_util/colors';
+import { ColorGenInput } from '../color-picker/interface';
+import { generateColor } from '../color-picker/util';
 
 export function parseColor(prefixCls: string, color?: string) {
   const isInternalColor = isPresetColor(color);
@@ -12,9 +14,12 @@ export function parseColor(prefixCls: string, color?: string) {
 
   const overlayStyle: React.CSSProperties = {};
   const arrowStyle: React.CSSProperties = {};
+  const colorRgb = generateColor(color as ColorGenInput);
+  const textColor = colorRgb.toHsb().b < 0.7 ? '#FFF' : '#000';
 
   if (color && !isInternalColor) {
     overlayStyle.background = color;
+    overlayStyle['--ant-tooltip-color'] = textColor;
     // @ts-ignore
     arrowStyle['--antd-arrow-background-color'] = color;
   }

--- a/components/tooltip/util.ts
+++ b/components/tooltip/util.ts
@@ -15,7 +15,8 @@ export function parseColor(prefixCls: string, color?: string) {
   const overlayStyle: React.CSSProperties = {};
   const arrowStyle: React.CSSProperties = {};
   const colorRgb = generateColor(color as ColorGenInput);
-  const textColor = colorRgb.toHsb().b < 0.7 ? '#FFF' : '#000';
+  const { b, s } = colorRgb.toHsb();
+  const textColor = b < 0.7 || s > 0.3 ? '#FFF' : '#000';
 
   if (color && !isInternalColor) {
     overlayStyle.background = color;

--- a/components/tooltip/util.ts
+++ b/components/tooltip/util.ts
@@ -14,10 +14,9 @@ export function parseColor(prefixCls: string, color?: string) {
 
   const overlayStyle: React.CSSProperties = {};
   const arrowStyle: React.CSSProperties = {};
-  const colorRgb = generateColor(color as ColorGenInput);
-  const { b, s } = colorRgb.toHsb();
-  const textColor = b < 0.7 || s > 0.3 ? '#FFF' : '#000';
-
+  const rgb = generateColor(color as ColorGenInput).toRgb();
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  const textColor = luminance < 0.5 ? '#FFF' : '#000';
   if (color && !isInternalColor) {
     overlayStyle.background = color;
     overlayStyle['--ant-tooltip-color'] = textColor;


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

https://github.com/ant-design/ant-design/issues/53893

### 💡 Background and Solution


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Adjust the text color based on the configured Tooltip props.color     |
| 🇨🇳 Chinese |      根据配置的背景色props.color 调整文字颜色    |
