### PR TITLE
fix<Input.OTP>: css token usage error

### DIFF
--- a/components/input/style/otp.ts
+++ b/components/input/style/otp.ts
@@ -26,7 +26,7 @@ const genOTPStyle: GenerateStyle<InputToken> = (token) => {
         },
         [`${componentCls}-mask-input`]: {
           color: 'transparent',
-          caretColor: 'var(--ant-color-text)',
+          caretColor: token.colorText,
         },
         [`${componentCls}-mask-input[type=number]::-webkit-inner-spin-button`]: {
           '-webkit-appearance': 'none',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54575

### 💡 Background and Solution

将css中`var(--ant-color-text)`修改为`token.colorText`，如果修改了prefixCls的值，--ant-color-text则没有被定义

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Input.OTP caretColor is wrong when customize `prefixCls`.   |
| 🇨🇳 Chinese |     修复自定义 `prefixCls` 时 Input.OTP 光标颜色不对的问题。     |
