### PR TITLE
fix(Space.Compact):Border cropping issue

### DIFF
--- a/components/style/compact-item-vertical.ts
+++ b/components/style/compact-item-vertical.ts
@@ -1,17 +1,25 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 
-import type { AliasToken, FullToken, OverrideComponent, CSSUtil } from '../theme/internal';
+import type { AliasToken, CSSUtil, FullToken, OverrideComponent } from '../theme/internal';
 
-function compactItemVerticalBorder(token: AliasToken & CSSUtil, parentCls: string): CSSObject {
+function compactItemVerticalBorder(
+  token: AliasToken & CSSUtil,
+  parentCls: string,
+  prefixCls: string,
+): CSSObject {
   return {
     // border collapse
     [`&-item:not(${parentCls}-last-item)`]: {
       marginBottom: token.calc(token.lineWidth).mul(-1).equal(),
     },
 
+    [`&-item:not(${prefixCls}-status-success)`]: {
+      zIndex: 3,
+    },
+
     '&-item': {
       '&:hover,&:focus,&:active': {
-        zIndex: 2,
+        zIndex: 3,
       },
 
       '&[disabled]': {
@@ -50,7 +58,7 @@ export function genCompactItemVerticalStyle<T extends OverrideComponent>(
 
   return {
     [compactCls]: {
-      ...compactItemVerticalBorder(token, compactCls),
+      ...compactItemVerticalBorder(token, compactCls, token.componentCls),
       ...compactItemBorderVerticalRadius(token.componentCls, compactCls),
     },
   };

--- a/components/style/compact-item-vertical.ts
+++ b/components/style/compact-item-vertical.ts
@@ -14,7 +14,7 @@ function compactItemVerticalBorder(
     },
 
     [`&-item:not(${prefixCls}-status-success)`]: {
-      zIndex: 3,
+      zIndex: 2,
     },
 
     '&-item': {

--- a/components/style/compact-item.ts
+++ b/components/style/compact-item.ts
@@ -1,6 +1,6 @@
 import type { CSSInterpolation, CSSObject } from '@ant-design/cssinjs';
 
-import type { AliasToken, FullToken, OverrideComponent, CSSUtil } from '../theme/internal';
+import type { AliasToken, CSSUtil, FullToken, OverrideComponent } from '../theme/internal';
 
 interface CompactItemOptions {
   focus?: boolean;
@@ -21,6 +21,7 @@ function compactItemBorder(
   token: AliasToken & CSSUtil,
   parentCls: string,
   options: CompactItemOptions,
+  prefixCls: string,
 ): CSSObject {
   const { focusElCls, focus, borderElCls } = options;
   const childCombinator = borderElCls ? '> *' : '';
@@ -28,20 +29,25 @@ function compactItemBorder(
     .filter(Boolean)
     .map((n) => `&:${n} ${childCombinator}`)
     .join(',');
+
   return {
     [`&-item:not(${parentCls}-last-item)`]: {
       marginInlineEnd: token.calc(token.lineWidth).mul(-1).equal(),
     },
 
+    [`&-item:not(${prefixCls}-status-success)`]: {
+      zIndex: 2,
+    },
+
     '&-item': {
       [hoverEffects]: {
-        zIndex: 2,
+        zIndex: 3,
       },
 
       ...(focusElCls
         ? {
             [`&${focusElCls}`]: {
-              zIndex: 2,
+              zIndex: 3,
             },
           }
         : {}),
@@ -95,7 +101,7 @@ export function genCompactItemStyle<T extends OverrideComponent>(
 
   return {
     [compactCls]: {
-      ...compactItemBorder(token, compactCls, options),
+      ...compactItemBorder(token, compactCls, options, componentCls),
       ...compactItemBorderRadius(componentCls, compactCls, options),
     },
   };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
 💄 Component style improvement

### 🔗 Related Issues
https://github.com/ant-design/ant-design/issues/54573

### 💡 Background and Solution

边框裁剪问题
原始：
disabled z-index = 0
所有的校验状态z-index = 1
hover、focus、 active状态z-index = 2
调整后：
disabled z-index = 0
校验成功z-index = 1
除校验成功状态z-index = 2
hover、focus、 active状态z-index = 3


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Border cropping issue     |
| 🇨🇳 Chinese |     边框裁剪问题      |
