### PR TITLE
Fix hover/active text color of filled button with href

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -349,9 +349,11 @@ const genPresetColorStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
           token,
           lightColor,
           {
+            color: darkColor,
             background: lightHoverColor,
           },
           {
+            color: darkColor,
             background: lightBorderColor,
           },
         ),
@@ -411,9 +413,11 @@ const genDefaultButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     token,
     token.colorFillTertiary,
     {
+      color: token.defaultColor,
       background: token.colorFillSecondary,
     },
     {
+      color: token.defaultColor,
       background: token.colorFill,
     },
   ),
@@ -468,9 +472,11 @@ const genPrimaryButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => 
     token,
     token.colorPrimaryBg,
     {
+      color: token.colorPrimary,
       background: token.colorPrimaryBgHover,
     },
     {
+      color: token.colorPrimary,
       background: token.colorPrimaryBorder,
     },
   ),
@@ -556,9 +562,11 @@ const genDangerousStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
     token,
     token.colorErrorBg,
     {
+      color: token.colorError,
       background: token.colorErrorBgFilledHover,
     },
     {
+      color: token.colorError,
       background: token.colorErrorBgActive,
     },
   ),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Filled buttons in hover/active doesn't have `color` property set which means that anchor tag color has a higher specificity than their base text color.

Before

<img width="76" height="205" alt="image" src="https://github.com/user-attachments/assets/c0f5b308-b81c-48a4-93ad-f416c154d506" />

After
<img width="76" height="205" alt="Screenshot From 2025-08-06 19-33-35" src="https://github.com/user-attachments/assets/ac832102-fc37-4168-9a4c-447a36e95465" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix hover/active text color of button with `variant="filled"` and  `href` set|
| 🇨🇳 Chinese | 修復 `variant="filled"` 並設置 `href` 的按鈕在懸停/點擊時的文字顏色|

Chinese changelog was generated using LLM, feel free to change it