### PR TITLE
docs: improve icon search expierence

### DIFF
--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -10,7 +10,8 @@ import debounce from 'lodash/debounce';
 import Category from './Category';
 import type { CategoriesKeys } from './fields';
 import { all, categories } from './fields';
-import type { IconName, IconsMeta } from './meta/index';
+import metaInfo from './meta';
+import type { IconName, IconsMeta } from './meta';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 
 export enum ThemeType {
@@ -53,10 +54,9 @@ const IconSearch: React.FC = () => {
     setDisplayState((prevState) => ({ ...prevState, theme: value as ThemeType }));
   }, []);
 
-  const renderCategories = useMemo<React.ReactNode | React.ReactNode[]>(async () => {
+  const renderCategories = useMemo<React.ReactNode | React.ReactNode[]>(() => {
     const { searchKey = '', theme } = displayState;
     // console.log('displayState:', displayState);
-    const metaInfo = await importIconsMeta();
     // console.log('metaInfo:', metaInfo);
     // loop over metaInfo to find all the icons which has searchKey in their tags
     let normalizedSearchKey = searchKey?.trim();
@@ -188,10 +188,6 @@ const IconSearch: React.FC = () => {
 };
 
 export default IconSearch;
-
-async function importIconsMeta(): Promise<IconsMeta> {
-  return (await import(`./meta/index`)).default;
-}
 
 type MatchedCategory = {
   category: string;

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -47,7 +47,7 @@ const IconSearch: React.FC = () => {
 
   const handleSearchIcon = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
     setDisplayState((prevState) => ({ ...prevState, searchKey: e.target.value }));
-  }, 300);
+  }, 400);
 
   const handleChangeTheme = useCallback((value: ThemeType) => {
     setDisplayState((prevState) => ({ ...prevState, theme: value as ThemeType }));

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -9,7 +9,7 @@ import debounce from 'lodash/debounce';
 
 import Category from './Category';
 import type { CategoriesKeys } from './fields';
-import { categories } from './fields';
+import { all, categories } from './fields';
 import type { IconName, IconsMeta } from './meta/index';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 
@@ -170,7 +170,10 @@ const IconSearch: React.FC = () => {
             onChange={handleChangeTheme}
           />
           <Input.Search
-            placeholder={intl.formatMessage({ id: 'app.docs.components.icon.search.placeholder' })}
+            placeholder={intl.formatMessage(
+              { id: 'app.docs.components.icon.search.placeholder' },
+              { total: all.length },
+            )}
             style={{ flex: 1, marginInlineStart: 16 }}
             allowClear
             autoFocus

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -10,6 +10,7 @@ import debounce from 'lodash/debounce';
 import Category from './Category';
 import type { CategoriesKeys } from './fields';
 import { categories } from './fields';
+import type { IconName, IconsMeta } from './meta/index';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 
 export enum ThemeType {
@@ -52,18 +53,30 @@ const IconSearch: React.FC = () => {
     setDisplayState((prevState) => ({ ...prevState, theme: value as ThemeType }));
   }, []);
 
-  const renderCategories = useMemo<React.ReactNode | React.ReactNode[]>(() => {
+  const renderCategories = useMemo<React.ReactNode | React.ReactNode[]>(async () => {
     const { searchKey = '', theme } = displayState;
+    // console.log('displayState:', displayState);
+    const metaInfo = await importIconsMeta();
+    // console.log('metaInfo:', metaInfo);
+    // loop over metaInfo to find all the icons which has searchKey in their tags
+    let normalizedSearchKey = searchKey?.trim();
 
-    const categoriesResult = Object.keys(categories)
-      .map((key) => {
+    if (normalizedSearchKey) {
+      normalizedSearchKey = normalizedSearchKey
+        .replace(/^<([a-z]*)\s\/>$/gi, (_, name) => name)
+        .replace(/(Filled|Outlined|TwoTone)$/, '')
+        .toLowerCase();
+    }
+
+    const tagMatchedCategoryObj = matchCategoriesFromTag(normalizedSearchKey, metaInfo);
+
+    // console.log('categoriesMatchedAgainstTag:', tagMatchedCategoryObj);
+
+    const namedMatchedCategoryObj = Object.keys(categories).reduce(
+      (acc, key) => {
         let iconList = categories[key as CategoriesKeys];
-        if (searchKey) {
-          const matchKey = searchKey
-
-            .replace(/^<([a-z]*)\s\/>$/gi, (_, name) => name)
-            .replace(/(Filled|Outlined|TwoTone)$/, '')
-            .toLowerCase();
+        if (normalizedSearchKey) {
+          const matchKey = normalizedSearchKey;
           iconList = iconList.filter((iconName) => iconName.toLowerCase().includes(matchKey));
         }
 
@@ -73,23 +86,44 @@ const IconSearch: React.FC = () => {
         ];
         iconList = iconList.filter((icon) => !ignore.includes(icon));
 
-        return {
+        acc[key] = {
           category: key,
-          icons: iconList
-            .map((iconName) => iconName + theme)
-            .filter((iconName) => allIcons[iconName]),
+          icons: iconList,
         };
+
+        return acc;
+      },
+      {} as Record<string, MatchedCategory>,
+    );
+
+    // merge matched categories from tag search
+    const merged = mergeCategory(namedMatchedCategoryObj, tagMatchedCategoryObj);
+    // console.log(
+    //   'namedMatchedCategoryObj, tagMatchedCategoryObj:',
+    //   namedMatchedCategoryObj,
+    //   tagMatchedCategoryObj,
+    // );
+    // console.log('merged:', merged);
+    const matchedCategories = Object.values(merged)
+      .map((item) => {
+        item.icons = item.icons
+          .map((iconName) => iconName + theme)
+          .filter((iconName) => allIcons[iconName]);
+
+        return item;
       })
-      .filter(({ icons }) => !!icons.length)
-      .map(({ category, icons }) => (
-        <Category
-          key={category}
-          title={category as CategoriesKeys}
-          theme={theme}
-          icons={icons}
-          newIcons={newIconNames}
-        />
-      ));
+      .filter(({ icons }) => !!icons.length);
+    // console.log('matchedCategories:', matchedCategories);
+
+    const categoriesResult = matchedCategories.map(({ category, icons }) => (
+      <Category
+        key={category}
+        title={category as CategoriesKeys}
+        theme={theme}
+        icons={icons}
+        newIcons={newIconNames}
+      />
+    ));
     return categoriesResult.length ? categoriesResult : <Empty style={{ margin: '2em 0' }} />;
   }, [displayState.searchKey, displayState.theme]);
 
@@ -151,3 +185,62 @@ const IconSearch: React.FC = () => {
 };
 
 export default IconSearch;
+
+async function importIconsMeta(): Promise<IconsMeta> {
+  return (await import(`./meta/index`)).default;
+}
+
+type MatchedCategory = {
+  category: string;
+  icons: string[];
+};
+
+function matchCategoriesFromTag(
+  searchKey: string,
+  metaInfo: IconsMeta,
+): Record<string, MatchedCategory> {
+  if (!searchKey) {
+    return {};
+  }
+
+  return Object.keys(metaInfo).reduce(
+    (acc, key) => {
+      const icon = metaInfo[key as IconName];
+      const category = icon.category;
+
+      if (icon.tags.some((tag) => tag.toLowerCase().includes(searchKey))) {
+        if (acc[category]) {
+          // if category exists, push icon to icons array
+          acc[category].icons.push(key);
+        } else {
+          // if category does not exist, create a new entry
+          acc[category] = {
+            category,
+            icons: [key],
+          };
+        }
+      }
+
+      return acc;
+    },
+    {} as Record<string, MatchedCategory>,
+  );
+}
+
+function mergeCategory(
+  categoryA: Record<string, MatchedCategory>,
+  categoryB: Record<string, MatchedCategory>,
+) {
+  const merged: Record<string, MatchedCategory> = { ...categoryA };
+
+  Object.keys(categoryB).forEach((key) => {
+    if (merged[key]) {
+      // merge icons array and remove duplicates
+      merged[key].icons = Array.from(new Set([...merged[key].icons, ...categoryB[key].icons]));
+    } else {
+      merged[key] = categoryB[key];
+    }
+  });
+
+  return merged;
+}

--- a/.dumi/theme/builtins/IconSearch/fields.ts
+++ b/.dumi/theme/builtins/IconSearch/fields.ts
@@ -1,6 +1,6 @@
 import * as AntdIcons from '@ant-design/icons/lib/icons';
 
-const all = Object.keys(AntdIcons)
+export const all = Object.keys(AntdIcons)
   .map((n) => n.replace(/(Outlined|Filled|TwoTone)$/, ''))
   .filter((n, i, arr) => arr.indexOf(n) === i);
 

--- a/.dumi/theme/builtins/IconSearch/meta/AccountBook.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/AccountBook.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...financial, 'ledger'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Alipay.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Alipay.ts
@@ -3,6 +3,6 @@ import type { IconMetaSchema } from './tags';
 
 export default {
   contributors: ['ant-design'],
-  tags: financial,
+  tags: [...financial],
   category: 'logo',
 } as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Alipay.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Alipay.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'logo',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Bank.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Bank.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/CarryOut.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/CarryOut.ts
@@ -1,0 +1,8 @@
+import { check } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: check,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Check.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Check.ts
@@ -1,0 +1,8 @@
+import { check } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: check,
+  category: 'suggestion',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/ClockSquare.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/ClockSquare.ts
@@ -1,0 +1,7 @@
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: ['time', 'watch', 'alarm'],
+  category: 'suggestion',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Comment.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Comment.ts
@@ -1,0 +1,8 @@
+import { ellipsis } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...ellipsis, 'feedback', 'discussion', 'reply', 'opinion', 'note'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Copy.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Copy.ts
@@ -1,0 +1,7 @@
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: ['复制', 'clone', 'duplicate'],
+  category: 'editor',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/CreditCard.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/CreditCard.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/CreditCard.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/CreditCard.ts
@@ -3,6 +3,6 @@ import type { IconMetaSchema } from './tags';
 
 export default {
   contributors: ['ant-design'],
-  tags: financial,
+  tags: [...financial],
   category: 'other',
 } as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Dash.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Dash.ts
@@ -1,0 +1,8 @@
+import { ellipsis } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...ellipsis],
+  category: 'editor',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Dollar.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Dollar.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Ellipsis.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Ellipsis.ts
@@ -1,0 +1,8 @@
+import { ellipsis } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...ellipsis],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Euro.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Euro.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Holder.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Holder.ts
@@ -1,0 +1,8 @@
+import { ellipsis } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...ellipsis],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/IssuesClose.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/IssuesClose.ts
@@ -1,0 +1,8 @@
+import { check } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...check],
+  category: 'suggestion',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/More.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/More.ts
@@ -1,0 +1,8 @@
+import { ellipsis } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...ellipsis, 'vertical'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/PayCircle.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/PayCircle.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/PoundCircle.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/PoundCircle.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/PropertySafety.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/PropertySafety.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...financial, 'safety', 'protection', 'security', 'shield'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/RedEnvelope.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/RedEnvelope.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: financial,
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Robot.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Robot.ts
@@ -1,0 +1,7 @@
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: ['ai'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Safety.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Safety.ts
@@ -1,0 +1,7 @@
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: ['check', 'tick', 'protection', 'security', 'shield', 'safety', 'privacy'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Safety.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Safety.ts
@@ -1,7 +1,8 @@
+import { check } from './tags';
 import type { IconMetaSchema } from './tags';
 
 export default {
   contributors: ['ant-design'],
-  tags: ['check', 'tick', 'protection', 'security', 'shield', 'safety', 'privacy'],
+  tags: [...check, 'protection', 'security', 'shield', 'safety', 'privacy'],
   category: 'other',
 } as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Schedule.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Schedule.ts
@@ -1,0 +1,8 @@
+import { check } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...check, 'time', 'clock', 'calendar'],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/Transaction.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/Transaction.ts
@@ -1,0 +1,8 @@
+import { financial } from './tags';
+import type { IconMetaSchema } from './tags';
+
+export default {
+  contributors: ['ant-design'],
+  tags: [...financial],
+  category: 'other',
+} as const satisfies IconMetaSchema;

--- a/.dumi/theme/builtins/IconSearch/meta/index.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/index.ts
@@ -1,0 +1,62 @@
+import AccountBook from './AccountBook';
+import Alipay from './Alipay';
+import Bank from './Bank';
+import CarryOut from './CarryOut';
+import Check from './Check';
+import ClockSquare from './ClockSquare';
+import Comment from './Comment';
+import Copy from './Copy';
+import CreditCard from './CreditCard';
+import Dash from './Dash';
+import Dollar from './Dollar';
+import Ellipsis from './Ellipsis';
+import Euro from './Euro';
+import Holder from './Holder';
+import IssuesClose from './IssuesClose';
+import More from './More';
+import PayCircle from './PayCircle';
+import PoundCircle from './PoundCircle';
+import PropertySafety from './PropertySafety';
+import RedEnvelope from './RedEnvelope';
+import Robot from './Robot';
+import Safety from './Safety';
+import Schedule from './Schedule';
+import Transaction from './Transaction';
+
+const all = {
+  AccountBook,
+  Alipay,
+  AlipayCircle: Alipay,
+  Bank,
+  CarryOut,
+  Check,
+  CheckCircle: Check,
+  CheckSquare: Check,
+  ClockSquare,
+  Comment,
+  Copy,
+  CreditCard,
+  Dash,
+  SmallDash: Dash,
+  Dollar,
+  Ellipsis,
+  Euro,
+  EuroCircle: Euro,
+  Holder,
+  IssuesClose,
+  More,
+  PayCircle,
+  PoundCircle,
+  Pound: PoundCircle,
+  PropertySafety,
+  RedEnvelope,
+  Robot,
+  Safety,
+  Schedule,
+  Transaction,
+};
+
+export type IconsMeta = typeof all;
+export type IconName = keyof IconsMeta;
+
+export default all;

--- a/.dumi/theme/builtins/IconSearch/meta/tags.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/tags.ts
@@ -57,6 +57,8 @@ export const financial = [
 
 export const ellipsis = [
   '...',
+  '。。。',
+  '…',
   'more',
   '更多',
   'dots',
@@ -67,4 +69,19 @@ export const ellipsis = [
   'dropdown',
   'options',
   'settings',
+  'et cetera',
+  'etc',
+  'loader',
+  'loading',
+  'progress',
+  'pending',
+  'throbber',
+  'spinner',
+  'operator',
+  'code',
+  'spread',
+  'rest',
+  'further',
+  'extra',
+  'overflow',
 ] as const;

--- a/.dumi/theme/builtins/IconSearch/meta/tags.ts
+++ b/.dumi/theme/builtins/IconSearch/meta/tags.ts
@@ -1,0 +1,70 @@
+import type { CategoriesKeys } from '../fields';
+
+export type IconMetaSchema = Readonly<{
+  contributors: string[];
+  tags: readonly string[];
+  category: CategoriesKeys;
+}>;
+
+export const check = [
+  'check',
+  'done',
+  'todo',
+  'tick',
+  'complete',
+  'finish',
+  'task',
+
+  'ok',
+  'success',
+  'confirm',
+  'approve',
+  'agree',
+  'validation',
+
+  '√',
+  '✔',
+  '✓',
+  '勾',
+  '对',
+  '正确',
+  'right',
+] as const;
+
+export const financial = [
+  'monetization',
+  'marketing',
+  'currency',
+  'money',
+  'payment',
+  'finance',
+  'cash',
+  'bank',
+  'transaction',
+  'balance',
+  'expense',
+  'income',
+  'budget',
+  'investment',
+  'savings',
+  'profit',
+  'cost',
+  'wealth',
+  'economy',
+  'wallet',
+  'exchange',
+] as const;
+
+export const ellipsis = [
+  '...',
+  'more',
+  '更多',
+  'dots',
+  'ellipsis',
+  'expand',
+  'collapse',
+  'menu',
+  'dropdown',
+  'options',
+  'settings',
+] as const;

--- a/.dumi/theme/locales/en-US.json
+++ b/.dumi/theme/locales/en-US.json
@@ -117,7 +117,7 @@
   "app.footer.weavefox.slogan": "AI Development with WeaveFox 🦊",
   "app.docs.color.pick-primary": "Pick your primary color",
   "app.docs.color.pick-background": "Pick your background color",
-  "app.docs.components.icon.search.placeholder": "Search icons here, click icon to copy code",
+  "app.docs.components.icon.search.placeholder": "Search {total} icons here, click icon to copy code",
   "app.docs.components.icon.outlined": "Outlined",
   "app.docs.components.icon.filled": "Filled",
   "app.docs.components.icon.two-tone": "Two Tone",

--- a/.dumi/theme/locales/zh-CN.json
+++ b/.dumi/theme/locales/zh-CN.json
@@ -116,7 +116,7 @@
   "app.footer.weavefox.slogan": "前端智能研发",
   "app.docs.color.pick-primary": "选择你的主色",
   "app.docs.color.pick-background": "选择你的背景色",
-  "app.docs.components.icon.search.placeholder": "在此搜索图标，点击图标可复制代码",
+  "app.docs.components.icon.search.placeholder": "在此搜索 {total} 个图标，点击图标可复制代码",
   "app.docs.components.icon.outlined": "线框风格",
   "app.docs.components.icon.filled": "实底风格",
   "app.docs.components.icon.two-tone": "双色风格",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

#### The specific problem to be addressed.

当我们在 https://ant-design.antgroup.com/components/icon-cn 搜索 icon 的时候，往往很难找到想要的 icon，因为目前仅通过名字匹配来搜索。比如输入 clone 无法搜索到 copy icon。
这个 PR 让我们可以通过近义词，中英文都可，甚至符号`...`、`√`
、`✔`、`✓`来找到我们想要的 icon。灵感来自 lucide icons https://lucide.dev/icons/ 。

When searching for icons in https://ant-design.antgroup.com/components/icon, it’s often hard to find the one you need because the current system only matches against the icon’s name.
This PR lets users locate the desired icon through synonyms—in both English and Chinese—and even via symbols such as “…”, “√”, “✔”, and “✓”.
<img width="968" height="467" alt="image" src="https://github.com/user-attachments/assets/cb62b981-4625-4219-944f-ab9b38e7c9da" />

#### List the final API implementation and usage if needed.
给每一个需要近义词的 icon 增加 tags，通过用户输入和 tag 匹配来达到我们扩大搜索召回率的问题，如果某个 icon 不需要可以不定义 tag，tag 放在 meta/[IconName].ts，结构为：
```ts

type IconMetaSchema = Readonly<{
  contributors: string[];
  tags: readonly string[];
  category: CategoriesKeys;
}>;

Every icon that needs wider discoverability is given extra tags. By matching the user’s query against these tags, we boost recall. Icons that don’t need extra keywords can simply omit any tags.
Tags are stored in `meta/[IconName].ts` with the following schema:

```ts
type IconMetaSchema = Readonly<{
  contributors: string[];
  tags: readonly string[];
  category: CategoriesKeys;
}>;
```
#### If there are UI/interaction changes, consider providing screenshots or GIFs.

<img width="982" height="467" alt="image" src="https://github.com/user-attachments/assets/cecd6238-88a0-480d-86cc-6260d63f791a" />
<img width="976" height="508" alt="image" src="https://github.com/user-attachments/assets/4930ff87-876e-49c1-9e85-79b44841e6fd" />

### 📝 Change Log

#### Changed
> 仅对使用 antd 文档的用户体验有提升，并未对组件 API 有改变。
> 
> No changes to component API just UX improvement for document site users.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Icons in the documentation now support synonym search—you can find them using Chinese, English, or even symbols.     |
| 🇨🇳 Chinese |     文档中的 icon 支持同义词搜索，可中文英文甚至符号搜索      |
