### PR TITLE
style(DatePicker): avoid important syntax in week panel cell inner style

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -443,57 +443,46 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
       },
 
       // ====================== Week Panel ======================
-      '&-week-panel': {
-        // Clear cell style
-        [`${componentCls}-cell`]: {
-          [`&:hover ${pickerCellInnerCls},
-            &-selected ${pickerCellInnerCls},
-            ${pickerCellInnerCls}`]: {
-            background: 'transparent',
+      '&-week-panel-row': {
+        td: {
+          '&:before': {
+            transition: `background ${motionDurationMid}`,
+          },
+
+          '&:first-child:before': {
+            borderStartStartRadius: borderRadiusSM,
+            borderEndStartRadius: borderRadiusSM,
+          },
+
+          '&:last-child:before': {
+            borderStartEndRadius: borderRadiusSM,
+            borderEndEndRadius: borderRadiusSM,
           },
         },
 
-        '&-row': {
-          td: {
+        '&:hover td:before': {
+          background: cellHoverBg,
+        },
+
+        '&-range-start td, &-range-end td, &-selected td, &-hover td': {
+          // Rise priority to override hover style
+          [`&${pickerCellCls}`]: {
             '&:before': {
-              transition: `background ${motionDurationMid}`,
+              background: colorPrimary,
             },
 
-            '&:first-child:before': {
-              borderStartStartRadius: borderRadiusSM,
-              borderEndStartRadius: borderRadiusSM,
+            [`&${componentCls}-cell-week`]: {
+              color: new FastColor(colorTextLightSolid).setA(0.5).toHexString(),
             },
 
-            '&:last-child:before': {
-              borderStartEndRadius: borderRadiusSM,
-              borderEndEndRadius: borderRadiusSM,
+            [pickerCellInnerCls]: {
+              color: colorTextLightSolid,
             },
           },
+        },
 
-          '&:hover td:before': {
-            background: cellHoverBg,
-          },
-
-          '&-range-start td, &-range-end td, &-selected td, &-hover td': {
-            // Rise priority to override hover style
-            [`&${pickerCellCls}`]: {
-              '&:before': {
-                background: colorPrimary,
-              },
-
-              [`&${componentCls}-cell-week`]: {
-                color: new FastColor(colorTextLightSolid).setA(0.5).toHexString(),
-              },
-
-              [pickerCellInnerCls]: {
-                color: colorTextLightSolid,
-              },
-            },
-          },
-
-          '&-range-hover td:before': {
-            background: controlItemBgActive,
-          },
+        '&-range-hover td:before': {
+          background: controlItemBgActive,
         },
       },
 

--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -449,7 +449,7 @@ export const genPanelStyle = (token: SharedPickerToken): CSSObject => {
           [`&:hover ${pickerCellInnerCls},
             &-selected ${pickerCellInnerCls},
             ${pickerCellInnerCls}`]: {
-            background: 'transparent !important',
+            background: 'transparent',
           },
         },
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [X] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - Currently, DatePicker component in week mode (picker='week') using !important syntax to style a cell inner's background. This causes significant issues for third-party developers when customization
> - Custom styles are overridden even with higher-specificity selectors, forcing devs to counter with their own !important declarations.

The !important anti-pattern limits customization flexibility and maintainability.

_Solution:_
Remove !important syntax here for better customization flexibility and maintainability
### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🎨  imp: remove important syntax to easier customize from third party         |
| 🇨🇳 Chinese |  🎨 优化：避免使用 !important 语法，便于第三方自定义         |
