### PR TITLE
fix: Tabs ref prop should work

### DIFF
--- a/components/tabs/__tests__/index.test.tsx
+++ b/components/tabs/__tests__/index.test.tsx
@@ -150,4 +150,10 @@ describe('Tabs', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('should support ref', () => {
+    const tabRef = React.createRef<React.ComponentRef<typeof Tabs>>();
+    render(<Tabs ref={tabRef} />);
+    expect(tabRef.current).toBeTruthy();
+  });
 });

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -52,123 +52,130 @@ export interface TabsProps
   items?: (Omit<Tab, 'destroyInactiveTabPane'> & CompatibilityProps)[];
 }
 
-const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
-  const {
-    type,
-    className,
-    rootClassName,
-    size: customSize,
-    onEdit,
-    hideAdd,
-    centered,
-    addIcon,
-    removeIcon,
-    moreIcon,
-    more,
-    popupClassName,
-    children,
-    items,
-    animated,
-    style,
-    indicatorSize,
-    indicator,
-    destroyInactiveTabPane,
-    destroyOnHidden,
-    ...otherProps
-  } = props;
-  const { prefixCls: customizePrefixCls } = otherProps;
-  const { direction, tabs, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
-  const prefixCls = getPrefixCls('tabs', customizePrefixCls);
-  const rootCls = useCSSVarCls(prefixCls);
-  const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
+const InternalTabs = React.forwardRef<React.ComponentRef<typeof RcTabs>, TabsProps>(
+  (props, ref) => {
+    const {
+      type,
+      className,
+      rootClassName,
+      size: customSize,
+      onEdit,
+      hideAdd,
+      centered,
+      addIcon,
+      removeIcon,
+      moreIcon,
+      more,
+      popupClassName,
+      children,
+      items,
+      animated,
+      style,
+      indicatorSize,
+      indicator,
+      destroyInactiveTabPane,
+      destroyOnHidden,
+      ...otherProps
+    } = props;
+    const { prefixCls: customizePrefixCls } = otherProps;
+    const { direction, tabs, getPrefixCls, getPopupContainer } = React.useContext(ConfigContext);
+    const prefixCls = getPrefixCls('tabs', customizePrefixCls);
+    const rootCls = useCSSVarCls(prefixCls);
+    const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
-  let editable: EditableConfig | undefined;
-  if (type === 'editable-card') {
-    editable = {
-      onEdit: (editType, { key, event }) => {
-        onEdit?.(editType === 'add' ? event : key!, editType);
-      },
-      removeIcon: removeIcon ?? tabs?.removeIcon ?? <CloseOutlined />,
-      addIcon: (addIcon ?? tabs?.addIcon) || <PlusOutlined />,
-      showAdd: hideAdd !== true,
-    };
-  }
-  const rootPrefixCls = getPrefixCls();
-
-  if (process.env.NODE_ENV !== 'production') {
-    const warning = devUseWarning('Tabs');
-
-    warning(
-      !('onPrevClick' in props) && !('onNextClick' in props),
-      'breaking',
-      '`onPrevClick` and `onNextClick` has been removed. Please use `onTabScroll` instead.',
-    );
-
-    warning(
-      !(indicatorSize || tabs?.indicatorSize),
-      'deprecated',
-      '`indicatorSize` has been deprecated. Please use `indicator={{ size: ... }}` instead.',
-    );
-
-    warning.deprecated(
-      !(
-        'destroyInactiveTabPane' in props || items?.some((item) => 'destroyInactiveTabPane' in item)
-      ),
-      'destroyInactiveTabPane',
-      'destroyOnHidden',
-    );
-  }
-
-  const size = useSize(customSize);
-
-  const mergedItems = useLegacyItems(items, children);
-
-  const mergedAnimated = useAnimateConfig(prefixCls, animated);
-
-  const mergedStyle: React.CSSProperties = { ...tabs?.style, ...style };
-
-  const mergedIndicator: TabsProps['indicator'] = {
-    align: indicator?.align ?? tabs?.indicator?.align,
-    size: indicator?.size ?? indicatorSize ?? tabs?.indicator?.size ?? tabs?.indicatorSize,
-  };
-
-  return wrapCSSVar(
-    <RcTabs
-      direction={direction}
-      getPopupContainer={getPopupContainer}
-      {...otherProps}
-      items={mergedItems}
-      className={classNames(
-        {
-          [`${prefixCls}-${size}`]: size,
-          [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type!),
-          [`${prefixCls}-editable-card`]: type === 'editable-card',
-          [`${prefixCls}-centered`]: centered,
+    let editable: EditableConfig | undefined;
+    if (type === 'editable-card') {
+      editable = {
+        onEdit: (editType, { key, event }) => {
+          onEdit?.(editType === 'add' ? event : key!, editType);
         },
-        tabs?.className,
-        className,
-        rootClassName,
-        hashId,
-        cssVarCls,
-        rootCls,
-      )}
-      popupClassName={classNames(popupClassName, hashId, cssVarCls, rootCls)}
-      style={mergedStyle}
-      editable={editable}
-      more={{
-        icon: tabs?.more?.icon ?? tabs?.moreIcon ?? moreIcon ?? <EllipsisOutlined />,
-        transitionName: `${rootPrefixCls}-slide-up`,
-        ...more,
-      }}
-      prefixCls={prefixCls}
-      animated={mergedAnimated}
-      indicator={mergedIndicator}
-      // TODO: In the future, destroyInactiveTabPane in rc-tabs needs to be upgrade to destroyOnHidden
-      destroyInactiveTabPane={destroyOnHidden ?? destroyInactiveTabPane}
-    />,
-  );
-};
+        removeIcon: removeIcon ?? tabs?.removeIcon ?? <CloseOutlined />,
+        addIcon: (addIcon ?? tabs?.addIcon) || <PlusOutlined />,
+        showAdd: hideAdd !== true,
+      };
+    }
+    const rootPrefixCls = getPrefixCls();
 
+    if (process.env.NODE_ENV !== 'production') {
+      const warning = devUseWarning('Tabs');
+
+      warning(
+        !('onPrevClick' in props) && !('onNextClick' in props),
+        'breaking',
+        '`onPrevClick` and `onNextClick` has been removed. Please use `onTabScroll` instead.',
+      );
+
+      warning(
+        !(indicatorSize || tabs?.indicatorSize),
+        'deprecated',
+        '`indicatorSize` has been deprecated. Please use `indicator={{ size: ... }}` instead.',
+      );
+
+      warning.deprecated(
+        !(
+          'destroyInactiveTabPane' in props ||
+          items?.some((item) => 'destroyInactiveTabPane' in item)
+        ),
+        'destroyInactiveTabPane',
+        'destroyOnHidden',
+      );
+    }
+
+    const size = useSize(customSize);
+
+    const mergedItems = useLegacyItems(items, children);
+
+    const mergedAnimated = useAnimateConfig(prefixCls, animated);
+
+    const mergedStyle: React.CSSProperties = { ...tabs?.style, ...style };
+
+    const mergedIndicator: TabsProps['indicator'] = {
+      align: indicator?.align ?? tabs?.indicator?.align,
+      size: indicator?.size ?? indicatorSize ?? tabs?.indicator?.size ?? tabs?.indicatorSize,
+    };
+
+    return wrapCSSVar(
+      <RcTabs
+        ref={ref}
+        direction={direction}
+        getPopupContainer={getPopupContainer}
+        {...otherProps}
+        items={mergedItems}
+        className={classNames(
+          {
+            [`${prefixCls}-${size}`]: size,
+            [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type!),
+            [`${prefixCls}-editable-card`]: type === 'editable-card',
+            [`${prefixCls}-centered`]: centered,
+          },
+          tabs?.className,
+          className,
+          rootClassName,
+          hashId,
+          cssVarCls,
+          rootCls,
+        )}
+        popupClassName={classNames(popupClassName, hashId, cssVarCls, rootCls)}
+        style={mergedStyle}
+        editable={editable}
+        more={{
+          icon: tabs?.more?.icon ?? tabs?.moreIcon ?? moreIcon ?? <EllipsisOutlined />,
+          transitionName: `${rootPrefixCls}-slide-up`,
+          ...more,
+        }}
+        prefixCls={prefixCls}
+        animated={mergedAnimated}
+        indicator={mergedIndicator}
+        // TODO: In the future, destroyInactiveTabPane in rc-tabs needs to be upgrade to destroyOnHidden
+        destroyInactiveTabPane={destroyOnHidden ?? destroyInactiveTabPane}
+      />,
+    );
+  },
+);
+
+type CompoundedComponent = typeof InternalTabs & { TabPane: typeof TabPane };
+
+const Tabs = InternalTabs as CompoundedComponent;
 Tabs.TabPane = TabPane;
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

> - The RcTabs component supports the ref prop, but the current Tabs component, which extends RcTabs, does not support passing a ref to drill down into the underlying RcTabs instance.

**_Solution:_**
Add forward ref to Tabs component

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Tabs `ref` prop not working     |
| 🇨🇳 Chinese |  修复 Tabs `ref` 属性不起作用的问题         |
