### PR TITLE
fix: Tabs ref prop should work

### DIFF
--- a/components/tabs/__tests__/index.test.tsx
+++ b/components/tabs/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Tabs from '..';
+import type { TabsRef } from '..';
 import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -149,5 +150,14 @@ describe('Tabs', () => {
       'Warning: [antd: Tabs] `indicatorSize` has been deprecated. Please use `indicator={{ size: ... }}` instead.',
     );
     errorSpy.mockRestore();
+  });
+
+  it('should support ref', () => {
+    const tabsRef = React.createRef<TabsRef>();
+    const { unmount } = render(<Tabs ref={tabsRef} />);
+    expect(tabsRef.current).toBeTruthy();
+    expect(tabsRef.current?.nativeElement).toBeInstanceOf(HTMLElement);
+    unmount();
+    expect(tabsRef.current).toBeNull();
   });
 });

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -33,6 +33,10 @@ export interface CompatibilityProps {
   destroyOnHidden?: boolean;
 }
 
+export interface TabsRef {
+  nativeElement: React.ComponentRef<typeof RcTabs> | null;
+}
+
 export interface TabsProps
   extends CompatibilityProps,
     Omit<RcTabsProps, 'editable' | 'destroyInactiveTabPane' | 'items'> {
@@ -52,7 +56,7 @@ export interface TabsProps
   items?: (Omit<Tab, 'destroyInactiveTabPane'> & CompatibilityProps)[];
 }
 
-const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
+const InternalTabs = React.forwardRef<TabsRef, TabsProps>((props, ref) => {
   const {
     type,
     className,
@@ -81,6 +85,12 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
   const prefixCls = getPrefixCls('tabs', customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls, rootCls);
+
+  const tabsRef = React.useRef<TabsRef['nativeElement']>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: tabsRef.current,
+  }));
 
   let editable: EditableConfig | undefined;
   if (type === 'editable-card') {
@@ -134,6 +144,7 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
 
   return wrapCSSVar(
     <RcTabs
+      ref={tabsRef}
       direction={direction}
       getPopupContainer={getPopupContainer}
       {...otherProps}
@@ -167,8 +178,11 @@ const Tabs: React.FC<TabsProps> & { TabPane: typeof TabPane } = (props) => {
       destroyInactiveTabPane={destroyOnHidden ?? destroyInactiveTabPane}
     />,
   );
-};
+});
 
+type CompoundedComponent = typeof InternalTabs & { TabPane: typeof TabPane };
+
+const Tabs = InternalTabs as CompoundedComponent;
 Tabs.TabPane = TabPane;
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

> - The RcTabs component supports the ref prop, but the current Tabs component, which extends RcTabs, does not support passing a ref to drill down into the underlying RcTabs instance.

**_Solution:_**
Add forward ref to Tabs component

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Tabs `ref` prop not working     |
| 🇨🇳 Chinese |  修复 Tabs `ref` 属性不起作用的问题         |
