### PR TITLE
fix(locale): add missing transfer component localization text of vi_VN

### DIFF
--- a/components/locale/vi_VN.ts
+++ b/components/locale/vi_VN.ts
@@ -61,6 +61,7 @@ const localeValues: Locale = {
     selectAll: 'Chọn tất cả',
     removeAll: 'Gỡ bỏ tất cả',
     selectInvert: 'Đảo ngược trang hiện tại',
+    deselectAll: 'Bỏ chọn tất cả',
   },
   Upload: {
     uploading: 'Đang tải lên...',


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a update of Vietnamese localization file

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [X] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
None. 

### 💡 Background and Solution

> - Transfer component is missing some localization texts of vi-VN.ts

**_Solution:_**
Add missing localization texts of vi-VN.ts for Transfer component

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add missing transfer component localization text of vi-VN    |
| 🇨🇳 Chinese |  添加 vi-VN 缺失的传输组件本地化文本 |
