### PR TITLE
feat[Notification]: Add onClose into closable

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -134,6 +134,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
     style,
     styles,
     classNames: notificationClassNames,
+    closable,
     ...restProps
   } = props;
 
@@ -168,7 +169,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   const rootCls = useCSSVarCls(prefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls, rootCls);
-
+  const closableOnClose = closable && typeof closable === 'object' ? closable.onClose : undefined;
   const [mergedClosable, mergedCloseIcon, , ariaProps] = useClosable(
     pickClosable(props),
     pickClosable(notificationContext),
@@ -198,7 +199,11 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
         prefixCls={prefixCls}
         eventKey="pure"
         duration={null}
-        closable={mergedClosable ? { closeIcon: mergedCloseIcon, ...ariaProps } : mergedClosable}
+        closable={
+          mergedClosable
+            ? { onClose: closableOnClose, closeIcon: mergedCloseIcon, ...ariaProps }
+            : mergedClosable
+        }
         className={classNames(notificationClassName, contextClassName)}
         content={
           <PureContent

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -169,8 +169,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   const rootCls = useCSSVarCls(prefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls, rootCls);
-  const closableOnClose = closable && typeof closable === 'object' ? closable.onClose : undefined;
-  const [mergedClosable, mergedCloseIcon, , ariaProps] = useClosable(
+  const [rawClosable, mergedCloseIcon, , ariaProps] = useClosable(
     pickClosable(props),
     pickClosable(notificationContext),
     {
@@ -179,6 +178,14 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
       closeIconRender: (icon) => getCloseIcon(prefixCls, icon),
     },
   );
+
+  const mergedClosable = rawClosable
+    ? {
+        onClose: closable && typeof closable === 'object' ? closable?.onClose : undefined,
+        closeIcon: mergedCloseIcon,
+        ...ariaProps,
+      }
+    : rawClosable;
 
   return (
     <div
@@ -199,11 +206,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
         prefixCls={prefixCls}
         eventKey="pure"
         duration={null}
-        closable={
-          mergedClosable
-            ? { onClose: closableOnClose, closeIcon: mergedCloseIcon, ...ariaProps }
-            : mergedClosable
-        }
+        closable={mergedClosable}
         className={classNames(notificationClassName, contextClassName)}
         content={
           <PureContent

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -185,7 +185,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
         closeIcon: mergedCloseIcon,
         ...ariaProps,
       }
-    : rawClosable;
+    : false;
 
   return (
     <div

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -298,6 +298,26 @@ describe('notification', () => {
     });
   });
 
+  it('should call both closable.onClose and onClose when close button clicked', async () => {
+    const handleClose = jest.fn();
+    const handleClosableClose = jest.fn();
+    notification.open({
+      title: 'Test Notification',
+      duration: 0,
+      closable: {
+        onClose: handleClosableClose,
+      },
+      onClose: handleClose,
+    });
+
+    await awaitPromise();
+    const closeBtn = document.body.querySelector('.ant-notification-notice-close');
+    fireEvent.click(closeBtn!);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(handleClosableClose).toHaveBeenCalledTimes(1);
+  });
+
   it('closeIcon should be update', async () => {
     const list = ['1', '2'];
     list.forEach((type) => {

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -93,7 +93,7 @@ The properties of config are as follows:
 | Property  | Description              | Type      | Default   | Version |
 | --------- | ------------------------ | --------- | --------- | ------- |
 | closeIcon | Custom close icon        | ReactNode | undefined | -       |
-| onClose   | Trigger when modal close | Function  | undefined | -       |
+| onClose   | Trigger when notification close | Function  | undefined | -       |
 
 ### Global configuration
 

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -88,6 +88,13 @@ The properties of config are as follows:
 
 `notification` also provides a global `config()` method that can be used for specifying the default options. Once this method is used, all the notification boxes will take into account these globally defined options when displaying.
 
+### ClosableType
+
+| Property  | Description              | Type      | Default   | Version |
+| --------- | ------------------------ | --------- | --------- | ------- |
+| closeIcon | Custom close icon        | ReactNode | undefined | -       |
+| onClose   | Trigger when modal close | Function  | undefined | -       |
+
 ### Global configuration
 
 `notification.config(options)`

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -54,6 +54,7 @@ config 参数如下：
 | actions | 自定义按钮组 | ReactNode | - | 5.24.0 |
 | ~~btn~~ | 自定义按钮组，请使用 `actions` 替换 | ReactNode | - | - |
 | className | 自定义 CSS class | string | - | - |
+| closable | 是否显示右上角的关闭按钮 | boolean \| [ClosableType](#closabletype) | true | - |
 | closeIcon | 自定义关闭图标 | ReactNode | true | 5.7.0：设置为 null 或 false 时隐藏关闭按钮 |
 | description | 通知提醒内容，必选 | ReactNode | - | - |
 | duration | 默认 4.5 秒后自动关闭，配置为 null 则不自动关闭 | number | 4.5 | - |
@@ -86,6 +87,13 @@ config 参数如下：
 | stack | 堆叠模式，超过阈值时会将所有消息收起 | boolean \| `{ threshold: number }` | `{ threshold: 3 }` | 5.10.0 |
 | top | 消息从顶部弹出时，距离顶部的位置，单位像素 | number | 24 |  |
 | maxCount | 最大显示数，超过限制时，最早的消息会被自动关闭 | number | - | 4.17.0 |
+
+### ClosableType
+
+| 参数      | 说明             | 类型      | 默认值    | 版本 |
+| --------- | ---------------- | --------- | --------- | ---- |
+| closeIcon | 自定义关闭图标   | ReactNode | undefined | -    |
+| onClose   | 当通知关闭时触发 | function  | -         | -    |
 
 ### 全局配置
 

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -43,7 +43,7 @@ export interface ArgsProps {
   closeIcon?: React.ReactNode;
   closable?:
     | boolean
-    | (Omit<Exclude<ClosableType, boolean>, 'disable'> & {
+    | (Exclude<ClosableType, boolean> & {
         onClose?: () => void;
       });
   props?: DivProps;

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -41,7 +41,7 @@ export interface ArgsProps {
   readonly type?: IconType;
   onClick?: () => void;
   closeIcon?: React.ReactNode;
-  closable?: ClosableType;
+  closable?: boolean | (Exclude<ClosableType, boolean> & { onClose?: () => void });
   props?: DivProps;
   role?: 'alert' | 'status';
 }

--- a/components/notification/interface.ts
+++ b/components/notification/interface.ts
@@ -41,7 +41,11 @@ export interface ArgsProps {
   readonly type?: IconType;
   onClick?: () => void;
   closeIcon?: React.ReactNode;
-  closable?: boolean | (Exclude<ClosableType, boolean> & { onClose?: () => void });
+  closable?:
+    | boolean
+    | (Omit<Exclude<ClosableType, boolean>, 'disable'> & {
+        onClose?: () => void;
+      });
   props?: DivProps;
   role?: 'alert' | 'status';
 }

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -200,7 +200,7 @@ export function useInternalNotification(
             closeIcon: mergedCloseIcon,
             ...ariaProps,
           }
-        : rawClosable;
+        : false;
 
       return originOpen({
         // use placement from props instead of hard-coding "topRight"

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -185,7 +185,8 @@ export function useInternalNotification(
         noticePrefixCls,
         getCloseIconConfig(closeIcon, notificationConfig, notification),
       );
-
+      const closableOnClose =
+        closable && typeof closable === 'object' ? closable.onClose : undefined;
       const [mergedClosable, mergedCloseIcon, , ariaProps] = computeClosable(
         pickClosable({ ...(notificationConfig || {}), ...config }),
         pickClosable(notificationContext),
@@ -237,7 +238,9 @@ export function useInternalNotification(
           contextClassNames.root,
         ),
         style: { ...contextStyles.root, ...styles.root, ...contextStyle, ...style },
-        closable: mergedClosable ? { closeIcon: mergedCloseIcon, ...ariaProps } : mergedClosable,
+        closable: mergedClosable
+          ? { onClose: closableOnClose, closeIcon: mergedCloseIcon, ...ariaProps }
+          : mergedClosable,
       });
     };
 

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -185,9 +185,7 @@ export function useInternalNotification(
         noticePrefixCls,
         getCloseIconConfig(closeIcon, notificationConfig, notification),
       );
-      const closableOnClose =
-        closable && typeof closable === 'object' ? closable.onClose : undefined;
-      const [mergedClosable, mergedCloseIcon, , ariaProps] = computeClosable(
+      const [rawClosable, mergedCloseIcon, , ariaProps] = computeClosable(
         pickClosable({ ...(notificationConfig || {}), ...config }),
         pickClosable(notificationContext),
         {
@@ -195,6 +193,14 @@ export function useInternalNotification(
           closeIcon: realCloseIcon,
         },
       );
+
+      const mergedClosable = rawClosable
+        ? {
+            onClose: closable && typeof closable === 'object' ? closable.onClose : undefined,
+            closeIcon: mergedCloseIcon,
+            ...ariaProps,
+          }
+        : rawClosable;
 
       return originOpen({
         // use placement from props instead of hard-coding "topRight"
@@ -238,9 +244,7 @@ export function useInternalNotification(
           contextClassNames.root,
         ),
         style: { ...contextStyles.root, ...styles.root, ...contextStyle, ...style },
-        closable: mergedClosable
-          ? { onClose: closableOnClose, closeIcon: mergedCloseIcon, ...ariaProps }
-          : mergedClosable,
+        closable: mergedClosable,
       });
     };
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@rc-component/menu": "~1.1.3",
     "@rc-component/motion": "~1.1.4",
     "@rc-component/mutate-observer": "^2.0.0",
-    "@rc-component/notification": "~1.0.0",
+    "@rc-component/notification": "~1.1.0",
     "@rc-component/pagination": "~1.1.1",
     "@rc-component/picker": "~1.3.0",
     "@rc-component/progress": "~1.0.1",

--- a/scripts/__snapshots__/check-site.ts.snap
+++ b/scripts/__snapshots__/check-site.ts.snap
@@ -152,9 +152,9 @@ exports[`site test Component components/modal en Page 1`] = `3`;
 
 exports[`site test Component components/modal zh Page 1`] = `3`;
 
-exports[`site test Component components/notification en Page 1`] = `3`;
+exports[`site test Component components/notification en Page 1`] = `4`;
 
-exports[`site test Component components/notification zh Page 1`] = `3`;
+exports[`site test Component components/notification zh Page 1`] = `4`;
 
 exports[`site test Component components/pagination en Page 1`] = `1`;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

close #54394 

### 💡 Background and Solution

无

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add the onClose method to be called in the closable property when the notification closes   |
| 🇨🇳 Chinese |      添加onClose方法在closable属性中在notification关闭时调用   |
