### PR TITLE
fix(Radio) : Radio.Group display shows jagged edges and left border of the first element in the new row overflows.

### DIFF
--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -339,7 +339,6 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
     lineWidth,
     lineType,
     colorBorder,
-    motionDurationSlow,
     motionDurationMid,
     buttonPaddingInline,
     fontSize,
@@ -381,7 +380,6 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       // strange align fix for chrome but works
       // https://gw.alipayobjects.com/zos/rmsportal/VFTfKXJuogBAXcvfAUWJ.gif
       borderBlockStartWidth: calc(lineWidth).add(0.02).equal(),
-      borderInlineStartWidth: 0,
       borderInlineEndWidth: lineWidth,
       cursor: 'pointer',
       transition: [
@@ -404,20 +402,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
       },
 
       '&:not(:first-child)': {
-        '&::before': {
-          position: 'absolute',
-          insetBlockStart: calc(lineWidth).mul(-1).equal(),
-          insetInlineStart: calc(lineWidth).mul(-1).equal(),
-          display: 'block',
-          boxSizing: 'content-box',
-          width: 1,
-          height: '100%',
-          paddingBlock: lineWidth,
-          paddingInline: 0,
-          backgroundColor: colorBorder,
-          transition: `background-color ${motionDurationSlow}`,
-          content: '""',
-        },
+        marginInlineStart: calc(lineWidth).mul(-1).equal(),
       },
 
       '&:first-child': {
@@ -487,6 +472,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
         color: colorPrimary,
         background: buttonCheckedBg,
         borderColor: colorPrimary,
+        borderWidth: lineWidth,
 
         '&::before': {
           backgroundColor: colorPrimary,

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -472,7 +472,6 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
         color: colorPrimary,
         background: buttonCheckedBg,
         borderColor: colorPrimary,
-        borderWidth: lineWidth,
 
         '&::before': {
           backgroundColor: colorPrimary,

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -401,8 +401,8 @@ const getRadioButtonStyle: GenerateStyle<RadioToken> = (token) => {
         height: '100%',
       },
 
-      '&:not(:first-child)': {
-        marginInlineStart: calc(lineWidth).mul(-1).equal(),
+      '&:not(:last-child)': {
+        marginInlineEnd: calc(lineWidth).mul(-1).equal(),
       },
 
       '&:first-child': {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 💄 Component style improvement

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54660

### 💡 Background and Solution

锯齿问题：
原因：浏览器将1px的border渲染成了0.8px（AI了一下原因是因为亚像素渲染​​（sub-pixel rendering）），而Group中左边的border要进行两边合并是用`before`模拟的，并且固定宽度是1px，因此就出现了问题

解决方式：不用`before`模拟，全用border来做，两边合并问题用marginInlineStart = lineWidth -1px 来做

溢出问题：
首个元素溢出1px，视觉上感觉没有对齐，不好看
解决方案：换成每行最后一个元素溢出（子元素没撑满父元素，不存在溢出问题），保持了左侧对齐状态
<img width="891" height="168" alt="image" src="https://github.com/user-attachments/assets/12daf923-2005-4f8f-a017-98f7b10c06cf" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Radio.Group display shows jagged edges and left border of the first element in the new row overflows.    |
| 🇨🇳 Chinese |     Radio.Group 展示出现锯齿  和 换行后第一个元素左侧溢出问题     |
