### PR TITLE
feat(radio): add allowClear prop

### DIFF
--- a/components/checkbox/useBubbleLock.ts
+++ b/components/checkbox/useBubbleLock.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import raf from 'rc-util/lib/raf';
 
 export interface BubbleLockOptions {
-  clickOnAfter?: (e: React.MouseEvent<HTMLInputElement>) => void;
+  afterInputClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
 }
 
 /**
@@ -37,7 +37,7 @@ export default function useBubbleLock(
 
     onOriginInputClick?.(e);
     // Execute after input click callback if provided
-    options?.clickOnAfter?.(e);
+    options?.afterInputClick?.(e);
   };
 
   return [onLabelClick, onInputClick] as const;

--- a/components/checkbox/useBubbleLock.ts
+++ b/components/checkbox/useBubbleLock.ts
@@ -1,6 +1,10 @@
 import React from 'react';
 import raf from 'rc-util/lib/raf';
 
+export interface BubbleLockOptions {
+  clickOnAfter?: (e: React.MouseEvent<HTMLInputElement>) => void;
+}
+
 /**
  * When click on the label,
  * the event will be stopped to prevent the label from being clicked twice.
@@ -8,6 +12,7 @@ import raf from 'rc-util/lib/raf';
  */
 export default function useBubbleLock(
   onOriginInputClick?: React.MouseEventHandler<HTMLInputElement>,
+  options?: BubbleLockOptions,
 ) {
   const labelClickLockRef = React.useRef<number | null>(null);
 
@@ -31,6 +36,8 @@ export default function useBubbleLock(
     }
 
     onOriginInputClick?.(e);
+    // Execute after input click callback if provided
+    options?.clickOnAfter?.(e);
   };
 
   return [onLabelClick, onInputClick] as const;

--- a/components/radio/demo/allowClear.md
+++ b/components/radio/demo/allowClear.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+支持单击已选中的单选框来清除选择。设置 `allowClear` 为 `true` 启用此功能。
+
+## en-US
+
+Support clicking the selected radio to clear the selection. Set `allowClear` to `true` to enable this feature.

--- a/components/radio/demo/allowClear.tsx
+++ b/components/radio/demo/allowClear.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import type { RadioChangeEvent } from 'antd';
+import { Flex, Radio } from 'antd';
+
+const App: React.FC = () => {
+  const [value1, setValue1] = useState('Apple');
+  const [value2, setValue2] = useState('Apple');
+  const [value3, setValue3] = useState('Apple');
+
+  const onChange1 = (e: RadioChangeEvent) => {
+    console.log('radio1 checked', e.target.value);
+    setValue1(e.target.value);
+  };
+
+  const onChange2 = (e: RadioChangeEvent) => {
+    console.log('radio2 checked', e.target.value);
+    setValue2(e.target.value);
+  };
+
+  const onChange3 = (e: RadioChangeEvent) => {
+    console.log('radio3 checked', e.target.value);
+    setValue3(e.target.value);
+  };
+
+  return (
+    <Flex vertical gap="middle">
+      <Radio.Group onChange={onChange1} value={value1} allowClear>
+        <Radio value="Apple">Apple</Radio>
+        <Radio value="Pear">Pear</Radio>
+        <Radio value="Orange">Orange</Radio>
+      </Radio.Group>
+      <Radio.Group onChange={onChange2} value={value2} allowClear optionType="button">
+        <Radio.Button value="Apple">Apple</Radio.Button>
+        <Radio.Button value="Pear">Pear</Radio.Button>
+        <Radio.Button value="Orange">Orange</Radio.Button>
+      </Radio.Group>
+      <Radio.Group
+        onChange={onChange3}
+        value={value3}
+        allowClear
+        optionType="button"
+        buttonStyle="solid"
+      >
+        <Radio.Button value="Apple">Apple</Radio.Button>
+        <Radio.Button value="Pear">Pear</Radio.Button>
+        <Radio.Button value="Orange">Orange</Radio.Button>
+      </Radio.Group>
+    </Flex>
+  );
+};
+
+export default App;

--- a/components/radio/demo/allowClear.tsx
+++ b/components/radio/demo/allowClear.tsx
@@ -3,9 +3,9 @@ import type { RadioChangeEvent } from 'antd';
 import { Flex, Radio } from 'antd';
 
 const App: React.FC = () => {
-  const [value1, setValue1] = useState('Apple');
-  const [value2, setValue2] = useState('Apple');
-  const [value3, setValue3] = useState('Apple');
+  const [value1, setValue1] = useState<string | undefined>('Apple');
+  const [value2, setValue2] = useState<string | undefined>('Apple');
+  const [value3, setValue3] = useState<string | undefined>('Apple');
 
   const onChange1 = (e: RadioChangeEvent) => {
     console.log('radio1 checked', e.target.value);

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -41,6 +41,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     defaultValue,
     value: customizedValue,
     block = false,
+    allowClear = false,
     onChange,
     onMouseEnter,
     onMouseLeave,
@@ -129,8 +130,8 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
   );
 
   const memoizedValue = React.useMemo<RadioGroupContextProps>(
-    () => ({ onChange: onRadioChange, value, disabled, name, optionType, block }),
-    [onRadioChange, value, disabled, name, optionType, block],
+    () => ({ onChange: onRadioChange, value, disabled, name, optionType, block, allowClear }),
+    [onRadioChange, value, disabled, name, optionType, block, allowClear],
   );
 
   return wrapCSSVar(

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -50,6 +50,7 @@ return (
 <code src="./demo/radiogroup-with-name.tsx">Radio.Group with name</code>
 <code src="./demo/size.tsx">Size</code>
 <code src="./demo/radiobutton-solid.tsx">Solid radio button</code>
+<code src="./demo/allowClear.tsx">Allow Clear</code>
 <code src="./demo/badge.tsx" debug>Badge style</code>
 <code src="./demo/wireframe.tsx" debug>Wireframe</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
@@ -75,7 +76,8 @@ Common props ref：[Common props](/docs/react/common-props)
 Radio group can wrap a group of `Radio`.
 
 | Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
+| allowClear | Support clicking the selected radio to clear the selection | boolean | false |  |  |
 | buttonStyle | The style type of radio button | `outline` \| `solid` | `outline` |  |
 | defaultValue | Default selected value | any | - |  |
 | disabled | Disable all radio buttons | boolean | false |  |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -80,7 +80,7 @@ return (
 <!-- prettier-ignore -->
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| allowClear | 支持单击已选中的单选框来清除选择 | boolean | false |  |  |
+| allowClear | 支持单击已选中的单选框来清除选择 | boolean | false |  |
 | buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |  |  |
 | defaultValue | 默认选中的值 | any | - |  |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |  |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -51,6 +51,7 @@ return (
 <code src="./demo/radiogroup-with-name.tsx">单选组合 - 配合 name 使用</code>
 <code src="./demo/size.tsx">大小</code>
 <code src="./demo/radiobutton-solid.tsx">填底的按钮样式</code>
+<code src="./demo/allowClear.tsx">支持清除</code>
 <code src="./demo/badge.tsx" debug>测试 Badge 的样式</code>
 <code src="./demo/wireframe.tsx" debug>线框风格</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
@@ -79,6 +80,7 @@ return (
 <!-- prettier-ignore -->
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| allowClear | 支持单击已选中的单选框来清除选择 | boolean | false |  |  |
 | buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |  |  |
 | defaultValue | 默认选中的值 | any | - |  |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |  |

--- a/components/radio/interface.ts
+++ b/components/radio/interface.ts
@@ -24,6 +24,7 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   block?: boolean;
+  allowClear?: boolean;
 }
 
 export interface RadioGroupContextProps {
@@ -39,6 +40,7 @@ export interface RadioGroupContextProps {
    */
   optionType?: RadioGroupOptionType;
   block?: boolean;
+  allowClear?: boolean;
 }
 
 export interface RadioProps extends AbstractCheckboxProps<RadioChangeEvent> {
@@ -49,6 +51,7 @@ export interface RadioProps extends AbstractCheckboxProps<RadioChangeEvent> {
    * @internal
    */
   optionType?: RadioGroupOptionType;
+  allowClear?: boolean;
 }
 
 export interface RadioChangeEventTarget extends RadioProps {

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -85,7 +85,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
 
   const bubbleLockOptions = React.useMemo<BubbleLockOptions>(
     () => ({
-      clickOnAfter: (e: React.MouseEvent<HTMLInputElement>) => {
+      afterInputClick: (e: React.MouseEvent<HTMLInputElement>) => {
         const allowClear = groupContext?.allowClear ?? props.allowClear;
         if (allowClear && radioProps.checked) {
           // Prevent default behaviors and clear selection

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -69,12 +69,10 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
   radioProps.disabled = radioProps.disabled ?? disabled;
 
   const onClearSelect = React.useCallback(() => {
-    if (!groupContext) return;
-
     const clearEvent = {
       target: {
         ...radioProps,
-        value: undefined,
+        value: groupContext ? undefined : props.value,
         checked: false,
       },
       stopPropagation: () => {},
@@ -83,7 +81,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     } as RadioChangeEvent;
 
     onChange(clearEvent);
-  }, [onChange, radioProps, groupContext]);
+  }, [onChange, props.value, props.name, props.disabled, groupContext]);
 
   const bubbleLockOptions = React.useMemo<BubbleLockOptions>(
     () => ({

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -68,20 +68,23 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
 
   radioProps.disabled = radioProps.disabled ?? disabled;
 
-  const onClearSelect = React.useCallback(() => {
-    const clearEvent = {
-      target: {
-        ...radioProps,
-        value: groupContext ? undefined : props.value,
-        checked: false,
-      },
-      stopPropagation: () => {},
-      preventDefault: () => {},
-      nativeEvent: {} as MouseEvent,
-    } as RadioChangeEvent;
+  const onClearSelect = React.useCallback(
+    (e: React.MouseEvent<HTMLInputElement>) => {
+      const clearEvent: RadioChangeEvent = {
+        target: {
+          ...radioProps,
+          value: groupContext ? undefined : props.value,
+          checked: false,
+        },
+        stopPropagation: () => e.stopPropagation(),
+        preventDefault: () => e.preventDefault(),
+        nativeEvent: e.nativeEvent as MouseEvent,
+      };
 
-    onChange(clearEvent);
-  }, [onChange, props.value, props.name, props.disabled, groupContext]);
+      onChange(clearEvent);
+    },
+    [onChange, props.value, props.name, props.disabled, groupContext],
+  );
 
   const bubbleLockOptions = React.useMemo<BubbleLockOptions>(
     () => ({
@@ -91,7 +94,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
           // Prevent default behaviors and clear selection
           e.preventDefault();
           e.stopPropagation();
-          onClearSelect();
+          onClearSelect(e);
         }
       },
     }),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> Add `allowClear` prop to Radio component for better user experience

### 💡 Background and Solution

**Problem:**
Users sometimes need to clear their radio selection after making a choice, but Radio components traditionally don't allow deselection once selected. This creates a UX limitation where users have to refresh or reset the form to clear their selection.

**Solution:**
Added `allowClear` prop to `Radio.Group` components that enables users to click on an already selected radio button to clear the selection.

**API Implementation:**
```tsx
// Radio.Group
<Radio.Group allowClear value={value} onChange={onChange}>
  <Radio value="A">Option A</Radio>
  <Radio value="B">Option B</Radio>
</Radio.Group>

```

**Features:**
- Support for`Radio.Group` components
- Compatible with all Radio variants (default, button style, solid button style)
- Maintains backward compatibility
- Logic abstracted into `useBubbleLock` for better code organization

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Radio: Add `allowClear` prop to support clearing selection by clicking selected radio |
| 🇨🇳 Chinese | - Radio: 新增 `allowClear` 属性，支持单击已选中的单选框来清除选择 |

> Submitted by Cursor