### PR TITLE
style: add will-change to fixed table cell shadow

### DIFF
--- a/components/table/style/fixed.ts
+++ b/components/table/style/fixed.ts
@@ -45,6 +45,8 @@ const genFixedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         transition: `box-shadow ${motionDurationSlow}`,
         content: '""',
         pointerEvents: 'none',
+        // fix issus: https://github.com/ant-design/ant-design/issues/54587
+        willChange: 'transform',
       },
 
       [`${componentCls}-cell-fix-left-all::after`]: {

--- a/components/table/style/fixed.ts
+++ b/components/table/style/fixed.ts
@@ -45,7 +45,7 @@ const genFixedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         transition: `box-shadow ${motionDurationSlow}`,
         content: '""',
         pointerEvents: 'none',
-        // fix issus: https://github.com/ant-design/ant-design/issues/54587
+        // fix issues: https://github.com/ant-design/ant-design/issues/54587
         willChange: 'transform',
       },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

issue: [https://github.com/ant-design/ant-design/issues/54587](https://github.com/ant-design/ant-design/issues/54587)

### 💡 Background and Solution
Resolve table header checkbox flickering issue
Add will-change property to the after pseudo-element of ant-table-selection-column

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Resolve table header checkbox flickering issue |
| 🇨🇳 Chinese | table 组件的 header checkbox 会出现闪烁 |
