### PR TITLE
fix: Nest form with noStyle context passing

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -13,7 +13,7 @@ import type { SizeType } from '../config-provider/SizeContext';
 import SizeContext from '../config-provider/SizeContext';
 import type { ColProps } from '../grid/col';
 import type { FormContextProps } from './context';
-import { FormContext, FormProvider, VariantContext } from './context';
+import { FormContext, FormProvider, NoFormStyle, VariantContext } from './context';
 import type { FeedbackIcons } from './FormItem';
 import useForm from './hooks/useForm';
 import type { FormInstance } from './hooks/useForm';
@@ -210,16 +210,18 @@ const InternalForm: React.ForwardRefRenderFunction<FormRef, FormProps> = (props,
             }}
           >
             <FormContext.Provider value={formContextValue}>
-              <FieldForm
-                id={name}
-                {...restFormProps}
-                name={name}
-                onFinishFailed={onInternalFinishFailed}
-                form={wrapForm}
-                ref={nativeElementRef}
-                style={{ ...contextStyle, ...style }}
-                className={formClassName}
-              />
+              <NoFormStyle status>
+                <FieldForm
+                  id={name}
+                  {...restFormProps}
+                  name={name}
+                  onFinishFailed={onInternalFinishFailed}
+                  form={wrapForm}
+                  ref={nativeElementRef}
+                  style={{ ...contextStyle, ...style }}
+                  className={formClassName}
+                />
+              </NoFormStyle>
             </FormContext.Provider>
           </FormProvider>
         </SizeContext.Provider>

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2598,4 +2598,43 @@ describe('Form', () => {
     await changeValue(0, '100');
     expectErrors([]);
   });
+
+  it('Nest Form.Item should not pass style to child Form', async () => {
+    const formRef = React.createRef<FormInstance<any>>();
+    const subFormRef = React.createRef<FormInstance<any>>();
+
+    const { container } = render(
+      <Form ref={formRef}>
+        <Form.Item name="root" rules={[{ required: true }]}>
+          <Form component={false} ref={subFormRef}>
+            <Form.Item noStyle name="child" rules={[{ required: true }]}>
+              <Input />
+            </Form.Item>
+          </Form>
+        </Form.Item>
+      </Form>,
+    );
+
+    // Parent validation
+    try {
+      await formRef.current?.validateFields();
+    } catch {
+      // Do nothing, just validate it
+    }
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.ant-input.ant-input-status-error')).toBeFalsy();
+
+    // Child validation
+    try {
+      await subFormRef.current?.validateFields();
+    } catch {
+      // Do nothing, just validate it
+    }
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.ant-input.ant-input-status-error')).toBeTruthy();
+  });
 });

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2616,11 +2616,11 @@ describe('Form', () => {
     );
 
     // Parent validation
-    try {
-      await formRef.current?.validateFields();
-    } catch {
-      // Do nothing, just validate it
-    }
+await formRef.current
+  ?.validateFields()
+  .catch(() => {
+    // Do nothing, just validate it
+  });
 
     await waitFakeTimer();
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2627,11 +2627,11 @@ await formRef.current
     expect(container.querySelector('.ant-input.ant-input-status-error')).toBeFalsy();
 
     // Child validation
-    try {
-      await subFormRef.current?.validateFields();
-    } catch {
-      // Do nothing, just validate it
-    }
+await subFormRef.current
+  ?.validateFields()
+  .catch(() => {
+    // Do nothing, just validate it
+  });
 
     await waitFakeTimer();
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #54709

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Form with nest Form that parent Form.Item `status` will pass to sub Fom's `noStyle` Form.Item.      |
| 🇨🇳 Chinese |    修复 Form 嵌套场景下，父级 Form.Item 的 `status` 会传递给子级 `noStyle` Form.Item 的问题。       |
