### PR TITLE
chore(qrcode): use direct icon import to enable tree shaking

### DIFF
--- a/components/qr-code/QrcodeStatus.tsx
+++ b/components/qr-code/QrcodeStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReloadOutlined } from '@ant-design/icons';
+import ReloadOutlined from '@ant-design/icons/ReloadOutlined';
 
 import Button from '../button';
 import type { Locale } from '../locale';


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

When using the QRCode component with tree shaking, the whole ant design icons library is loaded.

### 💡 Background and Solution

This PR updates the import for ReloadOutlined in QR code status component to the direct ESM path.

Using named imports from @ant-design/icons pulls all icons into the bundle, defeating tree shaking.

By importing ReloadOutlined directly, we allow bundlers like Webpack or Vite (and Shadow CLJS) to:
	•	Exclude unused icons from the final bundle
	•	Reduce bundle size, especially when using QR code or other lightweight components

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Replaced named import of ReloadOutlined with direct path to enable tree shaking and reduce bundle size. |
| 🇨🇳 Chinese | 将 ReloadOutlined 的命名导入替换为直接路径导入，以启用 tree shaking 并减少打包体积 |
