### PR TITLE
feat: Add vertical attribute to Radio Group component

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = `
 <div
@@ -1543,8 +1543,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
 
 exports[`renders components/radio/demo/radiogroup-more.tsx extend context correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-  style="display: flex; flex-direction: column; gap: 8px;"
+  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
 >
   <label
     class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
 <div
@@ -1525,8 +1525,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
 
 exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-  style="display:flex;flex-direction:column;gap:8px"
+  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
 >
   <label
     class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -369,4 +369,27 @@ describe('Radio Group', () => {
       });
     });
   });
+
+  describe('orientation attribute and vertical', () => {
+    it('vertical=true orientation=horizontal, result orientation=horizontal', () => {
+      const { container } = render(
+        <Radio.Group vertical orientation="horizontal">
+          <Radio value="A">Preference A</Radio>
+          <Radio value="B">Preference B</Radio>
+        </Radio.Group>,
+      );
+      expect(container.querySelector<HTMLDivElement>('.ant-radio-group')).toBeTruthy();
+      expect(container.querySelector<HTMLDivElement>('.ant-radio-group-vertical')).toBeNull();
+    });
+
+    it('vertical=true, result orientation=vertical', () => {
+      const { container } = render(
+        <Radio.Group vertical>
+          <Radio value="A">Preference A</Radio>
+          <Radio value="B">Preference B</Radio>
+        </Radio.Group>,
+      );
+      expect(container.querySelector<HTMLDivElement>('.ant-radio-group-vertical')).toBeTruthy();
+    });
+  });
 });

--- a/components/radio/demo/radiogroup-more.tsx
+++ b/components/radio/demo/radiogroup-more.tsx
@@ -2,12 +2,6 @@ import React, { useState } from 'react';
 import type { RadioChangeEvent } from 'antd';
 import { Input, Radio } from 'antd';
 
-const style: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-};
-
 const App: React.FC = () => {
   const [value, setValue] = useState(1);
 
@@ -17,7 +11,7 @@ const App: React.FC = () => {
 
   return (
     <Radio.Group
-      style={style}
+      vertical
       onChange={onChange}
       value={value}
       options={[

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -4,9 +4,12 @@ import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import classNames from 'classnames';
 
+import useOrientation from '../_util/hooks/useOrientation';
 import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
+import { FormItemInputContext } from '../form/context';
+import { toNamePathStr } from '../form/hooks/useForm';
 import { RadioGroupContextProvider } from './context';
 import type {
   RadioChangeEvent,
@@ -16,8 +19,6 @@ import type {
 } from './interface';
 import Radio from './radio';
 import useStyle from './style';
-import { FormItemInputContext } from '../form/context';
-import { toNamePathStr } from '../form/hooks/useForm';
 
 const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
@@ -46,6 +47,8 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     onMouseLeave,
     onFocus,
     onBlur,
+    orientation,
+    vertical,
   } = props;
 
   const [value, setValue] = useMergedState(defaultValue, {
@@ -112,7 +115,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
   }
 
   const mergedSize = useSize(customizeSize);
-
+  const [, mergedVertical] = useOrientation(orientation, vertical);
   const classString = classNames(
     groupPrefixCls,
     `${groupPrefixCls}-${buttonStyle}`,
@@ -136,7 +139,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
   return (
     <div
       {...pickAttrs(props, { aria: true, data: true })}
-      className={classString}
+      className={classNames(classString, { [`${prefixCls}-group-vertical`]: mergedVertical })}
       style={style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -76,15 +76,17 @@ Radio group can wrap a group of `Radio`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| block | Option to fit RadioGroup width to its parent width | boolean | false | 5.21.0 |
 | buttonStyle | The style type of radio button | `outline` \| `solid` | `outline` |  |
 | defaultValue | Default selected value | any | - |  |
 | disabled | Disable all radio buttons | boolean | false |  |
 | name | The `name` property of all `input[type="radio"]` children. If not set, it will fallback to a randomly generated name | string | - |  |
 | options | Set children optional | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
+| orientation | Orientation | `horizontal` \| `vertical` | `horizontal` |  |
 | size | The size of radio button style | `large` \| `middle` \| `small` | - |  |
 | value | Used for setting the currently selected value | any | - |  |
-| block | Option to fit RadioGroup width to its parent width | boolean | false | 5.21.0 |
+| vertical | If true, the Radio group will be vertical. Simultaneously existing with `orientation`, `orientation` takes priority | boolean | false |  |
 | onChange | The callback function that is triggered when the state changes | function(e:Event) | - |  |
 
 ### CheckboxOptionType

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -79,15 +79,17 @@ return (
 <!-- prettier-ignore -->
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| block | 将 RadioGroup 宽度调整为其父宽度的选项 | boolean | false | 5.21.0 |  |
 | buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |  |  |
 | defaultValue | 默认选中的值 | any | - |  |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |  |
 | name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性。若未设置，则将回退到随机生成的名称 | string | - |  |  |
 | options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |  |
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |  |
+| orientation | 排列方向 | `horizontal` \| `vertical` | `horizontal` |  |
 | size | 大小，只对按钮样式生效 | `large` \| `middle` \| `small` | - |  |  |
 | value | 用于设置当前选中的值 | any | - |  |  |
-| block | 将 RadioGroup 宽度调整为其父宽度的选项 | boolean | false | 5.21.0 |  |
+| vertical | 值为 true，Radio Group 为垂直方向。与 `orientation` 同时存在，以 `orientation` 优先 | boolean | false |  |
 | onChange | 选项变化时的回调函数 | function(e:Event) | - |  |  |
 
 ### CheckboxOptionType

--- a/components/radio/interface.ts
+++ b/components/radio/interface.ts
@@ -1,5 +1,6 @@
 import type * as React from 'react';
 
+import type { Orientation } from '../_util/hooks/useOrientation';
 import type { AbstractCheckboxProps } from '../checkbox/Checkbox';
 import type { AbstractCheckboxGroupProps } from '../checkbox/Group';
 import type { SizeType } from '../config-provider/SizeContext';
@@ -20,10 +21,12 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   children?: React.ReactNode;
   id?: string;
   optionType?: RadioGroupOptionType;
+  orientation?: Orientation;
   buttonStyle?: RadioGroupButtonStyle;
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   block?: boolean;
+  vertical?: boolean;
 }
 
 export interface RadioGroupContextProps {

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -131,6 +131,18 @@ const getGroupRadioStyle: GenerateStyle<RadioToken> = (token) => {
       [`> ${antCls}-badge:not(:first-child) > ${antCls}-button-wrapper`]: {
         borderInlineStart: 'none',
       },
+
+      [`&-vertical`]: {
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 8,
+        [`&${groupPrefixCls}-large`]: {
+          rowGap: 12,
+        },
+        [`&${groupPrefixCls}-small`]: {
+          rowGap: 4,
+        },
+      },
     },
   };
 };

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -136,12 +136,6 @@ const getGroupRadioStyle: GenerateStyle<RadioToken> = (token) => {
         display: 'flex',
         flexDirection: 'column',
         rowGap: token.marginXS,
-        [`&${groupPrefixCls}-large`]: {
-          rowGap: token.marginSM,
-        },
-        [`&${groupPrefixCls}-small`]: {
-          rowGap: token.marginXXS,
-        },
       },
     },
   };

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -135,12 +135,12 @@ const getGroupRadioStyle: GenerateStyle<RadioToken> = (token) => {
       [`&-vertical`]: {
         display: 'flex',
         flexDirection: 'column',
-        rowGap: 8,
+        rowGap: token.marginXS,
         [`&${groupPrefixCls}-large`]: {
-          rowGap: 12,
+          rowGap: token.marginSM,
         },
         [`&${groupPrefixCls}-small`]: {
-          rowGap: 4,
+          rowGap: token.marginXXS,
         },
       },
     },


### PR DESCRIPTION


### 🤔 This is a ...

- [X] 🆕 New feature

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54624

### 💡 Background and Solution

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Add vertical attribute to Radio.Group to allow vertical alignment     |
| 🇨🇳 Chinese |      给Radio.Group 增加vertical属性，允许纵向排列     |
