### PR TITLE
feat[Alert]: add onClose and afterClose to closable

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -46,6 +46,9 @@ export interface AlertProps {
   /** Callback when close Alert */
   onClose?: React.MouseEventHandler<HTMLButtonElement>;
   /** Trigger when animation ending of Alert */
+  /**
+   * @deprecated please use `closable.afterClose` instead.
+   */
   afterClose?: () => void;
   /** Whether to show icon */
   showIcon?: boolean;
@@ -198,10 +201,6 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
     props.onClose?.(e);
     closableOnClose?.();
   };
-  const handleAfterClose = () => {
-    afterClose?.();
-    closableAfterClose?.();
-  };
 
   const type = React.useMemo<AlertProps['type']>(() => {
     if (props.type !== undefined) {
@@ -282,7 +281,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
       motionAppear={false}
       motionEnter={false}
       onLeaveStart={(node) => ({ maxHeight: node.offsetHeight })}
-      onLeaveEnd={handleAfterClose}
+      onLeaveEnd={closableAfterClose ?? afterClose}
     >
       {({ className: motionClassName, style: motionStyle }, setRef) => (
         <div

--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -204,7 +204,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
 
   const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
     setClosed(true);
-    (closableOnClose ?? props?.onClose)?.(e);
+    (closableOnClose ?? props.onClose)?.(e);
   };
 
   const type = React.useMemo<AlertProps['type']>(() => {

--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -28,7 +28,8 @@ export interface AlertProps {
   closable?:
     | boolean
     | (Exclude<ClosableType, boolean> & {
-        onClose?: () => void;
+        /** Callback when close Alert */
+        onClose?: React.MouseEventHandler<HTMLButtonElement>;
       });
   /**
    * @deprecated please use `closable.closeIcon` instead.
@@ -43,7 +44,9 @@ export interface AlertProps {
   message?: React.ReactNode;
   /** Additional content of Alert */
   description?: React.ReactNode;
-  /** Callback when close Alert */
+  /**
+   * @deprecated please use `closable.onClose` instead.
+   */
   onClose?: React.MouseEventHandler<HTMLButtonElement>;
   /** Trigger when animation ending of Alert */
   /**
@@ -62,6 +65,9 @@ export interface AlertProps {
   rootClassName?: string;
   banner?: boolean;
   icon?: React.ReactNode;
+  /**
+   * @deprecated please use `closable.closeIcon` instead.
+   */
   closeIcon?: React.ReactNode;
   action?: React.ReactNode;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
@@ -198,8 +204,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
 
   const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
     setClosed(true);
-    props.onClose?.(e);
-    closableOnClose?.();
+    (closableOnClose ?? props?.onClose)?.(e);
   };
 
   const type = React.useMemo<AlertProps['type']>(() => {

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -28,18 +28,23 @@ describe('Alert', () => {
   it('should show close button and could be closed', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const onClose = jest.fn();
+    const handleClosableClose = jest.fn();
     const { container } = render(
       <Alert
         title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
         type="warning"
-        closable
+        closable={{ onClose: handleClosableClose }}
+        closeIcon
         onClose={onClose}
       />,
     );
 
     fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
-
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(handleClosableClose).toHaveBeenCalledTimes(1);
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
@@ -258,4 +263,23 @@ describe('Alert', () => {
     expect(descriptionElement.style.fontSize).toBe('20px');
     expect(actionElement.style.color).toBe('green');
   });
+
+  // it.only('should call both closable.afterClose and afterClose when close button clicked', async () => {
+  //   const handleClose = jest.fn();
+  //   const handleClosableClose = jest.fn();
+  //   const { container } = render(
+  //     <Alert
+  //       title="Success Tips"
+  //       type="success"
+  //       afterClose={handleClose}
+  //       closable={{ afterClose: handleClosableClose }}
+  //     />,
+  //   );
+
+  //   const closeBtn = container.querySelector('.ant-alert-close-icon');
+  //   fireEvent.click(closeBtn!);
+
+  //   expect(handleClose).toHaveBeenCalledTimes(1);
+  //   expect(handleClosableClose).toHaveBeenCalledTimes(1);
+  // });
 });

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -263,23 +263,4 @@ describe('Alert', () => {
     expect(descriptionElement.style.fontSize).toBe('20px');
     expect(actionElement.style.color).toBe('green');
   });
-
-  // it.only('should call both closable.afterClose and afterClose when close button clicked', async () => {
-  //   const handleClose = jest.fn();
-  //   const handleClosableClose = jest.fn();
-  //   const { container } = render(
-  //     <Alert
-  //       title="Success Tips"
-  //       type="success"
-  //       afterClose={handleClose}
-  //       closable={{ afterClose: handleClosableClose }}
-  //     />,
-  //   );
-
-  //   const closeBtn = container.querySelector('.ant-alert-close-icon');
-  //   fireEvent.click(closeBtn!);
-
-  //   expect(handleClose).toHaveBeenCalledTimes(1);
-  //   expect(handleClosableClose).toHaveBeenCalledTimes(1);
-  // });
 });

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -33,8 +33,7 @@ describe('Alert', () => {
       <Alert
         title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
         type="warning"
-        closable={{ onClose: handleClosableClose }}
-        closeIcon
+        closable={{ onClose: handleClosableClose, closeIcon }}
         onClose={onClose}
       />,
     );

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('Alert', () => {
       <Alert
         title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
         type="warning"
-        closable={{ onClose: handleClosableClose, closeIcon }}
+        closable={{ onClose: handleClosableClose, closeIcon: true }}
         onClose={onClose}
       />,
     );

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -28,6 +28,24 @@ describe('Alert', () => {
   it('should show close button and could be closed', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const onClose = jest.fn();
+    const { container } = render(
+      <Alert
+        title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
+        type="warning"
+        closable
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('onClose and closable.onClose', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const onClose = jest.fn();
     const handleClosableClose = jest.fn();
     const { container } = render(
       <Alert
@@ -39,10 +57,8 @@ describe('Alert', () => {
     );
 
     fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
-    act(() => {
-      jest.runAllTimers();
-    });
-    expect(onClose).toHaveBeenCalledTimes(1);
+
+    expect(onClose).toHaveBeenCalledTimes(0);
     expect(handleClosableClose).toHaveBeenCalledTimes(1);
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | action | The action of Alert | ReactNode | - | 4.9.0 |
-| ~~afterClose~~ | Called when close animation is finished | () => void | - |  |
+| ~~afterClose~~ | Called when close animation is finished, please use `closable.afterClose` instead | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
 | closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | Additional content of Alert | ReactNode | - |  |

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -48,15 +48,15 @@ Common props ref：[Common props](/docs/react/common-props)
 | title | Content of Alert | ReactNode | - |  |
 | showIcon | Whether to show icon | boolean | false, in `banner` mode default is true |  |
 | type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | string | `info`, in `banner` mode default is `warning` |  |
-| onClose | Callback when Alert is closed | (e: MouseEvent) => void | - |  |
+| ~~onClose~~ | Callback when Alert is closed, please use `closable.onClose` instead | (e: MouseEvent) => void | - |  |
 
 ### ClosableType
 
-| Property   | Description                             | Type      | Default | Version |
-| ---------- | --------------------------------------- | --------- | ------- | ------- |
-| afterClose | Called when close animation is finished | function  | -       | -       |
-| closeIcon  | Custom close icon                       | ReactNode | -       | -       |
-| onClose    | Callback when Alert is closed           | Function  | -       | -       |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| afterClose | Called when close animation is finished | function | - | - |
+| closeIcon | Custom close icon | ReactNode | - | - |
+| onClose | Callback when Alert is closed | (e: MouseEvent) => void | - | - |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -41,7 +41,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | action | The action of Alert | ReactNode | - | 4.9.0 |
 | afterClose | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
-| closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| ({ closeIcon?: React.ReactNode } & React.AriaAttributes) | `false` |  |
+| closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | Additional content of Alert | ReactNode | - |  |
 | icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
 | ~~message~~ | Content of Alert, please use `title` instead | ReactNode | - |  |
@@ -52,11 +52,11 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### ClosableType
 
-| Property   | Description                             | Type      | Default   | Version |
-| ---------- | --------------------------------------- | --------- | --------- | ------- |
-| afterClose | Called when close animation is finished | function  | -         | -       |
-| closeIcon  | Custom close icon                       | ReactNode | undefined | -       |
-| onClose    | Callback when Alert is closed           | Function  | undefined | -       |
+| Property   | Description                             | Type      | Default | Version |
+| ---------- | --------------------------------------- | --------- | ------- | ------- |
+| afterClose | Called when close animation is finished | function  | -       | -       |
+| closeIcon  | Custom close icon                       | ReactNode | -       | -       |
+| onClose    | Callback when Alert is closed           | Function  | -       | -       |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | action | The action of Alert | ReactNode | - | 4.9.0 |
-| afterClose | Called when close animation is finished | () => void | - |  |
+| ~~afterClose~~ | Called when close animation is finished | () => void | - |  |
 | banner | Whether to show as banner | boolean | false |  |
 | closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | Additional content of Alert | ReactNode | - |  |

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -50,6 +50,14 @@ Common props ref：[Common props](/docs/react/common-props)
 | type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | string | `info`, in `banner` mode default is `warning` |  |
 | onClose | Callback when Alert is closed | (e: MouseEvent) => void | - |  |
 
+### ClosableType
+
+| Property   | Description                             | Type      | Default   | Version |
+| ---------- | --------------------------------------- | --------- | --------- | ------- |
+| afterClose | Called when close animation is finished | function  | -         | -       |
+| closeIcon  | Custom close icon                       | ReactNode | undefined | -       |
+| onClose    | Callback when Alert is closed           | Function  | undefined | -       |
+
 ### Alert.ErrorBoundary
 
 | Property | Description | Type | Default | Version |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -42,7 +42,7 @@ group:
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
 | afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
-| closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| ({ closeIcon?: React.ReactNode } & React.AriaAttributes) | `false` |  |
+| closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
 | icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
 | ~~message~~ | 警告提示内容，请使用 `title` 替换 | ReactNode | - |  |
@@ -50,6 +50,14 @@ group:
 | showIcon | 是否显示辅助图标 | boolean | false，`banner` 模式下默认值为 true |  |
 | type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | string | `info`，`banner` 模式下默认值为 `warning` |  |
 | onClose | 关闭时触发的回调函数 | (e: MouseEvent) => void | - |  |
+
+### ClosableType
+
+| 参数       | 说明                         | 类型      | 默认值    | 版本 |
+| ---------- | ---------------------------- | --------- | --------- | ---- |
+| afterClose | 关闭动画结束后触发的回调函数 | function  | -         | -    |
+| closeIcon  | 自定义关闭图标               | ReactNode | undefined | -    |
+| onClose    | 关闭时触发的回调函数         | Function  | undefined | -    |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -53,11 +53,11 @@ group:
 
 ### ClosableType
 
-| 参数       | 说明                         | 类型      | 默认值    | 版本 |
-| ---------- | ---------------------------- | --------- | --------- | ---- |
-| afterClose | 关闭动画结束后触发的回调函数 | function  | -         | -    |
-| closeIcon  | 自定义关闭图标               | ReactNode | undefined | -    |
-| onClose    | 关闭时触发的回调函数         | Function  | undefined | -    |
+| 参数       | 说明                         | 类型      | 默认值 | 版本 |
+| ---------- | ---------------------------- | --------- | ------ | ---- |
+| afterClose | 关闭动画结束后触发的回调函数 | function  | -      | -    |
+| closeIcon  | 自定义关闭图标               | ReactNode | -      | -    |
+| onClose    | 关闭时触发的回调函数         | Function  | -      | -    |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -49,15 +49,15 @@ group:
 | title | 警告提示内容 | ReactNode | - |  |
 | showIcon | 是否显示辅助图标 | boolean | false，`banner` 模式下默认值为 true |  |
 | type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | string | `info`，`banner` 模式下默认值为 `warning` |  |
-| onClose | 关闭时触发的回调函数 | (e: MouseEvent) => void | - |  |
+| ~~onClose~~ | 关闭时触发的回调函数，请使用 `closable.onClose` 替换 | (e: MouseEvent) => void | - |  |
 
 ### ClosableType
 
-| 参数       | 说明                         | 类型      | 默认值 | 版本 |
-| ---------- | ---------------------------- | --------- | ------ | ---- |
-| afterClose | 关闭动画结束后触发的回调函数 | function  | -      | -    |
-| closeIcon  | 自定义关闭图标               | ReactNode | -      | -    |
-| onClose    | 关闭时触发的回调函数         | Function  | -      | -    |
+| 参数       | 说明                         | 类型                    | 默认值 | 版本 |
+| ---------- | ---------------------------- | ----------------------- | ------ | ---- |
+| afterClose | 关闭动画结束后触发的回调函数 | function                | -      | -    |
+| closeIcon  | 自定义关闭图标               | ReactNode               | -      | -    |
+| onClose    | 关闭时触发的回调函数         | (e: MouseEvent) => void | -      | -    |
 
 ### Alert.ErrorBoundary
 

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -40,7 +40,7 @@ group:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
-| afterClose | 关闭动画结束后触发的回调函数 | () => void | - |  |
+| ~~afterClose~~ | 关闭动画结束后触发的回调函数 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
 | closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -40,7 +40,7 @@ group:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | action | 自定义操作项 | ReactNode | - | 4.9.0 |
-| ~~afterClose~~ | 关闭动画结束后触发的回调函数 | () => void | - |  |
+| ~~afterClose~~ | 关闭动画结束后触发的回调函数，请使用 `closable.afterClose` 替换 | () => void | - |  |
 | banner | 是否用作顶部公告 | boolean | false |  |
 | closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  |

--- a/scripts/__snapshots__/check-site.ts.snap
+++ b/scripts/__snapshots__/check-site.ts.snap
@@ -4,9 +4,9 @@ exports[`site test Component components/affix en Page 1`] = `1`;
 
 exports[`site test Component components/affix zh Page 1`] = `1`;
 
-exports[`site test Component components/alert en Page 1`] = `2`;
+exports[`site test Component components/alert en Page 1`] = `3`;
 
-exports[`site test Component components/alert zh Page 1`] = `2`;
+exports[`site test Component components/alert zh Page 1`] = `3`;
 
 exports[`site test Component components/anchor en Page 1`] = `3`;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

 #54394 
 #53682 

### 💡 Background and Solution

无

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add the onClose and afterLoss methods to the closable property and call them when Alert is closed   |
| 🇨🇳 Chinese |      添加onClose方法和afterClose在closable属性中，在Alert关闭时调用   |
