### PR TITLE
fix(button): button href disabled accessibility not correct

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1307,6 +1307,7 @@ Array [
         </span>
       </button>
       <a
+        aria-disabled="false"
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
         href="https://www.google.com"
         tabindex="0"
@@ -1846,6 +1847,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
     class="ant-flex ant-flex-gap-small"
   >
     <a
+      aria-disabled="false"
       class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
       href="https://ant.design/index-cn"
       tabindex="0"
@@ -1855,6 +1857,7 @@ exports[`renders components/button/demo/disabled.tsx extend context correctly 1`
       </span>
     </a>
     <a
+      aria-disabled="true"
       class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-disabled"
       tabindex="-1"
     >
@@ -2333,6 +2336,7 @@ exports[`renders components/button/demo/icon.tsx extend context correctly 1`] = 
       </span>
     </button>
     <a
+      aria-disabled="false"
       class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
       href="https://www.google.com"
       tabindex="0"
@@ -2776,6 +2780,7 @@ Array [
         </span>
       </button>
       <a
+        aria-disabled="false"
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-icon-end"
         href="https://www.google.com"
         tabindex="0"

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -1211,6 +1211,7 @@ Array [
         </span>
       </button>
       <a
+        aria-disabled="false"
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
         href="https://www.google.com"
         tabindex="0"
@@ -1748,6 +1749,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
     class="ant-flex ant-flex-gap-small"
   >
     <a
+      aria-disabled="false"
       class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
       href="https://ant.design/index-cn"
       tabindex="0"
@@ -1757,6 +1759,7 @@ exports[`renders components/button/demo/disabled.tsx correctly 1`] = `
       </span>
     </a>
     <a
+      aria-disabled="true"
       class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-disabled"
       tabindex="-1"
     >
@@ -2151,6 +2154,7 @@ exports[`renders components/button/demo/icon.tsx correctly 1`] = `
       </span>
     </button>
     <a
+      aria-disabled="false"
       class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
       href="https://www.google.com"
       tabindex="0"
@@ -2512,6 +2516,7 @@ Array [
         </span>
       </button>
       <a
+        aria-disabled="false"
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-icon-end"
         href="https://www.google.com"
         tabindex="0"

--- a/components/button/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/button/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Button fixbug renders {0} , 0 and {false} 1`] = `
 <button
@@ -380,6 +380,7 @@ exports[`Button should support custom icon styles 1`] = `
 
 exports[`Button should support link button 1`] = `
 <a
+  aria-disabled="false"
   class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
   href="https://ant.design"
   tabindex="0"

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -368,6 +368,7 @@ const InternalCompoundedButton = React.forwardRef<
         onClick={handleClick}
         ref={mergedRef as React.Ref<HTMLAnchorElement>}
         tabIndex={mergedDisabled ? -1 : 0}
+        aria-disabled={mergedDisabled}
       >
         {iconNode}
         {kids}

--- a/components/dropdown/__tests__/__snapshots__/dropdown-button.test.tsx.snap
+++ b/components/dropdown/__tests__/__snapshots__/dropdown-button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DropdownButton rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
@@ -44,6 +44,7 @@ exports[`DropdownButton should support href like Button 1`] = `
   class="ant-space-compact ant-space-compact-block ant-dropdown-button"
 >
   <a
+    aria-disabled="false"
     class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-compact-item ant-btn-compact-first-item"
     href="https://ant.design"
     tabindex="0"

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -321,6 +321,7 @@ exports[`renders components/flex/demo/combination.tsx extend context correctly 1
           “antd is an enterprise-class UI design language and React UI library.”
         </h3>
         <a
+          aria-disabled="false"
           class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
           href="https://ant.design"
           tabindex="0"

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders components/flex/demo/align.tsx correctly 1`] = `
 <div
@@ -317,6 +317,7 @@ exports[`renders components/flex/demo/combination.tsx correctly 1`] = `
           “antd is an enterprise-class UI design language and React UI library.”
         </h3>
         <a
+          aria-disabled="false"
           class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
           href="https://ant.design"
           tabindex="0"


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [X] 🐞 Bug fix
- [X] ⌨️ Accessibility improvement

### Reproduce
I use VIM extension and found this issue in Ant Design
<img width="693" height="516" alt="image" src="https://github.com/user-attachments/assets/eba6b5d8-afc9-45b5-b8a6-a194b57b70d6" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     button href disabled accessibility not correct      |
| 🇨🇳 Chinese |    按钮 href 已禁用可访问性不正确       |
