### PR TITLE
fix(locale): add missing vietnamese translation for color picker, qrcode, text components

### DIFF
--- a/components/locale/vi_VN.ts
+++ b/components/locale/vi_VN.ts
@@ -81,6 +81,7 @@ const localeValues: Locale = {
     copy: 'Sao chép',
     copied: 'Đã sao chép',
     expand: 'Mở rộng',
+    collapse: 'Thu gọn',
   },
   Form: {
     optional: '(Tùy chọn)',
@@ -138,6 +139,13 @@ const localeValues: Locale = {
   QRCode: {
     expired: 'Mã QR hết hạn',
     refresh: 'Làm mới',
+    scanned: 'Đã quét',
+  },
+  ColorPicker: {
+    presetEmpty: 'Trống',
+    transparent: 'Trong suốt',
+    singleColor: 'Màu đơn',
+    gradientColor: 'Màu chuyển sắc',
   },
 };
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [X] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

> - Some vietnamese translations is missing at QRCode, Color Picker and Text component.

**_Solution:_** Add missing translations for those components via locale file

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add missing vietnamese translation for color picker, qrcode, text components  |
| 🇨🇳 Chinese |  为颜色选择器、二维码、文本组件添加缺失的越南语翻译   |
