### PR TITLE
fix(segmented): disabled segmented when form is disabled

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6132,6 +6132,81 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item ant-form-item-horizontal"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="Segmented"
+          >
+            Segmented
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                aria-label="segmented control"
+                class="ant-segmented ant-segmented-disabled"
+                role="radiogroup"
+              >
+                <div
+                  class="ant-segmented-group"
+                >
+                  <label
+                    class="ant-segmented-item ant-segmented-item-selected ant-segmented-item-disabled"
+                  >
+                    <input
+                      checked=""
+                      class="ant-segmented-item-input"
+                      disabled=""
+                      name="test-id"
+                      type="radio"
+                    />
+                    <div
+                      aria-selected="true"
+                      class="ant-segmented-item-label"
+                      title="Light"
+                    >
+                      Light
+                    </div>
+                  </label>
+                  <label
+                    class="ant-segmented-item ant-segmented-item-disabled"
+                  >
+                    <input
+                      class="ant-segmented-item-input"
+                      disabled=""
+                      name="test-id"
+                      type="radio"
+                    />
+                    <div
+                      aria-selected="false"
+                      class="ant-segmented-item-label"
+                      title="Dark"
+                    >
+                      Dark
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3244,6 +3244,81 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item ant-form-item-horizontal"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="Segmented"
+          >
+            Segmented
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                aria-label="segmented control"
+                class="ant-segmented ant-segmented-disabled"
+                role="radiogroup"
+              >
+                <div
+                  class="ant-segmented-group"
+                >
+                  <label
+                    class="ant-segmented-item ant-segmented-item-selected ant-segmented-item-disabled"
+                  >
+                    <input
+                      checked=""
+                      class="ant-segmented-item-input"
+                      disabled=""
+                      name="test-id"
+                      type="radio"
+                    />
+                    <div
+                      aria-selected="true"
+                      class="ant-segmented-item-label"
+                      title="Light"
+                    >
+                      Light
+                    </div>
+                  </label>
+                  <label
+                    class="ant-segmented-item ant-segmented-item-disabled"
+                  >
+                    <input
+                      class="ant-segmented-item-input"
+                      disabled=""
+                      name="test-id"
+                      type="radio"
+                    />
+                    <div
+                      aria-selected="false"
+                      class="ant-segmented-item-label"
+                      title="Dark"
+                    >
+                      Dark
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -11,6 +11,7 @@ import {
   InputNumber,
   Radio,
   Rate,
+  Segmented,
   Select,
   Slider,
   Switch,
@@ -123,6 +124,20 @@ const FormDisabledDemo: React.FC = () => {
         </Form.Item>
         <Form.Item label="Rate">
           <Rate />
+        </Form.Item>
+        <Form.Item label="Segmented">
+          <Segmented
+            options={[
+              {
+                label: 'Light',
+                value: 'Light',
+              },
+              {
+                label: 'Dark',
+                value: 'Dark',
+              },
+            ]}
+          />
         </Form.Item>
       </Form>
     </>

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -10,6 +10,7 @@ import RcSegmented from 'rc-segmented';
 import useId from 'rc-util/lib/hooks/useId';
 
 import { useComponentConfig } from '../config-provider/context';
+import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import useStyle from './style';
@@ -66,6 +67,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
     vertical,
     shape = 'default',
     name = defaultName,
+    disabled: customDisabled,
     ...restProps
   } = props;
 
@@ -81,6 +83,10 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
 
   // ===================== Size =====================
   const mergedSize = useSize(customSize);
+
+  // ===================== Disabled =====================
+  const contextDisabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? contextDisabled;
 
   // syntactic sugar to support `icon` for Segmented Item
   const extendedOptions = React.useMemo<RCSegmentedProps['options']>(
@@ -124,6 +130,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
     <RcSegmented
       {...restProps}
       name={name}
+      disabled={mergedDisabled}
       className={cls}
       style={mergedStyle}
       options={extendedOptions}


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [X] 🐞 Bug fix
- [X] 📽️ Demo improvement

### 🔗 Related Issues

Nonw

### 💡 Background and Solution

> - When `Form` disabled, the `Segmented` components inside `Form` is not disabled

Solution: Using `DisabledContext` to make `Segmented` disabled along with `Form` disabled

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix(segmented): disabled segmented when form is disabled  |
| 🇨🇳 Chinese |  修复（分段）：当表单被禁用时，分​​段被禁用   |
