### PR TITLE
fix: Modal Demo Page error

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -21,7 +21,7 @@
   scrollbar-width: thin;
   scrollbar-color: #eaeaea transparent;
   overflow-y: auto;
-  height: 100vh;
+  height: 100dvh;
 }
 
 .rc-footer {

--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -17,9 +17,11 @@
   border-radius: 6px;
 }
 
-html {
+#root {
   scrollbar-width: thin;
   scrollbar-color: #eaeaea transparent;
+  overflow-y: auto;
+  height: 100vh;
 }
 
 .rc-footer {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 📝 Site / documentation improvement


### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54758

### 💡 Background and Solution
Modal弹框为了锁定滚动条用了下面代码
https://github.com/react-component/util/blob/62e1415639b339acced085433f845603abdc6f37/src/Dom/scrollLocker.ts#L93

给body和html设置了`overflow-y: hidden;`由于官网的Menu和Header用了`position: sticky;`，粘性定位寻找的是最近的滚动元素来定位，最近的滚动元素是html，所以弹框后的`overflow-y: hidden;`和粘性定位有了冲突，所以导致CSS问题

解决方式：
给root设置`overflow-y: auto;`，即使Modal给body和html设置了`overflow-y: hidden;`也不会影响Menu和Header来寻找最近的滚动元素

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Modal Demo Page error       |
| 🇨🇳 Chinese |      修复Modal页面错误     |
