### PR TITLE
fix: Modal Demo Page error

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -17,11 +17,9 @@
   border-radius: 6px;
 }
 
-#root {
+html {
   scrollbar-width: thin;
   scrollbar-color: #eaeaea transparent;
-  overflow-y: auto;
-  height: 100dvh;
 }
 
 .rc-footer {

--- a/.dumi/theme/layouts/SidebarLayout/index.tsx
+++ b/.dumi/theme/layouts/SidebarLayout/index.tsx
@@ -1,16 +1,16 @@
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { createStyles } from 'antd-style';
+import { useSearchParams } from 'dumi';
 
 import CommonHelmet from '../../common/CommonHelmet';
 import Content from '../../slots/Content';
 import Sidebar from '../../slots/Sidebar';
-import { useSearchParams } from 'dumi';
 
 const useStyle = createStyles(({ css, token }) => ({
   main: css`
     display: flex;
-    margin-top: ${token.contentMarginTop}px;
+    margin-top: ${token.contentMarginTop + token.headerHeight}px;
   `,
 }));
 

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -50,7 +50,14 @@ const Content: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   return (
     <DemoContext value={contextValue}>
-      <Col xxl={20} xl={19} lg={18} md={18} sm={24} xs={24}>
+      <Col
+        xxl={{ span: 20, offset: 4 }}
+        xl={{ span: 19, offset: 5 }}
+        lg={{ span: 18, offset: 6 }}
+        md={{ span: 18, offset: 6 }}
+        sm={{ span: 24, offset: 0 }} // menu hidden
+        xs={{ span: 24, offset: 0 }} // menu hidden
+      >
         <DocAnchor showDebug={showDebug} debugDemos={debugDemos} />
         <article className={classNames(styles.articleWrapper, { rtl: isRTL })}>
           {meta.frontmatter?.title ? (

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -48,7 +48,7 @@ const useStyle = createStyles(({ token, css }) => {
       background: ${token.colorBgContainer};
       box-shadow: ${token.boxShadowTertiary};
       backdrop-filter: blur(8px);
-      width: 100dvw;
+      width: 100%;
 
 
       @media only screen and (max-width: ${token.mobileMaxWidth}px) {

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -41,13 +41,15 @@ const useStyle = createStyles(({ token, css }) => {
   const searchIconColor = '#ced4d9';
   return {
     header: css`
-      position: sticky;
+      position: fixed;
       top: 0;
       z-index: 1000;
       max-width: 100%;
       background: ${token.colorBgContainer};
       box-shadow: ${token.boxShadowTertiary};
       backdrop-filter: blur(8px);
+      width: 100dvw;
+
 
       @media only screen and (max-width: ${token.mobileMaxWidth}px) {
         text-align: center;

--- a/.dumi/theme/slots/Sidebar/index.tsx
+++ b/.dumi/theme/slots/Sidebar/index.tsx
@@ -92,7 +92,7 @@ const useStyle = createStyles(({ token, css }) => {
     `,
     mainMenu: css`
       z-index: 1;
-      position: sticky;
+      position: fixed;
       top: ${token.headerHeight + token.contentMarginTop}px;
       width: 100%;
       max-height: calc(100vh - ${token.headerHeight + token.contentMarginTop}px);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 📝 Site / documentation improvement

### 🔗 Related Issues
关联[issue54758](https://github.com/ant-design/ant-design/issues/54758)、[PR54767](https://github.com/ant-design/ant-design/pull/54767)


### 💡 Background and Solution


问题：Menu和Header`position: sticky;`和弹框后的`overflow-y: hidden;`冲突导致

PR54767将html滚动变为root滚动存在一系列问题
<img width="583" height="238" alt="image" src="https://github.com/user-attachments/assets/b3750d2a-f1be-48bc-b532-9a90c87df83b" />
现在换一种解法，将sticky改为fixed定位

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Modal Demo Page error     |
| 🇨🇳 Chinese |    修复Modal页面错误       |
