### PR TITLE
fix: Button token.paddingInline not working when shape="round"

### DIFF
--- a/components/button/demo/component-token.tsx
+++ b/components/button/demo/component-token.tsx
@@ -77,6 +77,16 @@ const App: React.FC = () => (
         </Button>
       </Flex>
     </ConfigProvider>
+    <ConfigProvider
+      theme={{
+        components: { Button: { paddingInline: 100 } },
+      }}
+    >
+      <Flex gap="small" wrap>
+        <Button>Default Button</Button>
+        <Button shape="round">Default Button</Button>
+      </Flex>
+    </ConfigProvider>
   </Flex>
 );
 

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -146,15 +146,13 @@ const genHoverActiveButtonStyle = (
 // ============================== Shape ===============================
 const genCircleButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   minWidth: token.controlHeight,
-  paddingInlineStart: 0,
-  paddingInlineEnd: 0,
+  paddingInline: 0,
   borderRadius: '50%',
 });
 
 const genRoundButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
   borderRadius: token.controlHeight,
-  paddingInlineStart: token.calc(token.controlHeight).div(2).equal(),
-  paddingInlineEnd: token.calc(token.controlHeight).div(2).equal(),
+  paddingInline: token.paddingInline ?? token.calc(token.controlHeight).div(2).equal(),
 });
 
 const genDisabledStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/pull/54777

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Button `token.paddingInline` not working when `shape="round"`.   |
| 🇨🇳 Chinese |  修复 Button 在 `shape="round"` 时自定义 `token.paddingInline` 不生效的问题。  |
