### PR TITLE
fix(Tabs): tabs remove icon not align centered vertically

### DIFF
--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -734,6 +734,7 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
 
       '&-remove': {
         flex: 'none',
+        lineHeight: 1,
         marginRight: {
           _skip_check_: true,
           value: token.calc(token.marginXXS).mul(-1).equal(),
@@ -779,6 +780,7 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token: TabsToken) => {
 
       [`& ${tabCls}-remove ${iconCls}`]: {
         margin: 0,
+        verticalAlign: 'middle',
       },
 
       [`${iconCls}:not(:last-child)`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 💄 Component style improvement

### 🔗 Related Issues

None

### 💡 Background and Solution

> - The remove icon in editable-card `Tabs` is misaligned vertically.

Solution: Update styling for editable-card `Tabs` to fix the issue


**Before:** 
<img width="604" height="120" alt="image" src="https://github.com/user-attachments/assets/74a825ff-33ce-497d-af0c-3328ae739cb6" />
<img width="855" height="394" alt="image" src="https://github.com/user-attachments/assets/b9fbccba-65ac-4a60-aedc-28cc85d47df3" />

**After:** 
<img width="598" height="120" alt="image" src="https://github.com/user-attachments/assets/883df456-9275-4a0c-9508-7253e87ef5b5" />
<img width="1041" height="794" alt="image" src="https://github.com/user-attachments/assets/a94f3126-5842-46c6-b2ca-e87f2654a4ed" />


Extensions used to check visual: `VisBug`
### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix(Tabs): tabs remove icon not align centered vertically  |
| 🇨🇳 Chinese |  修复（标签页）：标签页移除图标未垂直居中对齐 |
