### PR TITLE
feat: add component token support for notification background colors

### DIFF
--- a/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13,6 +13,68 @@ exports[`renders components/notification/demo/basic.tsx extend context correctly
 
 exports[`renders components/notification/demo/basic.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/notification/demo/component-token.tsx extend context correctly 1`] = `
+Array [
+  <h4>
+    Custom Theme (Enhanced Colors)
+  </h4>,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <span>
+          Custom Success
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Info
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Warning
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Error
+        </span>
+      </button>
+    </div>
+  </div>,
+]
+`;
+
+exports[`renders components/notification/demo/component-token.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/notification/demo/custom-icon.tsx extend context correctly 1`] = `
 <button
   class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"

--- a/components/notification/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo.test.ts.snap
@@ -11,6 +11,66 @@ exports[`renders components/notification/demo/basic.tsx correctly 1`] = `
 </button>
 `;
 
+exports[`renders components/notification/demo/component-token.tsx correctly 1`] = `
+Array [
+  <h4>
+    Custom Theme (Enhanced Colors)
+  </h4>,
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+  >
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <span>
+          Custom Success
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Info
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Warning
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined"
+        type="button"
+      >
+        <span>
+          Custom Error
+        </span>
+      </button>
+    </div>
+  </div>,
+]
+`;
+
 exports[`renders components/notification/demo/custom-icon.tsx correctly 1`] = `
 <button
   class="ant-btn ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"

--- a/components/notification/demo/component-token.md
+++ b/components/notification/demo/component-token.md
@@ -1,0 +1,14 @@
+---
+debug: true
+title:
+  zh-CN: 组件 Token
+  en-US: Component Token
+---
+
+## zh-CN
+
+展示新的组件 Token 功能，支持为不同类型的通知设置不同的背景色。可以通过 `colorSuccessBg`、`colorErrorBg`、`colorInfoBg`、`colorWarningBg` 来自定义各种类型通知的背景色。
+
+## en-US
+
+Demonstrates the new component token functionality that supports different background colors for different notification types. You can customize the background colors using `colorSuccessBg`, `colorErrorBg`, `colorInfoBg`, and `colorWarningBg` tokens.

--- a/components/notification/demo/component-token.tsx
+++ b/components/notification/demo/component-token.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button, notification, Space, ConfigProvider } from 'antd';
+
+type NotificationType = 'success' | 'info' | 'warning' | 'error';
+
+const CustomThemeDemo: React.FC = () => {
+  const [api, contextHolder] = notification.useNotification();
+
+  const openNotificationWithIcon = (type: NotificationType) => {
+    api[type]({
+      message: `${type.charAt(0).toUpperCase() + type.slice(1)} Notification`,
+      description: 'This notification uses custom component tokens for enhanced background colors.',
+      duration: 0,
+    });
+  };
+
+  return (
+    <>
+      <h4>Custom Theme (Enhanced Colors)</h4>
+      <Space>
+        <Button type="primary" onClick={() => openNotificationWithIcon('success')}>
+          Custom Success
+        </Button>
+        <Button onClick={() => openNotificationWithIcon('info')}>Custom Info</Button>
+        <Button onClick={() => openNotificationWithIcon('warning')}>Custom Warning</Button>
+        <Button danger onClick={() => openNotificationWithIcon('error')}>
+          Custom Error
+        </Button>
+      </Space>
+      {contextHolder}
+    </>
+  );
+};
+
+const App: React.FC = () => (
+  <ConfigProvider
+    theme={{
+      components: {
+        Notification: {
+          colorSuccessBg: '#d9f7be', // Custom light green for success
+          colorErrorBg: '#ffccc7', // Custom light red for error
+          colorInfoBg: '#bae0ff', // Custom light blue for info
+          colorWarningBg: '#ffffb8', // Custom light yellow for warning
+        },
+      },
+    }}
+  >
+    <CustomThemeDemo />
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -32,6 +32,7 @@ To display a notification message at any of the four corners of the viewport. Ty
 <code src="./demo/stack.tsx" version="5.10.0">Stack</code>
 <code src="./demo/show-with-progress.tsx" version="5.18.0">Show with progress</code>
 <code src="./demo/basic.tsx">Static Method (deprecated)</code>
+<code src="./demo/component-token.tsx" debug>Component Token</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API

--- a/components/notification/index.zh-CN.md
+++ b/components/notification/index.zh-CN.md
@@ -33,6 +33,7 @@ demo:
 <code src="./demo/stack.tsx" version="5.10.0">堆叠</code>
 <code src="./demo/show-with-progress.tsx" version="5.18.0">显示进度条</code>
 <code src="./demo/basic.tsx">静态方法（不推荐）</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 
 ## API

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -152,7 +152,6 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     background: notificationBg,
     borderRadius: borderRadiusLG,
     boxShadow,
-    overflow: 'hidden',
 
     [noticeCls]: {
       padding: notificationPadding,
@@ -160,6 +159,8 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       maxWidth: `calc(100vw - ${unit(token.calc(notificationMarginEdge).mul(2).equal())})`,
       lineHeight,
       wordWrap: 'break-word',
+      borderRadius: borderRadiusLG,
+      overflow: 'hidden',
 
       // Type-specific background colors
       '&-success': {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -21,11 +21,6 @@ export interface ComponentToken {
    */
   width: number | string;
   /**
-   * @desc 提醒框进度条背景色
-   * @descEN Background color of Notification progress bar
-   */
-  progressBg: string;
-  /**
    * @desc 成功提醒框容器背景色
    * @descEN Background color of success notification container
    */
@@ -391,7 +386,6 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 export const prepareComponentToken = (token: AliasToken) => ({
   zIndexPopup: token.zIndexPopupBase + CONTAINER_MAX_OFFSET + 50,
   width: 384,
-  progressBg: `linear-gradient(90deg, ${token.colorPrimaryBorderHover}, ${token.colorPrimary})`,
   colorSuccessBg: token.colorSuccessBg,
   colorErrorBg: token.colorErrorBg,
   colorInfoBg: token.colorInfoBg,

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -20,6 +20,31 @@ export interface ComponentToken {
    * @descEN Width of Notification
    */
   width: number | string;
+  /**
+   * @desc 提醒框进度条背景色
+   * @descEN Background color of Notification progress bar
+   */
+  progressBg: string;
+  /**
+   * @desc 成功提醒框容器背景色
+   * @descEN Background color of success notification container
+   */
+  colorSuccessBg?: string;
+  /**
+   * @desc 错误提醒框容器背景色
+   * @descEN Background color of error notification container
+   */
+  colorErrorBg?: string;
+  /**
+   * @desc 信息提醒框容器背景色
+   * @descEN Background color of info notification container
+   */
+  colorInfoBg?: string;
+  /**
+   * @desc 警告提醒框容器背景色
+   * @descEN Background color of warning notification container
+   */
+  colorWarningBg?: string;
 }
 
 /**
@@ -112,6 +137,10 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     width,
     notificationIconSize,
     colorText,
+    colorSuccessBg,
+    colorErrorBg,
+    colorInfoBg,
+    colorWarningBg,
   } = token;
 
   const noticeCls = `${componentCls}-notice`;
@@ -123,14 +152,28 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
     background: notificationBg,
     borderRadius: borderRadiusLG,
     boxShadow,
+    overflow: 'hidden',
 
     [noticeCls]: {
       padding: notificationPadding,
       width,
       maxWidth: `calc(100vw - ${unit(token.calc(notificationMarginEdge).mul(2).equal())})`,
-      overflow: 'hidden',
       lineHeight,
       wordWrap: 'break-word',
+
+      // Type-specific background colors
+      '&-success': {
+        background: colorSuccessBg,
+      },
+      '&-error': {
+        background: colorErrorBg,
+      },
+      '&-info': {
+        background: colorInfoBg,
+      },
+      '&-warning': {
+        background: colorWarningBg,
+      },
     },
 
     [`${noticeCls}-message`]: {
@@ -337,9 +380,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
     // ============================ Notice ============================
     {
       [componentCls]: {
-        [`${noticeCls}-wrapper`]: {
-          ...genNoticeStyle(token),
-        },
+        [`${noticeCls}-wrapper`]: genNoticeStyle(token),
       },
     },
   ];
@@ -349,6 +390,11 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 export const prepareComponentToken = (token: AliasToken) => ({
   zIndexPopup: token.zIndexPopupBase + CONTAINER_MAX_OFFSET + 50,
   width: 384,
+  progressBg: `linear-gradient(90deg, ${token.colorPrimaryBorderHover}, ${token.colorPrimary})`,
+  colorSuccessBg: token.colorSuccessBg,
+  colorErrorBg: token.colorErrorBg,
+  colorInfoBg: token.colorInfoBg,
+  colorWarningBg: token.colorWarningBg,
 });
 
 export const prepareNotificationToken: (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/ant-design/pull/54776#discussion_r2309014242
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/53447
close https://github.com/ant-design/ant-design/pull/54693
close https://github.com/ant-design/ant-design/pull/53646

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | notification 支持自定义不同类型的通知框背景色。          |
| 🇨🇳 Chinese | notification now supports custom background for each type.          |
