### PR TITLE
feat: The mentions component inherits the form's disable

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6132,6 +6132,47 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item ant-form-item-horizontal"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="Mentions"
+          >
+            Mentions
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-mentions ant-mentions-disabled ant-mentions-outlined"
+              >
+                <textarea
+                  class="rc-textarea rc-textarea-disabled"
+                  disabled=""
+                  rows="1"
+                >
+                  @afc163
+                </textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3244,6 +3244,47 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item ant-form-item-horizontal"
+    >
+      <div
+        class="ant-row ant-form-item-row"
+      >
+        <div
+          class="ant-col ant-col-4 ant-form-item-label"
+        >
+          <label
+            class=""
+            title="Mentions"
+          >
+            Mentions
+          </label>
+        </div>
+        <div
+          class="ant-col ant-col-14 ant-form-item-control"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-mentions ant-mentions-disabled ant-mentions-outlined"
+              >
+                <textarea
+                  class="rc-textarea rc-textarea-disabled"
+                  disabled=""
+                  rows="1"
+                >
+                  @afc163
+                </textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
 ]
 `;

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   Input,
   InputNumber,
+  Mentions,
   Radio,
   Rate,
   Select,
@@ -123,6 +124,9 @@ const FormDisabledDemo: React.FC = () => {
         </Form.Item>
         <Form.Item label="Rate">
           <Rate />
+        </Form.Item>
+        <Form.Item label="Mentions">
+          <Mentions defaultValue="@afc163" />
         </Form.Item>
       </Form>
     </>

--- a/components/mentions/__tests__/index.test.tsx
+++ b/components/mentions/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ConfigProvider, Form } from 'antd';
 
 import Mentions, { Option } from '..';
 import focusTest from '../../../tests/shared/focusTest';
@@ -132,5 +133,24 @@ describe('Mentions', () => {
     expect(
       wrapper.container.querySelector('.ant-mentions-dropdown-menu-item-active')?.textContent,
     ).toBe('Yesmeck');
+  });
+  describe('form disabled', () => {
+    it('set Input enabled', () => {
+      const { container } = render(
+        <Form disabled>
+          <ConfigProvider componentDisabled={false}>
+            <Form.Item name="textarea1" label="启用">
+              <Mentions />
+            </Form.Item>
+          </ConfigProvider>
+          <Form.Item name="textarea" label="禁用">
+            <Mentions />
+          </Form.Item>
+        </Form>,
+      );
+
+      expect(container.querySelector('#textarea1[disabled]')).toBeFalsy();
+      expect(container.querySelector('#textarea[disabled]')).toBeTruthy();
+    });
   });
 });

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -22,6 +22,7 @@ import { FormItemInputContext } from '../form/context';
 import useVariant from '../form/hooks/useVariants';
 import Spin from '../spin';
 import useStyle from './style';
+import DisabledContext from '../config-provider/DisabledContext';
 
 export const { Option } = RcMentions;
 
@@ -71,7 +72,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
     prefixCls: customizePrefixCls,
     className,
     rootClassName,
-    disabled,
+    disabled: customDisabled,
     loading,
     filterOption,
     children,
@@ -107,6 +108,9 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
     feedbackIcon,
   } = React.useContext(FormItemInputContext);
   const mergedStatus = getMergedStatus(contextStatus, customStatus);
+  // ===================== Disabled =====================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? disabled;
 
   const onFocus: React.FocusEventHandler<HTMLTextAreaElement> = (...args) => {
     if (restProps.onFocus) {
@@ -179,7 +183,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
       prefixCls={prefixCls}
       notFoundContent={notFoundContentEle}
       className={mergedClassName}
-      disabled={disabled}
+      disabled={mergedDisabled}
       allowClear={mergedAllowClear}
       direction={direction}
       style={{ ...contextMentions?.style, ...style }}
@@ -194,7 +198,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
       classNames={{
         mentions: classNames(
           {
-            [`${prefixCls}-disabled`]: disabled,
+            [`${prefixCls}-disabled`]: mergedDisabled,
             [`${prefixCls}-focused`]: focused,
             [`${prefixCls}-rtl`]: direction === 'rtl',
           },

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -109,8 +109,8 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
   } = React.useContext(FormItemInputContext);
   const mergedStatus = getMergedStatus(contextStatus, customStatus);
   // ===================== Disabled =====================
-  const disabled = React.useContext(DisabledContext);
-  const mergedDisabled = customDisabled ?? disabled;
+  const contextDisabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? contextDisabled;
 
   const onFocus: React.FocusEventHandler<HTMLTextAreaElement> = (...args) => {
     if (restProps.onFocus) {

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -192,6 +192,10 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
           tabSize: 'inherit',
         },
 
+        [`>textarea:disabled`]: {
+          color: colorTextDisabled,
+        },
+
         '> textarea': {
           width: '100%',
           border: 'none',


### PR DESCRIPTION

### 🤔 This is a ...

- [X] 🆕 New feature


### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/54828

### 💡 Background and Solution


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The mentions component inherits the form's disable     |
| 🇨🇳 Chinese |      Mentions 组件继承外部 Form 的 disabled     |
