### PR TITLE
feat: Support better customize for components customize 

### DIFF
--- a/components/_util/__tests__/useMergeSemantic.test.tsx
+++ b/components/_util/__tests__/useMergeSemantic.test.tsx
@@ -1,4 +1,16 @@
-import { mergeClassNames } from '../hooks/useMergeSemantic';
+import useMergeSemantic, { mergeClassNames } from '../hooks/useMergeSemantic';
+import { renderHook } from '@testing-library/react';
+
+// Mock schema
+const schema = {
+  _default: 'root',
+  container: {
+    _default: 'container-root',
+    header: {
+      _default: 'header-root',
+    },
+  },
+};
 
 describe('useMergeSemantic', () => {
   it('mergeClassNames', () => {
@@ -31,5 +43,50 @@ describe('useMergeSemantic', () => {
         active: 'dragger-b-active',
       },
     });
+  });
+
+  it('should merge without schema', () => {
+    const { result } = renderHook(() =>
+      useMergeSemantic([{ a: 'foo' }, { a: 'bar' }], [{ a: { color: 'blue' } }]),
+    );
+
+    const [classNames, styles] = result.current;
+    expect(classNames).toEqual({ a: 'foo bar' });
+    expect(styles).toEqual({ a: { color: 'blue' } });
+  });
+
+  it('should merge with schema', () => {
+    const { result } = renderHook(() =>
+      useMergeSemantic(
+        [{ container: { header: 'foo' } }],
+        [{ container: { header: { color: 'red' } } }],
+        schema,
+      ),
+    );
+
+    const [classNames, styles] = result.current;
+    expect(classNames.container.header).toHaveProperty('header-root', 'foo');
+    expect(styles.container.header).toEqual({ color: 'red' });
+  });
+
+  it('should support function classNames and styles with info.props', () => {
+    const { result } = renderHook(() =>
+      useMergeSemantic(
+        [
+          (info: { props: { active: boolean } }) =>
+            info.props.active ? { a: 'active' } : { a: 'inactive' },
+        ],
+        [
+          (info: { props: { active: boolean } }) =>
+            info.props.active ? { a: { color: 'green' } } : { a: { color: 'gray' } },
+        ],
+        undefined,
+        { props: { active: true } },
+      ),
+    );
+
+    const [classNames, styles] = result.current;
+    expect(classNames).toEqual({ a: 'active' });
+    expect(styles).toEqual({ a: { color: 'green' } });
   });
 });

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -113,9 +113,9 @@ export default function useMergeSemantic<
           ...info?.props,
         },
       } as { props: Props };
-      return val(tempInfo) as T;
+      return val(tempInfo);
     }
-    return val as T;
+    return val;
   };
 
   const resolvedClassNamesList = classNamesList.map(resolve);

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -86,7 +86,7 @@ function fillObjectBySchema<T extends object>(obj: T, schema: SemanticSchema): T
   return newObj;
 }
 
-type MaybeFn<T, Props> = T | ((info?: { props: Props }) => T);
+type MaybeFn<T, P> = T | ((info: { props: P }) => T) | undefined;
 type ObjectOnly<T> = T extends (...args: any) => any ? never : T;
 /**
  * Merge classNames and styles from multiple sources.

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -97,8 +97,8 @@ export default function useMergeSemantic<
   StylesType extends object,
   Props,
 >(
-  classNamesList: (ClassNamesType | undefined)[],
-  stylesList: (StylesType | undefined)[],
+  classNamesList: MaybeFn<ClassNamesType, Props>[],
+  stylesList: MaybeFn<StylesType, Props>[],
   schema?: SemanticSchema,
   info?: {
     props: Props;
@@ -108,7 +108,12 @@ export default function useMergeSemantic<
     val: MaybeFn<T | undefined, Props> | undefined,
   ): T | undefined => {
     if (typeof val === 'function') {
-      return val(info!) as T;
+      const tempInfo = {
+        props: {
+          ...info?.props,
+        },
+      } as { props: Props };
+      return val(tempInfo) as T;
     }
     return val as T;
   };

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -112,11 +112,13 @@ export default function useMergeSemantic<
     typeof item === 'function' ? item(info) : item,
   );
 
-  const mergedClassNames = useSemanticClassNames(
-    schema,
-    ...resolvedClassNamesList,
-  ) as ClassNamesType;
-  const mergedStyles = useSemanticStyles(...resolvedStylesList) as StylesType;
+  const mergedClassNames = useSemanticClassNames(schema, ...resolvedClassNamesList) as Partial<
+    Record<string, string>
+  >;
+
+  const mergedStyles = useSemanticStyles(...resolvedStylesList) as Partial<
+    Record<string, React.CSSProperties>
+  >;
 
   return React.useMemo(() => {
     if (!schema) {
@@ -124,8 +126,8 @@ export default function useMergeSemantic<
     }
 
     return [
-      fillObjectBySchema(mergedClassNames, schema) as ClassNamesType,
-      fillObjectBySchema(mergedStyles, schema) as StylesType,
+      fillObjectBySchema(mergedClassNames, schema) as Partial<Record<string, string>>,
+      fillObjectBySchema(mergedStyles, schema) as Partial<Record<string, React.CSSProperties>>,
     ] as const;
   }, [mergedClassNames, mergedStyles]);
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related

> - #54505

### 💡 Background and Solution

- 在组件和 ConfigProvider 层用的是 useMergeSemantic
- 支持 useMergeSemantic 中的 classNames 和 styles 解析支持传 function 解析 (info: { props }) => classNames / styles 返回最终的根据 props 的规则的 classNames 和 styles

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    feat: Support better customize for components customize       |
| 🇨🇳 Chinese |   feat: Support better customize for components customize        |
