### PR TITLE
fix(typography): correct margin when editable (#54848)

### DIFF
--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -190,7 +190,6 @@ export const getEditableStyles: GenerateStyle<TypographyToken, CSSObject> = (tok
       position: 'relative',
 
       'div&': {
-        position: 'relative',
         insetInlineStart: token.calc(token.paddingSM).mul(-1).equal(),
         insetBlockStart: token.calc(inputShift).div(-2).add(1).equal(),
         marginBottom: token.calc(inputShift).div(2).sub(2).equal(),

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -191,8 +191,8 @@ export const getEditableStyles: GenerateStyle<TypographyToken, CSSObject> = (tok
 
       'div&': {
         insetInlineStart: token.calc(token.paddingSM).mul(-1).equal(),
-        marginTop: token.calc(inputShift).mul(-1).equal(),
-        marginBottom: `calc(1em - ${unit(inputShift)})`,
+        marginTop: token.calc(inputShift).mul(0.15).equal(),
+        marginBottom: `calc(1.2em - ${unit(inputShift)})`,
       },
 
       [`${componentCls}-edit-content-confirm`]: {

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -190,9 +190,10 @@ export const getEditableStyles: GenerateStyle<TypographyToken, CSSObject> = (tok
       position: 'relative',
 
       'div&': {
+        position: 'relative',
         insetInlineStart: token.calc(token.paddingSM).mul(-1).equal(),
-        marginTop: token.calc(inputShift).mul(0.15).equal(),
-        marginBottom: `calc(1.2em - ${unit(inputShift)})`,
+        insetBlockStart: token.calc(inputShift).div(-2).add(1).equal(),
+        marginBottom: token.calc(inputShift).div(2).sub(2).equal(),
       },
 
       [`${componentCls}-edit-content-confirm`]: {

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -8,7 +8,6 @@
 }
 */
 import { gold } from '@ant-design/colors';
-import { unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
 import type { TypographyToken } from '.';


### PR DESCRIPTION
<html><head></head><body>
<h3>🤔 This is a ...</h3>
<ul class="contains-task-list">
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> 🐞 Bug fix</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> 💄 Component style improvement</p>
</li>
</ul>
<hr>
<h3>🔗 Related Issues</h3>
<p>Closes #54848</p>
<hr>
<h3>💡 Background and Solution</h3>
<p>The <code inline="">Typography</code> component applied an incorrect margin when in <strong>editable mode</strong>, which caused layout inconsistencies in surrounding content.</p>
<p>This PR updates the styles in <code inline="">mixins.ts</code> to ensure margins are handled correctly when the component is editable, fixing the spacing issue.</p>
<hr>
<h3>📝 Change Log</h3>

Language | Changelog
-- | --
🇺🇸 English | Fix incorrect margin in Typography when editable.
🇨🇳 Chinese | 修复 Typography 在可编辑状态下的错误边距。


<hr>
<h3>📸 Screenshots</h3>
<p><strong>Earlier</strong><br>
<img width="380" height="228" alt="image" src="https://github.com/user-attachments/assets/6926f64b-e937-4394-a30f-733823533417" />

</p>
<p><strong>Fixed Version</strong><br>
<img width="957" height="240" alt="image" src="https://github.com/user-attachments/assets/eec0be93-02c5-442b-bf7f-94e7054f094b" />

</p></body></html>