### PR TITLE
docs: add preset colors token

### DIFF
--- a/scripts/generate-token-meta.ts
+++ b/scripts/generate-token-meta.ts
@@ -40,6 +40,18 @@ function getTokenList(list?: DeclarationReflection[], source?: string) {
     }));
 }
 
+function getPresetColorsTokenList(presetColors: string[]) {
+  return presetColors.map((item) => ({
+    source: 'seed',
+    token: item,
+    type: 'color',
+    desc: `预设${item}颜色`,
+    descEn: `Preset ${item} color`,
+    name: `预设${item}颜色`,
+    nameEn: `Preset ${item} color`,
+  }));
+}
+
 const main = async () => {
   const app = await (Application as any).bootstrap(
     {
@@ -75,14 +87,16 @@ const main = async () => {
           } else if (type.name === 'AliasToken') {
             tokenMeta.alias = getTokenList(type.children, 'alias');
           } else if (type.name === 'PresetColors') {
+            console.log('type', (type?.type as any)?.target?.elements);
             presetColors = (type?.type as any)?.target?.elements?.map((item: any) => item.value);
           }
         });
 
-        // Exclude preset colors
-        tokenMeta.seed = tokenMeta.seed.filter(
-          (item) => !presetColors.some((color) => item.token.startsWith(color)),
-        );
+        // Exclude preset colors e.g. 'blue' 'blue-1' 'blue-2' ...
+        tokenMeta.seed = tokenMeta.seed
+          .filter((item) => !presetColors.some((color) => item.token.startsWith(color)))
+          // Incorporate preset colors
+          .concat(getPresetColorsTokenList(presetColors));
         tokenMeta.map = tokenMeta.map.filter(
           (item) => !presetColors.some((color) => item.token.startsWith(color)),
         );

--- a/scripts/generate-token-meta.ts
+++ b/scripts/generate-token-meta.ts
@@ -87,7 +87,6 @@ const main = async () => {
           } else if (type.name === 'AliasToken') {
             tokenMeta.alias = getTokenList(type.children, 'alias');
           } else if (type.name === 'PresetColors') {
-            console.log('type', (type?.type as any)?.target?.elements);
             presetColors = (type?.type as any)?.target?.elements?.map((item: any) => item.value);
           }
         });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54862

### 💡 Background and Solution

<Button color="pink" variant="solid">Solid</Button> 按钮的颜色是粉色，但是UI设计的粉色和这个粉色色号有一点差别

我尝试在`ConfigProvider `配置，发现可以生效，但是文档没有写出来
`<ConfigProvider theme={{ token: { pink: "#f00" } }}></ConfigProvider>`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add preset colors token      |
| 🇨🇳 Chinese |     添加preset colors token     |
