### PR TITLE
fix: Dropdown `onOpenChange` closure issue

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -457,4 +457,54 @@ describe('Dropdown', () => {
       ),
     ).toHaveClass('anticon-left');
   });
+
+  it('closure item click', () => {
+    let latestCnt = -1;
+
+    const Demo = () => {
+      const [cnt, setCnt] = React.useState(0);
+
+      const onOpenChange = () => {
+        latestCnt = cnt;
+      };
+
+      return (
+        <Dropdown
+          onOpenChange={onOpenChange}
+          menu={{
+            items: [
+              {
+                label: (
+                  <span
+                    className="bamboo"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setCnt((v) => v + 1);
+                    }}
+                  />
+                ),
+                key: '1',
+              },
+              {
+                label: <span className="little" />,
+                key: '2',
+              },
+            ],
+          }}
+          open
+        >
+          <span />
+        </Dropdown>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    // Change
+    fireEvent.click(container.querySelector('.bamboo')!);
+
+    // Close
+    fireEvent.click(container.querySelector('.little')!);
+    expect(latestCnt).toBe(1);
+  });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -4,10 +4,10 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import type { AlignType } from '@rc-component/trigger';
 import classNames from 'classnames';
 import RcDropdown from 'rc-dropdown';
+import type { MenuProps as RcMenuProps } from 'rc-menu';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'rc-util/lib/omit';
-import type { MenuProps as RcMenuProps } from 'rc-menu';
 
 import { useZIndex } from '../_util/hooks/useZIndex';
 import isPrimitive from '../_util/isPrimitive';
@@ -234,13 +234,13 @@ const Dropdown: CompoundedComponent = (props) => {
     borderRadius: token.borderRadius,
   });
 
-  const onMenuClick = React.useCallback(() => {
+  const onMenuClick = useEvent(() => {
     if (menu?.selectable && menu?.multiple) {
       return;
     }
     onOpenChange?.(false, { source: 'menu' });
     setOpen(false);
-  }, [menu?.selectable, menu?.multiple]);
+  });
 
   const renderOverlay = () => {
     // rc-dropdown already can process the function of overlay, but we have check logic here.


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #54879

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Dropdown click Menu.Item to trigger `onOpenChange` will get closure issue.       |
| 🇨🇳 Chinese |   修复 Dropdown 的 `onOpenChange` 在点击 Menu.Item 关闭时会遇到闭包的问题。        |
