### PR TITLE
fix(Input.Search): prevent hover color change for border and icon in disabled search button

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -659,7 +659,7 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
   return {
     [searchPrefixCls]: {
       [componentCls]: {
-        '&:hover, &:focus': {
+        '&:not([disabled]):hover, &:not([disabled]):focus': {
           [`+ ${componentCls}-group-addon ${searchPrefixCls}-button:not(${antCls}-btn-color-primary):not(${antCls}-btn-variant-text)`]:
             {
               borderInlineStartColor: token.colorPrimaryHover,
@@ -695,7 +695,7 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
           [`${searchPrefixCls}-button:not(${antCls}-btn-color-primary)`]: {
             color: token.colorTextDescription,
 
-            '&:hover': {
+            '&:not([disabled]):hover': {
               color: token.colorPrimaryHover,
             },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 🐞 Bug fix
- [X] 💄 Component style improvement

### 🔗 Related Issues

None

### 💡 Background and Solution

> - When hover on `disabled` state `Input.Search`, the color of search button's icon and left border changed incorrectly

**Solution:** Update styling for `Input.Search` to resolve this issue

**Result:**
Before: 
![Before](https://github.com/user-attachments/assets/2e5000ef-a7ce-4598-aea8-08e163fe95e8)

After:
![After](https://github.com/user-attachments/assets/0f3a3496-16f7-4bed-93e5-ae393c312576)

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Input.Search): prevent hover color change for border and icon in disabled search button  |
| 🇨🇳 Chinese | 修复（Input.Search）：防止禁用搜索按钮时边框和图标的悬停颜色发生变化   |
