### PR TITLE
fix: Table column align issue when scroll.x is true

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -26990,7 +26990,6 @@ exports[`ConfigProvider components Table configProvider 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="config-table-thead"
               >
@@ -27299,7 +27298,6 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="config-table-thead"
               >
@@ -27610,7 +27608,6 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="config-table-thead"
               >
@@ -27919,7 +27916,6 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="config-table-thead"
               >
@@ -28228,7 +28224,6 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="config-table-thead"
               >
@@ -28537,7 +28532,6 @@ exports[`ConfigProvider components Table normal 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -28846,7 +28840,6 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="prefix-Table-thead"
               >

--- a/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2614,7 +2614,6 @@ exports[`renders components/descriptions/demo/text.tsx extend context correctly 
                             <table
                               style="table-layout: auto;"
                             >
-                              <colgroup />
                               <thead
                                 class="ant-table-thead"
                               >

--- a/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
@@ -2444,7 +2444,6 @@ exports[`renders components/descriptions/demo/text.tsx correctly 1`] = `
                             <table
                               style="table-layout:auto"
                             >
-                              <colgroup />
                               <thead
                                 class="ant-table-thead"
                               >

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -900,7 +900,6 @@ Array [
                   <table
                     style="table-layout: auto;"
                   >
-                    <colgroup />
                     <thead
                       class="ant-table-thead"
                     >

--- a/components/empty/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.ts.snap
@@ -612,7 +612,6 @@ Array [
                   <table
                     style="table-layout:auto"
                   >
-                    <colgroup />
                     <thead
                       class="ant-table-thead"
                     >

--- a/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Table.expand click to expand 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -118,7 +118,6 @@ exports[`Table.filter renders custom filter icon as ReactNode 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -223,7 +222,6 @@ exports[`Table.filter renders custom filter icon as string correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -334,7 +332,6 @@ exports[`Table.filter renders custom filter icon with right Tooltip title 1`] = 
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -462,7 +459,6 @@ exports[`Table.filter renders filter correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Table.pagination Accepts pagination as true 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -189,7 +188,6 @@ exports[`Table.pagination renders pagination correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -347,7 +345,6 @@ exports[`Table.pagination renders pagination topLeft and bottomRight 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -514,7 +511,6 @@ exports[`Table.pagination should not crash when trigger onChange in render 1`] =
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Table renders JSX correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -132,7 +131,6 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -234,7 +232,6 @@ exports[`Table should render title 1`] = `
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -670,7 +667,6 @@ exports[`Table support wireframe 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -22,7 +22,6 @@ exports[`renders components/table/demo/basic.tsx extend context correctly 1`] = 
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -349,7 +348,6 @@ exports[`renders components/table/demo/bordered.tsx extend context correctly 1`]
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -565,7 +563,6 @@ exports[`renders components/table/demo/colspan-rowspan.tsx extend context correc
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -3465,7 +3462,6 @@ Array [
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -12092,7 +12088,7 @@ exports[`renders components/table/demo/fixed-header.tsx extend context correctly
             style="overflow: hidden;"
           >
             <table
-              style="table-layout: fixed;"
+              style="table-layout: fixed; min-width: 100%;"
             >
               <colgroup>
                 <col
@@ -13471,7 +13467,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
             style="overflow: hidden;"
           >
             <table
-              style="table-layout: fixed; width: calc(50% + 700px); min-width: 100%;"
+              style="table-layout: fixed; min-width: 100%; width: calc(50% + 700px);"
             >
               <colgroup>
                 <col
@@ -15046,7 +15042,6 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -16088,7 +16083,6 @@ Array [
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -16350,7 +16344,6 @@ exports[`renders components/table/demo/jsx.tsx extend context correctly 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -16700,7 +16693,6 @@ exports[`renders components/table/demo/multiple-sorter.tsx extend context correc
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -17184,7 +17176,6 @@ exports[`renders components/table/demo/narrow.tsx extend context correctly 1`] =
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -18422,7 +18413,6 @@ Array [
                                   <table
                                     style="table-layout: auto;"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -19315,7 +19305,6 @@ Array [
                                   <table
                                     style="table-layout: auto;"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -20208,7 +20197,6 @@ Array [
                                   <table
                                     style="table-layout: auto;"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -21612,7 +21600,6 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -21983,7 +21970,6 @@ Array [
               <table
                 style="table-layout: fixed;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -23146,7 +23132,6 @@ exports[`renders components/table/demo/responsive.tsx extend context correctly 1
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -28216,7 +28201,6 @@ Array [
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -28422,7 +28406,6 @@ Array [
               <table
                 style="table-layout: auto;"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -22,7 +22,6 @@ exports[`renders components/table/demo/basic.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -353,7 +352,6 @@ exports[`renders components/table/demo/bordered.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -567,7 +565,6 @@ exports[`renders components/table/demo/colspan-rowspan.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -3286,7 +3283,6 @@ Array [
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -3942,7 +3938,6 @@ exports[`renders components/table/demo/drag-column-sorting.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -4268,7 +4263,6 @@ exports[`renders components/table/demo/drag-sorting.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -10776,7 +10770,7 @@ exports[`renders components/table/demo/fixed-columns-header.tsx correctly 1`] = 
             style="overflow:hidden"
           >
             <table
-              style="table-layout:auto;visibility:hidden;width:max-content;min-width:100%"
+              style="table-layout:auto;visibility:hidden;min-width:100%;width:max-content"
             >
               <colgroup>
                 <col
@@ -13503,7 +13497,7 @@ exports[`renders components/table/demo/fixed-header.tsx correctly 1`] = `
             style="overflow:hidden"
           >
             <table
-              style="table-layout:fixed;visibility:hidden"
+              style="table-layout:fixed;visibility:hidden;min-width:100%"
             >
               <colgroup>
                 <col
@@ -14777,7 +14771,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
             style="overflow:hidden"
           >
             <table
-              style="table-layout:fixed;visibility:hidden;width:calc(700px + 50%);min-width:100%"
+              style="table-layout:fixed;visibility:hidden;min-width:100%;width:calc(700px + 50%)"
             >
               <colgroup>
                 <col
@@ -15933,7 +15927,6 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -16508,7 +16501,6 @@ Array [
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -16768,7 +16760,6 @@ exports[`renders components/table/demo/jsx.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -17122,7 +17113,6 @@ exports[`renders components/table/demo/multiple-sorter.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -17544,7 +17534,6 @@ exports[`renders components/table/demo/narrow.tsx correctly 1`] = `
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -18675,7 +18664,6 @@ Array [
                                   <table
                                     style="table-layout:auto"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -19334,7 +19322,6 @@ Array [
                                   <table
                                     style="table-layout:auto"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -19993,7 +19980,6 @@ Array [
                                   <table
                                     style="table-layout:auto"
                                   >
-                                    <colgroup />
                                     <thead
                                       class="ant-table-thead"
                                     >
@@ -21159,7 +21145,6 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -21534,7 +21519,6 @@ Array [
               <table
                 style="table-layout:fixed"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -22339,7 +22323,6 @@ exports[`renders components/table/demo/responsive.tsx correctly 1`] = `
             <table
               style="table-layout:auto"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -27121,7 +27104,6 @@ Array [
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -27327,7 +27309,6 @@ Array [
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -27526,7 +27507,7 @@ exports[`renders components/table/demo/sticky.tsx correctly 1`] = `
             style="overflow:hidden;top:64px"
           >
             <table
-              style="table-layout:fixed;visibility:hidden;width:1500px;min-width:100%"
+              style="table-layout:fixed;visibility:hidden;min-width:100%;width:1500px"
             >
               <colgroup>
                 <col
@@ -28444,7 +28425,7 @@ exports[`renders components/table/demo/sticky.tsx correctly 1`] = `
             style="overflow:hidden;bottom:0"
           >
             <table
-              style="table-layout:fixed;visibility:hidden;width:1500px;min-width:100%"
+              style="table-layout:fixed;visibility:hidden;min-width:100%;width:1500px"
             >
               <colgroup>
                 <col
@@ -28799,7 +28780,6 @@ exports[`renders components/table/demo/summary.tsx correctly 1`] = `
               <table
                 style="table-layout:auto"
               >
-                <colgroup />
                 <thead
                   class="ant-table-thead"
                 >
@@ -28981,7 +28961,7 @@ exports[`renders components/table/demo/summary.tsx correctly 1`] = `
               style="overflow:hidden"
             >
               <table
-                style="table-layout:fixed;visibility:hidden;width:2000px;min-width:100%"
+                style="table-layout:fixed;visibility:hidden;min-width:100%;width:2000px"
               >
                 <colgroup>
                   <col
@@ -29376,7 +29356,7 @@ exports[`renders components/table/demo/summary.tsx correctly 1`] = `
               style="overflow:hidden"
             >
               <table
-                style="table-layout:fixed;visibility:hidden;width:2000px;min-width:100%"
+                style="table-layout:fixed;visibility:hidden;min-width:100%;width:2000px"
               >
                 <colgroup>
                   <col

--- a/components/table/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Table renders empty table 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -169,7 +168,6 @@ exports[`Table renders empty table when emptyText is null 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -267,7 +265,6 @@ exports[`Table renders empty table with custom emptyText 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -692,7 +689,6 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >
@@ -867,7 +863,6 @@ exports[`Table should not render empty when loading 1`] = `
             <table
               style="table-layout: auto;"
             >
-              <colgroup />
               <thead
                 class="ant-table-thead"
               >

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "rc-slider": "~11.1.8",
     "rc-steps": "~6.0.1",
     "rc-switch": "~4.1.0",
-    "rc-table": "~7.52.6",
+    "rc-table": "~7.52.7",
     "rc-tabs": "~15.7.0",
     "rc-textarea": "~1.10.2",
     "rc-tooltip": "~6.4.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

close https://github.com/ant-design/ant-design/issues/54894
close https://github.com/ant-design/ant-design/issues/54907

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

The fix PR: https://github.com/react-component/table/pull/1341

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Table column align issue when scroll.x is true         |
| 🇨🇳 Chinese | 修复 Table 当 `scroll={{ x: true }}` 时列头不对齐的问题。          |
