### PR TITLE
chore(biome): ignore generated antd.css

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!server",
       "!scripts/previewEditor/**/*",
       "!**/*.tmp",
-      "!package.json"
+      "!package.json",
+      "!components/style/antd.css"
     ]
   },
   "formatter": {


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

这个文件大的惊人，而且不需要执行 biome format，会卡住很久，影响 biome lint 的使用

<img width="1126" height="49" alt="image" src="https://github.com/user-attachments/assets/1c5ba7f5-0867-4a60-8985-5b4620ab5c8b" />


gitinore 也忽略了它。 
<img width="1538" height="812" alt="image" src="https://github.com/user-attachments/assets/18e9d8ad-9590-4047-bd5f-522b9de98c12" />



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -     |
| 🇨🇳 Chinese |     -      |
